### PR TITLE
fix coding style for uploaders and statemgrs

### DIFF
--- a/heron/spi/src/java/com/twitter/heron/spi/scheduler/Command.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/scheduler/Command.java
@@ -1,3 +1,17 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.twitter.heron.spi.scheduler;
 
 public enum Command {
@@ -12,3 +26,4 @@ public enum Command {
     return Command.valueOf(commandString.toUpperCase());
   }
 }
+

--- a/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
@@ -44,12 +44,12 @@ public class SchedulerStateManagerAdaptor {
    * Construct SchedulerStateManagerAdaptor providing only the
    * interfaces used by scheduler.
    *
-   * @param delegate, the IStateManager which is already initialized.
+   * @param delegate an instance of IStateManager that is already initialized.
    * Noticed that the initialize and close of IStateManager is not in the
    * SchedulerStateManager. Users are restricted from using those interfaces
    * since it is upto the abstract scheduler to decide when to open and close.
-   * @param delegate, the instance of IStateManager
-   * @param timeout, the maximum time to wait in milliseconds
+   *
+   * @param timeout the maximum time to wait in milliseconds
    */
   public SchedulerStateManagerAdaptor(IStateManager delegate, int timeout) {
     this.delegate = delegate;
@@ -98,7 +98,7 @@ public class SchedulerStateManagerAdaptor {
   /**
    * Set the topology definition for the given topology
    *
-   * @param topologyName, the name of the topology
+   * @param topologyName the name of the topology
    * @return Boolean - Success or Failure
    */
   public Boolean setTopology(TopologyAPI.Topology topology, String topologyName) {

--- a/heron/spi/src/java/com/twitter/heron/spi/statemgr/WatchCallback.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/statemgr/WatchCallback.java
@@ -20,13 +20,16 @@ package com.twitter.heron.spi.statemgr;
  * Any event on that node will trigger the callback (processWatch).
  */
 public interface WatchCallback {
+
   /**
+   * When watch is triggered, process it
+   *
    * @param path the node path
    * @param eventType the WatchEventType
    */
-  public void processWatch(String path, WatchEventType eventType);
+  void processWatch(String path, WatchEventType eventType);
 
-  public enum WatchEventType {
+  enum WatchEventType {
     None,
     NodeCreated,
     NodeDeleted,

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemConfigKeys.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemConfigKeys.java
@@ -19,7 +19,7 @@ import java.util.logging.Logger;
 
 import com.twitter.heron.spi.common.Resource;
 
-public class LocalFileSystemConfigKeys {
+final class LocalFileSystemConfigKeys {
   private static final Logger LOG = Logger.getLogger(LocalFileSystemConfigKeys.class.getName());
 
   // holds the mapping of keys to their corresponding key strings
@@ -32,9 +32,13 @@ public class LocalFileSystemConfigKeys {
           "com.twitter.heron.statemgr.localfs.LocalFileSystemKeys",
           LocalFileSystemConstants.KEYS_YAML);
     } catch (ClassNotFoundException e) {
-      LOG.severe("Unable to load the local file system uploader keys class " + e);
-      System.exit(1);
+      throw new RuntimeException("Unable to load the local file system uploader keys class " + e);
     }
+  }
+
+  private LocalFileSystemConfigKeys() {
+    // Throw an exception if this ever *is* called
+    throw new AssertionError("Instantiating utility class " + this.getClass().getSimpleName());
   }
 
   /*

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemConstants.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemConstants.java
@@ -14,8 +14,13 @@
 
 package com.twitter.heron.statemgr.localfs;
 
-public class LocalFileSystemConstants {
+final class LocalFileSystemConstants {
 
   // name of the resource file that holds the config keys
   public static final String KEYS_YAML = "com/twitter/heron/statemgr/localfs/keys.yaml";
+
+  private LocalFileSystemConstants() {
+    // Throw an exception if this ever *is* called
+    throw new AssertionError("Instantiating utility class " + this.getClass().getSimpleName());
+  }
 }

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemContext.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemContext.java
@@ -22,11 +22,11 @@ public class LocalFileSystemContext extends Context {
   /**
    * Get the config specifying whether to initialize file directory hierarchy
    *
-   * @param Config, the config map
-   * @return true, if config does not exist, else the specified value
+   * @param config the config map
+   * @return true if config does not exist, else the specified value
    */
   public static boolean initLocalFileTree(Config config) {
-    return config.get(LocalFileSystemKeys.initializeFileTree()) == null ?
-        true : (Boolean) config.get(LocalFileSystemKeys.initializeFileTree());
+    return config.get(LocalFileSystemKeys.initializeFileTree()) == null
+        ? true : (Boolean) config.get(LocalFileSystemKeys.initializeFileTree());
   }
 }

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
@@ -38,17 +38,17 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
   private Config config;
 
   @Override
-  public void initialize(Config config) {
+  public void initialize(Config ipconfig) {
 
-    super.initialize(config);
-    this.config = config;
+    super.initialize(ipconfig);
+    this.config = ipconfig;
 
     // By default, we would init the file tree if it is not there
     boolean isInitLocalFileTree = LocalFileSystemContext.initLocalFileTree(config);
 
     if (isInitLocalFileTree && !initTree()) {
-      throw new IllegalArgumentException("Failed to initialize Local State manager. " +
-          "Check rootAddress: " + rootAddress);
+      throw new IllegalArgumentException("Failed to initialize Local State manager. "
+          + "Check rootAddress: " + rootAddress);
     }
   }
 
@@ -60,11 +60,23 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
     LOG.log(Level.FINE, "Execution state directory: {0}", getExecutionStateDir());
     LOG.log(Level.FINE, "Scheduler location directory: {0}", getSchedulerLocationDir());
 
-    if ((FileUtils.isDirectoryExists(getTopologyDir()) || FileUtils.createDirectory(getTopologyDir())) &&
-        (FileUtils.isDirectoryExists(getTMasterLocationDir()) || FileUtils.createDirectory(getTMasterLocationDir())) &&
-        (FileUtils.isDirectoryExists(getPhysicalPlanDir()) || FileUtils.createDirectory(getPhysicalPlanDir())) &&
-        (FileUtils.isDirectoryExists(getExecutionStateDir()) || FileUtils.createDirectory(getExecutionStateDir())) &&
-        (FileUtils.isDirectoryExists(getSchedulerLocationDir()) || FileUtils.createDirectory(getSchedulerLocationDir()))) {
+    boolean topologyDir = FileUtils.isDirectoryExists(getTopologyDir())
+        || FileUtils.createDirectory(getTopologyDir());
+
+    boolean tmasterLocationDir = FileUtils.isDirectoryExists(getTMasterLocationDir())
+        || FileUtils.createDirectory(getTMasterLocationDir());
+
+    boolean physicalPlanDir = FileUtils.isDirectoryExists(getPhysicalPlanDir())
+        || FileUtils.createDirectory(getPhysicalPlanDir());
+
+    boolean executionStateDir = FileUtils.isDirectoryExists(getExecutionStateDir())
+        || FileUtils.createDirectory(getExecutionStateDir());
+
+    boolean schedulerLocationDir =  FileUtils.isDirectoryExists(getSchedulerLocationDir())
+        || FileUtils.createDirectory(getSchedulerLocationDir());
+
+    if (topologyDir && tmasterLocationDir && physicalPlanDir && executionStateDir
+        && schedulerLocationDir) {
       return true;
     }
 
@@ -113,7 +125,8 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
   }
 
   @Override
-  public ListenableFuture<Boolean> setTMasterLocation(TopologyMaster.TMasterLocation location, String topologyName) {
+  public ListenableFuture<Boolean> setTMasterLocation(
+      TopologyMaster.TMasterLocation location, String topologyName) {
     return setData(getTMasterLocationPath(topologyName), location.toByteArray());
   }
 
@@ -123,12 +136,14 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
   }
 
   @Override
-  public ListenableFuture<Boolean> setPhysicalPlan(PhysicalPlans.PhysicalPlan physicalPlan, String topologyName) {
+  public ListenableFuture<Boolean> setPhysicalPlan(
+      PhysicalPlans.PhysicalPlan physicalPlan, String topologyName) {
     return setData(getPhysicalPlanPath(topologyName), physicalPlan.toByteArray());
   }
 
   @Override
-  public ListenableFuture<Boolean> setSchedulerLocation(Scheduler.SchedulerLocation location, String topologyName) {
+  public ListenableFuture<Boolean> setSchedulerLocation(
+      Scheduler.SchedulerLocation location, String topologyName) {
     return setData(getSchedulerLocationPath(topologyName), location.toByteArray());
   }
 
@@ -158,28 +173,37 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
   }
 
   @Override
-  public ListenableFuture<Scheduler.SchedulerLocation> getSchedulerLocation(WatchCallback watcher, String topologyName) {
-    return getData(getSchedulerLocationPath(topologyName), Scheduler.SchedulerLocation.newBuilder());
+  public ListenableFuture<Scheduler.SchedulerLocation> getSchedulerLocation(
+      WatchCallback watcher, String topologyName) {
+    return getData(getSchedulerLocationPath(topologyName),
+        Scheduler.SchedulerLocation.newBuilder());
   }
 
   @Override
-  public ListenableFuture<TopologyAPI.Topology> getTopology(WatchCallback watcher, String topologyName) {
+  public ListenableFuture<TopologyAPI.Topology> getTopology(
+      WatchCallback watcher, String topologyName) {
     return getData(getTopologyPath(topologyName), TopologyAPI.Topology.newBuilder());
   }
 
   @Override
-  public ListenableFuture<ExecutionEnvironment.ExecutionState> getExecutionState(WatchCallback watcher, String topologyName) {
-    return getData(getExecutionStatePath(topologyName), ExecutionEnvironment.ExecutionState.newBuilder());
+  public ListenableFuture<ExecutionEnvironment.ExecutionState> getExecutionState(
+      WatchCallback watcher, String topologyName) {
+    return getData(getExecutionStatePath(topologyName),
+        ExecutionEnvironment.ExecutionState.newBuilder());
   }
 
   @Override
-  public ListenableFuture<PhysicalPlans.PhysicalPlan> getPhysicalPlan(WatchCallback watcher, String topologyName) {
-    return getData(getPhysicalPlanPath(topologyName), PhysicalPlans.PhysicalPlan.newBuilder());
+  public ListenableFuture<PhysicalPlans.PhysicalPlan> getPhysicalPlan(
+      WatchCallback watcher, String topologyName) {
+    return getData(getPhysicalPlanPath(topologyName),
+        PhysicalPlans.PhysicalPlan.newBuilder());
   }
 
   @Override
-  public ListenableFuture<TopologyMaster.TMasterLocation> getTMasterLocation(WatchCallback watcher, String topologyName) {
-    return getData(getTMasterLocationPath(topologyName), TopologyMaster.TMasterLocation.newBuilder());
+  public ListenableFuture<TopologyMaster.TMasterLocation> getTMasterLocation(
+      WatchCallback watcher, String topologyName) {
+    return getData(getTMasterLocationPath(topologyName),
+        TopologyMaster.TMasterLocation.newBuilder());
   }
 
   @Override

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/ZkContext.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/ZkContext.java
@@ -17,10 +17,11 @@ package com.twitter.heron.statemgr.zookeeper;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Context;
 
-public class ZkContext extends Context {
+public final class ZkContext extends Context {
   public static final String IS_INITIALIZE_TREE = "heron.statemgr.zookeeper.is.initialize.tree";
   public static final String SESSION_TIMEOUT_MS = "heron.statemgr.zookeeper.session.timeout.ms";
-  public static final String CONNECTION_TIMEOUT_MS = "heron.statemgr.zookeeper.connection.timeout.ms";
+  public static final String CONNECTION_TIMEOUT_MS =
+      "heron.statemgr.zookeeper.connection.timeout.ms";
   public static final String RETRY_COUNT = "heron.statemgr.zookeeper.retry.count";
   public static final String RETRY_INTERVAL_MS = "heron.statemgr.zookeeper.retry.interval.ms";
 
@@ -42,5 +43,10 @@ public class ZkContext extends Context {
 
   public static int retryIntervalMs(Config config) {
     return config.getIntegerValue(RETRY_INTERVAL_MS);
+  }
+
+  private ZkContext() {
+    // Throw an exception if this ever *is* called
+    throw new AssertionError("Instantiating utility class " + this.getClass().getSimpleName());
   }
 }

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/ZkWatcherCallback.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/ZkWatcherCallback.java
@@ -19,11 +19,11 @@ import org.apache.zookeeper.Watcher;
 
 import com.twitter.heron.spi.statemgr.WatchCallback;
 
-public class ZkWatcherCallback {
-  static public Watcher makeZkWatcher(final WatchCallback watcher) {
-    return watcher == null ?
-        null :
-        new Watcher() {
+public final class ZkWatcherCallback {
+  public static Watcher makeZkWatcher(final WatchCallback watcher) {
+    return watcher == null
+        ? null
+        : new Watcher() {
           @Override
           public void process(WatchedEvent watchedEvent) {
             WatchCallback.WatchEventType watchEventType;
@@ -50,5 +50,10 @@ public class ZkWatcherCallback {
             watcher.processWatch(watchedEvent.getPath(), watchEventType);
           }
         };
+  }
+
+  private ZkWatcherCallback() {
+    // Throw an exception if this ever *is* called
+    throw new AssertionError("Instantiating utility class " + this.getClass().getSimpleName());
   }
 }

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
@@ -76,7 +76,8 @@ public class CuratorStateManager extends FileSystemStateManager {
     client.start();
 
     try {
-      if (!client.blockUntilConnected(ZkContext.connectionTimeoutMs(config), TimeUnit.MILLISECONDS)) {
+      if (!client.blockUntilConnected(ZkContext.connectionTimeoutMs(config),
+          TimeUnit.MILLISECONDS)) {
         throw new RuntimeException("Failed to initialize CuratorClient");
       }
     } catch (InterruptedException e) {
@@ -172,13 +173,14 @@ public class CuratorStateManager extends FileSystemStateManager {
 
     BackgroundCallback cb = new BackgroundCallback() {
       @Override
-      public void processResult(CuratorFramework client, CuratorEvent event) throws Exception {
+      public void processResult(CuratorFramework aClient, CuratorEvent event) throws Exception {
         byte[] data;
         if (event != null & (data = event.getData()) != null) {
           builder.mergeFrom(data);
           future.set((M) builder.build());
         } else {
-          future.setException(new RuntimeException("Failed to fetch data from path: " + event.getPath()));
+          future.setException(new RuntimeException("Failed to fetch data from path: "
+              + event.getPath()));
         }
       }
     };
@@ -193,7 +195,8 @@ public class CuratorStateManager extends FileSystemStateManager {
   }
 
   @Override
-  public ListenableFuture<Boolean> setTMasterLocation(TopologyMaster.TMasterLocation location, String topologyName) {
+  public ListenableFuture<Boolean> setTMasterLocation(
+      TopologyMaster.TMasterLocation location, String topologyName) {
     return createNode(getTMasterLocationPath(topologyName), location.toByteArray(), true);
   }
 
@@ -209,12 +212,14 @@ public class CuratorStateManager extends FileSystemStateManager {
   }
 
   @Override
-  public ListenableFuture<Boolean> setPhysicalPlan(PhysicalPlans.PhysicalPlan physicalPlan, String topologyName) {
+  public ListenableFuture<Boolean> setPhysicalPlan(
+      PhysicalPlans.PhysicalPlan physicalPlan, String topologyName) {
     return createNode(getPhysicalPlanPath(topologyName), physicalPlan.toByteArray(), false);
   }
 
   @Override
-  public ListenableFuture<Boolean> setSchedulerLocation(Scheduler.SchedulerLocation location, String topologyName) {
+  public ListenableFuture<Boolean> setSchedulerLocation(
+      Scheduler.SchedulerLocation location, String topologyName) {
     return createNode(getSchedulerLocationPath(topologyName), location.toByteArray(), true);
   }
 
@@ -250,28 +255,38 @@ public class CuratorStateManager extends FileSystemStateManager {
   }
 
   @Override
-  public ListenableFuture<TopologyMaster.TMasterLocation> getTMasterLocation(WatchCallback watcher, String topologyName) {
-    return getNodeData(watcher, getTMasterLocationPath(topologyName), TopologyMaster.TMasterLocation.newBuilder());
+  public ListenableFuture<TopologyMaster.TMasterLocation> getTMasterLocation(
+      WatchCallback watcher, String topologyName) {
+    return getNodeData(watcher, getTMasterLocationPath(topologyName),
+        TopologyMaster.TMasterLocation.newBuilder());
   }
 
   @Override
-  public ListenableFuture<Scheduler.SchedulerLocation> getSchedulerLocation(WatchCallback watcher, String topologyName) {
-    return getNodeData(watcher, getSchedulerLocationPath(topologyName), Scheduler.SchedulerLocation.newBuilder());
+  public ListenableFuture<Scheduler.SchedulerLocation> getSchedulerLocation(
+      WatchCallback watcher, String topologyName) {
+    return getNodeData(watcher, getSchedulerLocationPath(topologyName),
+        Scheduler.SchedulerLocation.newBuilder());
   }
 
   @Override
-  public ListenableFuture<TopologyAPI.Topology> getTopology(WatchCallback watcher, String topologyName) {
-    return getNodeData(watcher, getTopologyPath(topologyName), TopologyAPI.Topology.newBuilder());
+  public ListenableFuture<TopologyAPI.Topology> getTopology(
+      WatchCallback watcher, String topologyName) {
+    return getNodeData(watcher, getTopologyPath(topologyName),
+        TopologyAPI.Topology.newBuilder());
   }
 
   @Override
-  public ListenableFuture<ExecutionEnvironment.ExecutionState> getExecutionState(WatchCallback watcher, String topologyName) {
-    return getNodeData(watcher, getExecutionStatePath(topologyName), ExecutionEnvironment.ExecutionState.newBuilder());
+  public ListenableFuture<ExecutionEnvironment.ExecutionState> getExecutionState(
+      WatchCallback watcher, String topologyName) {
+    return getNodeData(watcher, getExecutionStatePath(topologyName),
+        ExecutionEnvironment.ExecutionState.newBuilder());
   }
 
   @Override
-  public ListenableFuture<PhysicalPlans.PhysicalPlan> getPhysicalPlan(WatchCallback watcher, String topologyName) {
-    return getNodeData(watcher, getPhysicalPlanPath(topologyName), PhysicalPlans.PhysicalPlan.newBuilder());
+  public ListenableFuture<PhysicalPlans.PhysicalPlan> getPhysicalPlan(
+      WatchCallback watcher, String topologyName) {
+    return getNodeData(watcher, getPhysicalPlanPath(topologyName),
+        PhysicalPlans.PhysicalPlan.newBuilder());
   }
 
   @Override

--- a/heron/uploaders/src/java/com/twitter/heron/uploader/hdfs/HdfsContext.java
+++ b/heron/uploaders/src/java/com/twitter/heron/uploader/hdfs/HdfsContext.java
@@ -17,9 +17,15 @@ package com.twitter.heron.uploader.hdfs;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Context;
 
-public class HdfsContext extends Context {
+final class HdfsContext extends Context {
   public static final String HADOOP_CONFIG_DIRECTORY = "heron.uploader.hdfs.config.directory";
-  public static final String HDFS_TOPOLOGIES_DIRECTORY_URI = "heron.uploader.hdfs.topologies.directory.uri";
+  public static final String HDFS_TOPOLOGIES_DIRECTORY_URI =
+      "heron.uploader.hdfs.topologies.directory.uri";
+
+  private HdfsContext() {
+    // Throw an exception if this ever *is* called
+    throw new AssertionError("Instantiating utility class " + this.getClass().getSimpleName());
+  }
 
   public static String hadoopConfigDirectory(Config config) {
     return config.getStringValue(HADOOP_CONFIG_DIRECTORY);

--- a/heron/uploaders/src/java/com/twitter/heron/uploader/hdfs/HdfsUploader.java
+++ b/heron/uploaders/src/java/com/twitter/heron/uploader/hdfs/HdfsUploader.java
@@ -26,15 +26,15 @@ import com.twitter.heron.spi.uploader.IUploader;
 public class HdfsUploader implements IUploader {
   private static final Logger LOG = Logger.getLogger(HdfsUploader.class.getName());
   // get the directory containing the file
-  String destTopologyDirectoryURI;
+  private String destTopologyDirectoryURI;
   private Config config;
   private String hadoopConfdir;
   private String topologyPackageLocation;
   private URI packageURI;
 
   @Override
-  public void initialize(Config config) {
-    this.config = config;
+  public void initialize(Config ipconfig) {
+    this.config = ipconfig;
 
     this.hadoopConfdir = HdfsContext.hadoopConfigDirectory(config);
     this.destTopologyDirectoryURI = HdfsContext.hdfsTopologiesDirectoryURI(config);
@@ -71,8 +71,8 @@ public class HdfsUploader implements IUploader {
     }
 
     // copy the topology package to target working directory
-    LOG.info("Uploading topology " + topologyPackageLocation +
-        " package to target hdfs " + packageURI.toString());
+    LOG.info("Uploading topology " + topologyPackageLocation
+        + " package to target hdfs " + packageURI.toString());
 
     if (!HdfsUtils.copyFromLocal(
         hadoopConfdir, topologyPackageLocation, packageURI.toString(), true)) {

--- a/heron/uploaders/src/java/com/twitter/heron/uploader/hdfs/HdfsUtils.java
+++ b/heron/uploaders/src/java/com/twitter/heron/uploader/hdfs/HdfsUtils.java
@@ -16,30 +16,30 @@ package com.twitter.heron.uploader.hdfs;
 
 import com.twitter.heron.spi.common.ShellUtils;
 
-public class HdfsUtils {
-  private HdfsUtils() {
+final class HdfsUtils {
 
+  private HdfsUtils() {
   }
 
   public static boolean isFileExists(String configDir, String fileURI, boolean isVerbose) {
     String command = String.format("hadoop --config %s fs -test -e %s", configDir, fileURI);
-    return (0 == ShellUtils.runProcess(isVerbose, command, null, null));
+    return 0 == ShellUtils.runProcess(isVerbose, command, null, null);
   }
 
   public static boolean createDir(String configDir, String dir, boolean isVerbose) {
     String command = String.format("hadoop --config %s fs -mkdir -p %s", configDir, dir);
-    return (0 == ShellUtils.runProcess(isVerbose, command, null, null));
+    return 0 == ShellUtils.runProcess(isVerbose, command, null, null);
   }
 
   public static boolean copyFromLocal(
       String configDir, String source, String target, boolean isVerbose) {
     String command = String.format("hadoop --config %s fs -copyFromLocal -f %s %s",
         configDir, source, target);
-    return (0 == ShellUtils.runProcess(isVerbose, command, null, null));
+    return 0 == ShellUtils.runProcess(isVerbose, command, null, null);
   }
 
   public static boolean remove(String configDir, String fileURI, boolean isVerbose) {
     String command = String.format("hadoop --config %s fs -rm %s", configDir, fileURI);
-    return (0 == ShellUtils.runProcess(isVerbose, command, null, null));
+    return 0 == ShellUtils.runProcess(isVerbose, command, null, null);
   }
 }

--- a/heron/uploaders/src/java/com/twitter/heron/uploader/localfs/LocalFileSystemConfigDefaults.java
+++ b/heron/uploaders/src/java/com/twitter/heron/uploader/localfs/LocalFileSystemConfigDefaults.java
@@ -19,7 +19,7 @@ import java.util.logging.Logger;
 
 import com.twitter.heron.spi.common.Resource;
 
-public class LocalFileSystemConfigDefaults {
+final class LocalFileSystemConfigDefaults {
   private static final Logger LOG = Logger.getLogger(
       LocalFileSystemDefaults.class.getName());
 
@@ -33,9 +33,13 @@ public class LocalFileSystemConfigDefaults {
           "com.twitter.heron.uploader.localfs.LocalFileSystemConfigDefaults",
           LocalFileSystemConstants.DEFAULTS_YAML);
     } catch (ClassNotFoundException e) {
-      LOG.severe("Unable to load the Defaults class " + e);
-      System.exit(1);
+      throw new RuntimeException("Unable to load the defaults class " + e);
     }
+  }
+
+  private LocalFileSystemConfigDefaults() {
+    // Throw an exception if this ever *is* called
+    throw new AssertionError("Instantiating utility class " + this.getClass().getSimpleName());
   }
 
   /*

--- a/heron/uploaders/src/java/com/twitter/heron/uploader/localfs/LocalFileSystemConfigKeys.java
+++ b/heron/uploaders/src/java/com/twitter/heron/uploader/localfs/LocalFileSystemConfigKeys.java
@@ -19,7 +19,7 @@ import java.util.logging.Logger;
 
 import com.twitter.heron.spi.common.Resource;
 
-public class LocalFileSystemConfigKeys {
+final class LocalFileSystemConfigKeys {
   private static final Logger LOG = Logger.getLogger(LocalFileSystemConfigKeys.class.getName());
 
   // holds the mapping of keys to their corresponding key strings
@@ -32,9 +32,13 @@ public class LocalFileSystemConfigKeys {
           "com.twitter.heron.uploader.localfs.LocalFileSystemConfigKeys",
           LocalFileSystemConstants.KEYS_YAML);
     } catch (ClassNotFoundException e) {
-      LOG.severe("Unable to load the local file system uploader keys class " + e);
-      System.exit(1);
+      throw new RuntimeException("Unable to load the local file system uploader keys class " + e);
     }
+  }
+
+  private LocalFileSystemConfigKeys() {
+    // Throw an exception if this ever *is* called
+    throw new AssertionError("Instantiating utility class " + this.getClass().getSimpleName());
   }
 
   /*

--- a/heron/uploaders/src/java/com/twitter/heron/uploader/localfs/LocalFileSystemConstants.java
+++ b/heron/uploaders/src/java/com/twitter/heron/uploader/localfs/LocalFileSystemConstants.java
@@ -14,11 +14,16 @@
 
 package com.twitter.heron.uploader.localfs;
 
-public class LocalFileSystemConstants {
+final class LocalFileSystemConstants {
 
   // name of the resource file that holds the config keys
   public static final String KEYS_YAML = "com/twitter/heron/uploader/localfs/keys.yaml";
 
   // name of the resource file that holds the default values for config keys
   public static final String DEFAULTS_YAML = "com/twitter/heron/uploader/localfs/defaults.yaml";
+
+  private LocalFileSystemConstants() {
+    // Throw an exception if this ever *is* called
+    throw new AssertionError("Instantiating utility class " + this.getClass().getSimpleName());
+  }
 }

--- a/heron/uploaders/src/java/com/twitter/heron/uploader/localfs/LocalFileSystemUploader.java
+++ b/heron/uploaders/src/java/com/twitter/heron/uploader/localfs/LocalFileSystemUploader.java
@@ -37,8 +37,8 @@ public class LocalFileSystemUploader implements IUploader {
   private String topologyPackageLocation;
 
   @Override
-  public void initialize(Config config) {
-    this.config = config;
+  public void initialize(Config ipconfig) {
+    this.config = ipconfig;
 
     this.destTopologyDirectory = LocalFileSystemContext.fileSystemDirectory(config);
 
@@ -94,8 +94,8 @@ public class LocalFileSystemUploader implements IUploader {
     }
 
     // copy the topology package to target working directory
-    LOG.fine("Copying topology " + topologyPackageLocation +
-        " package to target working directory " + filePath.toString());
+    LOG.fine("Copying topology " + topologyPackageLocation
+        + " package to target working directory " + filePath.toString());
 
     Path source = Paths.get(topologyPackageLocation);
     try {

--- a/heron/uploaders/src/java/com/twitter/heron/uploader/s3/S3Uploader.java
+++ b/heron/uploaders/src/java/com/twitter/heron/uploader/s3/S3Uploader.java
@@ -52,20 +52,22 @@ import com.twitter.heron.spi.uploader.IUploader;
 public class S3Uploader implements IUploader {
   private static final Logger LOG = Logger.getLogger(S3Uploader.class.getName());
 
-  String bucket;
-  AmazonS3Client s3Client;
-  String remoteFilePath;
+  private String bucket;
+  protected AmazonS3Client s3Client;
+  private String remoteFilePath;
 
-  // The path prefix will be prepended to the path inside the provided bucket. For example if you set bucket=foo and
-  // path_prefix=some/sub/folder then you can expect the final path in s3 to look like: 
+  // The path prefix will be prepended to the path inside the provided bucket.
+  // For example if you set bucket=foo and path_prefix=some/sub/folder then you
+  // can expect the final path in s3 to look like:
   // s3://foo/some/sub/folder/<topologyName>/topology.tar.gz
-  String pathPrefix;
+  private String pathPrefix;
 
-  // Stores the path to the backup version of the topology in case the deploy fails and it needs to be undone. This is
-  // the same as the existing path but prepended with `previous_`. This serves as a simple backup incase we need to revert.
-  String previousVersionFilePath;
+  // Stores the path to the backup version of the topology in case the deploy fails and
+  // it needs to be undone. This is the same as the existing path but prepended with `previous_`.
+  // This serves as a simple backup incase we need to revert.
+  private String previousVersionFilePath;
 
-  File packageFileHandler;
+  private File packageFileHandler;
 
   @Override
   public void initialize(Config config) {
@@ -98,7 +100,8 @@ public class S3Uploader implements IUploader {
     remoteFilePath = generateS3Path(pathPrefix, topologyName, packageFileHandler.getName());
 
     // Generate the location of the backup file incase we need to revert the deploy
-    previousVersionFilePath = generateS3Path(pathPrefix, topologyName, "previous_" + packageFileHandler.getName());
+    previousVersionFilePath = generateS3Path(pathPrefix, topologyName,
+        "previous_" + packageFileHandler.getName());
   }
 
   @Override
@@ -112,7 +115,8 @@ public class S3Uploader implements IUploader {
     try {
       s3Client.putObject(bucket, remoteFilePath, packageFileHandler);
     } catch (Exception e) {
-      LOG.log(Level.SEVERE, "Error writing topology package to " + bucket + " " + remoteFilePath, e);
+      LOG.log(Level.SEVERE, "Error writing topology package to "
+          + bucket + " " + remoteFilePath, e);
       return null;
     }
 
@@ -122,7 +126,8 @@ public class S3Uploader implements IUploader {
 
     // This will happen if the package does not actually exist in the place where we uploaded it to.
     if (resourceUrl == null) {
-      LOG.log(Level.SEVERE, "Resource not found for bucket " + bucket + " and path " + remoteFilePath);
+      LOG.log(Level.SEVERE, "Resource not found for bucket " + bucket 
+          + " and path " + remoteFilePath);
       return null;
     }
 
@@ -137,14 +142,14 @@ public class S3Uploader implements IUploader {
   /**
    * Generate the path to a file in s3 given a prefix, topologyName, and filename
    *
-   * @param pathPrefix designates any parent folders that should be prefixed to the resulting path
+   * @param pathPrefixParent designates any parent folders that should be prefixed to the resulting path
    * @param topologyName the name of the topology that we are uploaded
    * @param filename the name of the resulting file that is going to be uploaded
    * @return the full path of the package under the bucket. The bucket is not included in this path as it is a separate
    * argument that is passed to the putObject call in the s3 sdk.
    */
-  private String generateS3Path(String pathPrefix, String topologyName, String filename) {
-    List<String> pathParts = new ArrayList<>(Arrays.asList(pathPrefix.split("/")));
+  private String generateS3Path(String pathPrefixParent, String topologyName, String filename) {
+    List<String> pathParts = new ArrayList<>(Arrays.asList(pathPrefixParent.split("/")));
     pathParts.add(topologyName);
     pathParts.add(filename);
 
@@ -169,7 +174,8 @@ public class S3Uploader implements IUploader {
 
   @Override
   public void close() {
-    // Cleanup the backup file if it exists as its not needed anymore. This will succeed whether the file exists or not.
+    // Cleanup the backup file if it exists as its not needed anymore.
+    // This will succeed whether the file exists or not.
     s3Client.deleteObject(bucket, previousVersionFilePath);
   }
 }

--- a/heron/uploaders/tests/java/com/twitter/heron/uploader/localfs/LocalFileSystemConfigTest.java
+++ b/heron/uploaders/tests/java/com/twitter/heron/uploader/localfs/LocalFileSystemConfigTest.java
@@ -28,7 +28,7 @@ import junit.framework.Assert;
 
 public class LocalFileSystemConfigTest {
 
-  private static final String topologyPackageFile = "/tmp/something.tar.gz";
+  private static final String TOPOLOGY_PACKAGE_FILE = "/tmp/something.tar.gz";
 
   private Config getDefaultConfig() {
     Config config = Config.newBuilder()
@@ -91,7 +91,7 @@ public class LocalFileSystemConfigTest {
     uploader.initialize(config);
 
     String destFile = Paths.get(LocalFileSystemContext.fileSystemDirectory(config),
-        new File(topologyPackageFile).getName()).toString();
+        new File(TOPOLOGY_PACKAGE_FILE).getName()).toString();
 
     Assert.assertEquals(
         uploader.getTopologyFile(),
@@ -131,7 +131,7 @@ public class LocalFileSystemConfigTest {
     uploader.initialize(config);
 
     String destFile = Paths.get(LocalFileSystemContext.fileSystemDirectory(config),
-        new File(topologyPackageFile).getName()).toString();
+        new File(TOPOLOGY_PACKAGE_FILE).getName()).toString();
 
     Assert.assertEquals(
         uploader.getTopologyFile(),

--- a/heron/uploaders/tests/java/com/twitter/heron/uploader/localfs/LocalFileSystemConstantsTest.java
+++ b/heron/uploaders/tests/java/com/twitter/heron/uploader/localfs/LocalFileSystemConstantsTest.java
@@ -14,6 +14,12 @@
 
 package com.twitter.heron.uploader.localfs;
 
-public class LocalFileSystemConstantsTest {
-  public static final String TEST_DATA_PATH = "/heron/uploaders/tests/java/com/twitter/heron/uploader/localfs/testdata";
+final class LocalFileSystemConstantsTest {
+  public static final String TEST_DATA_PATH =
+      "/heron/uploaders/tests/java/com/twitter/heron/uploader/localfs/testdata";
+
+  private LocalFileSystemConstantsTest() {
+    // Throw an exception if this ever *is* called
+    throw new AssertionError("Instantiating utility class " + this.getClass().getSimpleName());
+  }
 }

--- a/heron/uploaders/tests/java/com/twitter/heron/uploader/localfs/LocalFileSystemUploaderTest.java
+++ b/heron/uploaders/tests/java/com/twitter/heron/uploader/localfs/LocalFileSystemUploaderTest.java
@@ -81,7 +81,8 @@ public class LocalFileSystemUploaderTest {
   public void testSourceNotExists() throws Exception {
 
     // identify the location of the test topology tar file
-    String topologyPackage = Paths.get(testTopologyDirectory, "doesnot-exist-topology.tar").toString();
+    String topologyPackage = Paths.get(
+        testTopologyDirectory, "doesnot-exist-topology.tar").toString();
 
     Config newconfig = Config.newBuilder()
         .putAll(config).put(Keys.topologyPackageFile(), topologyPackage).build();

--- a/heron/uploaders/tests/java/com/twitter/heron/uploader/s3/S3UploaderTest.java
+++ b/heron/uploaders/tests/java/com/twitter/heron/uploader/s3/S3UploaderTest.java
@@ -28,7 +28,10 @@ import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.ConfigKeys;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class S3UploaderTest {
   private S3Uploader uploader;
@@ -61,7 +64,9 @@ public class S3UploaderTest {
 
     URI uri = uploader.uploadPackage();
 
-    verify(mockS3Client).putObject(Mockito.eq(expectedBucket), Mockito.eq(expectedRemotePath), Mockito.any(File.class));
+    verify(mockS3Client).putObject(Mockito.eq(expectedBucket),
+        Mockito.eq(expectedRemotePath), Mockito.any(File.class));
+
     verify(mockS3Client).getResourceUrl(expectedBucket, expectedRemotePath);
 
     assertEquals(new URI("http://url"), uri);
@@ -78,8 +83,12 @@ public class S3UploaderTest {
 
     URI uri = uploader.uploadPackage();
 
-    verify(mockS3Client).copyObject(expectedBucket, expectedRemotePath, expectedBucket, expectedPreviousVersionPath);
-    verify(mockS3Client).putObject(Mockito.eq(expectedBucket), Mockito.eq(expectedRemotePath), Mockito.any(File.class));
+    verify(mockS3Client).copyObject(expectedBucket, expectedRemotePath, expectedBucket,
+        expectedPreviousVersionPath);
+
+    verify(mockS3Client).putObject(Mockito.eq(expectedBucket), Mockito.eq(expectedRemotePath),
+        Mockito.any(File.class));
+
     verify(mockS3Client).getResourceUrl(expectedBucket, expectedRemotePath);
 
     assertEquals(new URI("http://url"), uri);
@@ -91,8 +100,8 @@ public class S3UploaderTest {
     String expectedBucket = "bucket";
 
     when(mockS3Client.doesObjectExist(expectedBucket, expectedRemotePath)).thenReturn(true);
-    when(mockS3Client.putObject(Mockito.eq(expectedBucket), Mockito.eq(expectedRemotePath), Mockito.any(File.class)))
-        .thenThrow(AmazonClientException.class);
+    when(mockS3Client.putObject(Mockito.eq(expectedBucket), Mockito.eq(expectedRemotePath),
+        Mockito.any(File.class))).thenThrow(AmazonClientException.class);
 
     URI uri = uploader.uploadPackage();
     assertEquals(null, uri);
@@ -104,11 +113,13 @@ public class S3UploaderTest {
     String expectedPreviousVersionPath = "test-topology/previous_topology.tar.gz";
     String expectedBucket = "bucket";
 
-    when(mockS3Client.doesObjectExist(expectedBucket, expectedPreviousVersionPath)).thenReturn(true);
+    when(mockS3Client.doesObjectExist(
+        expectedBucket, expectedPreviousVersionPath)).thenReturn(true);
 
     uploader.undo();
 
-    verify(mockS3Client).copyObject(expectedBucket, expectedPreviousVersionPath, expectedBucket, expectedRemotePath);
+    verify(mockS3Client).copyObject(expectedBucket, expectedPreviousVersionPath,
+        expectedBucket, expectedRemotePath);
   }
 
   @Test
@@ -116,11 +127,13 @@ public class S3UploaderTest {
     String expectedPreviousVersionPath = "test-topology/previous_topology.tar.gz";
     String expectedBucket = "bucket";
 
-    when(mockS3Client.doesObjectExist(expectedBucket, expectedPreviousVersionPath)).thenReturn(false);
+    when(mockS3Client.doesObjectExist(expectedBucket, expectedPreviousVersionPath))
+        .thenReturn(false);
 
     uploader.undo();
 
-    verify(mockS3Client, never()).copyObject(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+    verify(mockS3Client, never()).copyObject(Mockito.anyString(),
+        Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
   }
 
   @Test
@@ -146,7 +159,8 @@ public class S3UploaderTest {
 
     uploader.uploadPackage();
 
-    verify(mockS3Client).putObject(Mockito.eq("bucket"), Mockito.eq(expectedRemotePath), Mockito.any(File.class));
+    verify(mockS3Client).putObject(Mockito.eq("bucket"),
+        Mockito.eq(expectedRemotePath), Mockito.any(File.class));
   }
 
 }


### PR DESCRIPTION
- Few are still remaining. This is due to catching a generic exception class - Exception. I think we should catch specific exceptions. I will leave it to the module owners

```
Starting audit...
[ERROR] /private/var/tmp/_bazel_kramasamy/1f558875898fb6bdc4d350f3762f8e5d/heron16/heron/uploaders/src/java/com/twitter/heron/uploader/s3/S3Uploader.java:117:7: Catching 'Exception' is not allowed. [IllegalCatch]
[ERROR] /private/var/tmp/_bazel_kramasamy/1f558875898fb6bdc4d350f3762f8e5d/heron16/heron/uploaders/src/java/com/twitter/heron/uploader/s3/S3Uploader.java:129: Line has trailing spaces. [RegexpSingleline]
[ERROR] /private/var/tmp/_bazel_kramasamy/1f558875898fb6bdc4d350f3762f8e5d/heron16/heron/uploaders/src/java/com/twitter/heron/uploader/s3/S3Uploader.java:166:9: Catching 'Exception' is not allowed. [IllegalCatch]
Audit done.
Checkstyle ends with 3 errors.
```

```
Starting audit...
[ERROR] /private/var/tmp/_bazel_kramasamy/1f558875898fb6bdc4d350f3762f8e5d/heron16/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java:90:9: Catching 'Exception' is not allowed. [IllegalCatch]
[ERROR] /private/var/tmp/_bazel_kramasamy/1f558875898fb6bdc4d350f3762f8e5d/heron16/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java:132:7: Catching 'Exception' is not allowed. [IllegalCatch]
[ERROR] /private/var/tmp/_bazel_kramasamy/1f558875898fb6bdc4d350f3762f8e5d/heron16/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java:148:7: Catching 'Exception' is not allowed. [IllegalCatch]
[ERROR] /private/var/tmp/_bazel_kramasamy/1f558875898fb6bdc4d350f3762f8e5d/heron16/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java:161:7: Catching 'Exception' is not allowed. [IllegalCatch]
[ERROR] /private/var/tmp/_bazel_kramasamy/1f558875898fb6bdc4d350f3762f8e5d/heron16/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java:190:7: Catching 'Exception' is not allowed. [IllegalCatch]
Audit done.
Checkstyle ends with 5 errors.
```
