### PR TITLE
Shut down all executor services in SchedulerMain when killing a topology

### DIFF
--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalScheduler.java
@@ -73,7 +73,7 @@ public class LocalScheduler implements IScheduler {
 
   @Override
   public void close() {
-
+    monitorService.shutdownNow();
   }
 
   /**


### PR DESCRIPTION
Shut down all executor services in SchedulerMain when killing a topology.
Otherwise, the SchedulerMain process may not exit due to live threads.
(Earlier we used System.exit() to forcibly exit the process, which is removed now.)
