### PR TITLE
return str type for __str__ function

### DIFF
--- a/heron/ui/src/python/handlers/common/graph.py
+++ b/heron/ui/src/python/handlers/common/graph.py
@@ -32,7 +32,7 @@ class Graph(object):
       self.edges[U].add(V)
 
   def __str__(self):
-    print self.edges
+    return str(self.edges)
 
   # Returns the maximum distance between any vertex and U in the connected 
   # component containing U


### PR DESCRIPTION
#### Problem:

According to [Python 2.7 Documentation: Data Model](https://docs.python.org/2.7/reference/datamodel.html#object.__str__):
> object.__str__(self)
Called by the str() built-in function and by the print statement to compute the “informal” string representation of an object. This differs from __repr__() in that it does not have to be a valid Python expression: a more convenient or concise representation may be used instead. **The return value must be a string object**.

However, currently ``__str__`` of ``Graph`` class at [heron/ui/src/python/handlers/common/graph](https://github.com/twitter/heron/blob/master/heron/ui/src/python/handlers/common/graph.py#L35) simply prints out the value. According to Python language's behavior, value ``None`` is returned by default, which is **not** a string object.

![image](https://cloud.githubusercontent.com/assets/3656079/16067030/61a6f548-326d-11e6-8354-89cfba2f80bd.png)


#### Solution:
change to ``return str(...)`` to return a string object



