### PR TITLE
Fix broken links from zookeeper and schedulers/ directory creation

### DIFF
--- a/website/content/docs/contributors/codebase.md
+++ b/website/content/docs/contributors/codebase.md
@@ -41,8 +41,8 @@ communication between components. Most `.proto` definition files can be found in
 [`heron/proto`]({{% githubMaster %}}/heron/proto).
 
 * **Cluster coordination** &mdash; Heron relies heavily on ZooKeeper for cluster
-coordination for distributed deployment, be it for [Mesos/Aurora](../../operators/deployment/aurora),
-[Mesos alone](../../operators/deployment/mesos), or for a [custom
+coordination for distributed deployment, be it for [Mesos/Aurora](../../operators/deployment/schedulers/aurora),
+[Mesos alone](../../operators/deployment/schedulers/mesos), or for a [custom
 scheduler](../custom-scheduler) that you build. More information on ZooKeeper
 components in the codebase can be found in the [State
 Management](#state-management) section below.
@@ -56,18 +56,18 @@ utilities, networking interfaces, and more.
 ## Cluster Scheduling
 
 Heron supports three cluster schedulers out of the box:
-[Mesos](../../operators/deployment/mesos),
-[Aurora](../../operators/deployment/aurora), and a [local
-scheduler](../../operators/deployment/local). The Java code for each of those
+[Mesos](../../operators/deployment/schedulers/mesos),
+[Aurora](../../operators/deployment/schedulers/aurora), and a [local
+scheduler](../../operators/deployment/schedulers/local). The Java code for each of those
 schedulers, as well as for the underlying scheduler API, can be found in
 [`heron/schedulers`]({{% githubMaster %}}/heron/schedulers).
 
 Info on custom schedulers can be found in [Implementing a Custom
 Scheduler](../custom-scheduler); info on the currently available schedulers
 can be found in [Deploying Heron on
-Aurora](../../operators/deployment/aurora), [Deploying Heron on
-Mesos](../../operators/deployment/mesos), and [Local
-Deployment](../../operators/deployment/local).
+Aurora](../../operators/deployment/schedulers/aurora), [Deploying Heron on
+Mesos](../../operators/deployment/schedulers/mesos), and [Local
+Deployment](../../operators/deployment/schedulers/local).
 
 ## State Management
 
@@ -146,8 +146,8 @@ The Python code for `heron` can be found in
 
 Sample configurations for different Heron schedulers 
 
-* [Local scheduler](../../operators/deployment/local) config can be found in [`heron/config/src/yaml/conf/local`]({{% githubMaster %}}/heron/config/src/yaml/conf/local),
-* [Aurora scheduler](../../operators/deployment/aurora) config can be found [`heron/config/src/yaml/conf/aurora`]({{% githubMaster %}}/heron/config/src/yaml/conf/aurora).
+* [Local scheduler](../../operators/deployment/schedulers/local) config can be found in [`heron/config/src/yaml/conf/local`]({{% githubMaster %}}/heron/config/src/yaml/conf/local),
+* [Aurora scheduler](../../operators/deployment/schedulers/aurora) config can be found [`heron/config/src/yaml/conf/aurora`]({{% githubMaster %}}/heron/config/src/yaml/conf/aurora).
 
 ### Heron Tracker
 

--- a/website/content/docs/contributors/custom-scheduler.md
+++ b/website/content/docs/contributors/custom-scheduler.md
@@ -5,9 +5,9 @@ title: Implementing a Custom Scheduler
 To run a Heron cluster, you'll need to set up a scheduler that is responsible
 for cluster management. Heron supports three schedulers out of the box:
 
-* [Mesos](../../operators/deployment/mesos)
-* [Aurora](../../operators/deployment/aurora)
-* [Local scheduler](../../operators/deployment/local)
+* [Mesos](../../operators/deployment/schedulers/mesos)
+* [Aurora](../../operators/deployment/schedulers/aurora)
+* [Local scheduler](../../operators/deployment/schedulers/local)
 
 If you'd like to run Heron on a not-yet-supported system, such as
 [YARN](https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/YARN.html)

--- a/website/content/docs/operators/deployment/index.md
+++ b/website/content/docs/operators/deployment/index.md
@@ -3,9 +3,9 @@
 Heron is designed to be run in clustered, scheduler-driven environments. It
 currently supports three scheduler options out of the box:
 
-* [Aurora](aurora)
-* [Mesos](mesos)
-* [Local scheduler](local)
+* [Aurora](schedulers/aurora)
+* [Mesos](schedulers/mesos)
+* [Local scheduler](schedulers/local)
 
 To implement a new scheduler, see
 [Implementing a Custom Scheduler](../../contributors/custom-scheduler).

--- a/website/content/docs/operators/deployment/schedulers/aurora.md
+++ b/website/content/docs/operators/deployment/schedulers/aurora.md
@@ -10,14 +10,14 @@ a [local scheduler](../local).
 
 Aurora doesn't have a Heron scheduler *per se*. Instead, when a topology is
 submitted to Heron, `heron-cli` interacts with Aurora to automatically stand up
-all the [components](../../../concepts/architecture) necessary to [manage
-topologies](../../heron-cli).
+all the [components](../../../../concepts/architecture) necessary to [manage
+topologies](../../../heron-cli).
 
 ## ZooKeeper
 
 To run Heron on Aurora, you'll need to set up a ZooKeeper cluster and configure
 Heron to communicate with it. Instructions can be found in [Setting up
-ZooKeeper](../zookeeper).
+ZooKeeper](../../statemanagers/zookeeper).
 
 ## Hosting Binaries
 
