### PR TITLE
Remove bazel from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ makeflags
 # Bazel generated files #
 #########################
 /bazel-*
-bazel
 scripts/compile/env_exec.sh
 config/heron-config.h
 tools/cpp/osx_gcc_wrapper.sh


### PR DESCRIPTION
This matches bazel anywhere in a path, which we don't want. It causes files under `tools/java/src/com/twitter/bazel/checkstyle` to be ignored for example, which has caused a few missed commits.
