### PR TITLE
removed client.yaml

### DIFF
--- a/heron/config/src/yaml/BUILD
+++ b/heron/config/src/yaml/BUILD
@@ -43,11 +43,6 @@ filegroup(
 )
 
 filegroup(
-    name = "conf-local-client",
-    srcs = ["conf/local/client.yaml"],
-)
-
-filegroup(
     name = "conf-local-packing",
     srcs = ["conf/local/packing.yaml"],
 )

--- a/scripts/centos5/BUILD
+++ b/scripts/centos5/BUILD
@@ -76,7 +76,6 @@ genrule(
         ":heron-core",
         ":conf-local-heron-internals",
         ":conf-local-metrics-sinks",
-        ":conf-local-client",
         ":conf-local-packing",
         ":conf-local-scheduler",
         ":conf-local-statemgr",
@@ -105,7 +104,6 @@ genrule(
         "--cp $(location hcli)                       bin/heron",
         "--cp $(location conf-local-heron-internals) conf/local/heron_internals.yaml",
         "--cp $(location conf-local-metrics-sinks)   conf/local/metrics_sinks.yaml",
-        "--cp $(location conf-local-client)          conf/local/client.yaml",
         "--cp $(location conf-local-packing)         conf/local/packing.yaml",
         "--cp $(location conf-local-scheduler)       conf/local/scheduler.yaml",
         "--cp $(location conf-local-statemgr)        conf/local/statemgr.yaml",
@@ -185,11 +183,6 @@ filegroup(
 filegroup(
     name = "conf-local-metrics-sinks",
     srcs = ["//heron/config/src/yaml:conf-local-metrics-sinks"],
-)
-
-filegroup(
-    name = "conf-local-client",
-    srcs = ["//heron/config/src/yaml:conf-local-client"],
 )
 
 filegroup(


### PR DESCRIPTION
This is not necessary since we can choose reasonable defaults for variables such as ${HERON_DIST}
