### PR TITLE
Show viz link only if it is present in execution state.

### DIFF
--- a/heron/config/src/yaml/tracker/heron_tracker.yaml
+++ b/heron/config/src/yaml/tracker/heron_tracker.yaml
@@ -25,5 +25,7 @@ statemgrs:
 #   {jobname} - Same as topology name
 #   {role}
 #   {submission_user}
+#
 # This is a sample, and should be changed to point to corresponding dashboard.
-viz.url.format: "http://localhost/{cluster}/{environ}/{jobname}/{role}/{submission_user}"
+#
+# viz.url.format: "http://localhost/{cluster}/{environ}/{jobname}/{role}/{submission_user}"

--- a/heron/tracker/src/python/config.py
+++ b/heron/tracker/src/python/config.py
@@ -45,7 +45,10 @@ class Config:
 
   def load_configs(self):
     self.statemgr_config.set_state_locations(self.configs[STATEMGRS_KEY])
-    self.viz_url_format = self.validated_viz_url_format(self.configs[VIZ_URL_FORMAT_KEY])
+    if VIZ_URL_FORMAT_KEY in self.configs:
+      self.viz_url_format = self.validated_viz_url_format(self.configs[VIZ_URL_FORMAT_KEY])
+    else:
+      self.viz_url_format = ""
 
   def validated_viz_url_format(self, viz_url_format):
     # We try to create a string by substituting all known

--- a/heron/ui/resources/static/js/alltopologies.js
+++ b/heron/ui/resources/static/js/alltopologies.js
@@ -39,9 +39,6 @@ var TopologyItem = React.createClass({
          <td className="col-md-1 toporeleaseversion">{topology.release_version}</td>
          <td className="col-md-1 toposubmittedby break-all">{topology.submission_user}</td>
          <td className="col-md-2 toposubmittedat no-break">{display_time}</td>
-         <td className="col-md-2 topobutton no-break">
-           <a className="btn btn-primary btn-sm" href={"/topologies/" + [topology.cluster, topology.environ, topology.name, "config"].join("/")} target="_self">Config</a>
-         </td>
        </tr>
     );
   }
@@ -176,7 +173,6 @@ var TopologyTable = React.createClass({
               <th onClick={sortBy("submission_time")} className={sortClass("submission_time")}>
                 Launched at
               </th>
-              <th style={linkHeaderStyle}></th>
             </thead>
 
             <tbody className="list">{items}</tbody>
@@ -304,7 +300,7 @@ var FilterableTopologyTable = React.createClass({
          </div>
        </div>
 
-       
+
      </div>
      <input id="search-box" placeholder="Search for a topology" type="text" className="form-control col-md-7" style={divStyle} autoFocus={true} onChange={this.handleFilterChange} defaultValue={this.state.filter}/>
      <TopologyTable  env={this.state.environ} cluster={this.state.cluster} filter={this.state.filter}/>

--- a/heron/ui/resources/templates/topology.html
+++ b/heron/ui/resources/templates/topology.html
@@ -126,6 +126,7 @@
           <td>
             <a class="btn btn-primary btn-xs" href="/topologies/{{cluster}}/{{environ}}/{{topology}}/config" target="_blank">Config</a>
             <a id="jobPageLink" class="btn btn-primary btn-xs" href={{job_page_link}} target="_blank">Job</a>
+            <a id="vizLink" class="btn btn-primary btn-xs" href="{{estate['viz']}}" target="_blank">Viz</a>
           </td>
         </tr>
       </tbody>
@@ -175,6 +176,11 @@
     // hide Job link if it is not there
     if ("{{job_page_link}}" === "") {
       document.getElementById("jobPageLink").style.display = "none";
+    }
+
+    // hide viz link if it is not there
+    if ("{{estate['viz']}}" === "") {
+      document.getElementById("vizLink").style.display = "none";
     }
 
     // display the topology name as the title


### PR DESCRIPTION
- Remove all links from home page.
- Add Viz link to topology page, but only if it is present in execution state.
- Make `viz.url.format` key optional in `heron-tracker.yaml`.
