### PR TITLE
website rename javadocs to docs w/ redirect

### DIFF
--- a/website/layouts/partials/navbar.ace
+++ b/website/layouts/partials/navbar.ace
@@ -16,7 +16,7 @@ nav.navbar.navbar-inverse.navbar-fixed-top role=navigation
     #hn-navbar.navbar-collapse.collapse
       ul.nav.navbar-nav.navbar-right
         li
-          a href=/docs/javadoc Javadocs
+          a href=/docs/getting-started Docs
         li 
           a href=/docs/resources Resources
         li


### PR DESCRIPTION
@kramasamy as discussed, Javadocs renamed to Docs with redirect to getting-started, similar to bazel.io
