### PR TITLE
stop using 'with open()' to handle files

### DIFF
--- a/3rdparty/python/cpplint/cpplint.py
+++ b/3rdparty/python/cpplint/cpplint.py
@@ -6112,10 +6112,11 @@ def ProcessConfigOverrides(filename):
               (name, cfg_file))
 
     except IOError:
-      file_handle.close()
       sys.stderr.write(
           "Skipping config file '%s': Can't open for reading\n" % cfg_file)
       keep_looking = False
+    finally:
+      file_handle.close()
 
   # Apply all the accumulated filters in reverse order (top-level directory
   # config options having the least priority).


### PR DESCRIPTION
1. ‘with open() as fd’ is added into python since version 2.5. For older versions like 2.4, this causes syntax error.
2. current bazel doesn’t allow us to chose which exact python version to run for building extra_action rule’s tool attribute. The generated py_binary picks up the /usr/bin/python automatically
3. For any host set python2.4 as default version of python, bazel fails to do the code style check due to the “syntax error”
