### PR TITLE
fix SchedulerLocation zk node

### DIFF
--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SchedulerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SchedulerMain.java
@@ -351,7 +351,7 @@ public class SchedulerMain {
       // write the scheduler location to state manager
       // Make sure it happens after IScheduler.onScheduler
       isSuccessful = SchedulerUtils.setSchedulerLocation(
-          runtime, server.getHost(), server.getPort(), scheduler);
+          runtime, server.getHost(), server.getPort(), scheduler, Context.schedulerService(config));
 
       if (isSuccessful) {
         // wait until kill request or some interrupt occurs if the scheduler starts successfully

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/SchedulerMainTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/SchedulerMainTest.java
@@ -117,7 +117,7 @@ public class SchedulerMainTest {
     PowerMockito.doReturn(true).
         when(SchedulerUtils.class, "setSchedulerLocation",
             Mockito.any(Config.class),
-            Mockito.anyString(), Mockito.anyInt(), Mockito.eq(scheduler));
+            Mockito.anyString(), Mockito.anyInt(), Mockito.eq(scheduler), Mockito.anyBoolean());
 
     // Avoid infinite waiting
     Shutdown shutdown = Mockito.mock(Shutdown.class);
@@ -193,7 +193,7 @@ public class SchedulerMainTest {
     PowerMockito.doReturn(false).
         when(SchedulerUtils.class, "setSchedulerLocation",
             Mockito.any(Config.class),
-            Mockito.anyString(), Mockito.anyInt(), Mockito.eq(scheduler));
+            Mockito.anyString(), Mockito.anyInt(), Mockito.eq(scheduler), Mockito.anyBoolean());
     Assert.assertFalse(schedulerMain.runScheduler());
 
     Mockito.verify(stateManager).close();

--- a/heron/spi/src/java/com/twitter/heron/spi/statemgr/IStateManager.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/statemgr/IStateManager.java
@@ -89,12 +89,12 @@ public interface IStateManager extends AutoCloseable {
       TopologyAPI.Topology topology, String topologyName);
 
   /**
-   * Set the scheduler location for the given top
+   * Set the scheduler location for the given topology
    *
    * @return Boolean - Success or Failure
    */
   ListenableFuture<Boolean> setSchedulerLocation(
-      Scheduler.SchedulerLocation location, String topologyName);
+      Scheduler.SchedulerLocation location, String topologyName, boolean isService);
 
   /**
    * Delete the tmaster location for the given topology

--- a/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
@@ -110,8 +110,11 @@ public class SchedulerStateManagerAdaptor {
    *
    * @return Boolean - Success or Failure
    */
-  public Boolean setSchedulerLocation(Scheduler.SchedulerLocation location, String topologyName) {
-    return awaitResult(delegate.setSchedulerLocation(location, topologyName));
+  public Boolean setSchedulerLocation(
+      Scheduler.SchedulerLocation location,
+      String topologyName,
+      boolean isService) {
+    return awaitResult(delegate.setSchedulerLocation(location, topologyName, isService));
   }
 
   /**

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/SchedulerUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/SchedulerUtils.java
@@ -65,7 +65,7 @@ public final class SchedulerUtils {
         // Set the SchedulerLocation at last step,
         // since some methods in IScheduler will provide correct values
         // only after IScheduler.onSchedule is invoked correctly
-        ret = setSchedulerLocation(runtime, scheduler);
+        ret = setLibSchedulerLocation(runtime, scheduler, false);
       } else {
         LOG.severe("Failed to invoke IScheduler as library");
       }
@@ -99,9 +99,6 @@ public final class SchedulerUtils {
     }
 
     int httpPort = freePorts.get(0);
-
-
-
 
     List<String> commands = new ArrayList<>();
 
@@ -221,15 +218,17 @@ public final class SchedulerUtils {
    *
    * @param runtime the runtime configuration
    * @param scheduler the IScheduler to provide more info
+   * @param isService true if the scheduler is a service; false otherwise
    */
-  public static boolean setSchedulerLocation(
+  public static boolean setLibSchedulerLocation(
       Config runtime,
-      IScheduler scheduler) {
+      IScheduler scheduler,
+      boolean isService) {
     // Dummy values since there is no running scheduler server
     final String serverHost = "scheduling_as_library";
     final int serverPort = -1;
 
-    return setSchedulerLocation(runtime, serverHost, serverPort, scheduler);
+    return setSchedulerLocation(runtime, serverHost, serverPort, scheduler, isService);
   }
 
   /**
@@ -244,7 +243,8 @@ public final class SchedulerUtils {
       Config runtime,
       String schedulerServerHost,
       int schedulerServerPort,
-      IScheduler scheduler) {
+      IScheduler scheduler,
+      boolean isService) {
 
     // Set scheduler location to host:port by default. Overwrite scheduler location if behind DNS.
     Scheduler.SchedulerLocation.Builder builder = Scheduler.SchedulerLocation.newBuilder()
@@ -263,7 +263,8 @@ public final class SchedulerUtils {
 
     LOG.log(Level.INFO, "Setting SchedulerLocation: {0}", location);
     SchedulerStateManagerAdaptor statemgr = Runtime.schedulerStateManagerAdaptor(runtime);
-    Boolean result = statemgr.setSchedulerLocation(location, Runtime.topologyName(runtime));
+    Boolean result =
+        statemgr.setSchedulerLocation(location, Runtime.topologyName(runtime), isService);
 
     if (result == null || !result) {
       LOG.severe("Failed to set Scheduler location");

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/NullStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/NullStateManager.java
@@ -75,7 +75,8 @@ public class NullStateManager implements IStateManager {
   @Override
   public ListenableFuture<Boolean> setSchedulerLocation(
       Scheduler.SchedulerLocation location,
-      String topologyName) {
+      String topologyName,
+      boolean isService) {
     return nullFuture;
   }
 

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
@@ -144,7 +144,7 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
 
   @Override
   public ListenableFuture<Boolean> setSchedulerLocation(
-      Scheduler.SchedulerLocation location, String topologyName) {
+      Scheduler.SchedulerLocation location, String topologyName, boolean isService) {
     return setData(getSchedulerLocationPath(topologyName), location.toByteArray());
   }
 

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
@@ -246,8 +246,10 @@ public class CuratorStateManager extends FileSystemStateManager {
   @Override
   public ListenableFuture<Boolean> setSchedulerLocation(
       Scheduler.SchedulerLocation location,
-      String topologyName) {
-    return createNode(getSchedulerLocationPath(topologyName), location.toByteArray(), false);
+      String topologyName,
+      boolean isService) {
+    // if isService, set the node as ephemeral node; set as persistent node otherwise
+    return createNode(getSchedulerLocationPath(topologyName), location.toByteArray(), isService);
   }
 
   @Override


### PR DESCRIPTION
1. set topology’s SchedulerLocation as ephemeral node is not correct: once the session ends, the whole data is deleted. Heron-Tracker always gets null result.
2. make scheduler location as a normal znode and delete it when cleaning the state
