### PR TITLE
Refactor RuntimeManagerMain and add unit tests

### DIFF
--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
@@ -41,11 +41,7 @@ import com.twitter.heron.spi.statemgr.IStateManager;
 import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
 import com.twitter.heron.spi.utils.ReflectionUtils;
 
-public final class RuntimeManagerMain {
-  private RuntimeManagerMain() {
-
-  }
-
+public class RuntimeManagerMain {
   private static final Logger LOG = Logger.getLogger(RuntimeManagerMain.class.getName());
 
   // Print usage options
@@ -229,6 +225,7 @@ public final class RuntimeManagerMain {
         .put(Keys.cluster(), cluster)
         .put(Keys.role(), role)
         .put(Keys.environ(), environ)
+        .put(Keys.verbose(), verbose)
         .put(Keys.topologyContainerId(), containerId);
 
     Config.Builder topologyConfig = Config.newBuilder()
@@ -249,10 +246,53 @@ public final class RuntimeManagerMain {
     LOG.fine("Static config loaded successfully ");
     LOG.fine(config.toString());
 
+    // Create a new instance of RuntimeManagerMain
+    RuntimeManagerMain runtimeManagerMain = new RuntimeManagerMain(config, command);
+    boolean isSuccessful = runtimeManagerMain.manageTopology();
+
+    // Log the result and exit
+    if (!isSuccessful) {
+      throw new RuntimeException(String.format("Failed to %s topology %s", command, topologyName));
+    } else {
+      LOG.log(Level.FINE, "Topology {0} {1} successfully", new Object[]{topologyName, command});
+    }
+  }
+
+  // holds all the config read
+  private final Config config;
+  // holds all runtime Config
+  private Config runtime;
+  // command to manange a topology
+  private final Command command;
+
+  public RuntimeManagerMain(
+      Config config,
+      Command command) throws IOException {
+    // initialize the options
+    this.config = config;
+    this.command = command;
+  }
+
+  /**
+   * Manager a topology
+   * 1. Instantiate necessary resources
+   * 2. Valid whether the runtime management is legal
+   * 3. Complete the runtime management for a specific command
+   *
+   * @return true if run runtimeManager successfully
+   */
+  public boolean manageTopology() {
+    String topologyName = Context.topologyName(config);
     // 1. Do prepare work
     // create an instance of state manager
     String statemgrClass = Context.stateManagerClass(config);
-    IStateManager statemgr = ReflectionUtils.newInstance(statemgrClass);
+    IStateManager statemgr;
+    try {
+      statemgr = ReflectionUtils.newInstance(statemgrClass);
+    } catch (IllegalAccessException | InstantiationException | ClassNotFoundException e) {
+      LOG.log(Level.SEVERE, "Failed to instantiate instances", e);
+      return false;
+    }
 
     boolean isSuccessful = false;
 
@@ -264,14 +304,27 @@ public final class RuntimeManagerMain {
       // TODO(mfu): timeout should read from config
       SchedulerStateManagerAdaptor adaptor = new SchedulerStateManagerAdaptor(statemgr, 5000);
 
-      boolean isValid = validateRuntimeManage(config, adaptor, topologyName);
+      boolean isValid = validateRuntimeManage(adaptor, topologyName);
 
       // 2. Try to manage topology if valid
       if (isValid) {
         // invoke the appropriate command to manage the topology
         LOG.log(Level.FINE, "Topology: {0} to be {1}ed", new Object[]{topologyName, command});
 
-        isSuccessful = manageTopology(config, command, adaptor);
+        // build the runtime config
+        runtime = Config.newBuilder()
+            .put(Keys.topologyName(), Context.topologyName(config))
+            .put(Keys.schedulerStateManagerAdaptor(), adaptor)
+            .build();
+
+        // Create a ISchedulerClient basing on the config
+        ISchedulerClient schedulerClient = getSchedulerClient();
+        if (schedulerClient == null) {
+          LOG.severe("Failed to initialize scheduler client");
+          return false;
+        }
+
+        isSuccessful = callRuntimeManagerRunner(schedulerClient);
       }
     } finally {
       // 3. Do post work basing on the result
@@ -281,16 +334,10 @@ public final class RuntimeManagerMain {
       SysUtils.closeIgnoringExceptions(statemgr);
     }
 
-    // Log the result and exit
-    if (!isSuccessful) {
-      throw new RuntimeException(String.format("Failed to %s topology %s", command, topologyName));
-    } else {
-      LOG.log(Level.FINE, "Topology {0} {1} successfully", new Object[]{topologyName, command});
-    }
+    return isSuccessful;
   }
 
-  public static boolean validateRuntimeManage(
-      Config config,
+  protected boolean validateRuntimeManage(
       SchedulerStateManagerAdaptor adaptor,
       String topologyName) {
     // Check whether the topology has already been running
@@ -314,31 +361,18 @@ public final class RuntimeManagerMain {
     return true;
   }
 
-  public static boolean manageTopology(
-      Config config, Command command,
-      SchedulerStateManagerAdaptor adaptor)
-      throws ClassNotFoundException, IllegalAccessException, InstantiationException, IOException {
-    // build the runtime config
-    Config runtime = Config.newBuilder()
-        .put(Keys.topologyName(), Context.topologyName(config))
-        .put(Keys.schedulerStateManagerAdaptor(), adaptor)
-        .build();
-
-    // Create a ISchedulerClient basing on the config
-    ISchedulerClient schedulerClient =
-        new SchedulerClientFactory(config, runtime).getSchedulerClient();
-    if (schedulerClient == null) {
-      throw new IllegalArgumentException("Failed to initialize scheduler client");
-    }
-
+  protected boolean callRuntimeManagerRunner(ISchedulerClient schedulerClient) {
     // create an instance of the runner class
     RuntimeManagerRunner runtimeManagerRunner =
         new RuntimeManagerRunner(config, runtime, command, schedulerClient);
-
 
     // invoke the appropriate handlers based on command
     boolean ret = runtimeManagerRunner.call();
 
     return ret;
+  }
+
+  protected ISchedulerClient getSchedulerClient() {
+    return new SchedulerClientFactory(config, runtime).getSchedulerClient();
   }
 }

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/client/SchedulerClientFactory.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/client/SchedulerClientFactory.java
@@ -41,10 +41,9 @@ public class SchedulerClientFactory {
    * Implementation of getSchedulerClient - Used to create objects
    * Currently it creates either HttpServiceSchedulerClient or LibrarySchedulerClient
    *
-   * @return getSchedulerClient created
+   * @return getSchedulerClient created. return null if failed to create ISchedulerClient instance
    */
-  public ISchedulerClient getSchedulerClient()
-      throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+  public ISchedulerClient getSchedulerClient() {
     LOG.fine("Creating scheduler client");
     ISchedulerClient schedulerClient;
 
@@ -67,7 +66,13 @@ public class SchedulerClientFactory {
     } else {
       // create an instance of scheduler
       final String schedulerClass = Context.schedulerClass(config);
-      final IScheduler scheduler = ReflectionUtils.newInstance(schedulerClass);
+      final IScheduler scheduler;
+      try {
+        scheduler = ReflectionUtils.newInstance(schedulerClass);
+      } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+        LOG.log(Level.SEVERE, "Failed to reflect new instance", e);
+        return null;
+      }
       LOG.fine("Invoke scheduler as a library");
 
       schedulerClient = new LibrarySchedulerClient(config, runtime, scheduler);

--- a/heron/scheduler-core/tests/java/BUILD
+++ b/heron/scheduler-core/tests/java/BUILD
@@ -46,6 +46,17 @@ java_test(
 )
 
 java_test(
+  name="runtime-manager-main_unittest",
+  srcs=glob(
+    ["**/RuntimeManagerMainTest.java"] +
+    ["**/util/TopologyUtilityTest.java"]
+  ),
+  deps=scheduler_deps_files  +
+    ["//heron/statemgrs/src/java:null-statemgr-java"],
+  size="small",
+)
+
+java_test(
   name="scheduler-main_unittest",
   srcs=glob(
     ["**/SchedulerMainTest.java"] +

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/RuntimeManagerMainTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/RuntimeManagerMainTest.java
@@ -1,0 +1,124 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.twitter.heron.scheduler;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.twitter.heron.proto.system.ExecutionEnvironment;
+import com.twitter.heron.scheduler.client.ISchedulerClient;
+import com.twitter.heron.spi.common.Command;
+import com.twitter.heron.spi.common.Config;
+import com.twitter.heron.spi.common.ConfigKeys;
+import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
+import com.twitter.heron.statemgr.NullStateManager;
+
+public class RuntimeManagerMainTest {
+  private static final String TOPOLOGY_NAME = "topologyName";
+  private static final String TOPOLOGY_ID = "topologyId";
+  private static final Command MOCK_COMMAND = Command.KILL;
+
+  @Test
+  public void testValidateRuntimeManage() throws Exception {
+    final String CLUSTER = "cluster";
+    final String ROLE = "role";
+    final String ENVIRON = "env";
+    Config config = Mockito.mock(Config.class);
+    Mockito.when(config.getStringValue(ConfigKeys.get("CLUSTER"))).thenReturn(CLUSTER);
+    Mockito.when(config.getStringValue(ConfigKeys.get("ROLE"))).thenReturn(ROLE);
+    Mockito.when(config.getStringValue(ConfigKeys.get("ENVIRON"))).thenReturn(ENVIRON);
+
+    SchedulerStateManagerAdaptor adaptor = Mockito.mock(SchedulerStateManagerAdaptor.class);
+    RuntimeManagerMain runtimeManagerMain = new RuntimeManagerMain(config, MOCK_COMMAND);
+
+    // Topology is not running
+    Mockito.when(adaptor.isTopologyRunning(Mockito.eq(TOPOLOGY_NAME))).thenReturn(false);
+    Assert.assertFalse(runtimeManagerMain.validateRuntimeManage(adaptor, TOPOLOGY_NAME));
+    Mockito.when(adaptor.isTopologyRunning(Mockito.eq(TOPOLOGY_NAME))).thenReturn(null);
+    Assert.assertFalse(runtimeManagerMain.validateRuntimeManage(adaptor, TOPOLOGY_NAME));
+
+    // Topology is running
+    Mockito.when(adaptor.isTopologyRunning(Mockito.eq(TOPOLOGY_NAME))).thenReturn(true);
+    ExecutionEnvironment.ExecutionState.Builder stateBuilder =
+        ExecutionEnvironment.ExecutionState.newBuilder().
+            setTopologyName(TOPOLOGY_NAME).
+            setTopologyId(TOPOLOGY_ID).
+            setCluster(CLUSTER).
+            setEnviron(ENVIRON);
+
+    // cluster/role/environ not matched
+    final String WRONG_ROLE = "wrong";
+    ExecutionEnvironment.ExecutionState wrongState = stateBuilder.setRole(WRONG_ROLE).build();
+    Mockito.when(adaptor.getExecutionState(Mockito.eq(TOPOLOGY_NAME))).thenReturn(null);
+    Assert.assertFalse(runtimeManagerMain.validateRuntimeManage(adaptor, TOPOLOGY_NAME));
+    Mockito.when(adaptor.getExecutionState(Mockito.eq(TOPOLOGY_NAME))).thenReturn(wrongState);
+    Assert.assertFalse(runtimeManagerMain.validateRuntimeManage(adaptor, TOPOLOGY_NAME));
+
+    // Matched
+    ExecutionEnvironment.ExecutionState correctState = stateBuilder.setRole(ROLE).build();
+    Mockito.when(adaptor.getExecutionState(Mockito.eq(TOPOLOGY_NAME))).thenReturn(correctState);
+    Assert.assertTrue(runtimeManagerMain.validateRuntimeManage(adaptor, TOPOLOGY_NAME));
+  }
+
+  /**
+   * Test manageTopology()
+   */
+  @Test
+  public void testManageTopology() throws Exception {
+    Config config = Mockito.mock(Config.class);
+    Mockito.when(config.getStringValue(ConfigKeys.get("TOPOLOGY_NAME"))).thenReturn(TOPOLOGY_NAME);
+
+    RuntimeManagerMain runtimeManagerMain =
+        Mockito.spy(new RuntimeManagerMain(config, MOCK_COMMAND));
+
+    // Failed to create state manager instance
+    final String CLASS_NOT_EXIST = "class_not_exist";
+    Mockito.when(config.getStringValue(ConfigKeys.get("STATE_MANAGER_CLASS"))).
+        thenReturn(CLASS_NOT_EXIST);
+    Assert.assertFalse(runtimeManagerMain.manageTopology());
+
+    // Valid state manager class
+    Mockito.when(config.getStringValue(ConfigKeys.get("STATE_MANAGER_CLASS"))).
+        thenReturn(NullStateManager.class.getName());
+
+    // Failed to valid
+    Mockito.doReturn(false).when(runtimeManagerMain).
+        validateRuntimeManage(Mockito.any(SchedulerStateManagerAdaptor.class),
+            Mockito.eq(TOPOLOGY_NAME));
+    Assert.assertFalse(runtimeManagerMain.manageTopology());
+
+    // Legal request
+    Mockito.doReturn(true).when(runtimeManagerMain).
+        validateRuntimeManage(Mockito.any(SchedulerStateManagerAdaptor.class),
+            Mockito.eq(TOPOLOGY_NAME));
+
+    // Failed to get ISchedulerClient
+    Mockito.doReturn(null).when(runtimeManagerMain).getSchedulerClient();
+    Assert.assertFalse(runtimeManagerMain.manageTopology());
+
+    // Successfully get ISchedulerClient
+    ISchedulerClient client = Mockito.mock(ISchedulerClient.class);
+    Mockito.doReturn(client).when(runtimeManagerMain).getSchedulerClient();
+
+    // Failed to callRuntimeManagerRunner
+    Mockito.doReturn(false).when(runtimeManagerMain).callRuntimeManagerRunner(client);
+    Assert.assertFalse(runtimeManagerMain.manageTopology());
+
+    // Happy path
+    Mockito.doReturn(true).when(runtimeManagerMain).callRuntimeManagerRunner(client);
+    Assert.assertTrue(runtimeManagerMain.manageTopology());
+  }
+}

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/client/SchedulerClientFactoryTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/client/SchedulerClientFactoryTest.java
@@ -15,9 +15,7 @@
 package com.twitter.heron.scheduler.client;
 
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
 import com.twitter.heron.proto.scheduler.Scheduler;
@@ -29,12 +27,6 @@ import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
 
 public class SchedulerClientFactoryTest {
   private static final String TOPOLOGY_NAME = "shiwei_0924_jiayou";
-
-  /**
-   * JUnit rule for expected exception
-   */
-  @Rule
-  public final ExpectedException exception = ExpectedException.none();
 
   @Test
   public void testGetServiceSchedulerClient() throws Exception {
@@ -79,11 +71,6 @@ public class SchedulerClientFactoryTest {
     final String SCHEDULER_CLASS_NOT_EXIST = "class_not_exist";
     Mockito.when(config.getStringValue(ConfigKeys.get("SCHEDULER_CLASS"))).
         thenReturn(SCHEDULER_CLASS_NOT_EXIST);
-    // Expect exceptions
-    exception.expect(ClassNotFoundException.class);
-    new SchedulerClientFactory(config, runtime).getSchedulerClient();
-
-    // Should not be invoked
-    Assert.assertFalse(false);
+    Assert.assertNull(new SchedulerClientFactory(config, runtime).getSchedulerClient());
   }
 }

--- a/heron/statemgrs/src/java/BUILD
+++ b/heron/statemgrs/src/java/BUILD
@@ -31,6 +31,25 @@ java_library(
 )
 
 java_library(
+    name = "null-statemgr-java",
+    srcs = glob(["**/NullStateManager.java"]),
+    deps = common_deps_files,
+)
+
+java_binary(
+    name = "null-statemgr-unshaded",
+    srcs = glob(["**/NullStateManager.java"]),
+    deps = common_deps_files,
+)
+
+genrule(
+    name = "heron-null-statemgr",
+    srcs = [":null-statemgr-unshaded_deploy.jar"],
+    outs = ["heron-null-statemgr.jar"],
+    cmd  = "cp $< $@",
+)
+
+java_library(
     name = "localfs-statemgr-java",
     srcs = glob(["**/FileSystemStateManager.java"]) + glob(["**/localfs/**/*.java"]),
     resources = glob(["**/localfs/**/*.yaml"]),


### PR DESCRIPTION
1. Make it a class can be Instantiated, rather than final class providing only static methods.
   So people can reuse it as a library; also it is easier for unit tests.
2. Add unit tests for RuntimeManagerMain
3. Small refactors on other places.
