### PR TITLE
Check that the core dump file is readable

### DIFF
--- a/heron/executor/src/python/heron-executor.py
+++ b/heron/executor/src/python/heron-executor.py
@@ -349,7 +349,8 @@ class HeronExecutor:
       (old_p, name, nattempts) = process_dict[pid]
       do_print("%s exited with status %d" % (name, status))
       # Just make it world readable
-      os.system("chmod a+r core.%d" % pid)
+      if os.path.isfile("core.%d" % pid):
+        os.system("chmod a+r core.%d" % pid)
       if nattempts > self.max_runs:
         do_print("%s exited too many times" % name)
         sys.exit(1)


### PR DESCRIPTION
On some systems core dump files have been turned off by default. This
change checks to make sure the core dump file exists before trying to
set its permissions.

The exact error is:
`chmod: cannot access 'core.45556'`

fixes https://github.com/twitter/heron/issues/286
