### PR TITLE
fail travis build fast if unit test fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,5 +38,4 @@ script:
   - gcc --version
   - which g++-4.8
   - g++ --version 
-  - scripts/travis/build.sh
-  - scripts/travis/test.sh
+  - scripts/travis/build.sh && scripts/travis/test.sh


### PR DESCRIPTION
Based on the travis ci doc (https://docs.travis-ci.com/user/customizing-the-build/#Customizing-the-Build-Step), even the build.sh fails, any following script will still be executed.

We changed to make the travis build fail fast if build.sh fails.
