### PR TITLE
Increase RAM for daemon processes in container

### DIFF
--- a/heron-conf/example/vagrant/aurora/aurora_scheduler.conf
+++ b/heron-conf/example/vagrant/aurora/aurora_scheduler.conf
@@ -13,7 +13,8 @@ packing.algorithm.class: com.twitter.heron.scheduler.util.RoundRobinPacking
 instance.cpu.default: 1
 instance.ram.default: 134217728
 instance.disk.default: 134217728
-stmgr.ram.default: 134217728
+# include stream mgr, metrics mgr or other daemon processes
+daemon.processes.ram.default: 1073741824
 heron.logging.directory: log-files
 heron.java.home.path: /usr/lib/jvm/java-8-openjdk-amd64/
 
@@ -36,4 +37,4 @@ heron.aurora.batch.size: 3
 
 topology.container.cpu: 1
 topology.container.ram: 1073741824
-topology.container.disk: 1073741824 
+topology.container.disk: 1073741824

--- a/heron/common/src/python/constants.py
+++ b/heron/common/src/python/constants.py
@@ -11,6 +11,8 @@ TOPOLOGY_COMPONENT_RAMMAP = "topology.component.rammap"
 TOPOLOGY_STMGRS = "topology.stmgrs"
 TOPOLOGY_WORKER_CHILDOPTS = "topology.worker.childopts"
 TOPOLOGY_ADDITIONAL_CLASSPATH = "topology.additional.classpath"
-RAM_FOR_STMGR = 1 * GB
+
+# include stream mgr, metrics mgr or other daemon processes
+RAM_FOR_DAEMON_PROCESSES = 2 * GB
 DEFAULT_RAM_FOR_INSTANCE = 1 * GB
 DEFAULT_DISK_PADDING_PER_CONTAINER = 12 * GB

--- a/heron/common/src/python/topology_helpers.py
+++ b/heron/common/src/python/topology_helpers.py
@@ -114,7 +114,7 @@ def get_ram_per_container(topology):
       ramsize += int(rammap[component_name])
     if ramsize > maxsize:
       maxsize = ramsize
-  return maxsize + constants.RAM_FOR_STMGR
+  return maxsize + constants.RAM_FOR_DAEMON_PROCESSES
 
 def get_component_rammap(topology):
   """
@@ -152,7 +152,7 @@ def get_component_rammap(topology):
   # memory equally
   requested_ram_per_container = get_container_ram_requested(topology)
   if requested_ram_per_container != None:
-    ram_for_jvms = requested_ram_per_container - constants.RAM_FOR_STMGR
+    ram_for_jvms = requested_ram_per_container - constants.RAM_FOR_DAEMON_PROCESSES
     ram_per_instance = int(ram_for_jvms / max_instances_in_a_container)
     rammap = {}
     for component in components:

--- a/heron/common/tests/python/topology_helpers_unittest.py
+++ b/heron/common/tests/python/topology_helpers_unittest.py
@@ -141,8 +141,8 @@ class TopologyHelpersTest(unittest.TestCase):
     # This is not a good way since this shows the internals
     # of the method. These methods need to be changed.
     # For example, ram_per_contaner could be taken as an argument.
-    original_ram_for_stmgr = constants.RAM_FOR_STMGR
-    constants.RAM_FOR_STMGR = 2
+    original_ram_for_stmgr = constants.RAM_FOR_DAEMON_PROCESSES
+    constants.RAM_FOR_DAEMON_PROCESSES = 2
 
     # When rammap is specified, it should be used.
     topology = self.mock_proto.create_mock_simple_topology(4,8)
@@ -180,12 +180,12 @@ class TopologyHelpersTest(unittest.TestCase):
     self.assertEqual(expected_component_rammap, component_rammap)
 
     # Unmock the things that we mocked.
-    constants.RAM_FOR_STMGR = original_ram_for_stmgr
+    constants.RAM_FOR_DAEMON_PROCESSES = original_ram_for_stmgr
 
   def test_get_ram_per_container(self):
     # Mock a few things
-    original_ram_for_stmgr = constants.RAM_FOR_STMGR
-    constants.RAM_FOR_STMGR = 2
+    original_ram_for_stmgr = constants.RAM_FOR_DAEMON_PROCESSES
+    constants.RAM_FOR_DAEMON_PROCESSES = 2
     original_default_ram_for_instance = constants.DEFAULT_RAM_FOR_INSTANCE
     constants.DEFAULT_RAM_FOR_INSTANCE = 1
 
@@ -216,5 +216,5 @@ class TopologyHelpersTest(unittest.TestCase):
     self.assertEqual(expected_ram_per_container, topology_helpers.get_ram_per_container(topology))
 
     # Unmock the things that we mocked.
-    constants.RAM_FOR_STMGR = original_ram_for_stmgr
+    constants.RAM_FOR_DAEMON_PROCESSES = original_ram_for_stmgr
     constants.DEFAULT_RAM_FOR_INSTANCE = original_default_ram_for_instance

--- a/heron/scheduler/tests/java/com/twitter/heron/scheduler/aurora/AuroraLauncherTest.java
+++ b/heron/scheduler/tests/java/com/twitter/heron/scheduler/aurora/AuroraLauncherTest.java
@@ -30,7 +30,7 @@ public class AuroraLauncherTest {
         Long.toString(1 * Constants.GB));
     schedulerConfig.properties.setProperty(RoundRobinPacking.INSTANCE_DISK_DEFAULT,
         Long.toString(1 * Constants.GB));
-    schedulerConfig.properties.setProperty(RoundRobinPacking.STMGR_RAM_DEFAULT,
+    schedulerConfig.properties.setProperty(RoundRobinPacking.RAM_FOR_DAEMON_PROCESSES,
         Long.toString(1 * Constants.GB));
     String stateMgrClass = "com.twitter.heron.spi.statemgr.NullStateManager";
     schedulerConfig.properties.setProperty(Constants.STATE_MANAGER_CLASS, stateMgrClass);


### PR DESCRIPTION
Currently when requesting RAM for a container, heron just takes stmgr, 1GB, into account.
This RB will increase it to 2GB, taking the metricsmgr into account too.

Test done:
1. Unit test
2. Custom release
