### PR TITLE
Fix Heron build date locale

### DIFF
--- a/docker/build-artifacts.sh
+++ b/docker/build-artifacts.sh
@@ -47,7 +47,7 @@ heron_build_user() {
 }
 
 heron_build_time() {
-  local build_time=$(date)
+  local build_time=$(LC_ALL=en_EN.utf8 date)
   echo $build_time
 }
 

--- a/scripts/release/status.sh
+++ b/scripts/release/status.sh
@@ -62,7 +62,7 @@ echo "HERON_BUILD_HOST ${build_host}"
 
 if [ -z ${HERON_BUILD_TIME+x} ];
 then
-  build_time=$(date)
+  build_time=$(LC_ALL=en_EN.utf8 date)
 else
   build_time=${HERON_BUILD_TIME}
 fi


### PR DESCRIPTION
This PR forcibly sets the date output to be in English. As my default locale is not English, I was getting a corrupted `release.yaml` file and thus was getting errors when trying to run an example topology:

```
 heron submit local ~/.heron/examples/heron-examples.jar com.twitter.heron.examples.ExclamationTopology ExclamationTopology
INFO: Launching topology 'ExclamationTopology'
Exception in thread "main" unacceptable character '' (0x87) special characters are not allowed
in "'reader'", position 45
    at org.yaml.snakeyaml.reader.StreamReader.checkPrintable(StreamReader.java:93)
    at org.yaml.snakeyaml.reader.StreamReader.update(StreamReader.java:192)
    at org.yaml.snakeyaml.reader.StreamReader.<init>(StreamReader.java:60)
    at org.yaml.snakeyaml.Yaml.load(Yaml.java:381)
    at com.twitter.heron.common.config.ConfigReader.loadFile(ConfigReader.java:78)
    at com.twitter.heron.spi.common.ClusterConfig.loadReleaseConfig(ClusterConfig.java:138)
    at com.twitter.heron.spi.common.ClusterConfig.loadConfig(ClusterConfig.java:169)
    at com.twitter.heron.scheduler.SubmitterMain.defaultConfigs(SubmitterMain.java:91)
    at com.twitter.heron.scheduler.SubmitterMain.main(SubmitterMain.java:304)
ERROR: Failed to launch topology 'ExclamationTopology' because User main failed with status 1. Bailing out...
INFO: Elapsed time: 1.173s.
```