### PR TITLE
Fix a bug in GlobalMetrics

### DIFF
--- a/heron/api/src/java/com/twitter/heron/api/metric/GlobalMetrics.java
+++ b/heron/api/src/java/com/twitter/heron/api/metric/GlobalMetrics.java
@@ -64,10 +64,10 @@ public enum GlobalMetrics implements Serializable {
   /**
    * Thread safe created increment of counterName. (Slow)
    */
-  public static void safeIncrBy(String counterName, int N) {
+  public static void safeIncrBy(String counterName, int incrValue) {
     synchronized (INSTANCE) {
       if (INSTANCE.registered) {
-        INSTANCE.metricsContainer.scope(counterName).incrBy(N);
+        INSTANCE.metricsContainer.scope(counterName).incrBy(incrValue);
       }
     }
   }


### PR DESCRIPTION
When invoking safeIncrBy(String counterName, int N), we need to increment the value.
