### PR TITLE
Redirect heron-shell logs to log-files directory.

### DIFF
--- a/heron/executor/src/python/heron-executor.py
+++ b/heron/executor/src/python/heron-executor.py
@@ -312,7 +312,8 @@ class HeronExecutor:
     retval = {}
 
     retval[self.heron_shell_binary] = ['%s' % self.heron_shell_binary,
-                             '--port=%s' % self.shell_port]
+                                       '--port=%s' % self.shell_port,
+                                       '--log_file_prefix=%s/heron-shell.log' % self.log_dir]
 
     return retval
 

--- a/heron/shell/src/python/main.py
+++ b/heron/shell/src/python/main.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import pkgutil
 import stat
@@ -204,5 +205,9 @@ app = tornado.web.Application([
 if __name__ == '__main__':
   define("port", default=9999, help="Runs on the given port", type=int)
   parse_command_line()
+
+  logger = logging.getLogger(__file__)
+  logger.info("Starting Heron Shell")
+
   app.listen(options.port)
   tornado.ioloop.IOLoop.instance().start()


### PR DESCRIPTION
`--log_file_prefix` is tornado's option that can be used to redirect all tornado's logs to a file. Since `heron-shell` is launched using python's `Popen` call, its stdout and other logs are lost. Now they will be part of the logs directory.
