### PR TITLE
fix the statemgr path for tracker to work

### DIFF
--- a/heron/statemgrs/src/python/config.py
+++ b/heron/statemgrs/src/python/config.py
@@ -20,7 +20,7 @@ class Config:
     conf_file = os.path.join("conf", conf_name + ".yaml")
 
     # Read the configuration file from package
-    confString = pkgutil.get_data("heron.state", conf_file)
+    confString = pkgutil.get_data("heron.statemgrs", conf_file)
     self.locations = yaml.load(confString)
     self.validate_state_locations()
 


### PR DESCRIPTION
This commit fixes the path of the resource file in tracker due to the changes in the path names during organization!
