### PR TITLE
added logs in executor during starting of a process

### DIFF
--- a/heron/executor/src/python/heron-executor.py
+++ b/heron/executor/src/python/heron-executor.py
@@ -333,6 +333,7 @@ class HeronExecutor:
     process_dict = { }
     # First start all the processes
     for (name, cmd) in commands.items():
+      print "Starting process %s %s" % (name, ' '.join(cmd))
       p = self.run_process(name, cmd)
       process_dict[p.pid] = (p, name, 1)
 


### PR DESCRIPTION
During the starting a process such as tmaster, stmgr, etc, the logs will specify the event of starting and after starting - helpful in debugging issues.
