### PR TITLE
Allow non-alpha-numeric characters for instanceIds in shell calls.

### DIFF
--- a/heron/shell/src/python/main.py
+++ b/heron/shell/src/python/main.py
@@ -193,7 +193,7 @@ app = tornado.web.Application([
   (r"^/jmap/([0-9]+$)", JmapHandler),
   (r"^/histo/([0-9]+$)", MemoryHistogramHandler),
   (r"^/jstack/([0-9]+$)", JstackHandler),
-  (r"^/pid/([a-zA-Z0-9_-]+$)", PidHandler),
+  (r"^/pid/(.*)", PidHandler),
   (r"^/browse/(.*)", BrowseHandler),
   (r"^/file/(.*)", FileHandler),
   (r"^/filedata/(.*)", FileDataHandler),


### PR DESCRIPTION
Instance Ids may contain characters other than [a-zA-Z0-9_]. For example, a '.'.
