### PR TITLE
Provide repeated job link for running topology

### DIFF
--- a/heron/proto/scheduler.proto
+++ b/heron/proto/scheduler.proto
@@ -9,9 +9,9 @@ message SchedulerLocation {
   required string topology_name = 1;
   // host:port or DNS address of scheduler which can be reached for runtime management.
   required string http_endpoint = 2;
-  // Optional link to topology's customized ui page
+  // Optional links to topology's customized ui page
   // Example: link to the Mesos Slave UI page displaying all scheduled containers
-  optional string job_page_link = 3;
+  repeated string job_page_link = 3;
 }
 
 //

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/NullScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/NullScheduler.java
@@ -14,6 +14,9 @@
 
 package com.twitter.heron.scheduler;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.twitter.heron.proto.scheduler.Scheduler;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.PackingPlan;
@@ -37,8 +40,8 @@ public class NullScheduler implements IScheduler {
   }
 
   @Override
-  public String getJobLink() {
-    return null;
+  public List<String> getJobLinks() {
+    return new ArrayList<>();
   }
 
   @Override

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
@@ -16,7 +16,9 @@ package com.twitter.heron.scheduler.aurora;
 
 import java.io.File;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
@@ -80,8 +82,8 @@ public class AuroraScheduler implements IScheduler {
   }
 
   @Override
-  public String getJobLink() {
-    return null;
+  public List<String> getJobLinks() {
+    return new ArrayList<>();
   }
 
   @Override

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalScheduler.java
@@ -16,6 +16,7 @@ package com.twitter.heron.scheduler.local;
 
 import java.io.File;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -210,8 +211,8 @@ public class LocalScheduler implements IScheduler {
   }
 
   @Override
-  public String getJobLink() {
-    return null;
+  public List<String> getJobLinks() {
+    return new ArrayList<>();
   }
 
   /**

--- a/heron/spi/src/java/com/twitter/heron/spi/scheduler/IScheduler.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/scheduler/IScheduler.java
@@ -15,6 +15,8 @@
 package com.twitter.heron.spi.scheduler;
 
 
+import java.util.List;
+
 import com.twitter.heron.proto.scheduler.Scheduler;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.PackingPlan;
@@ -51,12 +53,12 @@ public interface IScheduler extends AutoCloseable {
 
   /**
    * This method will be called after onScheduler
-   * It is responsible to return link to topology's customized ui page.
+   * It is responsible to return links to topology's customized ui pages.
    * Example: link to the Mesos Slave UI page displaying all scheduled containers
    *
-   * @return the link if any customized page. otherwise it returns null.
+   * @return the links if any customized page. It returns an empty list if no any links
    */
-  String getJobLink();
+  List<String> getJobLinks();
 
   /**
    * Called by SchedulerServer when it receives a http request to kill topology,

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/SchedulerUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/SchedulerUtils.java
@@ -57,6 +57,8 @@ public final class SchedulerUtils {
         // since some methods in IScheduler will provide correct values
         // only after IScheduler.onSchedule is invoked correctly
         ret = setSchedulerLocation(runtime, scheduler);
+      } else {
+        LOG.severe("Failed to invoke IScheduler as library");
       }
     } finally {
       scheduler.close();
@@ -97,8 +99,8 @@ public final class SchedulerUtils {
    * Set the location of scheduler for other processes to discover,
    * when invoke IScheduler as a library on client side
    *
-   * @param runtime, the runtime configuration
-   * @param scheduler, the IScheduler to provide more info
+   * @param runtime the runtime configuration
+   * @param scheduler the IScheduler to provide more info
    */
   public static boolean setSchedulerLocation(
       Config runtime,
@@ -113,10 +115,10 @@ public final class SchedulerUtils {
   /**
    * Set the location of scheduler for other processes to discover
    *
-   * @param runtime, the runtime configuration
-   * @param schedulerServerHost, the http server host that scheduler listens for receives requests
-   * @param schedulerServerPort, the http server port that scheduler listens for receives requests
-   * @param scheduler, the IScheduler to provide more info
+   * @param runtime the runtime configuration
+   * @param schedulerServerHost the http server host that scheduler listens for receives requests
+   * @param schedulerServerPort the http server port that scheduler listens for receives requests
+   * @param scheduler the IScheduler to provide more info
    */
   public static boolean setSchedulerLocation(
       Config runtime,
@@ -131,10 +133,10 @@ public final class SchedulerUtils {
             String.format("%s:%d", schedulerServerHost, schedulerServerPort));
 
     // Set the job link in SchedulerLocation if any
-    String jobLink = scheduler.getJobLink();
+    List<String> jobLinks = scheduler.getJobLinks();
     // Check whether IScheduler provides valid job link
-    if (jobLink != null && !jobLink.equals("")) {
-      builder.setJobPageLink(jobLink);
+    if (jobLinks != null) {
+      builder.addAllJobPageLink(jobLinks);
     }
 
     Scheduler.SchedulerLocation location = builder.build();


### PR DESCRIPTION
Currently, some schedulers can have customized job ui, for instance,
Mesos Slave UI page displaying all scheduled containers. And heron-ui may want this link and display it.
This PR:
1. Adds an interface in IScheduler to return optional job link if there is.
2. Adds repeated job link field in SchedulerLocation and always writes it to state manager.
3. Then other components, for instance, tracker can get job link value by querying state manager.
