### PR TITLE
Add metric measuring the time a bolt spending in execute()

### DIFF
--- a/heron/common/src/java/com/twitter/heron/common/utils/metrics/BoltMetrics.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/metrics/BoltMetrics.java
@@ -43,6 +43,7 @@ public class BoltMetrics {
   private final MultiCountMetric failCount;
   private final MultiCountMetric executeCount;
   private final MultiReducedMetric<MeanReducerState> executeLatency;
+
   // Time in nano-seconds spending in execute() at every interval
   private final MultiCountMetric executeTimeNs;
   private final MultiCountMetric emitCount;


### PR DESCRIPTION
Add metric measuring the time a bolt spending in execute(),
which is very helpful in debugging or tuning topology.
