### PR TITLE
Enable link checker in travis CI, fixes #689

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,5 +48,4 @@ script:
   - gcc --version
   - which g++-4.8
   - g++ --version
-  # TODO: change below from ; to && once all links are fixed so we fail build on bad ones
-  - (cd website && make site); scripts/travis/build.sh && scripts/travis/test.sh
+  - (cd website && make site) && scripts/travis/build.sh && scripts/travis/test.sh


### PR DESCRIPTION
We now have all links working. Now to enforce they stay that way in CI.
