### PR TITLE
Rewrite RoundRobinPacking class to fix bugs

### DIFF
--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.twitter.heron.api.generated.TopologyAPI;
@@ -27,44 +26,263 @@ import com.twitter.heron.spi.common.Constants;
 import com.twitter.heron.spi.common.Context;
 import com.twitter.heron.spi.common.PackingPlan;
 import com.twitter.heron.spi.packing.IPacking;
-import com.twitter.heron.spi.utils.Runtime;
 import com.twitter.heron.spi.utils.TopologyUtils;
 
 /**
  * Round-robin packing algorithm
+ * <p>
+ * This IPacking implementation generates PackingPlan: instances of the component are assigned
+ * to each container one by one in circular order, without any priority. Each container is expected
+ * to take equal number of instances if # of instances is multiple of # of containers.
+ * <p>
+ * Following semantics are guaranteed:
+ * 1. Every container requires same size of resource, i.e. same cpu, ram and disk.
+ * Consider that instances in different containers can be different, the value of size
+ * will be aligned to the max one.
+ * <p>
+ * 2. The size of resource required by the whole topology is equal to
+ * ((# of container specified in config) + 1) * (size of resource required for a single container).
+ * The extra 1 is considered for Heron internal container,
+ * i.e. the one containing Scheduler and TMaster.
+ * <p>
+ * 3. The disk required for a container is calculated as:
+ * value for com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_DISK_REQUESTED if exists, otherwise,
+ * (disk for instances in container) + (disk padding for heron internal process)
+ * <p>
+ * 4. The cpu required for a container is calculated as:
+ * value for com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_CPU_REQUESTED if exists, otherwise,
+ * (cpu for instances in container) + (cpu padding for heron internal process)
+ * <p>
+ * 5. The ram required for a container is calculated as:
+ * value for com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED if exists, otherwise,
+ * (ram for instances in container) + (ram padding for heron internal process)
+ * <p>
+ * 6. The ram required for one instance is calculated as:
+ * value in com.twitter.heron.api.Config.TOPOLOGY_COMPONENT_RAMMAP if exists, otherwise,
+ * - if com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED not exists:
+ * the default ram value for one instance
+ * - if com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED exists:
+ * ((TOPOLOGY_CONTAINER_RAM_REQUESTED) - (ram padding for heron internal process)
+ * - (ram used by instances within TOPOLOGY_COMPONENT_RAMMAP config))) /
+ * (the # of instances in container not specified in TOPOLOGY_COMPONENT_RAMMAP config)
+ * 7. The pack() return null if PackingPlan fails to pass the safe check, for instance,
+ * the size of ram for an instance is less than the minimal required value.
  */
 public class RoundRobinPacking implements IPacking {
   private static final Logger LOG = Logger.getLogger(RoundRobinPacking.class.getName());
-  private static final long DEFAULT_DISK_PADDING = 12 * Constants.GB;
+
+  // TODO(mfu): Read these values from Config
+  public static final long DEFAULT_DISK_PADDING_PER_CONTAINER = 12L * Constants.GB;
+  public static final long DEFAULT_RAM_PADDING_PER_CONTAINER = 2L * Constants.GB;
+  public static final double DEFAULT_CPU_PADDING_PER_CONTAINER = 1;
+  public static final long MIN_RAM_PER_INSTANCE = 192L * Constants.MB;
+
+  // Use as a stub as default number value when getting config value
+  public static final String NOT_SPECIFIED_NUMBER_VALUE = "-1";
 
   protected TopologyAPI.Topology topology;
-  protected long stmgrRamDefault;
+
   protected long instanceRamDefault;
   protected double instanceCpuDefault;
   protected long instanceDiskDefault;
 
   @Override
   public void initialize(Config config, Config runtime) {
-    this.stmgrRamDefault = Context.stmgrRam(config);
+    this.topology = com.twitter.heron.spi.utils.Runtime.topology(runtime);
+
     this.instanceRamDefault = Context.instanceRam(config);
     this.instanceCpuDefault = Context.instanceCpu(config).doubleValue();
     this.instanceDiskDefault = Context.instanceDisk(config);
-    this.topology = Runtime.topology(runtime);
   }
 
   @Override
   public PackingPlan pack() {
-    Map<String, List<String>> containerInstancesMap = getBasePacking();
-    return fillInResource(containerInstancesMap);
+    // Get the instances' round-robin allocation
+    Map<String, List<String>> roundRobinAllocation = getRoundRobinAllocation();
+
+    // Get the ram map for every instance
+    Map<String, Map<String, Long>> instancesRamMap =
+        getInstancesRamMapInContainer(roundRobinAllocation);
+
+    long containerDiskInBytes = getContainerDiskHint(roundRobinAllocation);
+    double containerCpu = getContainerCpuHint(roundRobinAllocation);
+
+    // Align the ram to the maximal one
+    long containerRam = getLargestContainerRam(instancesRamMap);
+
+    // Construct the PackingPlan
+    Map<String, PackingPlan.ContainerPlan> containerPlanMap = new HashMap<>();
+
+    for (Map.Entry<String, List<String>> entry : roundRobinAllocation.entrySet()) {
+      String containerId = entry.getKey();
+      List<String> instanceList = entry.getValue();
+
+      // Calculate the resource required for single instance
+      Map<String, PackingPlan.InstancePlan> instancePlanMap = new HashMap<>();
+      for (String instanceId : instanceList) {
+        long instanceRam = instancesRamMap.get(containerId).get(instanceId);
+
+        // Currently not yet support disk or cpu config for different components,
+        // so just use the default value.
+        long instanceDisk = instanceDiskDefault;
+        double instanceCpu = instanceCpuDefault;
+
+        PackingPlan.Resource resource =
+            new PackingPlan.Resource(instanceCpu, instanceRam, instanceDisk);
+        PackingPlan.InstancePlan instancePlan =
+            new PackingPlan.InstancePlan(
+                instanceId,
+                getComponentName(instanceId),
+                resource);
+        // Insert it into the map
+        instancePlanMap.put(instanceId, instancePlan);
+      }
+
+      PackingPlan.Resource resource =
+          new PackingPlan.Resource(containerCpu, containerRam, containerDiskInBytes);
+      PackingPlan.ContainerPlan containerPlan =
+          new PackingPlan.ContainerPlan(containerId, instancePlanMap, resource);
+
+      containerPlanMap.put(containerId, containerPlan);
+    }
+
+    // Take the heron internal container into account
+    int totalContainer = containerPlanMap.size() + 1;
+    long topologyRam = totalContainer * containerRam;
+    long topologyDisk = totalContainer * containerDiskInBytes;
+    double topologyCpu = totalContainer * containerCpu;
+
+    PackingPlan.Resource resource = new PackingPlan.Resource(
+        topologyCpu, topologyRam, topologyDisk);
+
+    PackingPlan plan = new PackingPlan(topology.getId(), containerPlanMap, resource);
+
+    // Check whether it is a valid PackingPlan
+    if (!isValidPackingPlan(plan)) {
+      return null;
+    }
+    return plan;
   }
 
   @Override
   public void close() {
+
   }
 
-  private int getLargestContainerSize(Map<String, List<String>> packing) {
+  /**
+   * Calculate the ram required by any instance in the container
+   *
+   * @param allocation the allocation of instances in different container
+   * @return A map: (containerId -> (instanceId -> instanceRequiredRam))
+   */
+  protected Map<String, Map<String, Long>> getInstancesRamMapInContainer(
+      Map<String, List<String>> allocation) {
+    Map<String, Long> ramMap =
+        TopologyUtils.getComponentRamMap(topology,
+            Long.parseLong(NOT_SPECIFIED_NUMBER_VALUE));
+
+    Map<String, Map<String, Long>> instancesRamMapInContainer = new HashMap<>();
+
+    for (Map.Entry<String, List<String>> entry : allocation.entrySet()) {
+      String containerId = entry.getKey();
+      Map<String, Long> ramInsideContainer = new HashMap<>();
+      instancesRamMapInContainer.put(containerId, ramInsideContainer);
+
+      // Calculate the actual value
+      long usedRam = 0;
+      for (String instanceId : entry.getValue()) {
+        String componentName = getComponentName(instanceId);
+        long ram = ramMap.get(componentName);
+
+        // Use component ram map if set
+        if (ram != Long.parseLong(NOT_SPECIFIED_NUMBER_VALUE)) {
+          ramInsideContainer.put(instanceId, ram);
+          usedRam += ram;
+        }
+      }
+
+      // Now we have calculated ram for instances specified in ComponentRamMap
+      // Then to calculate ram for the rest instances
+      long containerRamHint = getContainerRamHint(allocation);
+      int instancesAllocated = ramInsideContainer.size();
+      int instancesToAllocate = entry.getValue().size() - instancesAllocated;
+
+      if (instancesToAllocate != 0) {
+        // The ram map is partially set. We need to calculate ram for the rest
+
+        // We have different strategy depending on whether container ram is specified
+        // If container ram is specified
+        if (containerRamHint != Long.parseLong(NOT_SPECIFIED_NUMBER_VALUE)) {
+          // remove ram for heron internal process
+          long remainingRam = containerRamHint - DEFAULT_RAM_PADDING_PER_CONTAINER - usedRam;
+
+          // Split remaining ram evenly
+          long individualInstanceRam = remainingRam / instancesToAllocate;
+
+          // Put the results in instancesRam
+          for (String instanceId : entry.getValue()) {
+            if (!ramInsideContainer.containsKey(instanceId)) {
+              ramInsideContainer.put(instanceId, individualInstanceRam);
+            }
+          }
+        } else {
+          // If container ram is not specified
+          for (String instanceId : entry.getValue()) {
+            if (!ramInsideContainer.containsKey(instanceId)) {
+              ramInsideContainer.put(instanceId, instanceRamDefault);
+            }
+          }
+        }
+      }
+    }
+
+    return instancesRamMapInContainer;
+  }
+
+
+  /**
+   * Get the instances' allocation basing on round robin algorithm
+   *
+   * @return containerId -> list of InstanceId belonging to this container
+   */
+  protected Map<String, List<String>> getRoundRobinAllocation() {
+    Map<String, List<String>> allocation = new HashMap<>();
+    int numContainer = TopologyUtils.getNumContainers(topology);
+    int totalInstance = TopologyUtils.getTotalInstance(topology);
+    if (numContainer > totalInstance) {
+      throw new RuntimeException("More containers allocated than instance.");
+    }
+
+    for (int i = 1; i <= numContainer; ++i) {
+      allocation.put(getContainerId(i), new ArrayList<String>());
+    }
+
+    int index = 1;
+    int globalTaskIndex = 1;
+    Map<String, Integer> parallelismMap = TopologyUtils.getComponentParallelism(topology);
+    for (String component : parallelismMap.keySet()) {
+      int numInstance = parallelismMap.get(component);
+      for (int i = 0; i < numInstance; ++i) {
+        allocation.
+            get(getContainerId(index)).
+            add(getInstanceId(index, component, globalTaskIndex, i));
+
+        index = (index == numContainer) ? 1 : index + 1;
+        globalTaskIndex++;
+      }
+    }
+    return allocation;
+  }
+
+  /**
+   * Get # of instances in the largest container
+   *
+   * @param allocation the instances' allocation
+   * @return # of instances in the largest container
+   */
+  protected int getLargestContainerSize(Map<String, List<String>> allocation) {
     int max = 0;
-    for (List<String> instances : packing.values()) {
+    for (List<String> instances : allocation.values()) {
       if (instances.size() > max) {
         max = instances.size();
       }
@@ -75,16 +293,13 @@ public class RoundRobinPacking implements IPacking {
   /**
    * Provide cpu per container.
    *
-   * @param packing packing output.
+   * @param allocation packing output.
    * @return cpu per container.
    */
-  public double getContainerCpuHint(Map<String, List<String>> packing) {
+  protected double getContainerCpuHint(Map<String, List<String>> allocation) {
     List<TopologyAPI.Config.KeyValue> topologyConfig = topology.getTopologyConfig().getKvsList();
-    double totalInstanceCpu = instanceCpuDefault * TopologyUtils.getTotalInstance(topology);
-    // TODO(nbhagat): Add 1 more cpu for metrics manager also.
-    // TODO(nbhagat): Use max cpu here. To get max use packing information.
     double defaultContainerCpu =
-        (float) (1 + totalInstanceCpu / TopologyUtils.getNumContainers(topology));
+        DEFAULT_CPU_PADDING_PER_CONTAINER + getLargestContainerSize(allocation);
 
     String cpuHint = TopologyUtils.getConfigWithDefault(
         topologyConfig, com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_CPU_REQUESTED,
@@ -96,212 +311,94 @@ public class RoundRobinPacking implements IPacking {
   /**
    * Provide disk per container.
    *
-   * @param packing packing output.
+   * @param allocation packing output.
    * @return disk per container.
    */
-  public long getContainerDiskHint(Map<String, List<String>> packing) {
+  protected long getContainerDiskHint(Map<String, List<String>> allocation) {
     long defaultContainerDisk =
-        instanceDiskDefault * getLargestContainerSize(packing) + DEFAULT_DISK_PADDING;
+        instanceDiskDefault * getLargestContainerSize(allocation)
+            + DEFAULT_DISK_PADDING_PER_CONTAINER;
 
     List<TopologyAPI.Config.KeyValue> topologyConfig = topology.getTopologyConfig().getKvsList();
 
     String diskHint = TopologyUtils.getConfigWithDefault(
         topologyConfig, com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_DISK_REQUESTED,
-            Long.toString(defaultContainerDisk));
+        Long.toString(defaultContainerDisk));
 
     return Long.parseLong(diskHint);
   }
 
   /**
-   * Provide default ram for instances of component whose Ram requirement is not specified.
+   * Provide ram per container.
    *
-   * @return default ram in bytes.
+   * @param allocation packing
+   * @return Container ram requirement
    */
-  public long getDefaultInstanceRam(Map<String, List<String>> packing) {
+  public long getContainerRamHint(Map<String, List<String>> allocation) {
     List<TopologyAPI.Config.KeyValue> topologyConfig = topology.getTopologyConfig().getKvsList();
 
-    String containerRam = TopologyUtils.getConfigWithDefault(
-        topologyConfig, com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED, "-1");
+    String ramHint = TopologyUtils.getConfigWithDefault(
+        topologyConfig, com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED,
+        NOT_SPECIFIED_NUMBER_VALUE);
 
-    long containerRamRequested = Long.parseLong(containerRam);
-    return getDefaultInstanceRam(
-        packing, topology, instanceRamDefault, stmgrRamDefault, containerRamRequested);
+    return Long.parseLong(ramHint);
   }
 
   /**
-   * Check if user has provided ram for some component. Use user provided ram mapping to override
-   * default ram assignment from config. Default ram assignment depends on if user has provided
-   * by uniformly sharing remaining container's requested ram between all instance. If container
-   * ram is not provided than default is set from config.
+   * Get the ram size capable for the container requiring largest ram
    *
-   * @param packing packing
-   * @return Container ram requirement
+   * @param instancesRamMapInContainer the ram map for any instance in container
+   * (containerId -> (instanceId -> instanceRequiredRam))
+   * @return the ram size
    */
-  public long getContainerRamHint(Map<String, List<String>> packing) {
-    List<TopologyAPI.Config.KeyValue> topologyConfig = topology.getTopologyConfig().getKvsList();
+  protected long getLargestContainerRam(Map<String, Map<String, Long>> instancesRamMapInContainer) {
+    long maxContainerRam = 0;
+    for (Map<String, Long> map : instancesRamMapInContainer.values()) {
+      long usedRam = 0;
+      for (long ram : map.values()) {
+        usedRam += ram;
+      }
+      usedRam += DEFAULT_RAM_PADDING_PER_CONTAINER;
+      maxContainerRam = Math.max(maxContainerRam, usedRam);
+    }
 
-    // Get RAM mapping with default instance ram value.
-    Map<String, Long> ramMap = TopologyUtils.getComponentRamMap(
-        topology, getDefaultInstanceRam(packing));
-    // Find container with maximum ram.
-    long maxRamRequired = 0;
-    for (List<String> instances : packing.values()) {
-      long ramRequired = 0;
-      for (String instanceId : instances) {
-        String componentName = getComponentName(instanceId);
-        ramRequired += ramMap.get(componentName);
-      }
-      if (ramRequired > maxRamRequired) {
-        maxRamRequired = ramRequired;
+    return maxContainerRam;
+  }
+
+  /**
+   * Check whether the PackingPlan generated is valid
+   *
+   * @param plan The PackingPlan to check
+   * @return true if it is valid. Otherwise return false
+   */
+  protected boolean isValidPackingPlan(PackingPlan plan) {
+    for (PackingPlan.ContainerPlan containerPlan : plan.containers.values()) {
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.instances.values()) {
+        // Safe check
+        if (instancePlan.resource.ram < MIN_RAM_PER_INSTANCE) {
+          LOG.severe(String.format(
+              "Require at least %dMB ram. Given on %d MB",
+              MIN_RAM_PER_INSTANCE / Constants.MB, instancePlan.resource.ram / Constants.MB));
+
+          return false;
+        }
       }
     }
-    long defaultRequest = maxRamRequired + stmgrRamDefault;
-    long containerRamRequested = Long.parseLong(TopologyUtils.getConfigWithDefault(
-        topologyConfig, com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED,
-        "" + defaultRequest));
-    if (defaultRequest > containerRamRequested) {
-      LOG.log(Level.SEVERE,
-          "Container is set to value lower than computed defaults. This could be due"
-          + " to incorrect RAM map provided for components.");
-    }
-    return containerRamRequested;
+
+    return true;
   }
 
 
-  public int getNumContainers() {
-    List<TopologyAPI.Config.KeyValue> topologyConfig = topology.getTopologyConfig().getKvsList();
-    return Integer.parseInt(TopologyUtils.getConfigWithDefault(
-        topologyConfig, com.twitter.heron.api.Config.TOPOLOGY_STMGRS, "1").trim());
-  }
-
-  public String getContainerId(int index) {
+  public static String getContainerId(int index) {
     return "" + index;
   }
 
-  public String getInstanceId(
+  public static String getInstanceId(
       int containerIdx, String componentName, int instanceIdx, int componentIdx) {
     return String.format("%d:%s:%d:%d", containerIdx, componentName, instanceIdx, componentIdx);
   }
 
-  /**
-   * Fill in the resources for the base packing of instances into containers
-   */
-  public PackingPlan fillInResource(Map<String, List<String>> basePacking) {
-    Map<String, Long> ramMap = TopologyUtils.getComponentRamMap(
-        topology, getDefaultInstanceRam(basePacking));
-
-    Map<String, PackingPlan.ContainerPlan> containerPlanMap = new HashMap<>();
-
-    long containerRam = getContainerRamHint(basePacking);
-    long containerDisk = getContainerDiskHint(basePacking);
-    double containerCpu = getContainerCpuHint(basePacking);
-
-    for (Map.Entry<String, List<String>> entry : basePacking.entrySet()) {
-      String containerId = entry.getKey();
-      List<String> instanceList = entry.getValue();
-
-      Map<String, PackingPlan.InstancePlan> instancePlanMap = new HashMap<>();
-
-      for (String instanceId : instanceList) {
-        long instanceRam = ramMap.get(getComponentName(instanceId));
-        long instanceDisk = 1 * Constants.GB;  // Not used in aurora.
-
-        PackingPlan.Resource resource =
-            new PackingPlan.Resource(instanceCpuDefault, instanceRam, instanceDisk);
-        PackingPlan.InstancePlan instancePlan =
-            new PackingPlan.InstancePlan(instanceId, getComponentName(instanceId), resource);
-        instancePlanMap.put(instanceId, instancePlan);
-      }
-
-      PackingPlan.Resource resource =
-          new PackingPlan.Resource(containerCpu, containerRam, containerDisk);
-      PackingPlan.ContainerPlan containerPlan =
-          new PackingPlan.ContainerPlan(containerId, instancePlanMap, resource);
-
-      containerPlanMap.put(containerId, containerPlan);
-    }
-
-    // We also need to take TMASTER container into account
-    // TODO(mfu): Figure out a better definition
-    int totalContainer = containerPlanMap.size() + 1;
-    long topologyRam = totalContainer * containerRam;
-    long topologyDisk = totalContainer * containerDisk;
-    double topologyCpu = totalContainer * containerCpu;
-
-    PackingPlan.Resource resource = new PackingPlan.Resource(
-        topologyCpu, topologyRam, topologyDisk);
-    return new PackingPlan(topology.getId(), containerPlanMap, resource);
-  }
-
-  public String getComponentName(String instanceId) {
+  public static String getComponentName(String instanceId) {
     return instanceId.split(":")[1];
-  }
-
-  // Return: containerId -> list of InstanceId belonging to this container
-  private Map<String, List<String>> getBasePacking() {
-    Map<String, List<String>> packing = new HashMap<>();
-    int numContainer = getNumContainers();
-    int totalInstance = TopologyUtils.getTotalInstance(topology);
-    if (numContainer > totalInstance) {
-      throw new RuntimeException("More containers allocated than instance. Bailing out.");
-    }
-
-    for (int i = 1; i <= numContainer; ++i) {
-      packing.put(getContainerId(i), new ArrayList<String>());
-    }
-    int index = 1;
-    int globalTaskIndex = 1;
-    Map<String, Integer> parallelismMap = TopologyUtils.getComponentParallelism(topology);
-    for (String component : parallelismMap.keySet()) {
-      int numInstance = parallelismMap.get(component);
-      for (int i = 0; i < numInstance; ++i) {
-        packing.get(getContainerId(index)).add(getInstanceId(index, component, globalTaskIndex, i));
-        index = (index == numContainer) ? 1 : index + 1;
-        globalTaskIndex++;
-      }
-    }
-    return packing;
-  }
-
-  /**
-   * Provide default ram for instances of component whose Ram requirement is not specified.
-   *
-   * @param instanceRamDefaultValue Default value of instance ram. If no information is specified,
-   * This value will be used.
-   * @param stmgrRam Ram reserved for stream manager
-   * @param containerRamRequested If Container notion is valid then pass that, -1 otherwise.
-   * @return default ram in bytes.
-   */
-  public long getDefaultInstanceRam(Map<String, List<String>> packing,
-                                    TopologyAPI.Topology aTopology,
-                                    long instanceRamDefaultValue,
-                                    long stmgrRam,
-                                    long containerRamRequested) {
-    long defaultInstanceRam = instanceRamDefaultValue;
-
-    if (containerRamRequested != -1) {
-      Map<String, Long> ramMap = TopologyUtils.getComponentRamMap(aTopology, -1);
-      // Find the minimum possible ram that can be fit in this packing.
-      long minInstanceRam = Long.MAX_VALUE;
-      for (List<String> instances : packing.values()) {
-        Long ramRemaining = containerRamRequested - stmgrRam;  // Remove stmgr.
-        int defaultInstance = 0;
-        for (String id : instances) {
-          if (-1 != ramMap.get(getComponentName(id))) {
-            ramRemaining -= ramMap.get(getComponentName(id));  // Remove known ram
-          } else {
-            defaultInstance++;
-          }
-        }
-        // Evenly distribute remaining ram.
-        if (defaultInstance != 0 && minInstanceRam > (ramRemaining / defaultInstance)) {
-          minInstanceRam = ramRemaining / defaultInstance;
-        }
-      }
-      if (minInstanceRam != Integer.MAX_VALUE) {
-        defaultInstanceRam = minInstanceRam;
-      }
-    }
-    return defaultInstanceRam;
   }
 }

--- a/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/RoundRobinPackingTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/RoundRobinPackingTest.java
@@ -15,7 +15,9 @@
 package com.twitter.heron.packing.roundrobin;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -23,21 +25,280 @@ import org.junit.Test;
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.spi.common.ClusterDefaults;
 import com.twitter.heron.spi.common.Config;
+import com.twitter.heron.spi.common.Constants;
 import com.twitter.heron.spi.common.Keys;
 import com.twitter.heron.spi.common.PackingPlan;
 import com.twitter.heron.spi.utils.TopologyTests;
 import com.twitter.heron.spi.utils.TopologyUtils;
 
 public class RoundRobinPackingTest {
-  private int countCompoment(String component, Map<String, PackingPlan.InstancePlan> instances,
-                             RoundRobinPacking packing) {
+  private static final String BOLT_NAME = "bolt";
+  private static final String SPOUT_NAME = "spout";
+  private static final double DELTA = 0.1;
+
+  private int countCompoment(String component, Map<String, PackingPlan.InstancePlan> instances) {
     int count = 0;
     for (PackingPlan.InstancePlan pair : instances.values()) {
-      if (component.equals(packing.getComponentName(pair.id))) {
+      if (component.equals(RoundRobinPacking.getComponentName(pair.id))) {
         count++;
       }
     }
     return count;
+  }
+
+  protected TopologyAPI.Topology getTopology(
+      int spoutParallelism, int boltParallelism,
+      com.twitter.heron.api.Config topologyConfig) {
+    // Setup the spout parallelism
+    Map<String, Integer> spouts = new HashMap<>();
+    spouts.put(SPOUT_NAME, spoutParallelism);
+
+    // Setup the bolt parallelism
+    Map<String, Integer> bolts = new HashMap<>();
+    bolts.put(BOLT_NAME, boltParallelism);
+
+    TopologyAPI.Topology topology =
+        TopologyTests.createTopology("testTopology", topologyConfig, spouts, bolts);
+
+    return topology;
+  }
+
+  protected PackingPlan getRoundRobinPackingPlan(TopologyAPI.Topology topology) {
+    Config config = Config.newBuilder()
+        .put(Keys.topologyId(), topology.getId())
+        .put(Keys.topologyName(), topology.getName())
+        .putAll(ClusterDefaults.getDefaults())
+        .build();
+
+    Config runtime = Config.newBuilder()
+        .put(Keys.topologyDefinition(), topology)
+        .build();
+
+    RoundRobinPacking packing = new RoundRobinPacking();
+    packing.initialize(config, runtime);
+    PackingPlan output = packing.pack();
+
+    return output;
+  }
+
+  @Test
+  public void testCheckFailure() throws Exception {
+    int numContainers = 2;
+    int spoutParallelism = 4;
+    int boltParallelism = 3;
+
+    // Set up the topology and its config
+    com.twitter.heron.api.Config topologyConfig = new com.twitter.heron.api.Config();
+    topologyConfig.put(com.twitter.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
+
+    // Explicit set insufficient ram for container
+    long containerRam = -1L * Constants.GB;
+
+    topologyConfig.setContainerRamRequested(containerRam);
+
+    TopologyAPI.Topology topology =
+        getTopology(spoutParallelism, boltParallelism, topologyConfig);
+
+    PackingPlan packingPlan =
+        getRoundRobinPackingPlan(topology);
+
+    Assert.assertNull(packingPlan);
+  }
+
+  @Test
+  public void testDefaultResources() throws Exception {
+    int numContainers = 2;
+    int spoutParallelism = 4;
+    int boltParallelism = 3;
+
+    // Set up the topology and its config
+    com.twitter.heron.api.Config topologyConfig = new com.twitter.heron.api.Config();
+    topologyConfig.put(com.twitter.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
+
+    // No explicit resources required
+    TopologyAPI.Topology topologyNoExplicitResourcesConfig =
+        getTopology(spoutParallelism, boltParallelism, topologyConfig);
+    PackingPlan packingPlanNoExplicitResourcesConfig =
+        getRoundRobinPackingPlan(topologyNoExplicitResourcesConfig);
+
+    Assert.assertEquals(
+        (Math.max(spoutParallelism, boltParallelism)
+            + RoundRobinPacking.DEFAULT_CPU_PADDING_PER_CONTAINER) * (numContainers + 1),
+        packingPlanNoExplicitResourcesConfig.resource.cpu, DELTA);
+
+    Assert.assertEquals(
+        (Math.max(spoutParallelism, boltParallelism) * Constants.GB
+            + RoundRobinPacking.DEFAULT_RAM_PADDING_PER_CONTAINER) * (numContainers + 1),
+        packingPlanNoExplicitResourcesConfig.resource.ram);
+
+    Assert.assertEquals(
+        (Math.max(spoutParallelism, boltParallelism) * Constants.GB
+            + RoundRobinPacking.DEFAULT_DISK_PADDING_PER_CONTAINER) * (numContainers + 1),
+        packingPlanNoExplicitResourcesConfig.resource.disk);
+
+    Assert.assertEquals(numContainers,
+        packingPlanNoExplicitResourcesConfig.containers.size());
+  }
+
+  /**
+   * Test the scenario container level resource config are set
+   */
+  @Test
+  public void testContainerRequestedResources() throws Exception {
+    int numContainers = 2;
+    int spoutParallelism = 4;
+    int boltParallelism = 3;
+
+    // Set up the topology and its config
+    com.twitter.heron.api.Config topologyConfig = new com.twitter.heron.api.Config();
+    topologyConfig.put(com.twitter.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
+    // Explicit set resources for container
+    long containerRam = 10L * Constants.GB;
+    long containerDisk = 20L * Constants.GB;
+    float containerCpu = 30;
+
+    topologyConfig.setContainerRamRequested(containerRam);
+    topologyConfig.setContainerDiskRequested(containerDisk);
+    topologyConfig.setContainerCpuRequested(containerCpu);
+    TopologyAPI.Topology topologyExplicitResourcesConfig =
+        getTopology(spoutParallelism, boltParallelism, topologyConfig);
+    PackingPlan packingPlanExplicitResourcesConfig =
+        getRoundRobinPackingPlan(topologyExplicitResourcesConfig);
+
+    Assert.assertEquals(containerCpu * (numContainers + 1),
+        packingPlanExplicitResourcesConfig.resource.cpu, DELTA);
+
+    Assert.assertEquals(containerRam * (numContainers + 1),
+        packingPlanExplicitResourcesConfig.resource.ram);
+
+    Assert.assertEquals(containerDisk * (numContainers + 1),
+        packingPlanExplicitResourcesConfig.resource.disk);
+
+    Assert.assertEquals(numContainers,
+        packingPlanExplicitResourcesConfig.containers.size());
+
+    for (PackingPlan.ContainerPlan containerPlan
+        : packingPlanExplicitResourcesConfig.containers.values()) {
+      Assert.assertEquals(containerCpu, containerPlan.resource.cpu, DELTA);
+
+      Assert.assertEquals(containerRam, containerPlan.resource.ram);
+
+      Assert.assertEquals(containerDisk, containerPlan.resource.disk);
+
+      // All instances' resource requirement should be equal
+      // So the size of set should be 1
+      Set<PackingPlan.Resource> resources = new HashSet<>();
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.instances.values()) {
+        resources.add(instancePlan.resource);
+      }
+
+      Assert.assertEquals(1, resources.size());
+      int instancesCount = containerPlan.instances.values().size();
+      Assert.assertEquals(
+          (containerRam - RoundRobinPacking.DEFAULT_RAM_PADDING_PER_CONTAINER) / instancesCount,
+          resources.iterator().next().ram);
+    }
+  }
+
+  /**
+   * Test the scenario ram map config is partially set
+   */
+  @Test
+  public void testCompleteRamMapRequested() throws Exception {
+    int numContainers = 2;
+    int spoutParallelism = 4;
+    int boltParallelism = 3;
+
+    // Set up the topology and its config
+    com.twitter.heron.api.Config topologyConfig = new com.twitter.heron.api.Config();
+    topologyConfig.put(com.twitter.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
+
+    // Explicit set resources for container
+    // the value should be ignored, since we set the complete component ram map
+    long containerRam = Long.MAX_VALUE;
+
+    // Explicit set component ram map
+    long boltRam = 1L * Constants.GB;
+    long spoutRam = 2L * Constants.GB;
+
+    topologyConfig.setContainerRamRequested(containerRam);
+    topologyConfig.setComponentRam(BOLT_NAME, boltRam);
+    topologyConfig.setComponentRam(SPOUT_NAME, spoutRam);
+
+    TopologyAPI.Topology topologyExplicitRamMap =
+        getTopology(spoutParallelism, boltParallelism, topologyConfig);
+    PackingPlan packingPlanExplicitRamMap =
+        getRoundRobinPackingPlan(topologyExplicitRamMap);
+
+    // Ram for bolt should be the value in component ram map
+    for (PackingPlan.ContainerPlan containerPlan
+        : packingPlanExplicitRamMap.containers.values()) {
+      // The containerRam should be ignored, since we set the complete component ram map
+      Assert.assertNotEquals(containerRam, containerPlan.resource.ram);
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.instances.values()) {
+        if (instancePlan.componentName.equals(BOLT_NAME)) {
+          Assert.assertEquals(boltRam, instancePlan.resource.ram);
+        }
+        if (instancePlan.componentName.equals(SPOUT_NAME)) {
+          Assert.assertEquals(spoutRam, instancePlan.resource.ram);
+        }
+      }
+    }
+  }
+
+  /**
+   * Test the scenario ram map config is partially set
+   */
+  @Test
+  public void testPartialRamMap() throws Exception {
+    int numContainers = 2;
+    int spoutParallelism = 4;
+    int boltParallelism = 3;
+
+    // Set up the topology and its config
+    com.twitter.heron.api.Config topologyConfig = new com.twitter.heron.api.Config();
+    topologyConfig.put(com.twitter.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
+
+    // Explicit set resources for container
+    long containerRam = 10L * Constants.GB;
+
+    // Explicit set component ram map
+    long boltRam = 1L * Constants.GB;
+
+    topologyConfig.setContainerRamRequested(containerRam);
+    topologyConfig.setComponentRam(BOLT_NAME, boltRam);
+
+    TopologyAPI.Topology topologyExplicitRamMap =
+        getTopology(spoutParallelism, boltParallelism, topologyConfig);
+    PackingPlan packingPlanExplicitRamMap =
+        getRoundRobinPackingPlan(topologyExplicitRamMap);
+
+    // Ram for bolt should be the value in component ram map
+    for (PackingPlan.ContainerPlan containerPlan
+        : packingPlanExplicitRamMap.containers.values()) {
+      Assert.assertEquals(containerRam, containerPlan.resource.ram);
+      int boltCount = 0;
+      int instancesCount = containerPlan.instances.size();
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.instances.values()) {
+        if (instancePlan.componentName.equals(BOLT_NAME)) {
+          Assert.assertEquals(boltRam, instancePlan.resource.ram);
+          boltCount++;
+        }
+      }
+
+      // Ram for spout should be:
+      // (containerRam - all ram for bolt - ram for padding) / (# of spouts)
+      int spoutCount = instancesCount - boltCount;
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.instances.values()) {
+        if (instancePlan.componentName.equals(SPOUT_NAME)) {
+          Assert.assertEquals(
+              (containerRam
+                  - boltCount * boltRam
+                  - RoundRobinPacking.DEFAULT_RAM_PADDING_PER_CONTAINER) / spoutCount,
+              instancePlan.resource.ram);
+        }
+      }
+    }
   }
 
   /**
@@ -52,40 +313,13 @@ public class RoundRobinPackingTest {
     com.twitter.heron.api.Config topologyConfig = new com.twitter.heron.api.Config();
     topologyConfig.put(com.twitter.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
 
-    // Setup the spout parallelism
-    Map<String, Integer> spouts = new HashMap<>();
-    spouts.put("spout", componentParallelism);
-
-    // Setup the bolt parallelism
-    Map<String, Integer> bolts = new HashMap<>();
-    bolts.put("bolt", componentParallelism);
-
     TopologyAPI.Topology topology =
-        TopologyTests.createTopology("testTopology", topologyConfig, spouts, bolts);
+        getTopology(componentParallelism, componentParallelism, topologyConfig);
 
     int numInstance = TopologyUtils.getTotalInstance(topology);
-    Assert.assertEquals((spouts.size() + bolts.size()) * componentParallelism, numInstance);
-
-    Config config = Config.newBuilder()
-        .put(Keys.topologyId(), topology.getId())
-        .put(Keys.topologyName(), topology.getName())
-        .putAll(ClusterDefaults.getDefaults())
-        .build();
-
-    Config runtime = Config.newBuilder()
-        .put(Keys.topologyDefinition(), topology)
-        .build();
-
-    // DefaultConfigLoader configLoader = DefaultConfigLoader.class.newInstance();
-    // String stateMgrClass = "com.twitter.heron.statemgr.NullStateManager";
-    // String overrides = String.format("%s=%s", Constants.STATE_MANAGER_CLASS, stateMgrClass);
-    // configLoader.load("", overrides);
-
-    // Context context = new Context(configLoader, topology);
-
-    RoundRobinPacking packing = RoundRobinPacking.class.newInstance();
-    packing.initialize(config, runtime);
-    PackingPlan output = packing.pack();
+    // Two components
+    Assert.assertEquals(2 * componentParallelism, numInstance);
+    PackingPlan output = getRoundRobinPackingPlan(topology);
     Assert.assertEquals(numContainers, output.containers.size());
 
     for (PackingPlan.ContainerPlan container : output.containers.values()) {
@@ -93,9 +327,9 @@ public class RoundRobinPackingTest {
 
       // Verify each container got 2 spout and 2 bolt and container 1 got
       Assert.assertEquals(
-          2, countCompoment("spout", container.instances, packing));
+          2, countCompoment("spout", container.instances));
       Assert.assertEquals(
-          2, countCompoment("bolt", container.instances, packing));
+          2, countCompoment("bolt", container.instances));
     }
   }
 }

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/LaunchRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/LaunchRunner.java
@@ -119,6 +119,10 @@ public class LaunchRunner implements Callable<Boolean> {
     // get the packed plan
     packing.initialize(config, runtime);
     PackingPlan packedPlan = packing.pack();
+    if (packedPlan == null) {
+      LOG.severe("Failed to pack a valid PackingPlan. Check the config.");
+      return false;
+    }
 
     // Add the instanceDistribution to the runtime
     Config ytruntime = Config.newBuilder()

--- a/heron/spi/src/java/com/twitter/heron/spi/common/PackingPlan.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/PackingPlan.java
@@ -27,6 +27,12 @@ public class PackingPlan {
     this.resource = resource;
   }
 
+  @Override
+  public String toString() {
+    return String.format("{plan-id: %s, containers-list: %s, plan-resource: %s}",
+        id, containers.toString(), resource);
+  }
+
   /**
    * Pack the packing plan into a String describing instance distribution, used by executor
    *
@@ -60,14 +66,34 @@ public class PackingPlan {
    * Type definition of packing structure output.
    */
   public static class Resource {
-    public Double cpu;
-    public Long ram;
-    public Long disk;
+    public double cpu;
+    public long ram;
+    public long disk;
 
-    public Resource(Double cpu, Long ram, Long disk) {
+    public Resource(double cpu, long ram, long disk) {
       this.cpu = cpu;
       this.ram = ram;
       this.disk = disk;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj instanceof Resource) {
+        Resource r = (Resource) obj;
+        return (this.cpu == r.cpu) && (this.ram == r.ram) && (this.disk == r.disk);
+      } else {
+        return false;
+      }
+    }
+
+    @Override
+    public int hashCode() {
+      return (Long.hashCode(ram) << 2) & (Long.hashCode(disk) << 1) & (Double.hashCode(cpu));
+    }
+
+    @Override
+    public String toString() {
+      return String.format("{cpu: %f, ram: %d, disk: %d}", cpu, ram, disk);
     }
   }
 
@@ -80,6 +106,12 @@ public class PackingPlan {
       this.id = id;
       this.componentName = componentName;
       this.resource = resource;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("{instance-id: %s, componentName: %s, instance-resource: %s}",
+          id, componentName, resource.toString());
     }
   }
 
@@ -94,6 +126,12 @@ public class PackingPlan {
       this.id = id;
       this.instances = instances;
       this.resource = resource;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("{container-id: %s, instances-list: %s, container-resource: %s}",
+          id, instances.toString(), resource);
     }
   }
 }


### PR DESCRIPTION
Current RoundRobinPacking can not calculate the ram for each instance correctly,
when the container_ram_request is specified. Also, it lacks necessary unit tests to prove its
correctness.

This pull request rewrites the RoundRobinPacking and adds unit tests to make sure
it behaves as expected.