### PR TITLE
Fix broken script URL

### DIFF
--- a/scripts/packages/api_template_bin.sh
+++ b/scripts/packages/api_template_bin.sh
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Set help URL
+getting_started_url=http://heronstreaming.io/docs/getting-started
+
 # Heron self-extractable installer for api package
 function usage() {
   echo "Usage: $progname [options]" >&2
@@ -43,7 +46,7 @@ function check_unzip() {
   if ! which unzip >/dev/null; then
     echo >&2
     echo "unzip not found, please install the corresponding package." >&2
-    echo "See http://heronstreaming.io/docs/install.html for more information on" >&2
+    echo "See $getting_started_url for more information on" >&2
     echo "dependencies of Heron." >&2
     exit 1
   fi
@@ -54,7 +57,7 @@ function check_tar() {
   if ! which tar >/dev/null; then
     echo >&2
     echo "tar not found, please install the corresponding package." >&2
-    echo "See http://heronstreaming.io/docs/install.html for more information on" >&2
+    echo "See $getting_started_url for more information on" >&2
     echo "dependencies of Heron." >&2
     exit 1
   fi
@@ -65,7 +68,7 @@ function check_maven() {
   if ! which mvn >/dev/null; then
      echo >&2
      echo "maven not found, please install the corresponding package." >&2
-    echo "See http://heronstreaming.io/docs/install.html for more information on" >&2
+    echo "See $getting_started_url for more information on" >&2
     echo "dependencies of Heron." >&2
     exit 1
   fi
@@ -92,7 +95,7 @@ function check_java() {
   if [ ! -x "${JAVA_HOME}/bin/javac" ]; then
     echo >&2
     echo "Java not found, please install the corresponding package" >&2
-    echo "See http://heronstreaming.io/docs/install.html for more information on" >&2
+    echo "See $getting_started_url for more information on" >&2
     echo "dependencies of Heron." >&2
     exit 1
   fi
@@ -188,7 +191,7 @@ cat <<EOF
 
 Heron API is now installed!
 
-See http://heronstreaming.io/docs/getting-started.html for how to use Heron.
+See ${getting_started_url} for how to use Heron.
 EOF
 echo
 cat <<'EOF'

--- a/scripts/packages/client_template_bin.sh
+++ b/scripts/packages/client_template_bin.sh
@@ -16,6 +16,9 @@
 
 # Heron self-extractable installer for client package
 
+# Set help URL
+getting_started_url=http://heronstreaming.io/docs/getting-started
+
 # Installation and etc prefix can be overriden from command line
 install_prefix=${1:-"/usr/local/heron"}
 heronrc=${2:-"/usr/local/heron/etc/heron.heronrc"}
@@ -83,7 +86,7 @@ function test_write() {
 if ! which unzip >/dev/null; then
   echo >&2
   echo "unzip not found, please install the corresponding package." >&2
-  echo "See http://heronstreaming.io/docs/install.html for more information on" >&2
+  echo "See $getting_started_url for more information on" >&2
   echo "dependencies of Heron." >&2
   exit 1
 fi
@@ -93,7 +96,7 @@ fi
 if ! which tar >/dev/null; then
   echo >&2
   echo "tar not found, please install the corresponding package." >&2
-  echo "See http://heronstreaming.io/docs/install.html for more information on" >&2
+  echo "See $getting_started_url for more information on" >&2
   echo "dependencies of Heron." >&2
   exit 1
 fi
@@ -118,7 +121,7 @@ fi
 if [ ! -x "${JAVA_HOME}/bin/javac" ]; then
   echo >&2
   echo "Java not found, please install the corresponding package" >&2
-  echo "See http://heronstreaming.io/docs/install.html for more information on" >&2
+  echo "See $getting_started_url for more information on" >&2
   echo "dependencies of Heron." >&2
   exit 1
 fi
@@ -177,9 +180,9 @@ cat <<EOF
 
 Heron is now installed!
 
-Make sure you have "${bin}" in your path. 
+Make sure you have "${bin}" in your path.
 
-See http://heronstreaming.io/docs/getting-started.html for how to use Heron.
+See ${getting_started_url} for how to use Heron.
 EOF
 echo
 cat <<'EOF'

--- a/scripts/packages/tools_template_bin.sh
+++ b/scripts/packages/tools_template_bin.sh
@@ -16,6 +16,9 @@
 
 # Heron self-extractable installer for tools package
 
+# Set help URL
+getting_started_url=http://heronstreaming.io/docs/getting-started
+
 # Installation and etc prefix can be overriden from command line
 install_prefix=${1:-"/usr/local/herontools"}
 
@@ -74,7 +77,7 @@ function test_write() {
 if ! which unzip >/dev/null; then
   echo >&2
   echo "unzip not found, please install the corresponding package." >&2
-  echo "See http://heronstreaming.io/docs/install.html for more information on" >&2
+  echo "See $getting_started_url for more information on" >&2
   echo "dependencies of Heron." >&2
   exit 1
 fi
@@ -84,7 +87,7 @@ fi
 if ! which tar >/dev/null; then
   echo >&2
   echo "tar not found, please install the corresponding package." >&2
-  echo "See http://heronstreaming.io/docs/install.html for more information on" >&2
+  echo "See $getting_started_urlfor more information on" >&2
   echo "dependencies of Heron." >&2
   exit 1
 fi
@@ -109,7 +112,7 @@ fi
 if [ ! -x "${JAVA_HOME}/bin/javac" ]; then
   echo >&2
   echo "Java not found, please install the corresponding package" >&2
-  echo "See http://heronstreaming.io/docs/install.html for more information on" >&2
+  echo "See $getting_started_url for more information on" >&2
   echo "dependencies of Heron." >&2
   exit 1
 fi
@@ -155,9 +158,9 @@ cat <<EOF
 
 Heron Tools is now installed!
 
-Make sure you have "${bin}" in your path. 
+Make sure you have "${bin}" in your path.
 
-See http://heronstreaming.io/docs/getting-started.html for how to use Heron.
+See ${getting_started_url} for how to use Heron.
 EOF
 echo
 cat <<'EOF'

--- a/scripts/packages/tools_template_bin.sh
+++ b/scripts/packages/tools_template_bin.sh
@@ -87,7 +87,7 @@ fi
 if ! which tar >/dev/null; then
   echo >&2
   echo "tar not found, please install the corresponding package." >&2
-  echo "See $getting_started_urlfor more information on" >&2
+  echo "See $getting_started_url for more information on" >&2
   echo "dependencies of Heron." >&2
   exit 1
 fi

--- a/website/content/docs/getting-started.md
+++ b/website/content/docs/getting-started.md
@@ -1,6 +1,8 @@
 ---
 title: Quick Start Guide
 description: Run a single-node Heron cluster on your laptop
+aliases:
+  - /docs/install.html
 ---
 
 The easiest way to get started learning Heron is to install and run pre-compiled


### PR DESCRIPTION
The URL that is shown to users for more information (http://heronstreaming.io/docs/install.html) does not exist. This PR changes the script template to provide the correct URL (http://heronstreaming.io/docs/getting-started.html) and adds an alias to the Getting Started doc that will redirect users seeing the incorrect URL to the right doc.

The proper re-routing behavior can be seen by going to this link to my personal fork of the website: http://lucperkins.github.io/heron/docs/install.html
