### PR TITLE
Temporary solution to Javadocs issue (#797)

### DIFF
--- a/website/scripts/javadocs.sh
+++ b/website/scripts/javadocs.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 #set -e TODO: figure out why this breaks CI and re-enable (https://github.com/twitter/heron/issues/766)
 
-JAVADOC=javadoc
 FLAGS="-quiet"
 
 HERON_ROOT_DIR=$(git rev-parse --show-toplevel)
@@ -30,8 +29,9 @@ CLOSURE_CLASSES="$HERON_ROOT_DIR/bazel-bin/heron/storm/src/java/_javac/storm-com
 
 export CLASSPATH=$BIN_JARS:$GEN_JARS:$SCRIBE_JARS:$PROTO_JARS:$CLOSURE_CLASSES
 
-$JAVADOC $FLAGS -d $JAVADOC_OUTPUT_DIR $GEN_FILES $HERON_SRC_FILES $BACKTYPE_SRC_FILES $APACHE_SRC_FILES
-cp -rf $JAVADOC_OUTPUT_DIR $JAVADOC_STATIC_OUTPUT_DIR/api
+javadoc $FLAGS -d $JAVADOC_OUTPUT_DIR $GEN_FILES $HERON_SRC_FILES $BACKTYPE_SRC_FILES $APACHE_SRC_FILES
+
+ln -s $JAVADOC_OUTPUT_DIR $JAVADOC_STATIC_OUTPUT_DIR
 
 echo "Javdocs generated at $JAVADOC_OUTPUT_DIR"
 exit 0

--- a/website/scripts/javadocs.sh
+++ b/website/scripts/javadocs.sh
@@ -18,7 +18,7 @@ BACKTYPE_SRC_FILES=`find $HERON_ROOT_DIR -path "*/backtype/storm/*" -name "*.jav
 APACHE_SRC_FILES=`find $HERON_ROOT_DIR -path "*/org/apache/storm/*" -name "*.java"`
 GEN_FILES=`find $GEN_PROTO_DIR -name "*.java"`
 
-rm -rf $JAVADOC_OUTPUT_DIR
+rm -rf $JAVADOC_OUTPUT_DIR $JAVADOC_STATIC_OUTPUT_DIR/api
 mkdir -p $JAVADOC_OUTPUT_DIR $JAVADOC_STATIC_OUTPUT_DIR
 
 BIN_JARS=`find $HERON_ROOT_DIR/bazel-heron/_bin/. -name "*\.jar" | tr '\n' ':'`

--- a/website/scripts/javadocs.sh
+++ b/website/scripts/javadocs.sh
@@ -6,6 +6,7 @@ FLAGS="-quiet"
 
 HERON_ROOT_DIR=$(git rev-parse --show-toplevel)
 JAVADOC_OUTPUT_DIR=$HERON_ROOT_DIR/website/public/api
+JAVADOC_STATIC_OUTPUT_DIR=$HERON_ROOT_DIR/website/static
 GEN_PROTO_DIR=$HERON_ROOT_DIR/bazel-bin/heron/proto/_javac
 
 (cd $HERON_ROOT_DIR && bazel build \
@@ -19,7 +20,7 @@ APACHE_SRC_FILES=`find $HERON_ROOT_DIR -path "*/org/apache/storm/*" -name "*.jav
 GEN_FILES=`find $GEN_PROTO_DIR -name "*.java"`
 
 rm -rf $JAVADOC_OUTPUT_DIR
-mkdir -p $JAVADOC_OUTPUT_DIR
+mkdir -p $JAVADOC_OUTPUT_DIR $JAVADOC_STATIC_OUTPUT_DIR
 
 BIN_JARS=`find $HERON_ROOT_DIR/bazel-heron/_bin/. -name "*\.jar" | tr '\n' ':'`
 GEN_JARS=`find $HERON_ROOT_DIR/bazel-genfiles/external/. -name "*\.jar" | tr '\n' ':'`
@@ -30,6 +31,7 @@ CLOSURE_CLASSES="$HERON_ROOT_DIR/bazel-bin/heron/storm/src/java/_javac/storm-com
 export CLASSPATH=$BIN_JARS:$GEN_JARS:$SCRIBE_JARS:$PROTO_JARS:$CLOSURE_CLASSES
 
 $JAVADOC $FLAGS -d $JAVADOC_OUTPUT_DIR $GEN_FILES $HERON_SRC_FILES $BACKTYPE_SRC_FILES $APACHE_SRC_FILES
+cp -rf $JAVADOC_OUTPUT_DIR $JAVADOC_STATIC_OUTPUT_DIR/api
 
 echo "Javdocs generated at $JAVADOC_OUTPUT_DIR"
 exit 0


### PR DESCRIPTION
I'm not particularly fond of this solution and I hope that we can find a better one, but this is *a* solution that eliminates some unpleasant surprises for new users and seems to have very few potential downsides. Some background:

* As far as I can tell, in order to view the Javadocs locally when running `make serve` (which starts up the Hugo server to view the docs locally), they need to be in the `website/static` directory. This is important for developing the docs, fixing links, etc.
* But if the Javadocs are in `website/static` and not in `website/public`  then they can't be published to the `gh-pages` branch (and thus cannot go live on the site).
* Having the Javadocs in both locations provides a solution but it's not [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and feels kind of janky

Suggestions welcome!