### PR TITLE
Fix the incorrect ram map specification for heron-executor

### DIFF
--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
@@ -178,8 +178,7 @@ public class RoundRobinPacking implements IPacking {
   protected Map<String, Map<String, Long>> getInstancesRamMapInContainer(
       Map<String, List<String>> allocation) {
     Map<String, Long> ramMap =
-        TopologyUtils.getComponentRamMap(topology,
-            Long.parseLong(NOT_SPECIFIED_NUMBER_VALUE));
+        TopologyUtils.getComponentRamMapConfig(topology);
 
     Map<String, Map<String, Long>> instancesRamMapInContainer = new HashMap<>();
 
@@ -192,10 +191,8 @@ public class RoundRobinPacking implements IPacking {
       long usedRam = 0;
       for (String instanceId : entry.getValue()) {
         String componentName = getComponentName(instanceId);
-        long ram = ramMap.get(componentName);
-
-        // Use component ram map if set
-        if (ram != Long.parseLong(NOT_SPECIFIED_NUMBER_VALUE)) {
+        if (ramMap.containsKey(componentName)) {
+          long ram = ramMap.get(componentName);
           ramInsideContainer.put(instanceId, ram);
           usedRam += ram;
         }

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/LaunchRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/LaunchRunner.java
@@ -128,6 +128,7 @@ public class LaunchRunner implements Callable<Boolean> {
     Config ytruntime = Config.newBuilder()
         .putAll(runtime)
         .put(Keys.instanceDistribution(), packedPlan.getInstanceDistribution())
+        .put(Keys.componentRamMap(), packedPlan.getComponentRamDistribution())
         .build();
 
     // initialize the launcher

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SchedulerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SchedulerMain.java
@@ -325,11 +325,16 @@ public class SchedulerMain {
       // get a packed plan and schedule it
       packing.initialize(config, runtime);
       PackingPlan packedPlan = packing.pack();
+      if (packedPlan == null) {
+        LOG.severe("Failed to pack a valid PackingPlan. Check the config.");
+        return false;
+      }
 
       // Add the instanceDistribution to the runtime
       Config ytruntime = Config.newBuilder()
           .putAll(runtime)
           .put(Keys.instanceDistribution(), packedPlan.getInstanceDistribution())
+          .put(Keys.componentRamMap(), packedPlan.getComponentRamDistribution())
           .build();
 
       // initialize the scheduler

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
@@ -136,7 +136,7 @@ public class AuroraScheduler implements IScheduler {
     auroraProperties.put("TOPOLOGY_ID", topology.getId());
     auroraProperties.put("TOPOLOGY_DEFINITION_FILE",
         FileUtils.getBaseName(Context.topologyDefinitionFile(config)));
-    auroraProperties.put("INSTANCE_DISTRIBUTION", packing.getInstanceDistribution());
+    auroraProperties.put("INSTANCE_DISTRIBUTION", Runtime.instanceDistribution(runtime));
     auroraProperties.put("STATEMGR_CONNECTION_STRING",
         Context.stateManagerConnectionString(config));
     auroraProperties.put("STATEMGR_ROOT_PATH", Context.stateManagerRootPath(config));
@@ -150,9 +150,7 @@ public class AuroraScheduler implements IScheduler {
         TopologyUtils.makeClassPath(topology, Context.topologyJarFile(config)));
 
     auroraProperties.put("SANDBOX_SYSTEM_YAML", Context.systemConfigSandboxFile(config));
-    auroraProperties.put("COMPONENT_RAMMAP",
-        TopologyUtils.formatRamMap(
-            TopologyUtils.getComponentRamMap(topology, Context.instanceRam(config))));
+    auroraProperties.put("COMPONENT_RAMMAP", Runtime.componentRamMap(runtime));
     auroraProperties.put("COMPONENT_JVM_OPTS_IN_BASE64",
         formatJavaOpts(TopologyUtils.getComponentJvmOptions(topology)));
     auroraProperties.put("TOPOLOGY_PACKAGE_TYPE", Context.topologyPackageType(config));

--- a/heron/spi/src/java/com/twitter/heron/spi/common/PackingPlan.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/PackingPlan.java
@@ -14,6 +14,7 @@
 
 package com.twitter.heron.spi.common;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class PackingPlan {
@@ -34,7 +35,7 @@ public class PackingPlan {
   }
 
   /**
-   * Pack the packing plan into a String describing instance distribution, used by executor
+   * Get the String describing instance distribution from PackingPlan, used by executor
    *
    * @return String describing instance distribution
    */
@@ -60,6 +61,32 @@ public class PackingPlan {
     packingBuilder.deleteCharAt(packingBuilder.length() - 1);
 
     return packingBuilder.toString();
+  }
+
+  /**
+   * Get the formatted String describing component ram distribution from PackingPlan,
+   * used by executor
+   *
+   * @return String describing component ram distribution
+   */
+  public String getComponentRamDistribution() {
+    Map<String, Long> ramMap = new HashMap<>();
+    // The implementation assumes instances for the same component require same ram
+    for (ContainerPlan containerPlan : this.containers.values()) {
+      for (InstancePlan instancePlan : containerPlan.instances.values()) {
+        ramMap.put(instancePlan.componentName, instancePlan.resource.ram);
+      }
+    }
+
+    // Convert it into a formatted String
+    StringBuilder ramMapBuilder = new StringBuilder();
+    for (String component : ramMap.keySet()) {
+      ramMapBuilder.append(String.format("%s:%d,", component, ramMap.get(component)));
+    }
+
+    // Remove the duplicated "," at the end
+    ramMapBuilder.deleteCharAt(ramMapBuilder.length() - 1);
+    return ramMapBuilder.toString();
   }
 
   /**

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/SchedulerUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/SchedulerUtils.java
@@ -162,6 +162,7 @@ public final class SchedulerUtils {
   /**
    * Util method to get the arguments to the heron executor. This method creates the arguments
    * without the container index, which is the first argument to the executor
+   *
    * @param config The static Config
    * @param runtime The runtime Config
    * @param freePorts list of free ports
@@ -204,8 +205,7 @@ public final class SchedulerUtils {
     commands.add(Integer.toString(tmasterControllerPort));
     commands.add(Integer.toString(tmasterStatsPort));
     commands.add(Context.systemConfigSandboxFile(config));
-    commands.add(TopologyUtils.formatRamMap(
-        TopologyUtils.getComponentRamMap(topology, Context.instanceRam(config))));
+    commands.add(Runtime.componentRamMap(runtime));
     commands.add(SchedulerUtils.encodeJavaOpts(TopologyUtils.getComponentJvmOptions(topology)));
     commands.add(Context.topologyPackageType(config));
     commands.add(Context.topologyJarFile(config));
@@ -250,6 +250,7 @@ public final class SchedulerUtils {
 
   /**
    * Set the location of scheduler for other processes to discover
+   *
    * @param runtime the runtime configuration
    * @param schedulerEndpoint the endpoint that scheduler listens for receives requests
    * @param scheduler the IScheduler to provide more info

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/TopologyUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/TopologyUtils.java
@@ -29,7 +29,6 @@ import java.util.logging.Logger;
 
 import com.twitter.heron.api.Config;
 import com.twitter.heron.api.generated.TopologyAPI;
-import com.twitter.heron.spi.common.Constants;
 
 /**
  * Utility to process TopologyAPI.Topology proto
@@ -126,7 +125,7 @@ public final class TopologyUtils {
     }
 
     // Only verify ram map string well-formed.
-    getComponentRamMap(topology, -1);
+    getComponentRamMapConfig(topology);
     // Verify all bolts input streams exist. First get all output streams.
     Set<String> outputStreams = new HashSet<>();
     for (TopologyAPI.Spout spout : topology.getSpoutsList()) {
@@ -162,16 +161,22 @@ public final class TopologyUtils {
   }
 
 
-  public static Map<String, Long> getComponentRamMap(
-      TopologyAPI.Topology topology, long defaultRam) {
+  /**
+   * Parses the value in Config.TOPOLOGY_COMPONENT_RAMMAP,
+   * and returns a map containing only component specified.
+   * Returns a empty map if the Config is not set
+   *
+   * @param topology the topology def
+   * @return a map (componentName -> ram required)
+   */
+  public static Map<String, Long> getComponentRamMapConfig(TopologyAPI.Topology topology) {
     List<TopologyAPI.Config.KeyValue> topologyConfig = topology.getTopologyConfig().getKvsList();
     Map<String, Long> ramMap = new HashMap<>();
-    Set<String> componentNames = getComponentParallelism(topology).keySet();
-    for (String componentName : componentNames) {
-      ramMap.put(componentName, defaultRam);
-    }
 
-    // Apply Ram overrides
+    // Get the set of component names to make sure the config only specifies valid component name
+    Set<String> componentNames = getComponentParallelism(topology).keySet();
+
+    // Parse the config value
     String ramMapStr = getConfigWithDefault(topologyConfig, Config.TOPOLOGY_COMPONENT_RAMMAP, null);
     if (ramMapStr != null) {
       String[] ramMapTokens = ramMapStr.split(",");
@@ -183,28 +188,15 @@ public final class TopologyUtils {
         if (componentAndRam.length != 2) {
           throw new RuntimeException("Malformed component rammap");
         }
-        if (!ramMap.containsKey(componentAndRam[0])) {
+        if (!componentNames.contains(componentAndRam[0])) {
           throw new RuntimeException("Invalid component. " + componentAndRam[0] + " not found");
         }
         long requiredRam = Long.parseLong(componentAndRam[1]);
-        if (requiredRam < 128L * Constants.MB && requiredRam > 0) {
-          throw new RuntimeException(String.format(
-              "Component %s require at least 128MB ram. Given on %d MB",
-              componentAndRam[0], requiredRam / Constants.MB));
-        }
+
         ramMap.put(componentAndRam[0], requiredRam);
       }
     }
     return ramMap;
-  }
-
-  public static String formatRamMap(Map<String, Long> ramMap) {
-    StringBuilder ramMapBuilder = new StringBuilder();
-    for (String component : ramMap.keySet()) {
-      ramMapBuilder.append(String.format("%s:%d,", component, ramMap.get(component)));
-    }
-    ramMapBuilder.deleteCharAt(ramMapBuilder.length() - 1);
-    return ramMapBuilder.toString();
   }
 
   public static int getNumContainers(TopologyAPI.Topology topology) {

--- a/heron/spi/tests/java/com/twitter/heron/spi/utils/TopologyUtilsTest.java
+++ b/heron/spi/tests/java/com/twitter/heron/spi/utils/TopologyUtilsTest.java
@@ -64,13 +64,12 @@ public class TopologyUtilsTest {
     spouts.put("spout", componentParallelism);
     Map<String, Integer> bolts = new HashMap<>();
     bolts.put("bolt", componentParallelism);
-    long defaultValue = 1 * Constants.GB;
 
     // sort the component ram map
-    Map<String, Long> ramMap = new TreeMap<>(TopologyUtils.getComponentRamMap(
-        TopologyTests.createTopology("test", topologyConfig, spouts, bolts), defaultValue));
-    Assert.assertArrayEquals(new String[]{"bolt", "spout"}, ramMap.keySet().toArray());
-    Assert.assertArrayEquals(new Long[]{defaultValue, defaultValue}, ramMap.values().toArray());
+    Map<String, Long> ramMap = new TreeMap<>(TopologyUtils.getComponentRamMapConfig(
+        TopologyTests.createTopology("test", topologyConfig, spouts, bolts)));
+    // Component ram map is not set, the ramMap size should be 0
+    Assert.assertEquals(0, ramMap.size());
   }
 
   @Test
@@ -87,8 +86,8 @@ public class TopologyUtilsTest {
     topologyConfig.setComponentRam("bolt", boltRam);
 
     // sort the component ram map
-    Map<String, Long> ramMap = new TreeMap<>(TopologyUtils.getComponentRamMap(
-        TopologyTests.createTopology("test", topologyConfig, spouts, bolts), 0));
+    Map<String, Long> ramMap = new TreeMap<>(TopologyUtils.getComponentRamMapConfig(
+        TopologyTests.createTopology("test", topologyConfig, spouts, bolts)));
     Assert.assertArrayEquals(new String[]{"bolt", "spout"}, ramMap.keySet().toArray());
     Assert.assertArrayEquals(new Long[]{boltRam, spoutRam}, ramMap.values().toArray());
   }
@@ -101,15 +100,15 @@ public class TopologyUtilsTest {
     spouts.put("spout", componentParallelism);
     Map<String, Integer> bolts = new HashMap<>();
     bolts.put("bolt", componentParallelism);
-    long defaultValue = 1 * Constants.GB;
     long spoutRam = 2 * Constants.GB;
     topologyConfig.setComponentRam("spout", spoutRam);
 
     // sort the component ram map
-    Map<String, Long> ramMap = new TreeMap<>(TopologyUtils.getComponentRamMap(
-        TopologyTests.createTopology("test", topologyConfig, spouts, bolts), defaultValue));
-    Assert.assertArrayEquals(new String[]{"bolt", "spout"}, ramMap.keySet().toArray());
-    Assert.assertArrayEquals(new Long[]{defaultValue, spoutRam}, ramMap.values().toArray());
+    Map<String, Long> ramMap = new TreeMap<>(TopologyUtils.getComponentRamMapConfig(
+        TopologyTests.createTopology("test", topologyConfig, spouts, bolts)));
+    // Component ram map sets only spout's ram
+    Assert.assertArrayEquals(new String[]{"spout"}, ramMap.keySet().toArray());
+    Assert.assertArrayEquals(new Long[]{spoutRam}, ramMap.values().toArray());
 
   }
 


### PR DESCRIPTION
Currently when constructing the ram map for heron-executor in scheduler,
it just considers the component_ram_map config, i.e. ignores the container_ram_requested
config.

This pull request fixs this issue: it constructs the actual ram map from the actual packing plan,
which represents the processed value.