### PR TITLE
Clean configs inside conf folder

### DIFF
--- a/heron/config/src/yaml/conf/aurora/client.yaml
+++ b/heron/config/src/yaml/conf/aurora/client.yaml
@@ -1,6 +1,3 @@
-# location of the core package
-heron.package.core.uri:                      "file:///vagrant/.herondata/dist/heron-core-release.tar.gz"
-heron.directory.java.home:                   /usr/lib/jvm/java-1.8.0-openjdk-amd64/
-
-heron.config.role.required: false
-heron.config.env.required: false
+# Whether role/env is required to submit a topology. Default value is False.
+heron.config.role.required: True
+heron.config.env.required: True

--- a/heron/config/src/yaml/conf/aurora/scheduler.yaml
+++ b/heron/config/src/yaml/conf/aurora/scheduler.yaml
@@ -9,3 +9,6 @@ heron.directory.sandbox.java.home:           /usr/lib/jvm/java-1.8.0-openjdk-amd
 
 # Invoke the IScheduler as a library directly
 heron.scheduler.is.service:                  False
+
+# location of the core package
+heron.package.core.uri:                      "file:///vagrant/.herondata/dist/heron-core-release.tar.gz"

--- a/heron/config/src/yaml/conf/local/client.yaml
+++ b/heron/config/src/yaml/conf/local/client.yaml
@@ -1,5 +1,0 @@
-# location of the core package
-heron.package.core.uri:                      file://${HERON_DIST}/heron-core.tar.gz
-
-heron.config.role.required: false
-heron.config.env.required: false

--- a/heron/config/src/yaml/conf/local/scheduler.yaml
+++ b/heron/config/src/yaml/conf/local/scheduler.yaml
@@ -9,3 +9,6 @@ heron.scheduler.local.working.directory:     ${HOME}/.herondata/topologies/${CLU
 
 # location of java - pick it up from shell environment
 heron.directory.sandbox.java.home:           ${JAVA_HOME}
+
+# location of the core package
+heron.package.core.uri:                      file://${HERON_DIST}/heron-core.tar.gz

--- a/heron/config/src/yaml/conf/localzk/client.yaml
+++ b/heron/config/src/yaml/conf/localzk/client.yaml
@@ -1,2 +1,0 @@
-# location of the core package
-heron.package.core.uri:                      file://${HERON_DIST}/heron-core.tar.gz

--- a/heron/config/src/yaml/conf/localzk/scheduler.yaml
+++ b/heron/config/src/yaml/conf/localzk/scheduler.yaml
@@ -9,3 +9,6 @@ heron.scheduler.local.working.directory:     ${HOME}/.herondata/topologies/${CLU
 
 # location of java - pick it up from shell environment
 heron.directory.sandbox.java.home:           ${JAVA_HOME}
+
+# location of the core package
+heron.package.core.uri:                      file://${HERON_DIST}/heron-core.tar.gz

--- a/heron/config/src/yaml/conf/slurm/client.yaml
+++ b/heron/config/src/yaml/conf/slurm/client.yaml
@@ -1,5 +1,0 @@
-# location of the core package
-heron.package.core.uri:                      file://${HERON_DIST}/heron-core.tar.gz
-
-heron.config.role.required: false
-heron.config.env.required: false

--- a/heron/config/src/yaml/conf/slurm/scheduler.yaml
+++ b/heron/config/src/yaml/conf/slurm/scheduler.yaml
@@ -12,3 +12,6 @@ heron.directory.sandbox.java.home:           ${JAVA_HOME}
 
 # Invoke the IScheduler as a library directly
 heron.scheduler.is.service:                  False
+
+# location of the core package
+heron.package.core.uri:                      file://${HERON_DIST}/heron-core.tar.gz


### PR DESCRIPTION
1. Move heron.package.core.uri from client.yaml to scheduler.yaml
2. Clean unneeded config values, which are same as default values
3. Clean deprecated config
