### PR TITLE
standardize config-overrides parsing

### DIFF
--- a/heron/cli2/src/python/cli.py
+++ b/heron/cli2/src/python/cli.py
@@ -76,6 +76,10 @@ def get_heron_dir():
   """
   return normclasspath("/".join(os.path.realpath( __file__ ).split('/')[:-7]))
 
+def pass_config_overrides(namespace):
+  parts = namespace['config-overrides'].split('/')[:3]
+  return "dc=%s role=%s environ=%s" % (parts[0], parts[1], parts[2])
+
 def pass_cmdline_override(namespace):
   override = []
   for key in namespace.keys():
@@ -227,7 +231,7 @@ def submitfatjar(namespace):
                    args=args)
 
   try:
-    scheduler_overrides = namespace['config-overrides'] + ' ' + pass_cmdline_override(namespace)
+    scheduler_overrides = pass_config_overrides(namespace) + ' ' + pass_cmdline_override(namespace)
     launch_all_topologies_found(jarfile,
                                 tmpdir,
                                 namespace['config_loader'],
@@ -266,7 +270,7 @@ def submittar(namespace):
 
   exec_heron_tar(klass, tar_name, args, tmpdir)
   try:
-    scheduler_overrides = namespace['config-overrides'] + ' ' + pass_cmdline_override(namespace)
+    scheduler_overrides = pass_config_overrides(namespace) + ' ' + pass_cmdline_override(namespace)
     launch_all_topologies_found(tar_name,
                                 tmpdir,
                                 namespace['config_loader'],
@@ -333,7 +337,7 @@ def runtime_manage(namespace):
   command = namespace['command']
 
   try:
-    config_overrides = namespace['config-overrides'] + ' ' + pass_cmdline_override(namespace)
+    config_overrides = pass_config_overrides(namespace) + ' ' + pass_cmdline_override(namespace)
 
     exec_heron_class('com.twitter.heron.scheduler.service.RuntimeManagerMain',
                      get_heron_libs(SCHEDULER_RUN_JARS),

--- a/heron/scheduler/src/java/com/twitter/heron/scheduler/util/AbstractPropertiesConfigLoader.java
+++ b/heron/scheduler/src/java/com/twitter/heron/scheduler/util/AbstractPropertiesConfigLoader.java
@@ -82,6 +82,12 @@ public abstract class AbstractPropertiesConfigLoader implements IConfigLoader {
   }
 
   public boolean applyConfigOverride(String configOverride) {
-    return ConfigLoaderUtils.applyPropertyOverride(properties, preparePropertyOverride(configOverride));
+    Properties p = new Properties();
+    if (ConfigLoaderUtils.applyPropertyOverride(p, preparePropertyOverride(configOverride))) {
+      properties.putAll(p);
+      return true;
+    } else {
+      return false;
+    }
   }
 }

--- a/heron/scheduler/tests/java/com/twitter/heron/scheduler/aurora/AuroraConfigLoaderTest.java
+++ b/heron/scheduler/tests/java/com/twitter/heron/scheduler/aurora/AuroraConfigLoaderTest.java
@@ -19,7 +19,7 @@ public class AuroraConfigLoaderTest {
 
   @Test
   public void testAuroraOverrides() throws Exception {
-    String override = "dc/role/environ";
+    String override = "dc=dc role=role environ=environ";
     AuroraConfigLoader configLoader = AuroraConfigLoader.class.newInstance();
     // Disables version check
     configLoader.properties.setProperty(Constants.HERON_RELEASE_PACKAGE_NAME, "test");
@@ -31,7 +31,7 @@ public class AuroraConfigLoaderTest {
 
   @Test
   public void testAuroraOverridesWithDefaultOverrides() throws Exception {
-    String override = "dc/role/environ key1=value1 key2=value2";
+    String override = "dc=dc role=role environ=environ key1=value1 key2=value2";
     AuroraConfigLoader configLoader = AuroraConfigLoader.class.newInstance();
     configLoader.properties.setProperty(Constants.HERON_RELEASE_PACKAGE_NAME, "test");
     configLoader.applyConfigOverride(override);
@@ -44,7 +44,7 @@ public class AuroraConfigLoaderTest {
 
   @Test
   public void testAuroraRespectRespectHeronVersion() throws Exception {
-    StringBuilder override = new StringBuilder("dc/role/environ");
+    StringBuilder override = new StringBuilder("dc=dc role=role environ=environ");
 
     // Add required heron package defaults
     addConfig(override, Constants.HERON_RELEASE_PACKAGE_NAME, "testPackage");


### PR DESCRIPTION
at the heron-cli level, intercept dc/role/env and convert it to "dc=dc role=role environ=env" to be consistent with the other command line config properties.
