### PR TITLE
cli should bail out fast

### DIFF
--- a/heron/cli/src/python/main.py
+++ b/heron/cli/src/python/main.py
@@ -212,14 +212,13 @@ def main():
 
   if command != 'help' and command != 'version':
     command_line_args = extract_common_args(command, parser, command_line_args)
+    # bail out if args are empty
+    if not command_line_args:
+      return 1
     # register dirs cleanup function during exit
     files.append(command_line_args['override_config_file'])
 
   atexit.register(cleanup, files)
-
-  # bail out if args are empty
-  if not command_line_args:
-    return 1
 
   start = time.time() 
   retcode = run(command, parser, command_line_args, unknown_args)


### PR DESCRIPTION
If the extract_common_args returns an empty dict, we should bail out immediately. Otherwise, reading from the command_line_args['override_config_file'] will cause KeyError
