### PR TITLE
Distribute physical plan always with latest topology def

### DIFF
--- a/heron/proto/physical_plan.proto
+++ b/heron/proto/physical_plan.proto
@@ -33,6 +33,11 @@ message Instance {
 }
 
 message PhysicalPlan {
+  // PhysicalPlan maintains a dirty copy of topology def, which is owned by the topology node
+  // in state manager.
+  // This value is not guaranteed consistent with actual value, to avoid complicated transactional updates.
+  // To solve the consistent issue, it is required to update toplogy def's value with latest one from State Manager,
+  // and then to distribute the physical plan to all stream mgrs.
   required heron.proto.api.Topology topology = 1;
   repeated StMgr stmgrs = 2;
   repeated Instance instances = 3;

--- a/heron/tmaster/src/cpp/manager/tmaster.h
+++ b/heron/tmaster/src/cpp/manager/tmaster.h
@@ -84,6 +84,12 @@ class TMaster
   // in terms of workers
   bool ValidateStMgrsWithPhysicalPlan();
 
+  // If the assignment is already done, then:
+  // 1. Force updating the internal proto::api::Topology inside current_pplan_
+  // with latest one to solve the inconsistent topology def issue.
+  // 2. Distribute physical plan to all active stmgrs
+  bool DistributePhysicalPlan();
+
   // Function called after we set the tmasterlocation
   void SetTMasterLocationDone(proto::system::StatusCode _code);
   // Function called after we get the topology


### PR DESCRIPTION
Currently when tmaster receives an activate/deactivate request, it would only persist the changes in topology def to zk, withtout persisting the new physical plan. But when tmaster restarts, it would check the persistent physical plan to determine the topology state,

so:
1. Any topology state changes would not reflect after restart.
2. The topology states in topology def and physical plan are inconsistent.

This change would consider topology def the owner of topology states, and every time when tmaster
distributes physical plan to stream mgrs, it would first update its internal topology states with the correct
one from latest topology def.

By doing this, we could:
1. Avoid the transactional updates on topology def and physical plan.
2. Guarantee eventual consistency while also to provide correct behaviors.

In future, we might remove the topology def from physical plan to have guarantee one owner of the data.
