### PR TITLE
Add an utils method to close resources ignoring any exceptions

### DIFF
--- a/heron/common/src/java/com/twitter/heron/common/basics/SysUtils.java
+++ b/heron/common/src/java/com/twitter/heron/common/basics/SysUtils.java
@@ -16,8 +16,11 @@ package com.twitter.heron.common.basics;
 
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public final class SysUtils {
+  private static final Logger LOG = Logger.getLogger(SysUtils.class.getName());
 
   private SysUtils() {
   }
@@ -50,6 +53,26 @@ public final class SysUtils {
       return port;
     } catch (IOException ioe) {
       return -1;
+    }
+  }
+
+  /**
+   * Close a closable ignoring any exceptions.
+   * This method is used during cleanup, or in a finally block.
+   *
+   * @param closeable source or destination of data can be closed
+   */
+  public static void closeIgnoringExceptions(AutoCloseable closeable) {
+    if (closeable != null) {
+      try {
+        closeable.close();
+
+        // Suppress it since we ignore any exceptions
+        // SUPPRESS CHECKSTYLE IllegalCatch
+      } catch (Exception e) {
+        // Still log the Exception for issue tracing
+        LOG.log(Level.WARNING, String.format("Failed to close %s", closeable), e);
+      }
     }
   }
 }

--- a/heron/common/tests/java/com/twitter/heron/common/basics/SysUtilsTest.java
+++ b/heron/common/tests/java/com/twitter/heron/common/basics/SysUtilsTest.java
@@ -14,6 +14,8 @@
 
 package com.twitter.heron.common.basics;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.Random;
 
@@ -45,5 +47,20 @@ public class SysUtilsTest {
       long end = System.currentTimeMillis();
       Assert.assertTrue((end - start) >= expectedSleepTimeMs);
     }
+  }
+
+  @Test
+  public void testCloseIgnoringException() throws Exception {
+    Closeable closeable = new Closeable() {
+      @Override
+      public void close() throws IOException {
+        throw new RuntimeException("Deliberate exception to be ignored.");
+      }
+    };
+
+    // This invocation should not throw any exceptions
+    // Otherwise, the test will automatically fail
+    SysUtils.closeIgnoringExceptions(closeable);
+    Assert.assertTrue(true);
   }
 }

--- a/heron/instance/src/java/com/twitter/heron/instance/Gateway.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/Gateway.java
@@ -40,7 +40,7 @@ import com.twitter.heron.proto.system.PhysicalPlans;
  * It will new the streamManagerClient and metricsManagerClient in constructor and
  * ask them to connect with corresponding socket endpoint in run().
  */
