### PR TITLE
Clarify wording in doc on compiling heron

### DIFF
--- a/docs/developers/compiling.md
+++ b/docs/developers/compiling.md
@@ -109,13 +109,13 @@ $ bazel build --config=darwin --define RELEASE=0.1.0-SNAPSHOT release:packages
 ### Build Directory for Full Releases
 
 All `.tar` and `.tar.gz` files generated during Bazel's build process for a full
-release can be found in `bazel-genfiles/release`:
+release can be found in `bazel-bin/release`:
 
 ```bash
-$ ls bazel-genfiles/release
+$ ls bazel-bin/release
 RELEASE
-bazel-genfiles/release/heron-api-unversioned.tar
-bazel-genfiles/release/heron-api-unversioned.tar.gz
+bazel-bin/release/heron-api.tar
+bazel-bin/release/heron-api.tar.gz
 # etc
 ```
 


### PR DESCRIPTION
With the upgrades to the newer version of bazel the artifacts are now located in a different place and without version information attached to them.
