### PR TITLE
Correct heron developers doc

### DIFF
--- a/website/content/docs/contributors/custom-metrics-sink.md
+++ b/website/content/docs/contributors/custom-metrics-sink.md
@@ -19,15 +19,15 @@ Heron comes equipped out of the box with three metrics sinks that you can apply
 for a specific topology. The code for these sinks may prove helpful for
 implementing your own.
 
-* [`GraphiteSink`](/api/metrics/com/twitter/heron/metricsmgr/sink/GraphiteSink.html)
+* [`GraphiteSink`](/api/com/twitter/heron/metricsmgr/sink/GraphiteSink.html)
   --- Sends each `MetricsRecord` object to a
   [Graphite](http://graphite.wikidot.com/) instance according to a Graphite
   prefix.
-* [`ScribeSink`](/api/metrics/com/twitter/heron/metricsmgr/sink/ScribeSink.html)
+* [`ScribeSink`](/api/com/twitter/heron/metricsmgr/sink/ScribeSink.html)
   --- Sends each `MetricsRecord` object to a
   [Scribe](https://github.com/facebookarchive/scribe) instance according to a
   Scribe category and namespace.
-* [`FileSink`](/api/metrics/com/twitter/heron/metricsmgr/sink/FileSink.html)
+* [`FileSink`](/api/com/twitter/heron/metricsmgr/sink/FileSink.html)
   --- Writes each `MetricsRecord` object to a JSON file at a specified path.
 
 More on using those sinks in a Heron cluster can be found in [Metrics
@@ -59,7 +59,7 @@ dependencies {
 ## The `IMetricsSink` Interface
 
 Each metrics sink must implement the
-[`IMetricsSink`](http://heronproject.github.io/metrics-api/com/twitter/heron/metricsmgr/IMetricsSink)
+[`IMetricsSink`](/api/com/twitter/heron/spi/metricsmgr/sink/IMetricsSink.html)
 interface, which requires you to implement the following methods:
 
 * `void init(Map<String, Object> conf, SinkContext context)` --- Defines the

--- a/website/content/docs/contributors/custom-metrics-sink.md
+++ b/website/content/docs/contributors/custom-metrics-sink.md
@@ -129,7 +129,7 @@ public class PrintSink implements IMetricsSink {
 ## Configuring Your Custom Sink
 
 The configuration for your sink needs to be provided in the
-[YAML](http://www.yaml.org/) file at `heron/config/metrics_sinks.yaml`.
+[YAML](http://www.yaml.org/) file at `heron/config/src/yaml/conf/${CLUSTER}/metrics_sinks.yaml`.
 
 At the top of that file there's a `sinks` parameter that lists each available
 sink by name. You should add your sink to that list. Here's an example:
@@ -142,7 +142,7 @@ sinks:
   - print-sink
 ```
 
-For each sink you need to specify the following:
+For each sink you are required to specify the followings:
 
 * `class` --- The Java class name of your custom implementation of the
   `IMetricsSink` interface, e.g. `biz.acme.heron.metrics.PrintSink`.
@@ -164,10 +164,14 @@ print-sink:
   sink-restart-attempts: -1 # Attempt to restart forever
 ```
 
+It is optional to add other configurations for the sink. All configurations will be constructed
+ as an unmodifiable map `Map<String, Object> conf` and passed to `init(conf, context)`.
+
 ## Using Your Custom Sink
 
 Once you've made a JAR for your custom Java sink, distributed that JAR to
 `metrics-mgr-classpath` folder, and changed the configuration in
-`heron/config/metrics_sink.yaml`, you'll need to [re-compile
-Heron](../../developers/compiling). Any topology submitted using that compiled
-version of `heron-cli` will include the custom sink.
+`heron/config/src/yaml/conf/${CLUSTER}/metrics_sinks.yaml`. 
+Any topology submitted using that configuration will include the custom sink.You must [re-compile
+Heron](../../developers/compiling) if you want to include the configuration in a new heron-cli distribution. 
+

--- a/website/content/docs/contributors/custom-scheduler.md
+++ b/website/content/docs/contributors/custom-scheduler.md
@@ -3,7 +3,7 @@ title: Implementing a Custom Scheduler
 ---
 
 To run a Heron cluster, you'll need to set up a scheduler that is responsible
-for cluster management. Heron currently supports followings schedulers out of the box:
+for cluster management. Heron currently supports the followings schedulers out of the box:
 
 * [Aurora](../../operators/deployment/schedulers/aurora)
 * [Local scheduler](../../operators/deployment/schedulers/local)
@@ -52,17 +52,14 @@ Interface | Role | Examples
 [`IScheduler`](/api/com/twitter/heron/spi/scheduler/IScheduler.html) | Defines the scheduler object used to construct topologies | [local](/api/com/twitter/heron/scheduler/local/LocalScheduler.html)
 [`IUploader`](/api/com/twitter/heron/spi/uploader/IUploader.html) | Uploads the topology to a shared location accessible to the runtime environment of the topology | [local](/api/com/twitter/heron/uploader/localfs/LocalFileSystemUploader.html) [hdfs](/api/com/twitter/heron/uploader/hdfs/HdfsUploader.html) [s3](/api/com/twitter/heron/uploader/s3/S3Uploader.html)
 
-Your implementation of those interfaces will need to be on Heron's
-[classpath](https://docs.oracle.com/javase/tutorial/essential/environment/paths.html)
-when you [compile Heron](../../developers/compiling).
+Heron provides a number of built-in implementations out of box.
 
-Those interfaces and implementation are independent; you can choose and combine them to fit your use scenarios.
+## Running the Scheduler
 
-## Trying Out Your Scheduler
-
-Once you've implemented a custom scheduler (or other components), you'll need to specify implementation of all interfaces above
-in the [config](../../operators/deployment/configuration) . You'll also need to point to the config folder when submitting a topology via heron-cli. Here's an example [topology
-submission](../../operators/heron-cli#submitting-a-topology) command:
+To run the a custom scheduler, the implementation of the interface above must be specified in the [config](../../operators/deployment/configuration) .
+By default, the heron-cli looks for config under `${HERON_HOME}/conf/`. The location can be overridden using option `--config-path`. 
+Below is an example showing the command for [topology
+submission](../../operators/heron-cli#submitting-a-topology):
 
 ```bash
 $ heron submit [cluster-name-storing-your-new-config]/[role]/[env] \
@@ -70,3 +67,8 @@ $ heron submit [cluster-name-storing-your-new-config]/[role]/[env] \
     /path/to/topology/my-topology.jar \
     biz.acme.topologies.MyTopology 
 ```
+
+The implementation for each of the interface listed above must be on Heron's
+[classpath](https://docs.oracle.com/javase/tutorial/essential/environment/paths.html). 
+
+

--- a/website/content/docs/contributors/custom-scheduler.md
+++ b/website/content/docs/contributors/custom-scheduler.md
@@ -3,15 +3,15 @@ title: Implementing a Custom Scheduler
 ---
 
 To run a Heron cluster, you'll need to set up a scheduler that is responsible
-for cluster management. Heron currently supports two schedulers out of the box:
+for cluster management. Heron currently supports followings schedulers out of the box:
 
 * [Aurora](../../operators/deployment/schedulers/aurora)
 * [Local scheduler](../../operators/deployment/schedulers/local)
+* [Slurm scheduler](../../operators/deployment/schedulers/slurm)
 
 If you'd like to run Heron on a not-yet-supported system, such as
-[YARN](https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/YARN.html)
-or [Amazon ECS](https://aws.amazon.com/ecs/), you can create your own scheduler
-using Heron's [scheduler API](/api/scheduler/index.html), as detailed in the
+[Amazon ECS](https://aws.amazon.com/ecs/), you can create your own scheduler
+using Heron's spi, as detailed in the
 sections below.
 
 Java is currently the only supported language for custom schedulers. This may
@@ -47,48 +47,26 @@ interfaces:
 
 Interface | Role | Examples
 :-------- |:---- |:--------
-[`IConfigLoader`](/api/com/twitter/heron/spi/scheduler/IConfigLoader.html) | Parsing and loading of configuration for the scheduler | [Aurora](/api/scheduler/com/twitter/heron/scheduler/aurora/AuroraConfigLoader.html), [local](/api/scheduler/com/twitter/heron/scheduler/local/LocalConfigLoader.html)
-[`ILauncher`](/api/com/twitter/heron/spi/scheduler/ILauncher.html) | Defines how the scheduler is launched | [Aurora](/api/scheduler/com/twitter/heron/scheduler/aurora/AuroraLauncher.html), [local](/api/scheduler/com/twitter/heron/scheduler/local/LocalLauncher.html)
-[`IRuntimeManager`](/api/com/twitter/heron/spi/scheduler/IRuntimeManager.html) | Handles runtime tasks such as activating topologies, killing topologies, etc. | [Aurora](/api/scheduler/com/twitter/heron/scheduler/aurora/AuroraTopologyRuntimeManager.html), [local](/api/scheduler/com/twitter/heron/scheduler/local/LocalTopologyRuntimeManager.html)
-[`IScheduler`](/api/com/twitter/heron/spi/scheduler/IScheduler.html) | Defines the scheduler object used to construct topologies | [local](/api/scheduler/com/twitter/heron/scheduler/local/LocalScheduler.html)
-[`IUploader`](/api/com/twitter/heron/spi/scheduler/IUploader.html) | Uploads the topology to a shared location that must be accessible to the runtime environment of the topology | [local](/api/scheduler/com/twitter/heron/scheduler/local/LocalUploader.html)
+[`IPacking`](/api/com/twitter/heron/spi/packing/IPacking.html) | Defines the algorithm used to generate physical plan for a topology. | [RoundRobin](/api/com/twitter/heron/packing/roundrobin/RoundRobinPacking.html)
+[`ILauncher`](/api/com/twitter/heron/spi/scheduler/ILauncher.html) | Defines how the scheduler is launched | [Aurora](/api/com/twitter/heron/scheduler/aurora/AuroraLauncher.html), [local](/api/com/twitter/heron/scheduler/local/LocalLauncher.html)
+[`IScheduler`](/api/com/twitter/heron/spi/scheduler/IScheduler.html) | Defines the scheduler object used to construct topologies | [local](/api/com/twitter/heron/scheduler/local/LocalScheduler.html)
+[`IUploader`](/api/com/twitter/heron/spi/uploader/IUploader.html) | Uploads the topology to a shared location accessible to the runtime environment of the topology | [local](/api/com/twitter/heron/uploader/localfs/LocalFileSystemUploader.html) [hdfs](/api/com/twitter/heron/uploader/hdfs/HdfsUploader.html) [s3](/api/com/twitter/heron/uploader/s3/S3Uploader.html)
 
 Your implementation of those interfaces will need to be on Heron's
 [classpath](https://docs.oracle.com/javase/tutorial/essential/environment/paths.html)
 when you [compile Heron](../../developers/compiling).
 
-## Loading Configuration
-
-You can set up a configuration loader for a custom scheduler by implementing the
-[`IConfig`](/api/com/twitter/heron/spi/scheduler/IConfig.html)
-interface. You can use this interface to load configuration from any source
-you'd like, e.g. YAML files, JSON files, or a web service.
-
-If you'd like to load configuration from files using the same syntax as Heron's
-default configuration files for the Aurora and local schedulers (in
-`heron/cli2/src/python`), you can implement the
-[`DefaultConfigLoader`](/api/scheduler/com/twitter/heron/scheduler/util/DefaultConfigLoader.html)
-interface.
-
-## Configurable Parameters
-
-At the very least, your configuration loader will need to be able to load the
-class names (as strings) for your implementations of the components listed
-above, as you can see from the interface definition for
-[`IConfigLoader`](/api/com/twitter/heron/spi/scheduler/IConfigLoader.html).
+Those interfaces and implementation are independent; you can choose and combine them to fit your use scenarios.
 
 ## Trying Out Your Scheduler
 
-Once you've implemented a custom configuration loader, you'll need to specify
-your loader by class using the `--config-loader` flag. If your loader relies on
-a configuration file, specify the path of that file using the `--config-file`
-flag. Here's an example [topology
+Once you've implemented a custom scheduler (or other components), you'll need to specify implementation of all interfaces above
+in the [config](../../operators/deployment/configuration) . You'll also need to point to the config folder when submitting a topology via heron-cli. Here's an example [topology
 submission](../../operators/heron-cli#submitting-a-topology) command:
 
 ```bash
-$ heron-cli submit "topology.debug:true" \
+$ heron submit [cluster-name-storing-your-new-config]/[role]/[env] \
+    --config-path [config-folder-path-storing-your-new-config] \
     /path/to/topology/my-topology.jar \
-    biz.acme.topologies.MyTopology \
-    --config-file=/path/to/config/my_scheduler.conf \
-    --config-loader=biz.acme.config.MyConfigLoader
+    biz.acme.topologies.MyTopology 
 ```

--- a/website/content/docs/contributors/custom-scheduler.md
+++ b/website/content/docs/contributors/custom-scheduler.md
@@ -3,7 +3,7 @@ title: Implementing a Custom Scheduler
 ---
 
 To run a Heron cluster, you'll need to set up a scheduler that is responsible
-for cluster management. Heron currently supports the followings schedulers out of the box:
+for cluster management. Heron currently supports the following schedulers out of the box:
 
 * [Aurora](../../operators/deployment/schedulers/aurora)
 * [Local scheduler](../../operators/deployment/schedulers/local)
@@ -56,8 +56,8 @@ Heron provides a number of built-in implementations out of box.
 
 ## Running the Scheduler
 
-To run the a custom scheduler, the implementation of the interface above must be specified in the [config](../../operators/deployment/configuration) .
-By default, the heron-cli looks for config under `${HERON_HOME}/conf/`. The location can be overridden using option `--config-path`. 
+To run the a custom scheduler, the implementation of the interface above must be specified in the [config](../../operators/deployment/configuration).
+By default, the heron-cli looks for configurations under `${HERON_HOME}/conf/`. The location can be overridden using option `--config-path`. 
 Below is an example showing the command for [topology
 submission](../../operators/heron-cli#submitting-a-topology):
 

--- a/website/content/docs/contributors/custom-scheduler.md
+++ b/website/content/docs/contributors/custom-scheduler.md
@@ -56,7 +56,7 @@ Heron provides a number of built-in implementations out of box.
 
 ## Running the Scheduler
 
-To run the a custom scheduler, the implementation of the interface above must be specified in the [config](../../operators/deployment/configuration).
+To run the a custom scheduler, the implementation of the interfaces above must be specified in the [config](../../operators/deployment/configuration).
 By default, the heron-cli looks for configurations under `${HERON_HOME}/conf/`. The location can be overridden using option `--config-path`. 
 Below is an example showing the command for [topology
 submission](../../operators/heron-cli#submitting-a-topology):
@@ -68,7 +68,7 @@ $ heron submit [cluster-name-storing-your-new-config]/[role]/[env] \
     biz.acme.topologies.MyTopology 
 ```
 
-The implementation for each of the interface listed above must be on Heron's
+The implementation for each of the interfaces listed above must be on Heron's
 [classpath](https://docs.oracle.com/javase/tutorial/essential/environment/paths.html). 
 
 


### PR DESCRIPTION
1. Correct out-dated docs.
2. Fix broken links.