### PR TITLE
Add unit tests for RuntimeManagerRunner

### DIFF
--- a/heron/newscheduler/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/newscheduler/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
@@ -27,14 +27,20 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
 import com.twitter.heron.common.utils.logging.LoggingHelper;
+import com.twitter.heron.proto.scheduler.Scheduler;
+import com.twitter.heron.scheduler.client.HttpServiceSchedulerClient;
+import com.twitter.heron.scheduler.client.ISchedulerClient;
+import com.twitter.heron.scheduler.client.LibrarySchedulerClient;
 import com.twitter.heron.spi.common.ClusterConfig;
 import com.twitter.heron.spi.common.ClusterDefaults;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Context;
 import com.twitter.heron.spi.common.Keys;
 import com.twitter.heron.spi.scheduler.Command;
+import com.twitter.heron.spi.scheduler.IScheduler;
 import com.twitter.heron.spi.statemgr.IStateManager;
 import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
+import com.twitter.heron.spi.utils.Runtime;
 
 public class RuntimeManagerMain {
   private static final Logger LOG = Logger.getLogger(RuntimeManagerMain.class.getName());
@@ -309,13 +315,54 @@ public class RuntimeManagerMain {
         .put(Keys.schedulerStateManagerAdaptor(), adaptor)
         .build();
 
+    // Create a ISchedulerClient basing on the config
+    ISchedulerClient schedulerClient = getSchedulerClient(config, runtime);
+    if (schedulerClient == null) {
+      throw new IllegalArgumentException("Failed to initialize scheduler client");
+    }
+
     // create an instance of the runner class
     RuntimeManagerRunner runtimeManagerRunner =
-        new RuntimeManagerRunner(config, runtime, command);
+        new RuntimeManagerRunner(config, runtime, command, schedulerClient);
+
 
     // invoke the appropriate handlers based on command
     boolean ret = runtimeManagerRunner.call();
 
     return ret;
+  }
+
+  // TODO(mfu): Make it into Factory pattern if needed
+  public static ISchedulerClient getSchedulerClient(Config config, Config runtime)
+      throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+    LOG.fine("Creating scheduler client");
+    ISchedulerClient schedulerClient;
+
+    if (Context.schedulerService(config)) {
+      // get the instance of the state manager
+      SchedulerStateManagerAdaptor statemgr = com.twitter.heron.spi.utils.Runtime.schedulerStateManagerAdaptor(runtime);
+
+      Scheduler.SchedulerLocation schedulerLocation =
+          statemgr.getSchedulerLocation(Runtime.topologyName(runtime));
+
+      if (schedulerLocation == null) {
+        LOG.log(Level.SEVERE, "Failed to get scheduler location");
+        return null;
+      }
+
+      LOG.log(Level.FINE, "Scheduler is listening on location: {0} ", schedulerLocation.toString());
+
+      schedulerClient =
+          new HttpServiceSchedulerClient(config, runtime, schedulerLocation.getHttpEndpoint());
+    } else {
+      // create an instance of scheduler
+      final String schedulerClass = Context.schedulerClass(config);
+      final IScheduler scheduler = (IScheduler) Class.forName(schedulerClass).newInstance();
+      LOG.fine("Invoke scheduler as a library");
+
+      schedulerClient = new LibrarySchedulerClient(config, runtime, scheduler);
+    }
+
+    return schedulerClient;
   }
 }

--- a/heron/newscheduler/tests/java/BUILD
+++ b/heron/newscheduler/tests/java/BUILD
@@ -34,6 +34,17 @@ java_test(
   size="small",
 )
 
