### PR TITLE
Fix wrong indent in copying files in UI.

### DIFF
--- a/heron/ui/src/python/handlers/access/heron.py
+++ b/heron/ui/src/python/handlers/access/heron.py
@@ -378,12 +378,12 @@ class HeronQueryHandler(QueryHandler):
     for result in results:
       timelines.extend(result["timeline"])
 
-      result = dict(
-          status = "success",
-          starttime = timerange[0],
-          endtime = timerange[1],
-          result = dict(timeline = timelines)
-      )
+    result = dict(
+        status = "success",
+        starttime = timerange[0],
+        endtime = timerange[1],
+        result = dict(timeline = timelines)
+    )
 
     raise tornado.gen.Return(result)
 


### PR DESCRIPTION
This sometimes works because `result` variable does not go out of scope even though it is part of for loop. The problem occurs when `results` is empty and control never goes inside the loop and so `result` is never initialized.
