### PR TITLE
#974 update slf4j version from 1.7.7 to latest 1.7.21

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,7 +5,7 @@ httpcomponents_version = "4.3"
 jackson_version = "2.6.3"
 powermock_version = "1.6.2"
 reef_version = "0.14.0"
-slf4j_version = "1.7.7"
+slf4j_version = "1.7.21"
 
 maven_server(
   name = "default",


### PR DESCRIPTION
slf4j creates warning messages on stderr like following:

```
SLF4J: The following set of substitute loggers may have been accessed
SLF4J: during the initialization phase. Logging calls during this
SLF4J: phase were not honored. However, subsequent logging calls to these
SLF4J: loggers will work as normally expected.
SLF4J: See also http://www.slf4j.org/codes.html#substituteLogger
SLF4J: org.eclipse.aether.internal.impl.DefaultRepositorySystem
SLF4J: org.eclipse.aether.internal.impl.DefaultMetadataResolver
SLF4J: org.apache.maven.repository.internal.DefaultVersionResolver
```
update SLF4J version from 1.7.7 to latest 1.7.21 is likely to solve this issue.