### PR TITLE
use python2.7 for cpplint

### DIFF
--- a/3rdparty/python/cpplint/cpplint.py
+++ b/3rdparty/python/cpplint/cpplint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 #
 # Copyright (c) 2009 Google Inc. All rights reserved.
 #


### PR DESCRIPTION
It fails in Twitter environment where we are using 2.4 as default python
