### PR TITLE
Add Facebook Open Graph and Twitter Cards metadata

### DIFF
--- a/website/config.yaml
+++ b/website/config.yaml
@@ -18,7 +18,8 @@ PygmentsCodeFences: true
 
 # Site-level parameters available through .Site.Params.{key}
 params:
-  author: Luc Perkins
+  author: Twitter, Inc.
+  description: A realtime, distributed, fault-tolerant stream processing engine from Twitter
   versions:
     heron: 0.13.7
     bazel: 0.1.2
@@ -45,3 +46,14 @@ params:
     twitter: https://twitter.com/heronstreaming
     slack: https://heronusers.slack.com
     googleGroup: https://groups.google.com/forum/#!forum/heron-users
+  seo:
+    opengraph:
+      - property: locale
+        content: en_US
+      - property: type
+        content: article
+    twittercards:
+      - name: card
+        content: summary
+      - name: site
+        content: "@heronstreaming"

--- a/website/layouts/docs/single.ace
+++ b/website/layouts/docs/single.ace
@@ -2,6 +2,7 @@
 html lang={{.Site.LanguageCode}}
   head
     {{partial "meta.html" .}}
+    {{partial "docs/page-meta.html" .}}
     title {{.Site.Title}} Documentation - {{.Title}}
     {{partial "css.includes.html" .}}
     {{partial "js.includes.html" .}}

--- a/website/layouts/index.ace
+++ b/website/layouts/index.ace
@@ -2,6 +2,7 @@
 html lang={{.Site.LanguageCode}}
   head
     {{partial "meta.html" .}}
+    {{partial "index/index-meta.html" .}}
     title {{.Site.Title}}
     {{partial "css.includes.html" .}}
     {{partial "js.includes.html" .}}

--- a/website/layouts/partials/docs/page-meta.ace
+++ b/website/layouts/partials/docs/page-meta.ace
@@ -1,3 +1,4 @@
 meta property=og:site_name content={{.Title}}
+meta property=og:url content={{.URL}}
 meta property=og:description content={{.Description}}
 meta name=twitter:description content={{.Description}}

--- a/website/layouts/partials/docs/page-meta.ace
+++ b/website/layouts/partials/docs/page-meta.ace
@@ -1,0 +1,3 @@
+meta property=og:site_name content={{.Title}}
+meta property=og:description content={{.Description}}
+meta name=twitter:description content={{.Description}}

--- a/website/layouts/partials/index/index-meta.ace
+++ b/website/layouts/partials/index/index-meta.ace
@@ -1,0 +1,3 @@
+meta property=og:site_name content={{.Site.Title}}
+meta property=og:description content={{.Site.Params.description}}
+meta name=twitter:description content={{.Site.Params.description}}

--- a/website/layouts/partials/index/index-meta.ace
+++ b/website/layouts/partials/index/index-meta.ace
@@ -1,3 +1,4 @@
 meta property=og:site_name content={{.Site.Title}}
+meta property=og:url content={{.Site.BaseURL}}
 meta property=og:description content={{.Site.Params.description}}
 meta name=twitter:description content={{.Site.Params.description}}

--- a/website/layouts/partials/meta.ace
+++ b/website/layouts/partials/meta.ace
@@ -3,7 +3,7 @@ link rel="shortcut icon" type=image/png sizes=32x32 href={{.Site.Params.assets.f
 meta charset=utf-8
 meta http-equiv=X-UA-Compatible content="IE=edge,chrome=1"
 meta name=viewport content="width=device-width,initial-scale=1"
-meta name=generator content="Hugo {{.Hugo.Version}}"
+{{.Hugo.Generator}}
 {{range .Site.Params.seo.opengraph}}
 meta property=og:{{.property}} content={{.content}}
 {{end}}

--- a/website/layouts/partials/meta.ace
+++ b/website/layouts/partials/meta.ace
@@ -4,6 +4,14 @@ meta charset=utf-8
 meta http-equiv=X-UA-Compatible content="IE=edge,chrome=1"
 meta name=viewport content="width=device-width,initial-scale=1"
 meta name=generator content="Hugo {{.Hugo.Version}}"
-{{range .Site.Params.meta}}
-meta name={{.Name}} content={{.Content}}
+{{range .Site.Params.seo.opengraph}}
+meta property=og:{{.property}} content={{.content}}
 {{end}}
+meta property=og:title content={{.Site.Title}}
+meta property=og:image content={{.Site.Params.assets.logo}}
+meta property=og:url content={{.Site.BaseURL}}
+{{range .Site.Params.seo.twittercards}}
+meta name=twitter:{{.name}} content={{.content}}
+{{end}}
+meta name=twitter:title content={{.Site.Title}}
+meta name=twitter:image content={{.Site.Params.assets.textLogo}}


### PR DESCRIPTION
This PR adds some basic Open Graph and Twitter Cards metadata to each page. I make a distinction here between the index page and documents (i.e. material in `/docs`). Metadata that applies to all pages is templated in `layouts/partials/meta.ace` and supplied via the `params` in `config.yaml`; metadata that only applies to the index page is templated in `layouts/partials/index/index-meta.ace`; and metadata for documents is templated in `layouts/partials/docs/page-meta.ace`.