### PR TITLE
Remove localzk from heron_tracker.yaml.

### DIFF
--- a/heron/config/src/yaml/tracker/heron_tracker.yaml
+++ b/heron/config/src/yaml/tracker/heron_tracker.yaml
@@ -13,6 +13,7 @@ statemgrs:
     name: "local"
     rootpath: "~/.herondata/repository/state/local"
     tunnelhost: "localhost"
+#
 # To use 'localzk', launch a zookeeper server locally
 # and create the following paths:
 #   1. /heron/topologies

--- a/heron/config/src/yaml/tracker/heron_tracker.yaml
+++ b/heron/config/src/yaml/tracker/heron_tracker.yaml
@@ -13,12 +13,20 @@ statemgrs:
     name: "local"
     rootpath: "~/.herondata/repository/state/local"
     tunnelhost: "localhost"
-  -
-    type: "zookeeper"
-    name: "localzk"
-    hostport: "localhost:2181"
-    rootpath: "/heron"
-    tunnelhost: "localhost"
+# To use 'localzk', launch a zookeeper server locally
+# and create the following paths:
+#   1. /heron/topologies
+#   2. /heron/executionstate
+#   3. /heron/pplans
+#   4. /heron/tmasters
+#   5. /heron/schedulers
+#
+#  -
+#    type: "zookeeper"
+#    name: "localzk"
+#    hostport: "localhost:2181"
+#    rootpath: "/heron"
+#    tunnelhost: "localhost"
 
 # The URL that points to a topology's metrics dashboard.
 # This value can use following parameters to create a valid


### PR DESCRIPTION
Fixes #779 
Since ZK is not running by default on machines, this config can lead to failure in running tracker locally. So putting the ZK config in comments.