### PR TITLE
fix heron help/version command problem

### DIFF
--- a/heron/cli/src/python/main.py
+++ b/heron/cli/src/python/main.py
@@ -207,11 +207,15 @@ def main():
   # command to be execute
   command = command_line_args['subcommand']
 
+  # file resources to be cleaned when exit
+  files = []
+
   if command != 'help' and command != 'version':
     command_line_args = extract_common_args(command, parser, command_line_args)
     # register dirs cleanup function during exit
-    files = [command_line_args['override_config_file']]
-    atexit.register(cleanup, files)
+    files.append(command_line_args['override_config_file'])
+
+  atexit.register(cleanup, files)
 
   # bail out if args are empty
   if not command_line_args:


### PR DESCRIPTION
help and version subcommand are not working due to access an missing cli_arg ’override_config_file’.

To fix it, only access it for other subcommands 
