### PR TITLE
Fix instance links on one-instance-selected topology page.

### DIFF
--- a/heron/ui/resources/static/js/stat-trendlines.js
+++ b/heron/ui/resources/static/js/stat-trendlines.js
@@ -185,14 +185,14 @@ function StatTrendlines(cluster, environ, toponame, physicalPlan, logicalPlan) {
     }
 
     if (instance !== '*') {
+      container = instance.split("_")[1];
       target
         .append('div')
         .attr('class', 'text-center')
         .html([
-          '<a class="btn btn-primary btn-xs" target="_blank" href="' + physicalPlan.result.instances[instance].logfile + '">logs</a>',
-          '<a class="btn btn-primary btn-xs" target="_blank" href="' + physicalPlan.result.instances[instance].logfile.split('/log-file')[0].replace('file', 'task') + '">job</a>',
+          '<a class="btn btn-primary btn-xs" target="_blank" href="/topologies/' + cluster + '/' + environ + '/' + toponame + '/' + container + '/file?path=./log-files/' + instance + '.log.0">logs</a>',
+          '<a class="btn btn-primary btn-xs" target="_blank" href="/topologies/filestats/' + cluster + '/' + environ + '/' + toponame + '/' + container + '">job</a>',
           '<a class="btn btn-primary btn-xs" target="_blank" href="/topologies/' + cluster + '/' + environ + '/' + toponame + '/' + name + '/' + instance + '/exceptions">exceptions</a>',
-          '<a class="btn btn-primary btn-xs" target="_blank" href="' + physicalPlan.result.instances[instance].logfile.split('/file')[0] + '">host</a>',
           '<br>',
           instance
         ].join(' '));


### PR DESCRIPTION
When one instance is selected, some links appear near the stats-trend-line. These were not updated in previous PR when we switched to reading logs and stats through Tracker-UI instead of directly from heron-shell.

This PR fixes those links.
