### PR TITLE
Redefine PhysicalPlan, Topology and refactor TMaster

### DIFF
--- a/heron/proto/physical_plan.proto
+++ b/heron/proto/physical_plan.proto
@@ -5,6 +5,9 @@ option java_outer_classname = "PhysicalPlans";
 
 import "topology.proto";
 
+// This file defines the physical plan of a topology.
+// It reflects the dynamic running state of a topology.
+
 message StMgr {
   required string id = 1;
   required string host_name = 2;
@@ -33,11 +36,9 @@ message Instance {
 }
 
 message PhysicalPlan {
-  // PhysicalPlan maintains a dirty copy of topology def, which is owned by the topology node
-  // in state manager.
-  // This value is not guaranteed consistent with actual value, to avoid complicated transactional updates.
-  // To solve the consistent issue, it is required to update toplogy def's value with latest one from State Manager,
-  // and then to distribute the physical plan to all stream mgrs.
+  // Note that heron.proto.api.Topology, included in PhysicalPlan,
+  // reflect the actual dynamic running state of the topology.
+  // Query this value guarantees the correct running state of the topology.
   required heron.proto.api.Topology topology = 1;
   repeated StMgr stmgrs = 2;
   repeated Instance instances = 3;

--- a/heron/proto/topology.proto
+++ b/heron/proto/topology.proto
@@ -3,11 +3,27 @@ package heron.proto.api;
 option java_package = "com.twitter.heron.api.generated";
 option java_outer_classname = "TopologyAPI";
 
+// This file defines the logic plan of a topology, including
+// components definition, stream schema and others.
+// 1. Heron usbmitter pushes the message Topology to state manager at node: topologies/{topology_name}
+// 2. When TMaster first time starts, it reads Topology from state manager at node topologies/{topology_name},
+// 3. TMaster constructs and distribute PhysicalPlan basing on Topology and StrMgrHelloRequest.
+//    It also pushes the PhysicalPlan to state manager at node: pplans/{topology_name}
+//
+// Note:
+// 1. message PhysicalPlan also contains a copy of message Topolgoy. We distinguish them:
+//    - topologies/{topology_name} consist of the topology logic plan first submitted by user,
+//      it shall only be used to construct the PhysicalPlan when TMaster first time starts
+//    - pplans/{topology_name} reflects the dynamic state of the topology. Initially, it shall be the same
+//      as what user has submitted.
+//    Any runtime changes on Topology in are made to Topology inside the node pplans/{topology_name}.
+//    For instance, change of TopologyState in runtime will be made in the Topology inside the node pplans/{topology_name}.
+
 enum Grouping {
   SHUFFLE = 1;
   FIELDS = 2;
-  ALL = 3; 
-  LOWEST = 4; 
+  ALL = 3;
+  LOWEST = 4;
   NONE = 5;
   DIRECT = 6;
   CUSTOM = 7;

--- a/heron/tmaster/src/cpp/manager/tcontroller.cpp
+++ b/heron/tmaster/src/cpp/manager/tcontroller.cpp
@@ -53,19 +53,19 @@ void TController::HandleActivateRequest(IncomingHTTPRequest* request)
     delete request;
     return;
   }
-  if (tmaster_->getTopology() == NULL) {
+  if (tmaster_->getPhysicalPlan() == NULL) {
     LOG(ERROR) << "Tmaster still not initialized";
     http_server_->SendErrorReply(request, 500);
     delete request;
     return;
   }
-  if (id != tmaster_->getTopology()->id()) {
+  if (id != tmaster_->GetTopologyId()) {
     LOG(ERROR) << "Topology id does not match";
     http_server_->SendErrorReply(request, 400);
     delete request;
     return;
   }
-  if (tmaster_->getTopology()->state() != proto::api::PAUSED) {
+  if (tmaster_->GetTopologyState() != proto::api::PAUSED) {
     LOG(ERROR) << "Topology not in paused state";
     http_server_->SendErrorReply(request, 400);
     delete request;
@@ -107,19 +107,19 @@ void TController::HandleDeActivateRequest(IncomingHTTPRequest* request)
     delete request;
     return;
   }
-  if (tmaster_->getTopology() == NULL) {
+  if (tmaster_->getPhysicalPlan() == NULL) {
     LOG(ERROR) << "Tmaster still not initialized";
     http_server_->SendErrorReply(request, 500);
     delete request;
     return;
   }
-  if (id != tmaster_->getTopology()->id()) {
+  if (id != tmaster_->GetTopologyId()) {
     LOG(ERROR) << "Topology id does not match";
     http_server_->SendErrorReply(request, 400);
     delete request;
     return;
   }
-  if (tmaster_->getTopology()->state() != proto::api::RUNNING) {
+  if (tmaster_->GetTopologyState() != proto::api::RUNNING) {
     LOG(ERROR) << "Topology not in running state";
     http_server_->SendErrorReply(request, 400);
     delete request;


### PR DESCRIPTION
Earlier we defined that PhysicalPlan maintains a dirty copy of topology def, which is owned by the topology node in state manager.
Then it is possible that at some point of time, both PhysicalPlan and Topology node will maintain some dynamic data. It is bad,
especially when we need to make consistent changes on both nodes at the same instant(dramatically increasing the design complexity).

This pull request re-defines it. The Topology node maintains only the topology def first time submitted by the user.
And it shall only be used to construct the physical plan when TMaster first time starts.
Any runtime changes will reflect in PhysicalPlan, and all query for actual runtime data shall go to PhysicalPlan.

This guarantee will make future design and development much easier.

Test done.