-public class Gateway implements Runnable {
+public class Gateway implements Runnable, AutoCloseable {
   private static final Logger LOG = Logger.getLogger(Gateway.class.getName());
 
   // Some pre-defined value

--- a/heron/instance/src/java/com/twitter/heron/instance/HeronInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/HeronInstance.java
@@ -30,6 +30,7 @@ import com.twitter.heron.common.basics.Constants;
 import com.twitter.heron.common.basics.NIOLooper;
 import com.twitter.heron.common.basics.SingletonRegistry;
 import com.twitter.heron.common.basics.SlaveLooper;
+import com.twitter.heron.common.basics.SysUtils;
 import com.twitter.heron.common.config.SystemConfig;
 import com.twitter.heron.common.utils.logging.ErrorReportLoggingHandler;
 import com.twitter.heron.common.utils.logging.LoggingHelper;
@@ -130,9 +131,9 @@ public class HeronInstance {
     if (args.length < 10) {
       throw new RuntimeException(
           "Invalid arguments; Usage is java com.twitter.heron.instance.HeronInstance "
-          + "<topology_name> <topology_id> <instance_id> <component_name> <task_id> "
-          + "<component_index> <stmgr_id> <stmgr_port> <metricsmgr_port> "
-          + "<heron_internals_config_filename>");
+              + "<topology_name> <topology_id> <instance_id> <component_name> <task_id> "
+              + "<component_index> <stmgr_id> <stmgr_port> <metricsmgr_port> "
+              + "<heron_internals_config_filename>");
     }
 
     String topologyName = args[0];
@@ -252,7 +253,7 @@ public class HeronInstance {
 
     @Override
     public void run() {
-      gateway.close();
+      SysUtils.closeIgnoringExceptions(gateway);
 
       stop();
     }
@@ -263,7 +264,7 @@ public class HeronInstance {
 
     @Override
     public void run() {
-      slave.close();
+      SysUtils.closeIgnoringExceptions(slave);
     }
   }
 

--- a/heron/instance/src/java/com/twitter/heron/instance/Slave.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/Slave.java
@@ -37,7 +37,7 @@ import com.twitter.heron.proto.system.Metrics;
  * It is a Runnable so it could be executed in a Thread. During run(), it will begin the SlaveLooper's loop().
  */
 
-public class Slave implements Runnable {
+public class Slave implements Runnable, AutoCloseable {
   private static final Logger LOG = Logger.getLogger(Slave.class.getName());
 
   private final SlaveLooper slaveLooper;

--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/MetricsManager.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/MetricsManager.java
@@ -31,6 +31,7 @@ import com.twitter.heron.common.basics.Constants;
 import com.twitter.heron.common.basics.NIOLooper;
 import com.twitter.heron.common.basics.SingletonRegistry;
 import com.twitter.heron.common.basics.SlaveLooper;
+import com.twitter.heron.common.basics.SysUtils;
 import com.twitter.heron.common.basics.TypeUtils;
 import com.twitter.heron.common.config.SystemConfig;
 import com.twitter.heron.common.network.HeronSocketOptions;
@@ -342,7 +343,7 @@ public class MetricsManager {
       metricsManagerServer.removeSinkCommunicator(oldSinkExecutor.getCommunicator());
 
       // Close the sink
-      oldSinkExecutor.close();
+      SysUtils.closeIgnoringExceptions(oldSinkExecutor);
 
       if (oldSinkExecutor != null && thisSinkRetryAttempts != 0) {
         LOG.info(String.format("Restarting IMetricsSink: %s with %d available retries",

--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/executor/SinkExecutor.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/executor/SinkExecutor.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.basics.Constants;
 import com.twitter.heron.common.basics.SlaveLooper;
+import com.twitter.heron.common.basics.SysUtils;
 import com.twitter.heron.common.basics.TypeUtils;
 import com.twitter.heron.metricsmgr.MetricsSinksConfig;
 import com.twitter.heron.spi.metricsmgr.metrics.MetricsRecord;
@@ -37,7 +38,7 @@ import com.twitter.heron.spi.metricsmgr.sink.SinkContext;
  * 1. New MetricsRecord comes and notify the SinkExecutor to wake up to process it
  * 2. The time interval to invoke flush() is met so SinkExecutor would wake up to invoke flush()
  */
-public class SinkExecutor implements Runnable {
+public class SinkExecutor implements Runnable, AutoCloseable {
   private final IMetricsSink metricsSink;
   private final SlaveLooper slaveLooper;
 
@@ -84,8 +85,9 @@ public class SinkExecutor implements Runnable {
     return metricsInSinkQueue;
   }
 
+  @Override
   public void close() {
-    metricsSink.close();
+    SysUtils.closeIgnoringExceptions(metricsSink);
   }
 
   @Override

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
@@ -26,6 +26,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
+import com.twitter.heron.common.basics.SysUtils;
 import com.twitter.heron.common.utils.logging.LoggingHelper;
 import com.twitter.heron.proto.scheduler.Scheduler;
 import com.twitter.heron.proto.system.ExecutionEnvironment;
@@ -281,8 +282,7 @@ public final class RuntimeManagerMain {
       // Currently nothing to do here
 
       // 4. Close the resources
-//      runtimeManager.close();
-      statemgr.close();
+      SysUtils.closeIgnoringExceptions(statemgr);
     }
 
     // Log the result and exit

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SchedulerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SchedulerMain.java
@@ -29,6 +29,7 @@ import org.apache.commons.cli.ParseException;
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.Constants;
 import com.twitter.heron.common.basics.FileUtils;
+import com.twitter.heron.common.basics.SysUtils;
 import com.twitter.heron.common.config.SystemConfig;
 import com.twitter.heron.common.utils.logging.LoggingHelper;
 import com.twitter.heron.scheduler.server.SchedulerServer;
@@ -368,9 +369,9 @@ public class SchedulerMain {
       }
 
       // 4. Close the resources
-      scheduler.close();
-      packing.close();
-      statemgr.close();
+      SysUtils.closeIgnoringExceptions(scheduler);
+      SysUtils.closeIgnoringExceptions(packing);
+      SysUtils.closeIgnoringExceptions(statemgr);
     }
 
     return isSuccessful;

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
@@ -28,6 +28,7 @@ import org.apache.commons.cli.ParseException;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.FileUtils;
+import com.twitter.heron.common.basics.SysUtils;
 import com.twitter.heron.common.utils.logging.LoggingHelper;
 import com.twitter.heron.spi.common.ClusterConfig;
 import com.twitter.heron.spi.common.ClusterDefaults;
@@ -370,10 +371,10 @@ public final class SubmitterMain {
       }
 
       // 4. Close the resources
-      uploader.close();
-      packing.close();
-      launcher.close();
-      statemgr.close();
+      SysUtils.closeIgnoringExceptions(uploader);
+      SysUtils.closeIgnoringExceptions(packing);
+      SysUtils.closeIgnoringExceptions(launcher);
+      SysUtils.closeIgnoringExceptions(statemgr);
     }
 
     // Log the result and exit

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/client/LibrarySchedulerClient.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/client/LibrarySchedulerClient.java
@@ -16,6 +16,7 @@ package com.twitter.heron.scheduler.client;
 
 import java.util.logging.Logger;
 
+import com.twitter.heron.common.basics.SysUtils;
 import com.twitter.heron.proto.scheduler.Scheduler;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.scheduler.IScheduler;
@@ -44,7 +45,7 @@ public class LibrarySchedulerClient implements ISchedulerClient {
       scheduler.initialize(config, runtime);
       ret = scheduler.onRestart(restartTopologyRequest);
     } finally {
-      scheduler.close();
+      SysUtils.closeIgnoringExceptions(scheduler);
     }
 
     return ret;
@@ -58,7 +59,7 @@ public class LibrarySchedulerClient implements ISchedulerClient {
       scheduler.initialize(config, runtime);
       ret = scheduler.onKill(killTopologyRequest);
     } finally {
-      scheduler.close();
+      SysUtils.closeIgnoringExceptions(scheduler);
     }
 
     return ret;


### PR DESCRIPTION
1. Add an utils method to close resoures ignoring any exceptions, which can be used
   in cleanup or finally block, to prevent exceptions in close() quit the thread
   (skip rest cleanup.)
2. Add unit tests for this method.
3. Update the code to use this method when possible.
