### PR TITLE
Print heron-ui listening address in the console

### DIFF
--- a/heron/ui/src/python/main.py
+++ b/heron/ui/src/python/main.py
@@ -16,6 +16,7 @@
 
 import os, sys
 import argparse
+import socket
 
 import tornado.ioloop
 import tornado.options
@@ -95,7 +96,8 @@ def main(argv):
 
   # log additional information
   command_line_args = vars(parsed_args)
-  LOG.info("Running on port: %d", command_line_args['port'])
+  address = socket.gethostbyname(socket.gethostname())
+  LOG.info("Listening at http://%s:%d", address, command_line_args['port'])
   LOG.info("Using tracker url: %s", command_line_args['tracker_url'])
 
   # pass the options to tornado and start the ui server


### PR DESCRIPTION
Printing the listening url when the heron-ui starts up makes it easy for
people to either copy+paste the address or command + click (OSx) to
easily get to the heron ui.

Testing done:
1. Install new code
2. Start heron-ui with `heron-ui`
3. cmd+click the heron ui url in the output
