### PR TITLE
Always log spawned process's stderr

### DIFF
--- a/heron/spi/src/java/com/twitter/heron/spi/common/ShellUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/ShellUtils.java
@@ -73,14 +73,11 @@ public final class ShellUtils {
   public static int runSyncProcess(
       boolean verbose, boolean isInheritIO, String[] cmdline, StringBuilder stdout,
       StringBuilder stderr, File workingDirectory) {
-    // TODO(nbhagat): Update stdout and stderr
-
     StringBuilder pStdOut = stdout;
     StringBuilder pStdErr = stderr;
     try {
-      if (verbose) {
-        LOG.info("$> " + Arrays.toString(cmdline));
-      }
+      // Log the command for debugging
+      LOG.log(Level.FINE, "$> {0}", Arrays.toString(cmdline));
       Process process = getProcessBuilder(isInheritIO, cmdline, workingDirectory).start();
 
       int exitValue = process.waitFor();
@@ -92,9 +89,14 @@ public final class ShellUtils {
       }
       pStdOut.append(inputstreamToString(process.getInputStream()));
       pStdErr.append(inputstreamToString(process.getErrorStream()));
-      if (verbose) {
-        LOG.info(pStdOut.toString());
-        LOG.info(pStdErr.toString());
+
+      if (pStdOut.length() != 0) {
+        LOG.log(Level.FINE, "$> {0}", pStdOut.toString());
+      }
+
+      // Always log the stderr if there is any
+      if (pStdErr.length() != 0) {
+        LOG.log(Level.SEVERE, "$> {0}", pStdErr.toString());
       }
       return exitValue;
     } catch (IOException | InterruptedException e) {
@@ -110,9 +112,8 @@ public final class ShellUtils {
 
   public static Process runASyncProcess(
       boolean verbose, String[] command, File workingDirectory) {
-    if (verbose) {
-      LOG.info("$> " + Arrays.toString(command));
-    }
+    // Log the command for debugging
+    LOG.log(Level.FINE, "$> {0}", Arrays.toString(command));
 
     // For AsyncProcess, we will never inherit IO, since parent process will not
     // be guaranteed alive when children processing trying to flush to

--- a/heron/spi/src/java/com/twitter/heron/spi/common/ShellUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/ShellUtils.java
@@ -90,14 +90,11 @@ public final class ShellUtils {
       pStdOut.append(inputstreamToString(process.getInputStream()));
       pStdErr.append(inputstreamToString(process.getErrorStream()));
 
-      if (pStdOut.length() != 0) {
-        LOG.log(Level.FINE, "$> {0}", pStdOut.toString());
-      }
+      LOG.log(Level.FINE, "\tSTDOUT: {0}", pStdOut.toString());
 
       // Always log the stderr if there is any
-      if (pStdErr.length() != 0) {
-        LOG.log(Level.SEVERE, "$> {0}", pStdErr.toString());
-      }
+      LOG.log(Level.SEVERE, "\tSTDERR: {0}", pStdErr.toString());
+
       return exitValue;
     } catch (IOException | InterruptedException e) {
       LOG.severe("Failed to check status of packer " + e);


### PR DESCRIPTION

Currently only topology submission with flag "--verbose" will log the stdout && stderr
of a process spawned by heron. This pull request always logs the stderr even without "--verbose".