### PR TITLE
Refactor Scheduler interfaces

### DIFF
--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraLauncher.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraLauncher.java
@@ -35,6 +35,11 @@ public class AuroraLauncher implements ILauncher {
   }
 
   @Override
+  public void close() {
+
+  }
+
+  @Override
   public boolean prepareLaunch(PackingPlan packing) {
     return true;
   }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraRuntimeManager.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraRuntimeManager.java
@@ -26,6 +26,11 @@ public class AuroraRuntimeManager implements IRuntimeManager {
   }
 
   @Override
+  public void undo() {
+
+  }
+
+  @Override
   public boolean prepareRestart(Integer containerId) {
     return true;
   }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalLauncher.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalLauncher.java
@@ -55,6 +55,11 @@ public class LocalLauncher implements ILauncher {
         topologyWorkingDirectory, "topology.tar.gz").toString();
   }
 
+  @Override
+  public void close() {
+
+  }
+
   /**
    * Encode the JVM options
    *

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalRuntimeManager.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalRuntimeManager.java
@@ -23,6 +23,11 @@ public class LocalRuntimeManager implements IRuntimeManager {
   }
 
   @Override
+  public void undo() {
+
+  }
+
+  @Override
   public boolean prepareRestart(Integer containerId) {
     return true;
   }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalScheduler.java
@@ -62,6 +62,11 @@ public class LocalScheduler implements IScheduler {
     LOG.info("Executor for each container have been started.");
   }
 
+  @Override
+  public void close() {
+
+  }
+
   /**
    * Encode the JVM options
    *

--- a/heron/spi/src/java/com/twitter/heron/spi/metricsmgr/sink/IMetricsSink.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/metricsmgr/sink/IMetricsSink.java
@@ -11,7 +11,7 @@ import com.twitter.heron.spi.metricsmgr.metrics.MetricsRecord;
  * {@link #processRecord(MetricsRecord)} method.
  * And {@link #flush()} is called at an interval according to the configuration
  */
