### PR TITLE
Make all calls in SchedulerStateManagerAdaptor synchronized

### DIFF
--- a/heron/newscheduler/src/java/com/twitter/heron/scheduler/LaunchRunner.java
+++ b/heron/newscheduler/src/java/com/twitter/heron/scheduler/LaunchRunner.java
@@ -16,11 +16,8 @@ package com.twitter.heron.scheduler;
 
 import java.io.IOException;
 import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import com.google.common.util.concurrent.ListenableFuture;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.proto.system.ExecutionEnvironment;
@@ -30,7 +27,6 @@ import com.twitter.heron.spi.common.PackingPlan;
 import com.twitter.heron.spi.packing.IPacking;
 import com.twitter.heron.spi.scheduler.ILauncher;
 import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
-import com.twitter.heron.spi.utils.NetworkUtils;
 import com.twitter.heron.spi.utils.Runtime;
 
 /**
@@ -135,18 +131,19 @@ public class LaunchRunner implements Callable<Boolean> {
       return false;
     }
 
+    Boolean result;
     // store the execution state into the state manager
     ExecutionEnvironment.ExecutionState executionState = createExecutionState();
 
-    ListenableFuture<Boolean> sFuture = statemgr.setExecutionState(executionState, topologyName);
-    if (!NetworkUtils.awaitResult(sFuture, 5, TimeUnit.SECONDS)) {
+    result = statemgr.setExecutionState(executionState, topologyName);
+    if (result == null || !result) {
       LOG.severe("Failed to set execution state");
       return false;
     }
 
     // store the trimmed topology definition into the state manager
-    ListenableFuture<Boolean> tFuture = statemgr.setTopology(trimTopology(topology), topologyName);
-    if (!NetworkUtils.awaitResult(tFuture, 5, TimeUnit.SECONDS)) {
+    result = statemgr.setTopology(trimTopology(topology), topologyName);
+    if (result == null || !result) {
       LOG.severe("Failed to set topology");
       statemgr.deleteExecutionState(topologyName);
       return false;

--- a/heron/newscheduler/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/newscheduler/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
@@ -17,11 +17,8 @@ package com.twitter.heron.scheduler;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import com.google.common.util.concurrent.ListenableFuture;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.proto.scheduler.Scheduler;
@@ -32,7 +29,6 @@ import com.twitter.heron.spi.common.Context;
 import com.twitter.heron.spi.common.HttpUtils;
 import com.twitter.heron.spi.scheduler.IRuntimeManager;
 import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
-import com.twitter.heron.spi.utils.NetworkUtils;
 import com.twitter.heron.spi.utils.Runtime;
 
 public class RuntimeManagerRunner implements Callable<Boolean> {
@@ -93,11 +89,8 @@ public class RuntimeManagerRunner implements Callable<Boolean> {
     // fetch scheduler location from state manager
     LOG.log(Level.INFO, "Fetching scheduler location from state manager to {0} topology", command);
 
-    ListenableFuture<Scheduler.SchedulerLocation> locationFuture =
-        statemgr.getSchedulerLocation(null, Runtime.topologyName(runtime));
-
     Scheduler.SchedulerLocation schedulerLocation =
-        NetworkUtils.awaitResult(locationFuture, 5, TimeUnit.SECONDS);
+        statemgr.getSchedulerLocation(Runtime.topologyName(runtime));
 
     if (schedulerLocation == null) {
       LOG.log(Level.INFO, "Failed to get scheduler location to {0} topology", command);
@@ -407,42 +400,36 @@ public class RuntimeManagerRunner implements Callable<Boolean> {
     // get the instance of the state manager
     SchedulerStateManagerAdaptor statemgr = Runtime.schedulerStateManagerAdaptor(runtime);
 
-    ListenableFuture<Boolean> booleanFuture;
-    Boolean futureResult;
+    Boolean result;
 
-    booleanFuture = statemgr.deleteTopology(topologyName);
-    futureResult = NetworkUtils.awaitResult(booleanFuture, 5, TimeUnit.SECONDS);
-    if (futureResult == null || !futureResult) {
+    result = statemgr.deleteTopology(topologyName);
+    if (result == null || !result) {
       LOG.severe("Failed to clear topology state");
       return false;
     }
 
-    booleanFuture = statemgr.deleteExecutionState(topologyName);
-    futureResult = NetworkUtils.awaitResult(booleanFuture, 5, TimeUnit.SECONDS);
-    if (futureResult == null || !futureResult) {
+    result = statemgr.deleteExecutionState(topologyName);
+    if (result == null || !result) {
       LOG.severe("Failed to clear execution state");
       return false;
     }
 
     // It is possible that  TMasterLocation, PhysicalPlan and SchedulerLocation are not set
     // Just log but don't consider them failure
-    booleanFuture = statemgr.deleteTMasterLocation(topologyName);
-    futureResult = NetworkUtils.awaitResult(booleanFuture, 5, TimeUnit.SECONDS);
-    if (futureResult == null || !futureResult) {
+    result = statemgr.deleteTMasterLocation(topologyName);
+    if (result == null || !result) {
       // We would not return false since it is possible that TMaster didn't write physical plan
       LOG.severe("Failed to clear TMaster location. Check whether TMaster set it correctly.");
     }
 
-    booleanFuture = statemgr.deletePhysicalPlan(topologyName);
-    futureResult = NetworkUtils.awaitResult(booleanFuture, 5, TimeUnit.SECONDS);
-    if (futureResult == null || !futureResult) {
+    result = statemgr.deletePhysicalPlan(topologyName);
+    if (result == null || !result) {
       // We would not return false since it is possible that TMaster didn't write physical plan
       LOG.severe("Failed to clear physical plan. Check whether TMaster set it correctly.");
     }
 
-    booleanFuture = statemgr.deleteSchedulerLocation(topologyName);
-    futureResult = NetworkUtils.awaitResult(booleanFuture, 5, TimeUnit.SECONDS);
-    if (futureResult == null || !futureResult) {
+    result = statemgr.deleteSchedulerLocation(topologyName);
+    if (result == null || !result) {
       // We would not return false since it is possible that TMaster didn't write physical plan
       LOG.severe("Failed to clear scheduler location. Check whether Scheduler set it correctly.");
     }
@@ -457,9 +444,7 @@ public class RuntimeManagerRunner implements Callable<Boolean> {
   protected TopologyAPI.TopologyState getRuntimeTopologyState(String topologyName) {
     // get the instance of the state manager
     SchedulerStateManagerAdaptor statemgr = Runtime.schedulerStateManagerAdaptor(runtime);
-    ListenableFuture<PhysicalPlans.PhysicalPlan> physicalPlanFuture = statemgr.getPhysicalPlan(null, topologyName);
-    PhysicalPlans.PhysicalPlan plan =
-        NetworkUtils.awaitResult(physicalPlanFuture, 5, TimeUnit.SECONDS);
+    PhysicalPlans.PhysicalPlan plan = statemgr.getPhysicalPlan(topologyName);
 
     if (plan == null) {
       LOG.log(Level.SEVERE, "Failed to get physical plan for topology {0}", topologyName);

--- a/heron/newscheduler/src/java/com/twitter/heron/scheduler/SubmitterMain.java
+++ b/heron/newscheduler/src/java/com/twitter/heron/scheduler/SubmitterMain.java
@@ -16,9 +16,6 @@ package com.twitter.heron.scheduler;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.ConsoleHandler;
-import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -43,7 +40,6 @@ import com.twitter.heron.spi.scheduler.ILauncher;
 import com.twitter.heron.spi.statemgr.IStateManager;
 import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
 import com.twitter.heron.spi.uploader.IUploader;
-import com.twitter.heron.spi.utils.NetworkUtils;
 import com.twitter.heron.spi.utils.TopologyUtils;
 
 /**
@@ -252,7 +248,7 @@ public class SubmitterMain {
     }
 
     Level logLevel = Level.INFO;
-    if(cmd.hasOption("v")) {
+    if (cmd.hasOption("v")) {
       logLevel = Level.ALL;
     }
 
@@ -316,7 +312,10 @@ public class SubmitterMain {
       // initialize the state manager
       statemgr.initialize(config);
 
-      boolean isValid = validateSubmit(statemgr, topologyName);
+      // TODO(mfu): timeout should read from config
+      SchedulerStateManagerAdaptor adaptor = new SchedulerStateManagerAdaptor(statemgr, 5000);
+
+      boolean isValid = validateSubmit(adaptor, topologyName);
 
       // 2. Try to submit topology if valid
       if (isValid) {
@@ -329,7 +328,7 @@ public class SubmitterMain {
           LOG.severe("Failed to upload package.");
         } else {
           // Secondly, try to submit a topology
-          isSuccessful = submitTopology(config, topology, statemgr, launcher, packing, packageURI);
+          isSuccessful = submitTopology(config, topology, adaptor, launcher, packing, packageURI);
         }
       }
     } finally {
@@ -360,10 +359,9 @@ public class SubmitterMain {
     }
   }
 
-  public static boolean validateSubmit(IStateManager statemgr, String topologyName) {
+  public static boolean validateSubmit(SchedulerStateManagerAdaptor adaptor, String topologyName) {
     // Check whether the topology has already been running
-    Boolean isTopologyRunning =
-        NetworkUtils.awaitResult(statemgr.isTopologyRunning(topologyName), 5, TimeUnit.SECONDS);
+    Boolean isTopologyRunning = adaptor.isTopologyRunning(topologyName);
 
     if (isTopologyRunning != null && isTopologyRunning.equals(Boolean.TRUE)) {
       LOG.severe("Topology already exists");
@@ -384,7 +382,7 @@ public class SubmitterMain {
   }
 
   public static boolean submitTopology(Config config, TopologyAPI.Topology topology,
-                                       IStateManager statemgr, ILauncher launcher,
+                                       SchedulerStateManagerAdaptor adaptor, ILauncher launcher,
                                        IPacking packing, URI packageURI)
       throws ClassNotFoundException, InstantiationException, IllegalAccessException, IOException {
     // build the runtime config
@@ -392,7 +390,7 @@ public class SubmitterMain {
         .put(Keys.topologyId(), topology.getId())
         .put(Keys.topologyName(), topology.getName())
         .put(Keys.topologyDefinition(), topology)
-        .put(Keys.schedulerStateManagerAdaptor(), new SchedulerStateManagerAdaptor(statemgr))
+        .put(Keys.schedulerStateManagerAdaptor(), adaptor)
         .put(Keys.topologyPackageUri(), packageURI)
         .put(Keys.launcherClassInstance(), launcher)
         .put(Keys.packingClassInstance(), packing)

--- a/heron/newscheduler/src/java/com/twitter/heron/scheduler/server/ActivateRequestHandler.java
+++ b/heron/newscheduler/src/java/com/twitter/heron/scheduler/server/ActivateRequestHandler.java
@@ -53,7 +53,7 @@ public class ActivateRequestHandler implements HttpHandler {
     boolean isActivatedSuccessfully =
         scheduler.onActivate(activateTopologyRequest) &&
             TMasterUtils.sendToTMaster("activate",
-                com.twitter.heron.spi.utils.Runtime.topologyName(runtime),
+                Runtime.topologyName(runtime),
                 Runtime.schedulerStateManagerAdaptor(runtime));
 
     // prepare the response

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalScheduler.java
@@ -277,7 +277,12 @@ public class LocalScheduler implements IScheduler {
     // since we could not set it as ephemeral for local file system
     // We would not clean SchedulerLocation since we would not restart the Scheduler
     if (containerId == -1 || containerId == 0) {
-      stateManager.deleteTMasterLocation(LocalContext.topologyName(config));
+      Boolean result = stateManager.deleteTMasterLocation(LocalContext.topologyName(config));
+      if (result == null || !result) {
+        // We would not return false since it is possible that TMaster didn't write physical plan
+        LOG.severe("Failed to clear TMaster location. Check whether TMaster set it correctly.");
+        return false;
+      }
     }
 
     return true;

--- a/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
@@ -14,6 +14,12 @@
 
 package com.twitter.heron.spi.statemgr;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import com.google.common.util.concurrent.ListenableFuture;
 
 import com.twitter.heron.api.generated.TopologyAPI;
@@ -29,7 +35,10 @@ import com.twitter.heron.proto.tmaster.TopologyMaster;
  */
 
 public class SchedulerStateManagerAdaptor {
+  private static final Logger LOG = Logger.getLogger(SchedulerStateManagerAdaptor.class.getName());
+
   private final IStateManager delegate;
+  private final int timeout;
 
   /**
    * Construct SchedulerStateManagerAdaptor providing only the
@@ -40,9 +49,31 @@ public class SchedulerStateManagerAdaptor {
    * SchedulerStateManager. Users are restricted from using those interfaces
    * since it is upto the abstract scheduler to decide when to open and close.
    * @param delegate, the instance of IStateManager
+   * @param timeout, the maximum time to wait in milliseconds
    */
-  public SchedulerStateManagerAdaptor(IStateManager delegate) {
+  public SchedulerStateManagerAdaptor(IStateManager delegate, int timeout) {
     this.delegate = delegate;
+    this.timeout = timeout;
+  }
+
+  /**
+   * Waits for ListenableFuture to terminate. Cancels on timeout
+   */
+  protected <V> V awaitResult(ListenableFuture<V> future) {
+    return awaitResult(future, timeout, TimeUnit.MILLISECONDS);
+  }
+
+  /**
+   * Waits for ListenableFuture to terminate. Cancels on timeout
+   */
+  protected  <V> V awaitResult(ListenableFuture<V> future, int time, TimeUnit unit) {
+    try {
+      return future.get(time, unit);
+    } catch (InterruptedException | TimeoutException | ExecutionException e) {
+      LOG.log(Level.SEVERE, "Exception processing future ", e);
+      future.cancel(true);
+      return null;
+    }
   }
 
   /**
@@ -50,8 +81,8 @@ public class SchedulerStateManagerAdaptor {
    *
    * @return Boolean
    */
-  public ListenableFuture<Boolean> isTopologyRunning(String topologyName) {
-    return delegate.isTopologyRunning(topologyName);
+  public Boolean isTopologyRunning(String topologyName) {
+    return awaitResult(delegate.isTopologyRunning(topologyName));
   }
 
   /**
@@ -59,9 +90,9 @@ public class SchedulerStateManagerAdaptor {
    *
    * @return Boolean - Success or Failure
    */
-  public ListenableFuture<Boolean> setExecutionState(
+  public Boolean setExecutionState(
       ExecutionEnvironment.ExecutionState executionState, String topologyName) {
-    return delegate.setExecutionState(executionState, topologyName);
+    return awaitResult(delegate.setExecutionState(executionState, topologyName));
   }
 
   /**
@@ -70,9 +101,8 @@ public class SchedulerStateManagerAdaptor {
    * @param topologyName, the name of the topology
    * @return Boolean - Success or Failure
    */
-  public ListenableFuture<Boolean> setTopology(
-      TopologyAPI.Topology topology, String topologyName) {
-    return delegate.setTopology(topology, topologyName);
+  public Boolean setTopology(TopologyAPI.Topology topology, String topologyName) {
+    return awaitResult(delegate.setTopology(topology, topologyName));
   }
 
   /**
@@ -80,9 +110,8 @@ public class SchedulerStateManagerAdaptor {
    *
    * @return Boolean - Success or Failure
    */
-  public ListenableFuture<Boolean> setSchedulerLocation(
-      Scheduler.SchedulerLocation location, String topologyName) {
-    return delegate.setSchedulerLocation(location, topologyName);
+  public Boolean setSchedulerLocation(Scheduler.SchedulerLocation location, String topologyName) {
+    return awaitResult(delegate.setSchedulerLocation(location, topologyName));
   }
 
   /**
@@ -90,8 +119,8 @@ public class SchedulerStateManagerAdaptor {
    *
    * @return Boolean - Success or Failure
    */
-  public ListenableFuture<Boolean> deleteTMasterLocation(String topologyName) {
-    return delegate.deleteTMasterLocation(topologyName);
+  public Boolean deleteTMasterLocation(String topologyName) {
+    return awaitResult(delegate.deleteTMasterLocation(topologyName));
   }
 
   /**
@@ -99,8 +128,8 @@ public class SchedulerStateManagerAdaptor {
    *
    * @return Boolean - Success or Failure
    */
-  public ListenableFuture<Boolean> deleteExecutionState(String topologyName) {
-    return delegate.deleteExecutionState(topologyName);
+  public Boolean deleteExecutionState(String topologyName) {
+    return awaitResult(delegate.deleteExecutionState(topologyName));
   }
 
   /**
@@ -108,8 +137,8 @@ public class SchedulerStateManagerAdaptor {
    *
    * @return Boolean - Success or Failure
    */
-  public ListenableFuture<Boolean> deleteTopology(String topologyName) {
-    return delegate.deleteTopology(topologyName);
+  public Boolean deleteTopology(String topologyName) {
+    return awaitResult(delegate.deleteTopology(topologyName));
   }
 
   /**
@@ -117,8 +146,8 @@ public class SchedulerStateManagerAdaptor {
    *
    * @return Boolean - Success or Failure
    */
-  public ListenableFuture<Boolean> deletePhysicalPlan(String topologyName) {
-    return delegate.deletePhysicalPlan(topologyName);
+  public Boolean deletePhysicalPlan(String topologyName) {
+    return awaitResult(delegate.deletePhysicalPlan(topologyName));
   }
 
   /**
@@ -126,63 +155,53 @@ public class SchedulerStateManagerAdaptor {
    *
    * @return Boolean - Success or Failure
    */
-  public ListenableFuture<Boolean> deleteSchedulerLocation(
-      String topologyName) {
-    return delegate.deleteSchedulerLocation(topologyName);
+  public Boolean deleteSchedulerLocation(String topologyName) {
+    return awaitResult(delegate.deleteSchedulerLocation(topologyName));
   }
 
   /**
    * Get the tmaster location for the given topology
    *
-   * @param watcher @see com.twitter.heron.spi.statemgr.WatchCallback
    * @return TMasterLocation
    */
-  public ListenableFuture<TopologyMaster.TMasterLocation> getTMasterLocation(
-      WatchCallback watcher, String topologyName) {
-    return delegate.getTMasterLocation(watcher, topologyName);
+  public TopologyMaster.TMasterLocation getTMasterLocation(String topologyName) {
+    return awaitResult(delegate.getTMasterLocation(null, topologyName));
   }
 
   /**
    * Get the scheduler location for the given topology
    *
-   * @param watcher @see com.twitter.heron.spi.statemgr.WatchCallback
    * @return SchedulerLocation
    */
-  public ListenableFuture<Scheduler.SchedulerLocation> getSchedulerLocation(
-      WatchCallback watcher, String topologyName) {
-    return delegate.getSchedulerLocation(watcher, topologyName);
+  public Scheduler.SchedulerLocation getSchedulerLocation(String topologyName) {
+    return awaitResult(delegate.getSchedulerLocation(null, topologyName));
   }
 
-  /**
-   * Get the topology definition for the given topology
-   *
-   * @param watcher @see com.twitter.heron.spi.statemgr.WatchCallback
-   * @return Topology
-   */
-  public ListenableFuture<TopologyAPI.Topology> getTopology(
-      WatchCallback watcher, String topologyName) {
-    return delegate.getTopology(null, topologyName);
-  }
+// TODO(mfu): Currently this one is not used; comment it out.
+// /**
+//   * Get the topology definition for the given topology
+//   *
+//   * @return Topology
+//   */
+//  public TopologyAPI.Topology getTopology(String topologyName) {
+//    return awaitResult(delegate.getTopology(null, topologyName));
+//  }
 
   /**
    * Get the execution state for the given topology
    *
-   * @param watcher @see com.twitter.heron.spi.statemgr.WatchCallback
    * @return ExecutionState
    */
-  public ListenableFuture<ExecutionEnvironment.ExecutionState> getExecutionState(
-      WatchCallback watcher, String topologyName) {
-    return delegate.getExecutionState(null, topologyName);
+  public ExecutionEnvironment.ExecutionState getExecutionState(String topologyName) {
+    return awaitResult(delegate.getExecutionState(null, topologyName));
   }
 
   /**
    * Get the physical plan for the given topology
    *
-   * @param watcher @see com.twitter.heron.spi.statemgr.WatchCallback
    * @return PhysicalPlans.PhysicalPlan
    */
-  public ListenableFuture<PhysicalPlans.PhysicalPlan> getPhysicalPlan(
-      WatchCallback watcher, String topologyName) {
-    return delegate.getPhysicalPlan(null, topologyName);
+  public PhysicalPlans.PhysicalPlan getPhysicalPlan(String topologyName) {
+    return awaitResult(delegate.getPhysicalPlan(null, topologyName));
   }
 }

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/NetworkUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/NetworkUtils.java
@@ -15,27 +15,8 @@
 package com.twitter.heron.spi.utils;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-
-import java.net.HttpURLConnection;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.ProtocolException;
 import java.net.ServerSocket;
-import java.net.Socket;
-import java.net.SocketTimeoutException;
-import java.net.URL;
-import java.net.UnknownHostException;
-
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import com.google.common.util.concurrent.ListenableFuture;
-import com.sun.net.httpserver.HttpExchange;
 
 import com.twitter.heron.proto.system.Common;
 
@@ -43,23 +24,7 @@ import com.twitter.heron.proto.system.Common;
  * Utilities related to network.
  */
 public class NetworkUtils {
-  public static final String CONTENT_LENGTH = "Content-Length";
-  public static final String CONTENT_TYPE = "Content-Type";
-
   private static final Logger LOG = Logger.getLogger(NetworkUtils.class.getName());
-
-  /**
-   * Waits for ListenableFuture to terminate. Cancels on timeout
-   */
-  public static <V> V awaitResult(ListenableFuture<V> future, int time, TimeUnit unit) {
-    try {
-      return future.get(time, unit);
-    } catch (InterruptedException | TimeoutException | ExecutionException e) {
-      LOG.log(Level.SEVERE, "Exception processing future ", e);
-      future.cancel(true);
-      return null;
-    }
-  }
 
   /**
    * Get available port.

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/TMasterUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/TMasterUtils.java
@@ -17,11 +17,8 @@ package com.twitter.heron.spi.utils;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import com.google.common.util.concurrent.ListenableFuture;
 
 import com.twitter.heron.proto.tmaster.TopologyMaster;
 import com.twitter.heron.spi.common.HttpUtils;
@@ -44,11 +41,12 @@ public class TMasterUtils {
                                       SchedulerStateManagerAdaptor stateManager) {
     // fetch the TMasterLocation for the topology
     LOG.info("Fetching TMaster location for topology: " + topologyName);
-    ListenableFuture<TopologyMaster.TMasterLocation> locationFuture =
-        stateManager.getTMasterLocation(null, topologyName);
 
-    TopologyMaster.TMasterLocation location =
-        NetworkUtils.awaitResult(locationFuture, 5, TimeUnit.SECONDS);
+    TopologyMaster.TMasterLocation location = stateManager.getTMasterLocation(topologyName);
+    if (location == null) {
+      LOG.severe("Failed to fetch TMaster Location for topology: " + topologyName);
+      return false;
+    }
     LOG.info("Fetched TMaster location for topology: " + topologyName);
 
     // for the url request to be sent to TMaster


### PR DESCRIPTION
1. Make all calls in SchedulerStateManagerAdaptor synchronized, i.e. wait for the result unless timeout
2. Correct corresponding invocation of methods in SchedulerStateManagerAdaptor
3. Fix some misuse of IStateManager or SchedulerStateManagerAdaptor
