### PR TITLE
Export heron-spi jar

### DIFF
--- a/heron/spi/src/java/BUILD
+++ b/heron/spi/src/java/BUILD
@@ -89,7 +89,7 @@ java_library(
         "//heron/common/src/java:basics-java",
         "//heron/common/src/java:config-java",
     ],
-    resources = common_resource_files, 
+    resources = common_resource_files,
 )
 
 java_library(
@@ -97,7 +97,7 @@ java_library(
     srcs = glob([
         "**/spi/utils/**/*.java",
     ]),
-    deps = utils_deps_files, 
+    deps = utils_deps_files,
 )
 
 java_library(
@@ -105,7 +105,7 @@ java_library(
     srcs = glob([
         "**/spi/packing/**/*.java",
     ]),
-    deps = packing_deps_files, 
+    deps = packing_deps_files,
 )
 
 java_library(
@@ -113,7 +113,7 @@ java_library(
     srcs = glob([
         "**/spi/scheduler/**/*.java",
     ]),
-    deps = scheduler_deps_files, 
+    deps = scheduler_deps_files,
 )
 
 java_library(
@@ -145,4 +145,20 @@ java_library(
         ["**/spi/statemgr/**/*.java"],
     ),
     deps = statemgr_deps_files,
+)
+
+java_binary(
+    name = "spi-unshaded",
+    srcs = glob([
+        "**/spi/utils/**/*.java",
+        "**/spi/common/**/*.java",
+    ]),
+    deps = utils_deps_files,
+)
+
+genrule(
+    name = "heron-spi-jar",
+    srcs = [":spi-unshaded_deploy.jar"],
+    outs = ["heron-spi.jar"],
+    cmd  = "cp $< $@",
 )

--- a/scripts/centos5/BUILD
+++ b/scripts/centos5/BUILD
@@ -169,6 +169,7 @@ genrule(
     srcs = [
         ":release.yaml",
         ":hapi",
+        ":hspi",
         ":hstorm",
     ],
     outs = [
@@ -180,6 +181,7 @@ genrule(
         "$(location package_release.sh)              $(location heron-api.tar.gz)",
         "--cp $(location release.yaml)               release.yaml",
         "--cp $(location hapi)                       heron-api.jar",
+        "--cp $(location hspi)                       heron-spi.jar",
         "--cp $(location hstorm)                     heron-storm.jar",
     ]),
     heuristic_label_expansion = False,
@@ -355,6 +357,11 @@ filegroup(
 filegroup(
     name = "hapi",
     srcs = ["//heron/api/src/java:heron-api"],
+)
+
+filegroup(
+    name = "hspi",
+    srcs = ["//heron/api/src/java:heron-spi"],
 )
 
 filegroup(

--- a/scripts/packages/api_template_bin.sh
+++ b/scripts/packages/api_template_bin.sh
@@ -139,6 +139,9 @@ function install_to_maven() {
   mvn install:install-file -q -Dfile="${tmp_dir}/heron-api.jar" -DgroupId="com.twitter.heron" \
     -DartifactId="heron-api" -Dversion="SNAPSHOT" -Dpackaging="jar"
 
+  mvn install:install-file -q -Dfile="${tmp_dir}/heron-spi.jar" -DgroupId="com.twitter.heron" \
+    -DartifactId="heron-spi" -Dversion="SNAPSHOT" -Dpackaging="jar"
+
   mvn install:install-file -q -Dfile="${tmp_dir}/heron-storm.jar" -DgroupId="com.twitter.heron" \
     -DartifactId="heron-storm" -Dversion="SNAPSHOT" -Dpackaging="jar"
 

--- a/tools/rules/heron_api.bzl
+++ b/tools/rules/heron_api.bzl
@@ -7,5 +7,6 @@ def heron_api_files():
 def heron_api_lib_files():
     return [
         "//heron/api/src/java:heron-api",
+        "//heron/spi/src/java:heron-spi-jar",
         "//heron/storm/src/java:heron-storm",
     ] 


### PR DESCRIPTION
The heron-spi jar is needed for developing custom schedulers, packing
algorithms, etc. We will want to upload this jar to maven central along
with the api and storm compatibility layer.

Related to: https://github.com/twitter/heron/issues/935