### PR TITLE
force version and timestamp to be string

### DIFF
--- a/heron/spi/src/java/com/twitter/heron/spi/common/Context.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Context.java
@@ -47,8 +47,8 @@ public class Context {
     return cfg.getStringValue(ConfigKeys.get("BUILD_TIME"));
   }
 
-  public static String buildTimeStamp(Config cfg) {
-    return cfg.getStringValue(ConfigKeys.get("BUILD_TIMESTAMP"));
+  public static Long buildTimeStamp(Config cfg) {
+    return cfg.getLongValue(ConfigKeys.get("BUILD_TIMESTAMP"));
   }
 
   public static String buildHost(Config cfg) {

--- a/scripts/packages/package_info_generator.sh
+++ b/scripts/packages/package_info_generator.sh
@@ -58,7 +58,7 @@ done
 
 echo "heron.build.version : '${release_name}'"
 echo "heron.build.time : ${build_time}"
-echo "heron.build.timestamp : '${build_timestamp}'"
+echo "heron.build.timestamp : ${build_timestamp}"
 echo "heron.build.host : ${build_host}"
 echo "heron.build.user : ${build_user}"
 echo "heron.build.git.revision : ${git_hash}"

--- a/scripts/packages/package_info_generator.sh
+++ b/scripts/packages/package_info_generator.sh
@@ -56,9 +56,9 @@ for i in "${@}"; do
   done <<<"$(cat $i)"
 done
 
-echo "heron.build.version : ${release_name}"
+echo "heron.build.version : '${release_name}'"
 echo "heron.build.time : ${build_time}"
-echo "heron.build.timestamp : ${build_timestamp}"
+echo "heron.build.timestamp : '${build_timestamp}'"
 echo "heron.build.host : ${build_host}"
 echo "heron.build.user : ${build_user}"
 echo "heron.build.git.revision : ${git_hash}"


### PR DESCRIPTION
#920 

Tested locally:
```
Heron is now installed!

Make sure you have "/Users/nlu/bin" in your path.

See http://heronstreaming.io/docs/getting-started for how to use Heron.

heron.build.version : 'neng/fix-version-type'
heron.build.time : Tue Jun 14 21:10:18 PDT 2016
heron.build.timestamp : '1465963818000'
heron.build.host : tw-mbp-nlu
heron.build.user : nlu
heron.build.git.revision : e53c0cf173799dd7802ac3f3bb4e16fad8cdfa04
heron.build.git.status : Modified
```