### PR TITLE
Add note that Tracker requires ZK paths before starting.

### DIFF
--- a/heron/config/src/yaml/tracker/heron_tracker.yaml
+++ b/heron/config/src/yaml/tracker/heron_tracker.yaml
@@ -15,12 +15,8 @@ statemgrs:
     tunnelhost: "localhost"
 #
 # To use 'localzk', launch a zookeeper server locally
-# and create the following paths:
-#   1. /heron/topologies
-#   2. /heron/executionstate
-#   3. /heron/pplans
-#   4. /heron/tmasters
-#   5. /heron/schedulers
+# and create the following path:
+#   *. /heron/topologies
 #
 #  -
 #    type: "zookeeper"

--- a/website/content/docs/operators/heron-tracker.md
+++ b/website/content/docs/operators/heron-tracker.md
@@ -51,15 +51,25 @@ statemgrs:
     name: "local"
     rootpath: "~/.herondata/repository/state/local"
     tunnelhost: "localhost"
-  -
-    type: "zookeeper"
-    name: "localzk"
-    hostport: "localhost:2181"
-    rootpath: "/heron/cluster"
-    tunnelhost: "localhost"
+#
+# To use 'localzk', launch a zookeeper server locally
+# and create the following path:
+#  *. /heron/topologies
+#
+#  -
+#    type: "zookeeper"
+#    name: "localzk"
+#    hostport: "localhost:2181"
+#    rootpath: "/heron"
+#    tunnelhost: "localhost" -
 ```
 
-Note that topologies from all the state managers would be read.
+Topologies from all the state managers would be read and can be queried from
+Tracker.
+
+Not that Tracker does not create any zookeeper nodes itself. It is a readonly
+service. If you launch the Tracker without creating `/topologies` node under the
+rootpath, Tracker will fail with a `NoNodeError`.
 
 #### 2. Viz URL Format
 

--- a/website/content/docs/operators/heron-tracker.md
+++ b/website/content/docs/operators/heron-tracker.md
@@ -67,7 +67,7 @@ statemgrs:
 Topologies from all the state managers would be read and can be queried from
 Tracker.
 
-Not that Tracker does not create any zookeeper nodes itself. It is a readonly
+Note that Tracker does not create any zookeeper nodes itself. It is a readonly
 service. If you launch the Tracker without creating `/topologies` node under the
 rootpath, Tracker will fail with a `NoNodeError`.
 


### PR DESCRIPTION
Tracker is a readonly service that does not create ZK nodes if they don't exist, and it might fail with `NoNodeError` if `/topologies` node does not exist under the rootpath. This PR adds this note to the documentation.

Fixes #824.