### PR TITLE
Fix links in main page footer

### DIFF
--- a/website/layouts/partials/footer.ace
+++ b/website/layouts/partials/footer.ace
@@ -4,10 +4,10 @@ footer.footer.hn-footer role=contentinfo
       .col-lg-12
         ul.hn-footer-links
           li
-            a href=docs/contributors/codebase/ Governance
+            a href=docs/contributors/governance/ Governance
           li
-            a href=docs/contributors/codebase/ Roadmap
+            a href=docs/contributors/roadmap/ Roadmap
           li
-            a href=docs/contributors/codebase/ Support
+            a href=docs/contributors/support/ Support
 
-        p © 2016 Twitter
+        p {{.Now.Year}} Twitter


### PR DESCRIPTION
At the moment, all links in the main page's footer go to the [Heron Code Organization](http://twitter.github.io/heron/docs/contributors/codebase/) page. This PR provides the proper URLs and allows for auto-updating the year in the copyright.