### PR TITLE
tweak circle positioning and initial color

### DIFF
--- a/heron/ui/resources/static/css/visstyle.css
+++ b/heron/ui/resources/static/css/visstyle.css
@@ -190,11 +190,16 @@ circle.background {
 .status-circle {
   padding: 2px 3px;
   color: #f0f5fa;
-  -webkit-text-stroke: 0.5px #aaa;
+  fill: currentColor;
+  stroke-width: 0.5px;
+  stroke: #aaa;
+  margin: 0;
+  padding: 0;
+  vertical-align: text-bottom;
 }
 
 a:hover .status-circle {
-  -webkit-text-stroke: 0.5px #000;
+  stroke: #000;
 }
 
 .toplevel-stat {

--- a/heron/ui/resources/static/js/colors.js
+++ b/heron/ui/resources/static/js/colors.js
@@ -4,7 +4,7 @@
 
 (function () {
   function toggleColors () {
-    localStorage.colors = localStorage.colors === 'leonid' ? 'default' : 'leonid';
+    localStorage.colors = localStorage.colors === 'colorblind' ? 'default' : 'colorblind';
     window.location.reload();
   }
 

--- a/heron/ui/resources/static/js/plan-stats.js
+++ b/heron/ui/resources/static/js/plan-stats.js
@@ -75,7 +75,7 @@
       // green/red
       'default': ['#1a9850', '#fdae61', '#d73027'],
       // blue/red
-      'leonid': ['#2166ac', '#f7f7f7', '#b2182b']
+      'colorblind': ['#2166ac', '#f7f7f7', '#b2182b']
     };
 
     rowData.forEach(function (d) {
@@ -125,10 +125,14 @@
         d3.event.stopPropagation();
       });
 
-    var topLevelStatus = links.append('span')
+    var topLevelStatus = links.append('svg')
         .attr('class', 'status-circle')
-        .style('visibility', 'hidden')
-        .html('&#11044;');
+        .attr('width', 20)
+        .attr('height', 15)
+      .append('circle')
+        .attr('cx', 8)
+        .attr('cy', 8)
+        .attr('r', 7);
 
     links.append('span')
         .text(function (d) { return d.time.name; });


### PR DESCRIPTION
- Fix variable name for colorblind-friendly palette
- Change circles to be SVGs so that they render properly in more browsers
- Change circles at initial load so that they are visible but colored with "no data" color until metrics appear

<img width="1221" alt="screen shot 2016-05-11 at 9 53 30 am" src="https://cloud.githubusercontent.com/assets/1480504/15183595/b4e9792a-175f-11e6-9e91-2228ee9a1f4d.png">
