### PR TITLE
add ci timing info to log output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,4 +48,4 @@ script:
   - gcc --version
   - which g++-4.8
   - g++ --version
-  - (cd website && make site) && scripts/travis/build.sh && scripts/travis/test.sh
+  - scripts/travis/ci.sh

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -6,16 +6,6 @@
 
 set -e
 
-declare -A timings
-
-function start_timer {
-  timings[$1]=`date +%s`
-}
-
-function end_timer {
-  timings[$1]=`date +%s`
-}
-
 # verify that jars have not been added to the repo
 JARS=`find . -name "*.jar"`
 if [ "$JARS" ]; then

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -6,6 +6,16 @@
 
 set -e
 
+declare -A timings
+
+function start_timer {
+  timings[$1]=`date +%s`
+}
+
+function end_timer {
+  timings[$1]=`date +%s`
+}
+
 # verify that jars have not been added to the repo
 JARS=`find . -name "*.jar"`
 if [ "$JARS" ]; then

--- a/scripts/travis/ci.sh
+++ b/scripts/travis/ci.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+DIR=`dirname $0`
+
+source ${DIR}/common.sh
+
+start_timer "make site"
+(cd website && make site)
+end_timer "make site"
+
+start_timer "${DIR}/build.sh"
+${DIR}/build.sh
+end_timer "${DIR}/build.sh"
+
+start_timer "${DIR}/test.sh"
+${DIR}/test.sh
+end_timer "${DIR}/test.sh"
+
+print_timer_summary

--- a/scripts/travis/common.sh
+++ b/scripts/travis/common.sh
@@ -15,9 +15,9 @@ function __assert_task_name {
 
 function __secs_to_readable_date {
   if [ "`uname`" == "Darwin" ]; then
-    echo `date -r $1 +%Y-%m-%d:%H:%M:%S`
+    echo `date -r $1 +'%Y-%m-%d %H:%M:%S'`
   else
-    echo `date -d @$1 +%Y-%m-%d:%H:%M:%S`
+    echo `date -d @$1 +'%Y-%m-%d %H:%M:%S'`
   fi
 }
 

--- a/scripts/travis/common.sh
+++ b/scripts/travis/common.sh
@@ -9,25 +9,25 @@ function die {
 TIMINGS=()
 DELIM="::"
 
-function assert_task_name {
+function __assert_task_name {
   [[ $1 != *"$DELIM"* ]] || die "timer task name '$1' name must not contain ::"
 }
 
-function readable_date {
+function __secs_to_readable_date {
   echo `date -r $1 +%Y-%m-%d:%H:%M:%S`
 }
 
 # Call start_timer "some timer name" to start a timer with that name
 function start_timer {
-  assert_task_name "$1"
+  __assert_task_name "$1"
   local start=`date +%s`
   TIMINGS+=("${1}${DELIM}start=${start}")
-  echo "Starting $1 at `readable_date $start`"
+  echo "Starting $1 at `__secs_to_readable_date $start`"
 }
 
 # Call end_timer "some timer name" to end a timer with that name
 function end_timer {
-  assert_task_name $1
+  __assert_task_name $1
   local end=`date +%s`
   for ((i = 0; i < ${#TIMINGS[@]}; i++)); do
     value="${TIMINGS[$i]}"
@@ -46,7 +46,7 @@ function end_timer {
 
   TIMINGS+=("${1}${DELIM}end=${end}")
   TIMINGS+=("${1}${DELIM}duration=${duration}")
-  echo "Finished $1 at `readable_date $end` ($duration secs)"
+  echo "Finished $1 at `__secs_to_readable_date $end` ($duration secs)"
 }
 
 # Prints a summary of all completed timers

--- a/tools/travis-ci/bazel.rc
+++ b/tools/travis-ci/bazel.rc
@@ -7,6 +7,9 @@ test --ram_utilization_factor=10
 # This is so we understand failures better
 build --verbose_failures
 
+build --show_timestamps
+test --show_timestamps
+
 # Limits the jobs to 25 since the resources are limited
 build --jobs 25
 
@@ -19,7 +22,6 @@ build --experimental_action_listener=tools/cpp:compile_cpp
 build --experimental_action_listener=tools/java:compile_java
 # TODO: enable this: build --experimental_action_listener=tools/python:compile_python
 build --workspace_status_command scripts/release/status.sh
-build --verbose_failures
 
 # This is so we use a recent enough GCC when building.
 build --crosstool_top //tools/travis-ci/toolchain:CROSSTOOL


### PR DESCRIPTION
To help understand where CI times are spent. Relates to #799.