### PR TITLE
Set ExecutionState completely in LauncherRunner

### DIFF
--- a/heron/newscheduler/src/java/com/twitter/heron/scheduler/LaunchRunner.java
+++ b/heron/newscheduler/src/java/com/twitter/heron/scheduler/LaunchRunner.java
@@ -40,24 +40,40 @@ public class LaunchRunner implements Callable<Boolean> {
     this.packing = Runtime.packingClassInstance(runtime);
   }
 
-  public ExecutionEnvironment.ExecutionState createBasicExecutionState() {
-    ExecutionEnvironment.ExecutionState executionState;
+  public ExecutionEnvironment.ExecutionState createExecutionState() {
+    // TODO(mfu): These values should read from config
+    String releaseUsername = "heron";
+    String releaseTag = "heron-core";
+    String releaseVersion = "live";
+
     TopologyAPI.Topology topology = Runtime.topology(runtime);
 
     ExecutionEnvironment.ExecutionState.Builder builder =
         ExecutionEnvironment.ExecutionState.newBuilder();
 
     // set the topology name, id, submitting user and time
-    builder.setTopologyName(topology.getName());
-    builder.setTopologyId(topology.getId());
-    builder.setSubmissionTime(System.currentTimeMillis() / 1000);
-    builder.setSubmissionUser(System.getProperty("user.name"));
+    builder.setTopologyName(topology.getName()).
+        setTopologyId(topology.getId())
+        .setSubmissionTime(System.currentTimeMillis() / 1000)
+        .setSubmissionUser(System.getProperty("user.name"))
+        .setCluster(Context.cluster(config))
+        .setRole(Context.role(config))
+        .setEnviron(Context.environ(config));
 
-    if (!builder.isInitialized()) {
-      return null;
+    // build the heron release state
+    ExecutionEnvironment.HeronReleaseState.Builder releaseBuilder =
+        ExecutionEnvironment.HeronReleaseState.newBuilder();
+
+    releaseBuilder.setReleaseUsername(releaseUsername);
+    releaseBuilder.setReleaseTag(releaseTag);
+    releaseBuilder.setReleaseVersion(releaseVersion);
+
+    builder.setReleaseState(releaseBuilder);
+    if (builder.isInitialized()) {
+      return builder.build();
+    } else {
+      throw new RuntimeException("Failed to create execution state");
     }
-    executionState = builder.build();
-    return executionState;
   }
 
   /**
@@ -106,8 +122,7 @@ public class LaunchRunner implements Callable<Boolean> {
     }
 
     // store the execution state into the state manager
-    ExecutionEnvironment.ExecutionState executionState =
-        launcher.updateExecutionState(createBasicExecutionState());
+    ExecutionEnvironment.ExecutionState executionState = createExecutionState();
 
     ListenableFuture<Boolean> sFuture = statemgr.setExecutionState(executionState, topologyName);
     if (!NetworkUtils.awaitResult(sFuture, 5, TimeUnit.SECONDS)) {

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraLauncher.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraLauncher.java
@@ -10,7 +10,6 @@ import javax.xml.bind.DatatypeConverter;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.FileUtils;
-import com.twitter.heron.proto.system.ExecutionEnvironment;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Context;
 import com.twitter.heron.spi.common.PackingPlan;
@@ -138,37 +137,5 @@ public class AuroraLauncher implements ILauncher {
   @Override
   public boolean postLaunch(PackingPlan packing) {
     return true;
-  }
-
-  @Override
-  public ExecutionEnvironment.ExecutionState updateExecutionState(ExecutionEnvironment.ExecutionState executionState) {
-    // TODO(mfu): These values should read from config
-    String releaseUsername = "heron";
-    String releaseTag = "heron-core-release";
-    String releaseVersion = "releaseVersion";
-    String uploadVersion = "uploadVersion";
-
-    ExecutionEnvironment.ExecutionState.Builder builder =
-        ExecutionEnvironment.ExecutionState.newBuilder().mergeFrom(executionState);
-
-    builder.setCluster(Context.cluster(config))
-        .setRole(Context.role(config))
-        .setEnviron(Context.environ(config));
-
-    // Set the HeronReleaseState
-    ExecutionEnvironment.HeronReleaseState.Builder releaseBuilder =
-        ExecutionEnvironment.HeronReleaseState.newBuilder();
-
-    releaseBuilder.setReleaseUsername(releaseUsername);
-    releaseBuilder.setReleaseTag(releaseTag);
-    releaseBuilder.setReleaseVersion(releaseVersion);
-    releaseBuilder.setUploaderVersion(uploadVersion);
-
-    builder.setReleaseState(releaseBuilder);
-    if (builder.isInitialized()) {
-      return builder.build();
-    } else {
-      throw new RuntimeException("Failed to create execution state");
-    }
   }
 }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalLauncher.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalLauncher.java
@@ -141,38 +141,6 @@ public class LocalLauncher implements ILauncher {
     return true;
   }
 
-  @Override
-  public ExecutionEnvironment.ExecutionState updateExecutionState(
-      ExecutionEnvironment.ExecutionState executionState) {
-    String release = "local-live";
-
-    // build the heron release state
-    ExecutionEnvironment.HeronReleaseState.Builder releaseBuilder =
-        ExecutionEnvironment.HeronReleaseState.newBuilder();
-
-    releaseBuilder.setReleaseUsername(LocalContext.role(config));
-    releaseBuilder.setReleaseTag(release);
-    releaseBuilder.setReleaseVersion(release);
-    releaseBuilder.setUploaderVersion(release);
-
-    // build the execution state
-    ExecutionEnvironment.ExecutionState.Builder builder =
-        ExecutionEnvironment.ExecutionState.newBuilder();
-
-    builder.mergeFrom(executionState)
-        .setDc(LocalContext.cluster(config))
-        .setCluster(LocalContext.cluster(config))
-        .setRole(LocalContext.role(config))
-        .setEnviron(LocalContext.environ(config))
-        .setReleaseState(releaseBuilder);
-
-    if (!builder.isInitialized()) {
-      throw new RuntimeException("Failed to create execution state");
-    }
-
-    return builder.build();
-  }
-
   /**
    * Download heron core and the topology packages into topology working directory
    *

--- a/heron/spi/src/java/com/twitter/heron/spi/scheduler/ILauncher.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/scheduler/ILauncher.java
@@ -1,6 +1,5 @@
 package com.twitter.heron.spi.scheduler;
 
-import com.twitter.heron.proto.system.ExecutionEnvironment;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.PackingPlan;
 
@@ -49,15 +48,4 @@ public interface ILauncher extends AutoCloseable {
    * @return true if successful
    */
   boolean postLaunch(PackingPlan packing);
-
-  /**
-   * Add/Modify additional information in execution state. Returns new ExecutionState created using
-   * current execution state and adding additional Launch specific information
-   * TODO(nbhagat): Don't overload heron's ExecutionState with scheduler specific data.
-   *
-   * @param executionState Default execution state with all required fields set.
-   * @return Updated execution state.
-   */
-  ExecutionEnvironment.ExecutionState updateExecutionState(
-      ExecutionEnvironment.ExecutionState executionState);
 }

--- a/heron/spi/src/java/com/twitter/heron/spi/scheduler/NullLauncher.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/scheduler/NullLauncher.java
@@ -1,6 +1,5 @@
 package com.twitter.heron.spi.scheduler;
 
-import com.twitter.heron.proto.system.ExecutionEnvironment;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.PackingPlan;
 
@@ -29,11 +28,6 @@ public class NullLauncher implements ILauncher {
   @Override
   public boolean postLaunch(PackingPlan packing) {
     return true;
-  }
-
-  @Override
-  public ExecutionEnvironment.ExecutionState updateExecutionState(ExecutionEnvironment.ExecutionState executionState) {
-    return executionState;
   }
 }
 


### PR DESCRIPTION
Currently ILauncher implementation is expected to update details in ExecutionState, which may not be so intuitive (see LocalLauncher.updateExecutionState).heron-tracker ignores any topologies available in state manager if the cluster and role info is not provided by ILaucher implementation.

LaunchRunner has complete information, including cluster and others, and it can be set it at creation time. It reduces the complexity to implement ILauncher.
