### PR TITLE
Quote java classpath argument

### DIFF
--- a/heron/cli2/src/python/cli.py
+++ b/heron/cli2/src/python/cli.py
@@ -103,7 +103,7 @@ def exec_heron_class(klass, libjars, extrajars=[], args=[]):
 
   if VERBOSE:
     print('$> %s' % ' '.join(all_args))
-  status = subprocess.call(all_args)
+  status = subprocess.call(all_args, shell=True)
   if status != 0:
     print "User main failed with status %d. Bailing out..." % status
     sys.exit(1)


### PR DESCRIPTION
The classpath argument must be quoted when including multiple classpath
dependencies.
