### PR TITLE
website - contributor docs

### DIFF
--- a/website/content/docs/contributors/community.md
+++ b/website/content/docs/contributors/community.md
@@ -15,9 +15,31 @@ In general, contributions that fix bugs or add features (as opposed to stylistic
 Continue to [Heron Architecture](../../concepts/architecture/),
 [Compiling Heron](../../developers/compiling/compiling/), or [Heron Codebase](../codebase/).
 
+### Patch Acceptance Process
+1.  Please read the Heron [governance plan](../governance).
+
+2. Discuss your plan and design, and get agreement on our heron-core@googlegroups.com mailing list.
+
+3. Prepare a GitHub commit that implements the feature. Don't forget to add tests.
+
+<!--
+4. TODO - pre commit process (travis-ci)
+--> 
+
+4. Complete a code review with a core contributor using the heron-core@googlegroups.com mailing list. Amend your existing commit and re-push to make changes to your patch.
+
+5. An engineer at Twitter applies the patch to our internal version control system.
+
+<!--
+7. TODO - post commit process
+-->
+
 <!--
 TODO: links to sourcecode and dev and user groups
 TODO: links to code style setup
 TODO: how to get running in intellij
 -->
+
+
+Next: Review the [Heron Codebase](../codebase)
 

--- a/website/content/docs/contributors/governance.md
+++ b/website/content/docs/contributors/governance.md
@@ -1,0 +1,49 @@
+---
+title: Governance
+---
+
+The Heron project was initially developed at Twitter and is now led by a group of self-managing core contributors with additional contributions by the community. Core contributors expect that candidate core contributors will successfully submit a number of patches or new functionality, demonstrate an understanding of project codebase, and express a willingness to be active group members before they become core contributors.
+
+Core contributors are added by two supporting votes from core contributors on the mailing list and no core contributor veto within four business days.
+
+Twitter uses the open source Heron project release builds in production and remains committed to contributing to the open source project roadmap.  Therefore, core contributors will roll back changes if, for example, they break the internal Twitter production processes.
+
+### Accepting Contributions
+Please also see our [contribution guidelines](../community).
+
+
+### Policy
+Heron is supported by *core contributors*, a group of people who cooperatively and actively support the overall project.  In contrast, general contributors are not actively supporting the overall project, but instead are contributing individual changes. At this time, the majority of core contributors are currently employed by Twitter or have previously been employed by Twitter (see below for the full list).  
+
+1. We require all contributors to agree to [Twitter's Contributor License Agreement (CLA)](../license).
+
+2. We accept well-written, well-tested functional contributions compatible with Bazel builds, in an appropriate directory with clearly documented support policies.
+
+3. We accept well-written, well-tested bug fixes to built-in functions.
+
+4. We accept well-written, well-tested feature contributions if a core contributor assumes support responsibilities, i.e., readily answers support questions and works on bugs. This includes feature contributions from external contributors. If there is no core contributor to support a feature, then we will deprecate and subsequently delete the feature - we will give three months' notice in such cases.
+
+5. We will not accept untested changes, except in very rare cases with appropriate cause.
+
+6. We require a pre-commit code review from a core contributor for all changes. 
+
+7. We will roll back changes if, for example, they break the internal Twitter development processes of any of the core contributors.
+
+8. We are implementing an open governance model where multiple parties have commit access, roll-back rights, and can provide explicit support for features or rules.  Contributions are subject to approval (or in rare circumstances veto) by core committers.
+
+9. We will work with interested parties to improve existing extension points and to establish new extension points if they do not run counter to the internal requirements of any of the core contributors.
+
+### Are you done open sourcing Heron?
+We hope the open source process is complete.  We currently have all code reviews, bug tracking, and design decisions happening publicly, with the Heron community involved. However, as Heron is used in production at Twitter, some changes may simply appear in the Heron repository based on Twitter’s needs, at Twitter’s discretion.. Despite this occasional need to remain flexible in updating the project, we want to support external developers and collaborate to develop and support additional features. Thus, we are opening up the code, even though some of the development is still happening internal to Twitter. Please let us know if anything seems unclear or unjustified as we transition to an open model.
+
+### Are there parts of Heron that will never be open sourced?
+No - all components of Heron will be fully open sourced and able to be supported by open source tools.  Twitter will use the open source releases in production.  As with others who may implement and contribute to the Heron project, Twitter may use Heron with  some functionality, or employ technology complementing Heron, that is not currently planned to become open sourced.  
+### Core Contributors
+Contact the core team at: heron-core@googlegroups.com.
+
+The current group is:
+
+[Karthik Ramasamy (Twitter)](https://github.com/kramasamy)
+
+
+#### Contributors

--- a/website/content/docs/contributors/license.md
+++ b/website/content/docs/contributors/license.md
@@ -1,0 +1,4 @@
+---
+title: Twitter License Agreement (CLA)
+---
+<!-- TODO -->

--- a/website/content/docs/contributors/roadmap.md
+++ b/website/content/docs/contributors/roadmap.md
@@ -1,0 +1,26 @@
+---
+title: Feature Roadmap
+---
+
+This document describes the Heron core contributors’ plans for introducing features that will be incorporated into version 1.0. Note that this roadmap only includes features that the Heron core contributors team itself intends to support. We anticipate that a number of other features will be added by community contributors.
+
+For beta releases, the Heron team will maintain two code repositories:
+
+1. A non-public Twitter-internal repository, containing both the mirror of the public Heron Github repository and small proprietary Twitter-specific extensions and features.
+
+2. An external [GitHub repository](https://github.com/twitter/heron), containing only the Heron code.
+
+### Feature list
+In the following list, each feature is associated with a corresponding milestone. The convention for the priorities are:
+
+1. `P0` feature will block the milestone; we will delay the milestone date until the feature is shipped.
+
+2. `P1` feature can delay the milestone if the feature can be shipped with a reasonable delay (2 months max).
+
+3. `P2` feature will be dropped and rescheduled for later rather than delaying the milestone.
+
+<!--
+TODO - add feature Roadmap
+-->
+
+We will update this list when reaching each milestone; some milestones may also be refined if appropriate.

--- a/website/content/docs/contributors/support.md
+++ b/website/content/docs/contributors/support.md
@@ -1,0 +1,29 @@
+---
+title: Support Policy
+---
+Core contributors generally avoid making backwards-incompatible changes and are dedicated to remain backwards-compatible with the [Apache Storm API](http://storm.apache.org/) whenever possible. Substantial unit and integration tests are performed before every release to reasonably ensure reliability at scale.
+
+However, occasionally backwards-incompatible changes are required in order to fix bugs, to make further improvements to the system, such as improving performance or usability, or to lock down APIs that are known to be brittle.
+
+This document gives an overview of features that are widely used and considered stable. Stability implies that changes will be backwards compatible, or that a migration path is provided.  It also covers features that are unstable. Unstable features are not yet widely used, or are already planned to change them significantly, possibly in ways that are not backwards compatible.
+
+Before a major change happens, you can reasonably expect that advanced notice will be provided on the mailing list. Just ask on heron-users@googlegroups.com.
+
+All undocumented features are subject to change at any time without prior notice. Features that are documented but marked *experimental* are also subject to change at any time without prior notice.
+
+Heron relies on the Google [Bazel](http://bazel.io) build tool which is also in Beta.  Therefore, the Bazel Skylark macro and rules language (anything written in a .bzl file) is still subject to change. The Bazel Google group is in the process of migrating Google to Skylark, and expect the macro language to stabilize as part of that process. 
+
+Please help keep discover issues: report bugs and regressions in the [GitHub bugtracker](https://github.com/twitter/heron/issues). Heron core contributors will make an effort to triage all reported issues within 2 business days.
+
+### Releases
+We regularly publish [binary releases of Heron](https://github.com/twitter/heron/releases). To that end, release candidates are announced on heron-users; these are binaries that have passed all unit and integration tests. Over the next few days, regression tests are run, such as on applicable build targets at Twitter. If you have a critical project using Heron, it is recommended that you establish an automated testing process that tracks the current release candidate, and report any regressions.
+
+If no regressions are discovered, official binaries are released after a week. However, regressions can delay the release of a release candidate. If regressions are found, corresponding cherry-picks are applied to the release candidate to fix those regressions. If no further regressions are found for two business days, but not before a week has elapsed since the first release candidate, the full binaries are released.
+
+### Release versioning
+Version 0.14.0 is our first release marking the start of our beta phase. Until version 1.0.0, we increase the MINOR version every time we reach a new milestone.
+Version 1.0.0 marks the end of our beta phase; afterwards, we will label each release with a version number of the form MAJOR.MINOR.PATCH according to the [semantic version 2.0.0 document](http://semver.org/).
+
+### Current Status
+Stable
+We expect the following rules and features to be stable. They are widely used within Twitter, so our internal testing should ensure that there are no major breakages.

--- a/website/content/docs/developers/troubleshooting.md
+++ b/website/content/docs/developers/troubleshooting.md
@@ -1,4 +1,6 @@
-## Topology Troubleshooting Guide
+---
+title: Topology Troubleshooting Guide
+---
 
 ### Overview
 

--- a/website/content/docs/developers/tuning.md
+++ b/website/content/docs/developers/tuning.md
@@ -1,4 +1,6 @@
-## Topology Tuning Guide
+---
+title: Topology Tuning Guide
+---
 
 ### Overview
 

--- a/website/data/toc.yaml
+++ b/website/data/toc.yaml
@@ -81,3 +81,9 @@ sections:
     sublinks:
       - name: Community
         url: /docs/contributors/community
+      - name: Roadmap
+        url: /docs/contributors/roadmap
+      - name: Governance
+        url: /docs/contributors/governance
+      - name: Support
+        url: /docs/contributors/support


### PR DESCRIPTION
@kramasamy docs as reviewed by legal.  as discussed, TODOs include:
1. Twitter contributor license agreement (CLA) currently a placeholder
2. feature roadmap
3. contrib/committer list
4. create heron-core@googlegroups.com
5. fill out community (intellij, etc.,) todos.
