### PR TITLE
Clean up execution state proto.

### DIFF
--- a/heron/proto/execution_state.proto
+++ b/heron/proto/execution_state.proto
@@ -8,8 +8,6 @@ message HeronReleaseState {
   optional string release_tag = 2;
   // This is the user facing release version
   optional string release_version = 3;
-  // This is the uploader version
-  optional string uploader_version = 4;
 }
 
 message ExecutionState {
@@ -17,12 +15,12 @@ message ExecutionState {
   required string topology_id = 2;
   // The time the topology was submitted
   // Unix time
-  optional int64 submission_time = 4;
+  optional int64 submission_time = 3;
   // The username who launched the topology
-  optional string submission_user = 5;
+  optional string submission_user = 4;
 
-  optional string environ = 7;
-  optional string role = 8;
-  optional HeronReleaseState release_state = 9;
-  optional string cluster = 10;
+  required string cluster = 5;
+  required string environ = 6;
+  required string role = 7;
+  optional HeronReleaseState release_state = 8;
 }

--- a/heron/tracker/src/python/tracker.py
+++ b/heron/tracker/src/python/tracker.py
@@ -168,7 +168,6 @@ class Tracker:
       "release_username": execution_state.release_state.release_username,
       "release_tag": execution_state.release_state.release_tag,
       "release_version": execution_state.release_state.release_version,
-      "uploader_version": execution_state.release_state.uploader_version,
       "has_physical_plan": None,
       "has_tmaster_location": None,
     }


### PR DESCRIPTION
- Rearrange the numbers for proto fields.
- Made some fields required, like `cluster`, `environ` and `role`.
- Removed some unused fields.
- Address comments from #531 
