### PR TITLE
Error immediately when generating javadocs.

### DIFF
--- a/website/scripts/javadocs.sh
+++ b/website/scripts/javadocs.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-
-# TODO: turn this back on once all the javadoc errors are fixed
 set -e
 
 HERON_ROOT_DIR=$(git rev-parse --show-toplevel)


### PR DESCRIPTION
Since `javadocs.sh` exits with 0 with only warnings (all because `javadoc` wants to transitively generate doc for `com.google.protobuf` but can't find doc for it), we can restore `set -e` now.
#370 can be closed now
