### PR TITLE
Fix broken Dockerfile code sample syntax

### DIFF
--- a/website/Makefile
+++ b/website/Makefile
@@ -2,7 +2,7 @@ setup:
 	@brew list hugo || brew install hugo
 	@npm install
 	@pip uninstall requests
-	@pip install linkchecker pygments requests==2.9.0
+	@pip install linkchecker pygments==2.1.3 requests==2.9.0
 
 clean:
 	rm -rf public/*


### PR DESCRIPTION
At the moment, the `Dockerfile` syntax highlighting on [this page](http://twitter.github.io/heron/docs/developers/compiling/docker/) is broken because it was generated using an outdated version of [Pygments](http://pygments.org/), which is used by [Hugo](http://gohugo.io/) to generate those snippets. This PR changes the website setup script to include installation of Pygments 2.1.3, which supports the `Dockerfile` syntax.