+java_test(
+  name="runtime-manager-runner_unittest",
+  srcs=glob(
+    ["**/RuntimeManagerRunnerTest.java"] +
+    ["**/util/TopologyUtilityTest.java"]
+  ),
+  deps=scheduler_deps_files,
+  size="small",
+)
+
+
 # Following unit tests are for class under package com.twitter.heron.scheduler.client
 
 java_test(

--- a/heron/newscheduler/tests/java/com/twitter/heron/scheduler/RuntimeManagerRunnerTest.java
+++ b/heron/newscheduler/tests/java/com/twitter/heron/scheduler/RuntimeManagerRunnerTest.java
@@ -1,0 +1,110 @@
+package com.twitter.heron.scheduler;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.twitter.heron.proto.scheduler.Scheduler;
+import com.twitter.heron.scheduler.client.ISchedulerClient;
+import com.twitter.heron.spi.common.Config;
+import com.twitter.heron.spi.common.ConfigKeys;
+import com.twitter.heron.spi.common.Keys;
+import com.twitter.heron.spi.scheduler.Command;
+import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
+import com.twitter.heron.spi.utils.SchedulerUtils;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({SchedulerUtils.class})
+public class RuntimeManagerRunnerTest {
+  private static final String topologyName = "testTopology";
+  private final Config config = Mockito.mock(Config.class);
+  private final Config runtime = Mockito.mock(Config.class);
+
+  @Before
+  public void setUp() throws Exception {
+    Mockito.when(config.getStringValue(ConfigKeys.get("TOPOLOGY_NAME"))).thenReturn(topologyName);
+  }
+
+  @Test
+  public void testCall() throws Exception {
+    ISchedulerClient client = Mockito.mock(ISchedulerClient.class);
+
+    // Restart Runner
+    RuntimeManagerRunner restartRunner =
+        Mockito.spy(new RuntimeManagerRunner(config, runtime, Command.RESTART, client));
+    Mockito.doReturn(true).when(restartRunner).restartTopologyHandler(topologyName);
+    Assert.assertTrue(restartRunner.call());
+    Mockito.verify(restartRunner).restartTopologyHandler(topologyName);
+
+    // Kill Runner
+    RuntimeManagerRunner killRunner =
+        Mockito.spy(new RuntimeManagerRunner(config, runtime, Command.KILL, client));
+    Mockito.doReturn(true).when(killRunner).killTopologyHandler(topologyName);
+    Assert.assertTrue(killRunner.call());
+    Mockito.verify(killRunner).killTopologyHandler(topologyName);
+  }
+
+  @Test
+  public void testRestartTopologyHandler() throws Exception {
+    ISchedulerClient client = Mockito.mock(ISchedulerClient.class);
+    SchedulerStateManagerAdaptor adaptor = Mockito.mock(SchedulerStateManagerAdaptor.class);
+    RuntimeManagerRunner runner = new RuntimeManagerRunner(config, runtime, Command.RESTART, client);
+
+    // Restart container 1, not containing TMaster
+    Scheduler.RestartTopologyRequest restartTopologyRequest = Scheduler.RestartTopologyRequest.newBuilder()
+        .setTopologyName(topologyName).setContainerIndex(1).build();
+    Mockito.when(config.getIntegerValue(ConfigKeys.get("TOPOLOGY_CONTAINER_ID"))).thenReturn(1);
+
+    // Failure case
+    Mockito.when(client.restartTopology(restartTopologyRequest)).thenReturn(false);
+    Assert.assertFalse(runner.restartTopologyHandler(topologyName));
+    // Should not invoke DeleteTMasterLocation
+    Mockito.verify(adaptor, Mockito.never()).deleteTMasterLocation(topologyName);
+    // Success case
+    Mockito.when(client.restartTopology(restartTopologyRequest)).thenReturn(true);
+    Assert.assertTrue(runner.restartTopologyHandler(topologyName));
+    // Should not invoke DeleteTMasterLocation
+    Mockito.verify(adaptor, Mockito.never()).deleteTMasterLocation(topologyName);
+
+
+    // Restart container 0, containing TMaster
+    Mockito.when(config.getIntegerValue(ConfigKeys.get("TOPOLOGY_CONTAINER_ID"))).thenReturn(0);
+    Mockito.when(runtime.get(Keys.schedulerStateManagerAdaptor())).thenReturn(adaptor);
+    Mockito.when(adaptor.deleteTMasterLocation(topologyName)).thenReturn(false);
+    Assert.assertFalse(runner.restartTopologyHandler(topologyName));
+    // DeleteTMasterLocation should be invoked
+    Mockito.verify(adaptor).deleteTMasterLocation(topologyName);
+  }
+
+  @Test
+  public void testKillTopologyHandler() throws Exception {
+    Scheduler.KillTopologyRequest killTopologyRequest = Scheduler.KillTopologyRequest.newBuilder()
+        .setTopologyName(topologyName).build();
+    ISchedulerClient client = Mockito.mock(ISchedulerClient.class);
+    RuntimeManagerRunner runner = new RuntimeManagerRunner(config, runtime, Command.KILL, client);
+
+    // Failed to invoke client's killTopology
+    Mockito.when(client.killTopology(killTopologyRequest)).thenReturn(false);
+    Assert.assertFalse(runner.killTopologyHandler(topologyName));
+    Mockito.verify(client).killTopology(killTopologyRequest);
+
+    // Failed to clean states
+    Mockito.when(client.killTopology(killTopologyRequest)).thenReturn(true);
+    PowerMockito.spy(SchedulerUtils.class);
+    PowerMockito.doReturn(false).when(SchedulerUtils.class, "cleanState", Mockito.eq(topologyName),
+        Mockito.any(SchedulerStateManagerAdaptor.class));
+    Assert.assertFalse(runner.killTopologyHandler(topologyName));
+    Mockito.verify(client, Mockito.times(2)).killTopology(killTopologyRequest);
+
+    // Success case
+    PowerMockito.doReturn(true).when(SchedulerUtils.class, "cleanState", Mockito.eq(topologyName),
+        Mockito.any(SchedulerStateManagerAdaptor.class));
+    Assert.assertTrue(runner.killTopologyHandler(topologyName));
+    Mockito.verify(client, Mockito.times(3)).killTopology(killTopologyRequest);
+  }
+}

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalScheduler.java
@@ -35,7 +35,6 @@ import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.PackingPlan;
 import com.twitter.heron.spi.common.ShellUtils;
 import com.twitter.heron.spi.scheduler.IScheduler;
-import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
 import com.twitter.heron.spi.utils.NetworkUtils;
 import com.twitter.heron.spi.utils.Runtime;
 import com.twitter.heron.spi.utils.TopologyUtils;
@@ -248,21 +247,6 @@ public class LocalScheduler implements IScheduler {
         if (containerId == processToContainer.get(p)) {
           p.destroy();
         }
-      }
-    }
-
-    // get the instance of state manager to clean state
-    SchedulerStateManagerAdaptor stateManager = Runtime.schedulerStateManagerAdaptor(runtime);
-
-    // If we restart the container including TMaster, wee need to clean TMasterLocation,
-    // since we could not set it as ephemeral for local file system
-    // We would not clean SchedulerLocation since we would not restart the Scheduler
-    if (containerId == -1 || containerId == 0) {
-      Boolean result = stateManager.deleteTMasterLocation(LocalContext.topologyName(config));
-      if (result == null || !result) {
-        // We would not return false since it is possible that TMaster didn't write physical plan
-        LOG.severe("Failed to clear TMaster location. Check whether TMaster set it correctly.");
-        return false;
       }
     }
 

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
@@ -41,6 +41,7 @@ import com.twitter.heron.statemgr.FileSystemStateManager;
 import com.twitter.heron.statemgr.zookeeper.ZkContext;
 import com.twitter.heron.statemgr.zookeeper.ZkWatcherCallback;
 
+// TODO(mfu): Add Proxy or tunnel support, rather than to return the value stored directly
 public class CuratorStateManager extends FileSystemStateManager {
   private static final Logger LOG = Logger.getLogger(CuratorStateManager.class.getName());
   private CuratorFramework client;


### PR DESCRIPTION
1. Add unit tests for RuntimeManagerRunner
2. Fix bugs: when restarting container containing TMaster, we need to clear TMasterLocation.
3. Refactor to make RuntimeManagerRunner more reasonable
