### PR TITLE
373 bazel configure anaconda - deterministic install location

### DIFF
--- a/bazel_configure.py
+++ b/bazel_configure.py
@@ -146,13 +146,6 @@ def discover_version(path):
   if version:
     return version
 
-  # with python anaconda, --V returns this:
-  # Python 2.7.11 :: Anaconda 2.2.0 (x86_64)
-  if "anaconda" in path:
-    version = first_line.split(' ')[1]
-    if version:
-      return version
-
   # on centos, /usr/bin/gcc --version returns this:
   #   gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-4)
   redhat_line = re.search('(.*)\s+[0-9]+\s+\(Red Hat .*\)$', first_line)
@@ -174,6 +167,14 @@ def discover_version(path):
   mac_line = re.search('^(Apple LLVM version\s+[\d\.]+)\s+\(clang.*', first_line)
   if mac_line:
     version = get_trailing_version(mac_line.group(1))
+    if version:
+      return version
+
+  # with python anaconda, --V returns this:
+  # Python 2.7.11 :: Anaconda 2.2.0 (x86_64)
+  anaconda_line = re.search('.*\s+Anaconda\s+.*\s', first_line)
+  if anaconda_line:
+    version = anaconda_line.group(0).split(' ')[1]
     if version:
       return version
 


### PR DESCRIPTION
#373 anaconda bazel-configure with deterministic install location (using regex on 'Anaconda') format Python 2.7.11 :: Anaconda 2.2.0 (x86_64)