-public interface IMetricsSink {
+public interface IMetricsSink extends AutoCloseable {
   /**
    * Initialize the MetricsSink
    *
@@ -20,25 +20,25 @@ public interface IMetricsSink {
    * Attempts to modify the returned map,
    * whether direct or via its collection views, result in an UnsupportedOperationException.
    */
-  public void init(Map<String, Object> conf, SinkContext context);
+  void init(Map<String, Object> conf, SinkContext context);
 
   /**
    * Process a metrics record in the sink
    *
    * @param record the record to put
    */
-  public void processRecord(MetricsRecord record);
+  void processRecord(MetricsRecord record);
 
   /**
    * Flush any buffered metrics
    * It would be called at an interval according to the configuration
    */
-  public void flush();
+  void flush();
 
   /**
    * Closes this stream and releases any system resources associated
    * with it. If the stream is already closed then invoking this
    * method has no effect.
    */
-  public void close();
+  void close();
 }

--- a/heron/spi/src/java/com/twitter/heron/spi/packing/IPacking.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/packing/IPacking.java
@@ -7,12 +7,12 @@ import com.twitter.heron.spi.common.PackingPlan;
  * Packing algorithm to use for packing multiple instances into containers. Packing hints like
  * number of container may be passed through scheduler config.
  */
-public interface IPacking {
-  
+public interface IPacking extends AutoCloseable {
+
   /**
-   * Initialize the packing algorithm with the static and runtime config 
+   * Initialize the packing algorithm with the static and runtime config
    */
-  public void initialize(Config config, Config runtime);
+  void initialize(Config config, Config runtime);
 
   /**
    * Called by scheduler to generate container packing.
@@ -25,6 +25,10 @@ public interface IPacking {
   /**
    * This is to for disposing or cleaning up any internal state accumulated by
    * the uploader
+   * <p/>
+   * Closes this stream and releases any system resources associated
+   * with it. If the stream is already closed then invoking this
+   * method has no effect.
    */
-  public void close();
+  void close();
 }

--- a/heron/spi/src/java/com/twitter/heron/spi/scheduler/ILauncher.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/scheduler/ILauncher.java
@@ -1,13 +1,13 @@
 package com.twitter.heron.spi.scheduler;
 
 import com.twitter.heron.proto.system.ExecutionEnvironment;
-import com.twitter.heron.spi.common.PackingPlan;
 import com.twitter.heron.spi.common.Config;
+import com.twitter.heron.spi.common.PackingPlan;
 
 /**
  * Launches scheduler. heron-cli will create Launcher object using default no argument constructor.
  */
-public interface ILauncher {
+public interface ILauncher extends AutoCloseable {
   /**
    * Initialize Launcher with Config, Uploader and topology. These object
    * will be passed from submitter main. Config will contain information that launcher may use
@@ -15,6 +15,16 @@ public interface ILauncher {
    * services which will launch scheduler.
    */
   void initialize(Config config, Config runtime);
+
+  /**
+   * This is to for disposing or cleaning up any internal state accumulated by
+   * the ILauncher
+   * <p/>
+   * Closes this stream and releases any system resources associated
+   * with it. If the stream is already closed then invoking this
+   * method has no effect.
+   */
+  void close();
 
   /**
    * Will be called locally before trying to launch topology remotely

--- a/heron/spi/src/java/com/twitter/heron/spi/scheduler/IRuntimeManager.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/scheduler/IRuntimeManager.java
@@ -2,7 +2,7 @@ package com.twitter.heron.spi.scheduler;
 
 import com.twitter.heron.spi.common.Config;
 
-public interface IRuntimeManager {
+public interface IRuntimeManager extends AutoCloseable {
   enum Command {
     KILL,
     ACTIVATE,
@@ -16,7 +16,20 @@ public interface IRuntimeManager {
 
   void initialize(Config config, Config runtime);
 
+  /**
+   * This is to for disposing or cleaning up any internal state accumulated by
+   * the RuntimeManager
+   * <p/>
+   * Closes this stream and releases any system resources associated
+   * with it. If the stream is already closed then invoking this
+   * method has no effect.
+   */
   void close();
+
+  /**
+   * In case launch fails, this is called to clean up state, if any.
+   */
+  void undo();
 
   boolean prepareRestart(Integer containerId);
 

--- a/heron/spi/src/java/com/twitter/heron/spi/scheduler/IScheduler.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/scheduler/IScheduler.java
@@ -2,24 +2,34 @@ package com.twitter.heron.spi.scheduler;
 
 
 import com.twitter.heron.proto.scheduler.Scheduler;
-import com.twitter.heron.spi.common.PackingPlan;
 import com.twitter.heron.spi.common.Config;
+import com.twitter.heron.spi.common.PackingPlan;
 
 /**
  * Scheduler object responsible for bringing up topology. Will be instantiated using no-arg
  * constructor.
  */
-public interface IScheduler {
+public interface IScheduler extends AutoCloseable {
   /**
    * This will initialize scheduler using config file. Will be called during start.
    */
   void initialize(Config config, Config runtime);
 
   /**
+   * This is to for disposing or cleaning up any internal state accumulated by
+   * the scheduler
+   * <p/>
+   * Closes this stream and releases any system resources associated
+   * with it. If the stream is already closed then invoking this
+   * method has no effect.
+   */
+  void close();
+
+  /**
    * This method will be called after initialize.
    * It is responsible for grabbing resource to launch executor and make sure they
    * get launched.
-   * <p>
+   * <p/>
    *
    * @param packing Initial mapping suggested by running packing algorithm.
    */

--- a/heron/spi/src/java/com/twitter/heron/spi/scheduler/NullLauncher.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/scheduler/NullLauncher.java
@@ -12,6 +12,11 @@ public class NullLauncher implements ILauncher {
   }
 
   @Override
+  public void close() {
+
+  }
+
+  @Override
   public boolean prepareLaunch(PackingPlan packing) {
     return true;
   }

--- a/heron/spi/src/java/com/twitter/heron/spi/scheduler/NullScheduler.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/scheduler/NullScheduler.java
@@ -12,6 +12,11 @@ public class NullScheduler implements IScheduler {
   }
 
   @Override
+  public void close() {
+
+  }
+
+  @Override
   public void schedule(PackingPlan packing) {
 
   }

--- a/heron/spi/src/java/com/twitter/heron/spi/statemgr/IStateManager.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/statemgr/IStateManager.java
@@ -35,25 +35,32 @@ import com.twitter.heron.spi.common.Config;
  * is called with result code upon the completion of the operation.
  */
 
-public interface IStateManager {
+public interface IStateManager extends AutoCloseable {
   /**
    * Initialize the uploader with the incoming context.
    */
-  public void initialize(Config config);
+  void initialize(Config config);
 
-  public void close();
+  /**
+   * This is to for disposing or cleaning up any internal state accumulated by
+   * the StateManager
+   * <p/>
+   * Closes this stream and releases any system resources associated
+   * with it. If the stream is already closed then invoking this
+   * method has no effect.
+   */
+  void close();
 
   /**
    * Is the given topology in RUNNING state?
-   * @param topologyName
+   *
    * @return Boolean
    */
   ListenableFuture<Boolean> isTopologyRunning(String topologyName);
 
   /**
    * Set the execution state for the given topology
-   * @param executionState
-   * @param topologyName
+   *
    * @return Boolean - Success or Failure
    */
   ListenableFuture<Boolean> setExecutionState(
@@ -61,8 +68,7 @@ public interface IStateManager {
 
   /**
    * Set the topology definition for the given topology
-   * @param topology
-   * @param topologyName
+   *
    * @return Boolean - Success or Failure
    */
   ListenableFuture<Boolean> setTopology(
@@ -70,8 +76,7 @@ public interface IStateManager {
 
   /**
    * Set the scheduler location for the given top
-   * @param location
-   * @param topologyName
+   *
    * @return Boolean - Success or Failure
    */
   ListenableFuture<Boolean> setSchedulerLocation(
@@ -79,43 +84,43 @@ public interface IStateManager {
 
   /**
    * Delete the tmaster location for the given topology
-   * @param topologyName
+   *
    * @return Boolean - Success or Failure
    */
   ListenableFuture<Boolean> deleteTMasterLocation(String topologyName);
 
   /**
    * Delete the execution state for the given topology
-   * @param topologyName
+   *
    * @return Boolean - Success or Failure
    */
   ListenableFuture<Boolean> deleteExecutionState(String topologyName);
 
   /**
    * Delete the topology definition for the given topology
-   * @param topologyName
+   *
    * @return Boolean - Success or Failure
    */
   ListenableFuture<Boolean> deleteTopology(String topologyName);
 
   /**
    * Delete the physical plan for the given topology
-   * @param topologyName
+   *
    * @return Boolean - Success or Failure
    */
   ListenableFuture<Boolean> deletePhysicalPlan(String topologyName);
 
   /**
    * Delete the scheduler location for the given topology
-   * @param topologyName
+   *
    * @return Boolean - Success or Failure
    */
   ListenableFuture<Boolean> deleteSchedulerLocation(String topologyName);
 
   /**
    * Get the tmaster location for the given topology
+   *
    * @param watcher @see com.twitter.heron.spi.statemgr.WatchCallback
-   * @param topologyName
    * @return TMasterLocation
    */
   ListenableFuture<TopologyMaster.TMasterLocation> getTMasterLocation(
@@ -123,8 +128,8 @@ public interface IStateManager {
 
   /**
    * Get the scheduler location for the given topology
+   *
    * @param watcher @see com.twitter.heron.spi.statemgr.WatchCallback
-   * @param topologyName
    * @return SchedulerLocation
    */
   ListenableFuture<Scheduler.SchedulerLocation> getSchedulerLocation(
@@ -132,8 +137,8 @@ public interface IStateManager {
 
   /**
    * Get the topology definition for the given topology
+   *
    * @param watcher @see com.twitter.heron.spi.statemgr.WatchCallback
-   * @param topologyName
    * @return Topology
    */
   ListenableFuture<TopologyAPI.Topology> getTopology(
@@ -141,8 +146,8 @@ public interface IStateManager {
 
   /**
    * Get the execution state for the given topology
+   *
    * @param watcher @see com.twitter.heron.spi.statemgr.WatchCallback
-   * @param topologyName
    * @return ExecutionState
    */
   ListenableFuture<ExecutionEnvironment.ExecutionState> getExecutionState(
@@ -150,8 +155,7 @@ public interface IStateManager {
 
   /**
    * Set the location of Tmaster.
-   * @param location
-   * @param topologyName
+   *
    * @return Boolean - Success or Failure
    */
   ListenableFuture<Boolean> setTMasterLocation(
@@ -159,8 +163,7 @@ public interface IStateManager {
 
   /**
    * Set the physical plan for the given topology
-   * @param physicalPlan
-   * @param topologyName
+   *
    * @return Boolean - Success or Failure
    */
   ListenableFuture<Boolean> setPhysicalPlan(
@@ -168,8 +171,8 @@ public interface IStateManager {
 
   /**
    * Get the physical plan for the given topology
+   *
    * @param watcher @see com.twitter.heron.spi.statemgr.WatchCallback
-   * @param topologyName
    * @return PhysicalPlan
    */
   ListenableFuture<PhysicalPlans.PhysicalPlan> getPhysicalPlan(

--- a/heron/spi/src/java/com/twitter/heron/spi/uploader/IUploader.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/uploader/IUploader.java
@@ -19,7 +19,7 @@ import com.twitter.heron.spi.common.Config;
  * Implementation of IUploader is required to have a no argument constructor
  * that will be called to create an instance of IUploader.
  */
-public interface IUploader {
+public interface IUploader extends AutoCloseable {
   /**
    * Initialize the uploader with the incoming context.
    */
@@ -42,6 +42,10 @@ public interface IUploader {
   /**
    * This is to for disposing or cleaning up any internal state accumulated by
    * the uploader
+   * <p/>
+   * Closes this stream and releases any system resources associated
+   * with it. If the stream is already closed then invoking this
+   * method has no effect.
    */
   void close();
 }


### PR DESCRIPTION
1. Add close(), which acts as the deconstructor for the interfaces.
   Currently the lacking of close() is in fact in-completed.
2. Make interfaces extend AutoClosbale, which allow them be used in try-resource statement.
3. Add undo() in IRuntimeManager.
4. Remove public modifier in interfaces
5. Update the implementation align with the updated interfaces.

Invoke these methods appropriately will be in next PR. This PR can also guarantee the backward compatibility.
