### PR TITLE
Fix jQuery URL

### DIFF
--- a/website/config.yaml
+++ b/website/config.yaml
@@ -34,7 +34,7 @@ params:
       - /css/font-awesome.min.css
       - /css/pygments.css
     js:
-      - http://code.jquery.com/jquery-2.2.1.min.js
+      - https://code.jquery.com/jquery-2.2.1.min.js
       - /js/app.min.js
   tagline: A realtime, distributed, fault-tolerant stream processing engine from Twitter
   github:


### PR DESCRIPTION
The current jQuery URL (as set in `website/config.yaml`, under `params:assets:js`) is HTTP when it should be HTTPS, which may cause issues in HTTPS only environments.