### PR TITLE
Clarify wording on the example tracker state configuration files

### DIFF
--- a/heron/statemgrs/conf/localfilestateconf.yaml
+++ b/heron/statemgrs/conf/localfilestateconf.yaml
@@ -1,6 +1,6 @@
 ## Contains the sources where the states are stored.
 # Each source has these attributes:
-# 1. type - type of state manager (zk or file, etc.)
+# 1. type - type of state manager (zookeeper or file, etc.)
 # 2. name - name to be used for this source
 # 3. host - currently only used to connect to zk
 # 4. port - port to connect to

--- a/heron/statemgrs/conf/localstateconf.yaml
+++ b/heron/statemgrs/conf/localstateconf.yaml
@@ -1,6 +1,6 @@
 ## Contains the sources where the states are stored.
 # Each source has these attributes:
-# 1. type - type of state manager (zk or file, etc.)
+# 1. type - type of state manager (zookeeer or file, etc.)
 # 2. name - name to be used for this source
 # 3. host - currently only used to connect to zk
 # 4. port - port to connect to


### PR DESCRIPTION
The tracker will ignore any types that it does not know about and the
type in the comment, zk, was not correct which lead to some confusion.
