### PR TITLE
The SingletonRegistry used in Localmode prevents testing with multiple test cases

### DIFF
--- a/heron/localmode/src/java/com/twitter/heron/localmode/LocalMode.java
+++ b/heron/localmode/src/java/com/twitter/heron/localmode/LocalMode.java
@@ -20,8 +20,15 @@ import com.twitter.heron.localmode.executors.StreamExecutor;
 import com.twitter.heron.localmode.utils.PhysicalPlanUtil;
 import com.twitter.heron.proto.system.PhysicalPlans;
 
+
+/**
+ * One LocalMode instance can only submit one topology. Please have multiple LocalMode instances
+ * for multiple topologies.
+ */
 public class LocalMode {
   private static final Logger LOG = Logger.getLogger(LocalMode.class.getName());
+
+  private SystemConfig systemConfig;
 
   private final List<InstanceExecutor> instanceExecutors = new LinkedList<>();
 
@@ -31,6 +38,50 @@ public class LocalMode {
   private StreamExecutor streamExecutor;
 
   private MetricsExecutor metricsExecutor;
+
+  public LocalMode() {
+    this(true);
+  }
+
+  public LocalMode(boolean initialize) {
+    if (initialize) {
+      init();
+    }
+  }
+
+  protected void init() {
+    // Instantiate the System Config
+    this.systemConfig = getSystemConfig();
+
+    // Add the SystemConfig into SingletonRegistry. We synchronized on the singleton object here to
+    // make sure the "check and register" is atomic. And wrapping the containsSingleton and
+    // registerSystemConfig for easy of unit testing
+    synchronized (SingletonRegistry.INSTANCE) {
+      if (!isSystemConfigExisted()) {
+        LOG.info("System config not existed. Registering...");
+        registerSystemConfig(systemConfig);
+        LOG.info("System config registered.");
+      } else {
+        LOG.info("System config already existed.");
+      }
+    }
+  }
+
+  /**
+   * Check if the system config is already registered into the SingleRegistry
+   * @return true if it's registered; false otherwise
+   */
+  protected boolean isSystemConfigExisted() {
+    return SingletonRegistry.INSTANCE.containsSingleton(Constants.HERON_SYSTEM_CONFIG);
+  }
+
+  /**
+   * Register the given system config
+   * @param systemConfig
+   */
+  protected void registerSystemConfig(SystemConfig systemConfig) {
+    SingletonRegistry.INSTANCE.registerSingleton(Constants.HERON_SYSTEM_CONFIG, systemConfig);
+  }
 
   /**
    * Handler for catching exceptions thrown by any threads (owned either by topology or heron
@@ -70,12 +121,6 @@ public class LocalMode {
     PhysicalPlans.PhysicalPlan pPlan = PhysicalPlanUtil.getPhysicalPlan(topologyToRun);
 
     LOG.info("Physical Plan: \n" + pPlan);
-
-    // Instantiate the System Config
-    SystemConfig systemConfig = getSystemConfig();
-
-    // Add the SystemConfig into SingletonRegistry
-    SingletonRegistry.INSTANCE.registerSingleton(Constants.HERON_SYSTEM_CONFIG, systemConfig);
 
     // Create the stream executor
     streamExecutor = new StreamExecutor(pPlan);

--- a/heron/localmode/tests/java/BUILD
+++ b/heron/localmode/tests/java/BUILD
@@ -94,3 +94,10 @@ java_test(
     deps = test_deps_files, 
     size = "small",
 )
+
+java_test(
+    name = "local-mode_unittest",
+    srcs = glob(["**/LocalModeTest.java"]),
+    deps = test_deps_files,
+    size = "small",
+)

--- a/heron/localmode/tests/java/com/twitter/heron/localmode/LocalModeTest.java
+++ b/heron/localmode/tests/java/com/twitter/heron/localmode/LocalModeTest.java
@@ -1,0 +1,63 @@
+package com.twitter.heron.localmode;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.twitter.heron.common.basics.SingletonRegistry;
+import com.twitter.heron.common.config.SystemConfig;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * LocalMode Tester
+ */
+public class LocalModeTest {
+  /**
+   * Method: Init()
+   */
+  @Test
+  public void testInit() throws Exception {
+    clearSingletonRegistry();
+    LocalMode spyLocalMode = spy(new LocalMode(false));
+
+    spyLocalMode.init();
+    verify(spyLocalMode, times(1)).isSystemConfigExisted();
+    verify(spyLocalMode, times(1)).registerSystemConfig(any(SystemConfig.class));
+
+    spyLocalMode.init();
+    verify(spyLocalMode, times(2)).isSystemConfigExisted();
+    verify(spyLocalMode, times(1)).registerSystemConfig(any(SystemConfig.class));
+  }
+
+  @Test
+  public void testTwoLocaMode() throws Exception {
+    clearSingletonRegistry();
+    try {
+      LocalMode spyLocalMode1 = spy(new LocalMode(false));
+      spyLocalMode1.init();
+      verify(spyLocalMode1, times(1)).isSystemConfigExisted();
+      verify(spyLocalMode1, times(1)).registerSystemConfig(any(SystemConfig.class));
+
+      LocalMode spyLocalMode2 = spy(new LocalMode(false));
+      spyLocalMode2.init();
+      verify(spyLocalMode2, times(1)).isSystemConfigExisted();
+      verify(spyLocalMode2, times(0)).registerSystemConfig(any(SystemConfig.class));
+    } catch (Exception e) {
+      fail(String.format("Exception %s thrown while creating two LocalMode", e));
+    }
+  }
+
+  private static void clearSingletonRegistry() throws Exception {
+    // Remove the Singleton by Reflection
+    Field field = SingletonRegistry.INSTANCE.getClass().getDeclaredField("singletonObjects");
+    field.setAccessible(true);
+    Map<String, Object> singletonObjects = (Map<String, Object>) field.get(SingletonRegistry.INSTANCE);
+    singletonObjects.clear();
+  }
+}


### PR DESCRIPTION
The SingletonRegistry used in Localmode prevents testing with multiple test cases. The reason is once a SystemConfig is registered, any later registreing attempts will cause exceptions. To resolve this issue, the following 2 changes are made:
1. Register the SystemConfig only once at LocalMode construct with init() method
2. Add synchronization to the methods in SingletonRegistry to avoid contention
