### PR TITLE
website googlegroups changed to heron-dev

### DIFF
--- a/website/content/docs/contributors/community.md
+++ b/website/content/docs/contributors/community.md
@@ -18,7 +18,7 @@ Continue to [Heron Architecture](../../concepts/architecture/),
 ### Patch Acceptance Process
 1.  Please read the Heron [governance plan](../governance).
 
-2. Discuss your plan and design, and get agreement on our heron-core@googlegroups.com mailing list.
+2. Discuss your plan and design, and get agreement on our heron-dev@googlegroups.com mailing list.
 
 3. Prepare a GitHub commit that implements the feature. Don't forget to add tests.
 
@@ -26,7 +26,7 @@ Continue to [Heron Architecture](../../concepts/architecture/),
 4. TODO - pre commit process (travis-ci)
 --> 
 
-4. Complete a code review with a core contributor using the heron-core@googlegroups.com mailing list. Amend your existing commit and re-push to make changes to your patch.
+4. Complete a code review with a core contributor using the heron-dev@googlegroups.com mailing list. Amend your existing commit and re-push to make changes to your patch.
 
 5. An engineer at Twitter applies the patch to our internal version control system.
 

--- a/website/content/docs/contributors/governance.md
+++ b/website/content/docs/contributors/governance.md
@@ -39,7 +39,7 @@ We hope the open source process is complete.  We currently have all code reviews
 ### Are there parts of Heron that will never be open sourced?
 No - all components of Heron will be fully open sourced and able to be supported by open source tools.  Twitter will use the open source releases in production.  As with others who may implement and contribute to the Heron project, Twitter may use Heron with  some functionality, or employ technology complementing Heron, that is not currently planned to become open sourced.  
 ### Core Contributors
-Contact the core team at: heron-core@googlegroups.com.
+Contact the core team at: heron-dev@googlegroups.com.
 
 The current group is:
 


### PR DESCRIPTION
heron-core changed to heron-dev (including in "contact core group") since outside members cannot post to private group, per @kramasamy 
