### PR TITLE
make cpplint compatible with python2.4

### DIFF
--- a/3rdparty/python/cpplint/cpplint.py
+++ b/3rdparty/python/cpplint/cpplint.py
@@ -6073,48 +6073,49 @@ def ProcessConfigOverrides(filename):
     
     file_handle = open(cfg_file)
     try:
-      for line in file_handle:
-        line, _, _ = line.partition('#')  # Remove comments.
-        if not line.strip():
-          continue
-
-        name, _, val = line.partition('=')
-        name = name.strip()
-        val = val.strip()
-        if name == 'set noparent':
-          keep_looking = False
-        elif name == 'filter':
-          cfg_filters.append(val)
-        elif name == 'exclude_files':
-          # When matching exclude_files pattern, use the base_name of
-          # the current file name or the directory name we are processing.
-          # For example, if we are checking for lint errors in /foo/bar/baz.cc
-          # and we found the .cfg file at /foo/CPPLINT.cfg, then the config
-          # file's "exclude_files" filter is meant to be checked against "bar"
-          # and not "baz" nor "bar/baz.cc".
-          if base_name:
-            pattern = re.compile(val)
-            if pattern.match(base_name):
-              sys.stderr.write('Ignoring "%s": file excluded by "%s". '
-                               'File path component "%s" matches '
-                               'pattern "%s"\n' %
-                               (filename, cfg_file, base_name, val))
-              return False
-        elif name == 'linelength':
-          global _line_length
-          try:
-              _line_length = int(val)
-          except ValueError:
-              sys.stderr.write('Line length must be numeric.')
-        else:
-          sys.stderr.write(
-              'Invalid configuration option (%s) in file %s\n' %
-              (name, cfg_file))
-
-    except IOError:
-      sys.stderr.write(
+      try:
+        for line in file_handle:
+          line, _, _ = line.partition('#')  # Remove comments.
+          if not line.strip():
+            continue
+    
+          name, _, val = line.partition('=')
+          name = name.strip()
+          val = val.strip()
+          if name == 'set noparent':
+            keep_looking = False
+          elif name == 'filter':
+            cfg_filters.append(val)
+          elif name == 'exclude_files':
+            # When matching exclude_files pattern, use the base_name of
+            # the current file name or the directory name we are processing.
+            # For example, if we are checking for lint errors in /foo/bar/baz.cc
+            # and we found the .cfg file at /foo/CPPLINT.cfg, then the config
+            # file's "exclude_files" filter is meant to be checked against "bar"
+            # and not "baz" nor "bar/baz.cc".
+            if base_name:
+              pattern = re.compile(val)
+              if pattern.match(base_name):
+                sys.stderr.write('Ignoring "%s": file excluded by "%s". '
+                                 'File path component "%s" matches '
+                                 'pattern "%s"\n' %
+                                 (filename, cfg_file, base_name, val))
+                return False
+          elif name == 'linelength':
+            global _line_length
+            try:
+                _line_length = int(val)
+            except ValueError:
+                sys.stderr.write('Line length must be numeric.')
+          else:
+            sys.stderr.write(
+                'Invalid configuration option (%s) in file %s\n' %
+                (name, cfg_file))
+    
+      except IOError:
+        sys.stderr.write(
           "Skipping config file '%s': Can't open for reading\n" % cfg_file)
-      keep_looking = False
+        keep_looking = False
     finally:
       file_handle.close()
 


### PR DESCRIPTION
1. python 2.4 doesn’t support try…except…finally syntax
2. the pex_binary rule isn’t helpful since _pex.py itself is using ‘with open()’ syntax
3. the ultimate solution is to make bazel take the python version to host_configuration which is being discussed in bazel user group
