### PR TITLE
Limit the maximum size of heron tuple set

### DIFF
--- a/heron/common/src/java/com/twitter/heron/common/config/SystemConfig.java
+++ b/heron/common/src/java/com/twitter/heron/common/config/SystemConfig.java
@@ -131,6 +131,12 @@ public class SystemConfig {
       = "heron.instance.set.data.tuple.capacity";
 
   /**
+   * The maximum size in bytes of data tuple to batch in a HeronDataTupleSet protobuf
+   */
+  public static final String INSTANCE_SET_DATA_TUPLE_SIZE_BYTES
+      = "heron.instance.set.data.tuple.size.bytes";
+
+  /**
    * The size of packets read from stream manager will be determined by the minimal of
    * (a) time based (b) size based
    */
@@ -341,6 +347,11 @@ public class SystemConfig {
   public int getInstanceSetDataTupleCapacity() {
     return TypeUtils.getInteger(this.config.get(
         SystemConfig.INSTANCE_SET_DATA_TUPLE_CAPACITY));
+  }
+
+  public long getInstanceSetDataTupleSizeBytes() {
+    return TypeUtils.getInteger(this.config.get(
+        SystemConfig.INSTANCE_SET_DATA_TUPLE_SIZE_BYTES));
   }
 
   public int getInstanceSetControlTupleCapacity() {

--- a/heron/common/src/java/com/twitter/heron/common/config/SystemConfig.java
+++ b/heron/common/src/java/com/twitter/heron/common/config/SystemConfig.java
@@ -272,7 +272,7 @@ public class SystemConfig {
   /**
    * The size of packets read from socket will be determined by the minimal of:
    * (a) time based (b) size based
-   *
+   * <p>
    * Time based, the maximum batch time in ms for instance to read from socket per attempt
    */
   public static final String METRICSMGR_NETWORK_READ_BATCH_TIME_MS
@@ -287,7 +287,7 @@ public class SystemConfig {
   /**
    * The size of packets written to socket will be determined by the minimal of
    * (a) time based (b) size based
-   *
+   * <p>
    * Time based, the maximum batch time in ms to write to socket
    */
   public static final String METRICSMGR_NETWORK_WRITE_BATCH_TIME_MS
@@ -350,8 +350,11 @@ public class SystemConfig {
   }
 
   public long getInstanceSetDataTupleSizeBytes() {
-    return TypeUtils.getInteger(this.config.get(
-        SystemConfig.INSTANCE_SET_DATA_TUPLE_SIZE_BYTES));
+    // TODO(mfu): Provide default values for all configs uniformly
+    // TODO(mfu): https://github.com/twitter/heron/issues/970
+    Object value = this.config.get(
+        SystemConfig.INSTANCE_SET_DATA_TUPLE_SIZE_BYTES);
+    return value == null ? Long.MAX_VALUE : TypeUtils.getLong(value);
   }
 
   public int getInstanceSetControlTupleCapacity() {

--- a/heron/config/src/yaml/conf/aurora/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/aurora/heron_internals.yaml
@@ -198,6 +198,9 @@ heron.instance.network.options.socket.received.buffer.size.bytes: 8738000
 # The maximum # of data tuple to batch in a HeronDataTupleSet protobuf
 heron.instance.set.data.tuple.capacity: 1024
 
+# The maximum size in bytes of data tuple to batch in a HeronDataTupleSet protobuf
+heron.instance.set.data.tuple.size.bytes: 8388608
+
 # The maximum # of control tuple to batch in a HeronControlTupleSet protobuf
 heron.instance.set.control.tuple.capacity: 1024
 

--- a/heron/config/src/yaml/conf/examples/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/examples/heron_internals.yaml
@@ -198,6 +198,9 @@ heron.instance.network.options.socket.received.buffer.size.bytes: 8738000
 # The maximum # of data tuple to batch in a HeronDataTupleSet protobuf
 heron.instance.set.data.tuple.capacity: 1024
 
+# The maximum size in bytes of data tuple to batch in a HeronDataTupleSet protobuf
+heron.instance.set.data.tuple.size.bytes: 8388608
+
 # The maximum # of control tuple to batch in a HeronControlTupleSet protobuf
 heron.instance.set.control.tuple.capacity: 1024
 

--- a/heron/config/src/yaml/conf/local/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/local/heron_internals.yaml
@@ -198,6 +198,9 @@ heron.instance.network.options.socket.received.buffer.size.bytes: 8738000
 # The maximum # of data tuple to batch in a HeronDataTupleSet protobuf
 heron.instance.set.data.tuple.capacity: 1024
 
+# The maximum size in bytes of data tuple to batch in a HeronDataTupleSet protobuf
+heron.instance.set.data.tuple.size.bytes: 8388608
+
 # The maximum # of control tuple to batch in a HeronControlTupleSet protobuf
 heron.instance.set.control.tuple.capacity: 1024
 

--- a/heron/config/src/yaml/conf/localzk/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/localzk/heron_internals.yaml
@@ -198,6 +198,9 @@ heron.instance.network.options.socket.received.buffer.size.bytes: 8738000
 # The maximum # of data tuple to batch in a HeronDataTupleSet protobuf
 heron.instance.set.data.tuple.capacity: 1024
 
+# The maximum size in bytes of data tuple to batch in a HeronDataTupleSet protobuf
+heron.instance.set.data.tuple.size.bytes: 8388608
+
 # The maximum # of control tuple to batch in a HeronControlTupleSet protobuf
 heron.instance.set.control.tuple.capacity: 1024
 

--- a/heron/config/src/yaml/conf/slurm/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/slurm/heron_internals.yaml
@@ -196,7 +196,10 @@ heron.instance.network.options.socket.send.buffer.size.bytes: 6553600
 heron.instance.network.options.socket.received.buffer.size.bytes: 8738000 
 
 # The maximum # of data tuple to batch in a HeronDataTupleSet protobuf
-heron.instance.set.data.tuple.capacity: 1024 
+heron.instance.set.data.tuple.capacity: 1024
+
+# The maximum size in bytes of data tuple to batch in a HeronDataTupleSet protobuf
+heron.instance.set.data.tuple.size.bytes: 8388608
 
 # The maximum # of control tuple to batch in a HeronControlTupleSet protobuf
 heron.instance.set.control.tuple.capacity: 1024 

--- a/heron/config/src/yaml/conf/test/test_heron_internals.yaml
+++ b/heron/config/src/yaml/conf/test/test_heron_internals.yaml
@@ -179,6 +179,9 @@ heron.instance.network.options.socket.received.buffer.size.bytes: 8738000
 # The maximum # of data tuple to batch in a HeronDataTupleSet protobuf
 heron.instance.set.data.tuple.capacity: 256
 
+# The maximum size in bytes of data tuple to batch in a HeronDataTupleSet protobuf
+heron.instance.set.data.tuple.size.bytes: 8388608
+
 # The maximum # of control tuple to batch in a HeronControlTupleSet protobuf
 heron.instance.set.control.tuple.capacity: 256
 

--- a/heron/config/src/yaml/conf/yarn/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/yarn/heron_internals.yaml
@@ -198,6 +198,9 @@ heron.instance.network.options.socket.received.buffer.size.bytes: 8738000
 # The maximum # of data tuple to batch in a HeronDataTupleSet protobuf
 heron.instance.set.data.tuple.capacity: 1024
 
+# The maximum size in bytes of data tuple to batch in a HeronDataTupleSet protobuf
+heron.instance.set.data.tuple.size.bytes: 8388608
+
 # The maximum # of control tuple to batch in a HeronControlTupleSet protobuf
 heron.instance.set.control.tuple.capacity: 1024
 

--- a/heron/instance/src/java/com/twitter/heron/network/MetricsManagerClient.java
+++ b/heron/instance/src/java/com/twitter/heron/network/MetricsManagerClient.java
@@ -99,6 +99,10 @@ public class MetricsManagerClient extends HeronClient {
 
   // Send out all the data
   public void sendAllMessage() {
+    if (!isConnected()) {
+      return;
+    }
+
     LOG.info("Flushing all pending data in MetricsManagerClient");
     // Collect all tuples in queue
     for (Communicator<Metrics.MetricPublisherPublishMessage> c : outMetricsQueues) {

--- a/heron/instance/src/java/com/twitter/heron/network/StreamManagerClient.java
+++ b/heron/instance/src/java/com/twitter/heron/network/StreamManagerClient.java
@@ -196,6 +196,10 @@ public class StreamManagerClient extends HeronClient {
 
   // Send out all the data
   public void sendAllMessage() {
+    if (!isConnected()) {
+      return;
+    }
+
     LOG.info("Flushing all pending data in StreamManagerClient");
     // Collect all tuples in queue
     int size = outStreamQueue.size();


### PR DESCRIPTION
Currently heron can only limit # of tuples inside heron tuple set, but can not limit the size in bytes.
Sometimes misconfig can lead to constructing protobuf bigger than default limitation to parse (64M).

This pull request limits the maximum size of heron tuple set. It is a soft bound, calculating the size of
tuple set. And once the size exceeds the limitation, we will create a new heron tuple set.