@@ -26,7 +26,7 @@ variety of Heron binaries, which can be hosted wherever you'd like, so long as
 it's accessible to Aurora (for example in [Amazon
 S3](https://aws.amazon.com/s3/) or using a local blob storage solution). You can
 build those binaries using the instructions in [Creating a New Heron
-Release](../../../developers/compiling#building-a-full-release-package).
+Release](../../../../developers/compiling#building-a-full-release-package).
 
 Once your Heron binaries are hosted somewhere that is accessible to Aurora, you
 should run tests to ensure that Aurora can successfully fetch them.
@@ -43,14 +43,14 @@ any machine that has the `heron-cli` tool can be used to manage Heron topologies
 (i.e. can submit topologies, activate and deactivate them, etc.).
 
 The most important thing at this stage is to ensure that `heron-cli` is synced
-across all machines that will be [working with topologies](../../heron-cli).
+across all machines that will be [working with topologies](../../../heron-cli).
 Once that has been ensured, you can use Aurora as a scheduler by specifying the
 proper configuration and configuration loader when managing topologies.
 
 ### Specifying a Configuration
 
 You'll need to specify a scheduler configuration at all stages of a topology's
-[lifecycle](../../../concepts/topologies#topology-lifecycle) by using the
+[lifecycle](../../../../concepts/topologies#topology-lifecycle) by using the
 `--config-file` flag to point at a configuration file. There is a default Aurora
 configuration located in the Heron repository at
 `heron/cli/src/python/aurora_scheduler.conf`. You can use this file as is,

--- a/website/content/docs/operators/deployment/schedulers/local.md
+++ b/website/content/docs/operators/deployment/schedulers/local.md
@@ -12,7 +12,7 @@ When deploying locally, you can use one of two coordination mechanisms:
 2. [The local filesystem](#local-filesystem)
 
 **Note**: Deploying a Heron cluster locally is not to be confused with Heron's
-[local mode](../developers/java/local-mode.html). Local mode enables you to run
+[local mode](../../developers/java/local-mode.html). Local mode enables you to run
 topologies in a cluster-agnostic JVM process for the purpose of development and
 debugging, while the local scheduler stands up a Heron cluster on a single
 machine.
@@ -20,10 +20,10 @@ machine.
 ## How Local Deployment Works
 
 Using the local scheduler is similar to deploying Heron on other systems in
-that you use the [Heron CLI](../../heron-cli) to manage topologies. The
+that you use the [Heron CLI](../../../heron-cli) to manage topologies. The
 difference is in the configuration and [scheduler
-overrides](../../heron-cli#submitting-a-topology) that you provide when
-you [submit a topology](../../heron-cli#submitting-a-topology).
+overrides](../../../heron-cli#submitting-a-topology) that you provide when
+you [submit a topology](../../../heron-cli#submitting-a-topology).
 
 ### Required Scheduler Overrides
 
@@ -37,13 +37,13 @@ overrides:
   coordination.
 
 For info on scheduler overrides, see the documentation on using the [Heron
-CLI](../../heron-cli).
+CLI](../../../heron-cli).
 
 ### Optional Scheduler Overrides
 
 The `heron.core.release.package` parameter is optional. It specifies the path to
 a local TAR file for the `core` component of the desired Heron release. Assuming
-that you've built a full [Heron release](../../../developers/compiling#building-a-full-release-package), this TAR will be
+that you've built a full [Heron release](../../../../developers/compiling#building-a-full-release-package), this TAR will be
 located by default at `bazel-genfiles/release/heron-core-unversioned.tar`,
 relative to the root of your Heron repository. If you set
 `heron.core.release.package`, Heron will update all local binaries in Heron's
@@ -53,7 +53,7 @@ the binaries already contained in Heron's working directory.
 ### CLI Flags
 
 In addition to setting scheduler overrides, you'll need to set the following
-[CLI flags](../../heron-cli):
+[CLI flags](../../../heron-cli):
 
 * `--config-file` &mdash; This flag needs to point to the `local_scheduler.conf`
   file in `heron/cli/src/python/local_scheduler.conf`.

--- a/website/content/docs/operators/deployment/schedulers/mesos.md
+++ b/website/content/docs/operators/deployment/schedulers/mesos.md
@@ -9,14 +9,14 @@ a scheduler or using a [local scheduler](../local).
 ## How Heron on Mesos Works
 
 Heron's Mesos scheduler interacts with Mesos to stand up all of the
-[components](../../../concepts/architecture) necessary to [manage
-topologies](../../heron-cli).
+[components](../../../../concepts/architecture) necessary to [manage
+topologies](../../../heron-cli).
 
 ## ZooKeeper
 
 To run Heron on Mesos, you'll need to set up a ZooKeeper cluster and configure
 Heron to communicate with it. Instructions can be found in [Setting up
-ZooKeeper](../zookeeper).
+ZooKeeper](../../statemanagers/zookeeper).
 
 ## Hosting Binaries
 
@@ -24,7 +24,7 @@ In order to deploy Heron, your Mesos cluster will need to have access to a
 variety of Heron binaries, which can be hosted wherever you'd like, so long as
 it's accessible to Mesos (for example in [Amazon S3](https://aws.amazon.com/s3/)
 or using a local blog storage solution). You can build those binaries using the
-instructions in [Creating a New Heron Release](../../../developers/compiling#building-a-full-release-package).
+instructions in [Creating a New Heron Release](../../../../developers/compiling#building-a-full-release-package).
 
 Once your Heron binaries are hosted somewhere that's accessible to Mesos, you
 should run tests to ensure that Mesos can successfully fetch them.
@@ -52,14 +52,14 @@ any machine that has the `heron-cli` tool can be used to manage Heron
 topologies (i.e. can submit topologies, activate and deactivate them, etc.).
 
 The most important thing at this stage is to ensure that `heron-cli` is synced
-across all machines that will be [working with topologies](../../heron-cli).
+across all machines that will be [working with topologies](../../../heron-cli).
 Once that has been ensured, you can use Mesos as a scheduler by specifying the
 proper configuration and configuration loader when managing topologies.
 
 ### Specifying a Configuration
 
 You'll need to specify a scheduler configuration at all stages of a topology's
-[lifecycle](../../../concepts/topologies#topology-lifecycle) by using the
+[lifecycle](../../../../concepts/topologies#topology-lifecycle) by using the
 `--config-file` flag to point at a configuration file. There is a default Mesos
 configuration located in the Heron repository at
 `heron/cli/src/python/mesos_scheduler.conf`. You can use this file as is,

--- a/website/content/docs/operators/heron-tracker.md
+++ b/website/content/docs/operators/heron-tracker.md
@@ -8,7 +8,7 @@ that information through a JSON REST API.  More on the role of the Tracker can
 be found [here](../../concepts/architecture#heron-tracker).
 
 The Tracker can run within your Heron cluster (e.g.
-[Mesos](../../operators/deployment/mesos) or [Aurora](../../operators/deployment/aurora)) or
+[Mesos](../../operators/deployment/schedulers/mesos) or [Aurora](../../operators/deployment/schedulers/aurora)) or
 outside of it, provided that the machine on which it runs has access to your
 Heron cluster.
 


### PR DESCRIPTION
Fixes broken links from #592. @kramasamy when moving pages the links to them need to be updated. You can do the following to make sure you haven't missed any:

```
cd website
make linkchecker
```
