### PR TITLE
Refactored scheduler interfaces and bug fixed

### DIFF
--- a/heron/newscheduler/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/newscheduler/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
@@ -232,10 +232,8 @@ public class RuntimeManagerMain {
       // 3. Do post work basing on the result
       // Currently nothing to do here
 
-      // 4. Do generic cleaning
-      // close the runtime manager
+      // 4. Close the resources
       runtimeManager.close();
-      // close the state manager
       statemgr.close();
     }
 

--- a/heron/newscheduler/src/java/com/twitter/heron/scheduler/SubmitterMain.java
+++ b/heron/newscheduler/src/java/com/twitter/heron/scheduler/SubmitterMain.java
@@ -286,6 +286,7 @@ public class SubmitterMain {
     String topologyName = topology.getName();
 
     boolean isSuccessful = false;
+    URI packageURI = null;
     // Put it in a try block so that we can always clean resources
     try {
       // initialize the state manager
@@ -299,7 +300,7 @@ public class SubmitterMain {
         LOG.log(Level.INFO, "Topology {0} to be submitted", topologyName);
 
         // Firstly, try to upload necessary packages
-        URI packageURI = uploadPackage(config, uploader);
+        packageURI = uploadPackage(config, uploader);
         if (packageURI == null) {
           LOG.severe("Failed to upload package.");
         } else {
@@ -310,15 +311,16 @@ public class SubmitterMain {
     } finally {
       // 3. Do post work basing on the result
       if (!isSuccessful) {
-        // Undo if failed to submit
-        uploader.undo();
-        launcher.undo();
+        // Undo the upload if failed to submit && the upload is successful
+        if (packageURI != null) {
+          uploader.undo();
+        }
       }
 
-      // 4. Do generic cleaning
-      // close the uploader
+      // 4. Close the resources
       uploader.close();
-      // close the state manager
+      packing.close();
+      launcher.close();
       statemgr.close();
     }
 

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraLauncher.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraLauncher.java
@@ -141,11 +141,6 @@ public class AuroraLauncher implements ILauncher {
   }
 
   @Override
-  public void undo() {
-    // Currently nothing need to do here
-  }
-
-  @Override
   public ExecutionEnvironment.ExecutionState updateExecutionState(ExecutionEnvironment.ExecutionState executionState) {
     // TODO(mfu): These values should read from config
     String releaseUsername = "heron";

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraRuntimeManager.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraRuntimeManager.java
@@ -26,11 +26,6 @@ public class AuroraRuntimeManager implements IRuntimeManager {
   }
 
   @Override
-  public void undo() {
-
-  }
-
-  @Override
   public boolean prepareRestart(Integer containerId) {
     return true;
   }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalLauncher.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalLauncher.java
@@ -141,11 +141,6 @@ public class LocalLauncher implements ILauncher {
   }
 
   @Override
-  public void undo() {
-    // Currently nothing need to do here
-  }
-
-  @Override
   public ExecutionEnvironment.ExecutionState updateExecutionState(
       ExecutionEnvironment.ExecutionState executionState) {
     String release = "local-live";

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalRuntimeManager.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalRuntimeManager.java
@@ -23,11 +23,6 @@ public class LocalRuntimeManager implements IRuntimeManager {
   }
 
   @Override
-  public void undo() {
-
-  }
-
-  @Override
   public boolean prepareRestart(Integer containerId) {
     return true;
   }

--- a/heron/spi/src/java/com/twitter/heron/spi/scheduler/ILauncher.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/scheduler/ILauncher.java
@@ -51,11 +51,6 @@ public interface ILauncher extends AutoCloseable {
   boolean postLaunch(PackingPlan packing);
 
   /**
-   * In case launch fails, this is called to clean up state, if any.
-   */
-  void undo();
-
-  /**
    * Add/Modify additional information in execution state. Returns new ExecutionState created using
    * current execution state and adding additional Launch specific information
    * TODO(nbhagat): Don't overload heron's ExecutionState with scheduler specific data.

--- a/heron/spi/src/java/com/twitter/heron/spi/scheduler/IRuntimeManager.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/scheduler/IRuntimeManager.java
@@ -26,11 +26,6 @@ public interface IRuntimeManager extends AutoCloseable {
    */
   void close();
 
-  /**
-   * In case launch fails, this is called to clean up state, if any.
-   */
-  void undo();
-
   boolean prepareRestart(Integer containerId);
 
   boolean postRestart(Integer containerId);

--- a/heron/spi/src/java/com/twitter/heron/spi/scheduler/NullLauncher.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/scheduler/NullLauncher.java
@@ -32,11 +32,6 @@ public class NullLauncher implements ILauncher {
   }
 
   @Override
-  public void undo() {
-
-  }
-
-  @Override
   public ExecutionEnvironment.ExecutionState updateExecutionState(ExecutionEnvironment.ExecutionState executionState) {
     return executionState;
   }


### PR DESCRIPTION
1. Remove the undo() method in interface ILauncher and IRuntimeManager,
   since the implementation of undo() is tricky and error prone. Also, in practice there are
   rare cases undo needed. For instance, Local\* and Aurora\* have empty implementations in undo().
2. Invoke the close() of all interfaces in finally block to guarantee the resource release.
3. Fix the bug that to invoke IUploader.undo() even if IUploader.uploadPackage has not been called.
