### PR TITLE
Fix  UnsupportedOperationException in AuroraUtils

### DIFF
--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraUtils.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraUtils.java
@@ -1,11 +1,12 @@
 package com.twitter.heron.scheduler.aurora;
 
+import com.twitter.heron.spi.common.ShellUtils;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
-
-import com.twitter.heron.spi.common.ShellUtils;
 
 /**
  * This file defines Utils methods used by Aurora
@@ -17,7 +18,7 @@ public class AuroraUtils {
   public static boolean createAuroraJob(String jobName, String cluster, String role, String env,
                                         String auroraFilename, Map<String, String> bindings,
                                         boolean isVerbose) {
-    List<String> auroraCmd = Arrays.asList("aurora", "job", "create", "--wait-until", "RUNNING");
+    List<String> auroraCmd = new ArrayList<>(Arrays.asList("aurora", "job", "create", "--wait-until", "RUNNING"));
 
     for (Map.Entry<String, String> binding : bindings.entrySet()) {
       auroraCmd.add("--bind");
@@ -33,26 +34,26 @@ public class AuroraUtils {
     }
 
     return 0 == ShellUtils.runProcess(
-        isVerbose, (String[]) auroraCmd.toArray(), new StringBuilder(), new StringBuilder());
+        isVerbose, auroraCmd.toArray(new String[0]), new StringBuilder(), new StringBuilder());
   }
 
   // Kill an aurora job
   public static boolean killAuroraJob(String jobName, String cluster, String role, String env,
                                       boolean isVerbose) {
-    List<String> auroraCmd = Arrays.asList("aurora", "job", "killall");
+    List<String> auroraCmd = new ArrayList<>(Arrays.asList("aurora", "job", "killall"));
     String jobSpec = String.format("%s/%s/%s/%s", cluster, role, env, jobName);
     auroraCmd.add(jobSpec);
 
     appendAuroraCommandOptions(auroraCmd, isVerbose);
 
     return 0 == ShellUtils.runProcess(
-        isVerbose, (String[]) auroraCmd.toArray(), new StringBuilder(), new StringBuilder());
+        isVerbose, auroraCmd.toArray(new String[0]), new StringBuilder(), new StringBuilder());
   }
 
   // Restart an aurora job
   public static boolean restartAuroraJob(String jobName, String cluster, String role, String env,
                                          int containerId, boolean isVerbose) {
-    List<String> auroraCmd = Arrays.asList("aurora", "job", "restart");
+    List<String> auroraCmd = new ArrayList<>(Arrays.asList("aurora", "job", "restart"));
     String jobSpec = String.format("%s/%s/%s/%s", cluster, role, env, jobName);
     if (containerId != -1) {
       jobSpec = String.format("%s/%s", jobSpec, "" + containerId);
@@ -62,7 +63,7 @@ public class AuroraUtils {
     appendAuroraCommandOptions(auroraCmd, isVerbose);
 
     return 0 == ShellUtils.runProcess(
-        isVerbose, (String[]) auroraCmd.toArray(), new StringBuilder(), new StringBuilder());
+        isVerbose, auroraCmd.toArray(new String[0]), new StringBuilder(), new StringBuilder());
   }
 
   // Static method to append verbose and batching options if needed


### PR DESCRIPTION
`Arrays.asList` returns an immutable abstract implementation of list and
cannot have elements added to it. This change wraps the array list
returned in a mutable copy of the list to allow adding more arguments to
the auroraCmd.

```
java.lang.UnsupportedOperationException
        at java.util.AbstractList.add(AbstractList.java:148)
        at java.util.AbstractList.add(AbstractList.java:108)
        at com.twitter.heron.scheduler.aurora.AuroraUtils.createAuroraJob(AuroraUtils.java:23)
        at com.twitter.heron.scheduler.aurora.AuroraLauncher.launch(AuroraLauncher.java:124)
        at com.twitter.heron.scheduler.LaunchRunner.call(LaunchRunner.java:128)
        at com.twitter.heron.scheduler.SubmitterMain.submitTopology(SubmitterMain.java:376)
        at com.twitter.heron.scheduler.SubmitterMain.main(SubmitterMain.java:306)
```

This also fixes exception when casting the list to a string array.
`List.toArray` also returns an Object[] instead of a typed array. By
adding a typed array to the `List.toArray` argument list it will convert
it to the approriate type and does not need to be cast.

```
java.lang.ClassCastException: [Ljava.lang.Object; cannot be cast to [Ljava.lang.String;
        at com.twitter.heron.scheduler.aurora.AuroraUtils.createAuroraJob(AuroraUtils.java:38)
        at com.twitter.heron.scheduler.aurora.AuroraLauncher.launch(AuroraLauncher.java:124)
        at com.twitter.heron.scheduler.LaunchRunner.call(LaunchRunner.java:128)
        at com.twitter.heron.scheduler.SubmitterMain.submitTopology(SubmitterMain.java:376)
        at com.twitter.heron.scheduler.SubmitterMain.main(SubmitterMain.java:306)
```
