### PR TITLE
Remove dependency on log4j-over-slf4j

### DIFF
--- a/3rdparty/java/BUILD
+++ b/3rdparty/java/BUILD
@@ -69,7 +69,6 @@ java_library(
     deps = [
         "@slf4j-api//jar",
         "@slf4j-jdk//jar",
-        "@log4j-over-slf4j//jar",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -137,11 +137,6 @@ maven_jar(
 )
 
 maven_jar(
-  name = "log4j-over-slf4j",
-  artifact = "org.slf4j:log4j-over-slf4j:" + slf4j_version
-)
-
-maven_jar(
   name = "mesos",
   artifact = "org.apache.mesos:mesos:0.22.0",
 )

--- a/tools/rules/heron_client.bzl
+++ b/tools/rules/heron_client.bzl
@@ -54,5 +54,4 @@ def heron_client_lib_3rdparty_files():
         "@protobuf-java//jar",
         "@slf4j-api//jar",
         "@slf4j-jdk//jar",
-        "@log4j-over-slf4j//jar",
     ]


### PR DESCRIPTION
This fixes #620. Heron does not use log4j api and hence does not need
log4j-over-slf4j. Packing this jar can result in conflicts in cases where
slf4j-log4j binding is present.