### PR TITLE
Add YARN scheduler documentation

### DIFF
--- a/website/content/docs/operators/deployment/index.md
+++ b/website/content/docs/operators/deployment/index.md
@@ -22,6 +22,7 @@ supports several scheduler options:
   * [Aurora](schedulers/aurora)
   * [Local](schedulers/local)
   * [Slurm](schedulers/slurm)
+  * [YARN](schedulers/yarn)
 
 * **State Manager** --- Heron state manager tracks the state of all deployed
 topologies. The topology state includes its logical plan,

--- a/website/content/docs/operators/deployment/schedulers/yarn.md
+++ b/website/content/docs/operators/deployment/schedulers/yarn.md
@@ -2,51 +2,52 @@
 title: Apache Hadoop YARN Cluster (Experimental)
 ---
 
-In addition to out-of-the-box scheduler for [Aurora](../aurora), Heron can also be deployed on a
-YARN cluster with the YARN Scheduler. YARN
-scheduler is implemented using Apache REEF framework.
+In addition to out-of-the-box schedulers for [Aurora](../aurora), Heron can also be deployed on a
+YARN cluster with the YARN scheduler. The YARN scheduler is implemented using the 
+[Apache REEF](https://reef.apache.org/) framework.
 
-**Key features** of YARN scheduler:
+**Key features** of the YARN scheduler:
 
-* **Heterogeneous container allocation:** YARN scheduler will request heterogeneous containers from
-YARN Resource Manager. In other words the topology will not use more resources than what is needed.
+* **Heterogeneous container allocation:** The YARN scheduler will request heterogeneous containers
+from the YARN ResourceManager [RM](http://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/YARN.html). In other words the topology will not request more resources than what is really needed.
 
-* **Container reuse:** REEF framework allows YARN scheduler to retain containers
+* **Container reuse:** The REEF framework allows the YARN scheduler to retain containers
 across events like topology restarts.
 
-## How topology deployment on YARN Cluster Works
+## Topology deployment on a YARN Cluster
 
-Using the YARN scheduler is similar to deploying Heron on other clusters, i.e. using the Heron cli.
-This document assumes that Hadoop client is installed and configured.
+Using the YARN scheduler is similar to deploying Heron on other clusters, i.e. using the
+[Heron CLI](/docs/operators/heron-cli/).
+This document assumes that the Hadoop yarn client is installed and configured.
 
-YARN scheduler uses REEF framework. Following steps are executed when a Heron topology is submitted,
+Following steps are executed when a Heron topology is submitted:
 
-1. REEF client copies `Heron Core package` and `topology package` on the distributed file system.
-1. It then starts YARN Application Master (AM) for the topology.
-1. The AM subsequently invokes `Heron Scheduler` in the same process.
-1. This is followed by container allocation for Topology Master and workers. As a result `N+2`
+1. The REEF client copies the `Heron Core package` and the `topology package` on the distributed file system.
+1. It then starts the YARN Application Master (AM) for the topology.
+1. The AM subsequently invokes the `Heron Scheduler` in the same process.
+1. This is followed by container allocation for the topology's master and workers. As a result `N+2`
 containers are allocated for each topology.
 
-### Configure Hadoop classpath
+### Configuring the Heron client classpath
 
 1. Command `hadoop classpath` provides a list of jars needed to submit a hadoop job. Copy all jars
 to `HERON_INSTALL_DIR/lib/scheduler`.
-  * Do not copy commons-cli jar if it is older than version 1.3.1
+  * Do not copy commons-cli jar if it is older than version 1.3.1.
 1. Create a jar containing core-site.xml and yarn-site.xml. Add this jar to
-`HERON_INSTALL_DIR/lib/scheduler` too
+`HERON_INSTALL_DIR/lib/scheduler` too.
 
-> YARN scheduler needs Hadoop and YARN jars in the classpath. Heron currently does not allow
+> The YARN scheduler needs Hadoop and YARN jars in the classpath. Heron currently does not allow
 > customizing client classpath. Hadoop and YARN jars are version dependent and should not be
-> bundled with Heron distribution. So, this manual step is needed till this Heron issue
+> bundled with the Heron distribution. So, this manual step is needed till this Heron issue
 > ([271] (https://github.com/twitter/heron/issues/271)) is fixed.
 
-### Configure YARN scheduler
+### Configure the YARN scheduler
 
 A set of default configuration files are provided with Heron in the [conf/yarn]
 (https://github.com/twitter/heron/tree/master/heron/config/src/yaml/conf/yarn) directory.
 The default configuration uses the local state manager. This will work with single-node local
-YARN installation only. Zookeeper based state management will be needed for topology
-deployment on multi-node YARN cluster.
+YARN installation only. A Zookeeper based state management will be needed for topology
+deployment on a multi-node YARN cluster.
 
 1. Custom Heron Launcher for YARN: `YarnLauncher`
 1. Custom Heron Scheduler for YARN: `YarnScheduler`
@@ -59,7 +60,7 @@ deployment on multi-node YARN cluster.
 ### Topology Submission
 **Command**
 
-`heron submit yarn heron-examples.jar com.twitter.heron.examples.AckingTopology AckingTopology`
+`$ heron submit yarn heron-examples.jar com.twitter.heron.examples.AckingTopology AckingTopology`
 
 **Sample Output**
 
@@ -82,7 +83,7 @@ com.twitter.heron.scheduler.yarn.ReefClientSideHandlers INFO:  Topology AckingTo
 
 **Verification**
 
-Visit YARN http console or execute `yarn application -list` on yarn client host.
+Visit the YARN http console or execute command `yarn application -list` on a yarn client host.
 
 ```
 Total number of applications (application-types: [] and states: [SUBMITTED, ACCEPTED, RUNNING]):1
@@ -93,30 +94,32 @@ application_1466548964728_0004	      AckingTopology	                YARN	     he
 ### Topology termination
 **Command**
 
-`heron kill yarn AckingTopology`
+`$ heron kill yarn AckingTopology`
 
 
-###Log File location###
-Assuming HDFS as the file system, Heron logs and REEF logs can be found in the following locations
-1. Logs generated when YARN AM starts:
+###Log File location
+
+Assuming HDFS as the file system, Heron logs and REEF logs can be found in the following locations:
+
+1. Logs generated when the topologies AM starts:
 `<LOG_DIR>/userlogs/application_1466548964728_0004/container_1466548964728_0004_01_000001/driver.stderr`
 
-1. Scheduler logs are created on the first/AM container:
+1. Ths scheduler's logs are created on the first/AM container:
 `<NM_LOCAL_DIR>/usercache/heron/appcache/application_1466548964728_0004/container_1466548964728_0004_01_000001/log-files`
 
-1. Logs generated when TMaster starts in its container:
+1. Logs generated when the TMaster starts in its container:
 `<LOG_DIR>/userlogs/application_1466548964728_0004/container_1466548964728_0004_01_000002/evaluator.stderr`
 
-1. TMaster logs are created on the second container owned by the topology app:
+1. The TMaster's logs are created on the second container owned by the topology app:
 `<NM_LOCAL_DIR>/usercache/heron/appcache/application_1466548964728_0004/container_1466548964728_0004_01_000002/log-files`
 
-1. Worker logs are created on the remaining containers in Node's local directory
+1. Worker logs are created on the remaining containers in the YARN NodeManager's local directory.
 
 
 ## Work in Progress
 
-1. YARN Scheduler will restart any failed workers and TM processes. However AM HA is not
+1. The YARN Scheduler will restart any failed workers and TMaster containers. However [AM HA](https://hadoop.apache.org/docs/r2.7.1/hadoop-yarn/hadoop-yarn-site/ResourceManagerHA.html)  is not
  supported yet. As a result AM failure will result in topology failure.
  Issue: [#949](https://github.com/twitter/heron/issues/949)
 1. TMaster and Scheduler are started in separate containers. Increased network latency can result
- in warning or failures. Issue: [#951] (https://github.com/twitter/heron/issues/951)
+ in warnings or failures. Issue: [#951] (https://github.com/twitter/heron/issues/951)

--- a/website/content/docs/operators/deployment/schedulers/yarn.md
+++ b/website/content/docs/operators/deployment/schedulers/yarn.md
@@ -1,0 +1,122 @@
+---
+title: Apache Hadoop YARN Cluster (Experimental)
+---
+
+In addition to out-of-the-box scheduler for [Aurora](../aurora), Heron can also be deployed on a
+YARN cluster with the YARN Scheduler. YARN
+scheduler is implemented using Apache REEF framework.
+
+**Key features** of YARN scheduler:
+
+* **Heterogeneous container allocation:** YARN scheduler will request heterogeneous containers from
+YARN Resource Manager. In other words the topology will not use more resources than what is needed.
+
+* **Container reuse:** REEF framework allows YARN scheduler to retain containers
+across events like topology restarts.
+
+## How topology deployment on YARN Cluster Works
+
+Using the YARN scheduler is similar to deploying Heron on other clusters, i.e. using the Heron cli.
+This document assumes that Hadoop client is installed and configured.
+
+YARN scheduler uses REEF framework. Following steps are executed when a Heron topology is submitted,
+
+1. REEF client copies `Heron Core package` and `topology package` on the distributed file system.
+1. It then starts YARN Application Master (AM) for the topology.
+1. The AM subsequently invokes `Heron Scheduler` in the same process.
+1. This is followed by container allocation for Topology Master and workers. As a result `N+2`
+containers are allocated for each topology.
+
+### Configure Hadoop classpath
+
+1. Command `hadoop classpath` provides a list of jars needed to submit a hadoop job. Copy all jars
+to `HERON_INSTALL_DIR/lib/scheduler`.
+  * Do not copy commons-cli jar if it is older than version 1.3.1
+1. Create a jar containing core-site.xml and yarn-site.xml. Add this jar to
+`HERON_INSTALL_DIR/lib/scheduler` too
+
+> YARN scheduler needs Hadoop and YARN jars in the classpath. Heron currently does not allow
+> customizing client classpath. Hadoop and YARN jars are version dependent and should not be
+> bundled with Heron distribution. So, this manual step is needed till this Heron issue
+> ([271] (https://github.com/twitter/heron/issues/271)) is fixed.
+
+### Configure YARN scheduler
+
+A set of default configuration files are provided with Heron in the [conf/yarn]
+(https://github.com/twitter/heron/tree/master/heron/config/src/yaml/conf/yarn) directory.
+The default configuration uses the local state manager. This will work with single-node local
+YARN installation only. Zookeeper based state management will be needed for topology
+deployment on multi-node YARN cluster.
+
+1. Custom Heron Launcher for YARN: `YarnLauncher`
+1. Custom Heron Scheduler for YARN: `YarnScheduler`
+1. State manager for multi-node deployment:
+`com.twitter.heron.statemgr.zookeeper.curator.CuratorStateManager`
+1. `YarnLauncher` performs the job of uploader also. So `NullUploader` is used.
+
+## Topology management
+
+### Topology Submission
+**Command**
+
+`heron submit yarn heron-examples.jar com.twitter.heron.examples.AckingTopology AckingTopology`
+
+**Sample Output**
+
+```
+INFO: Launching topology 'AckingTopology'
+...
+...
+Powered by
+     ___________  ______  ______  _______
+    /  ______  / /  ___/ /  ___/ /  ____/
+   /     _____/ /  /__  /  /__  /  /___
+  /  /\  \     /  ___/ /  ___/ /  ____/
+ /  /  \  \   /  /__  /  /__  /  /
+/__/    \__\ /_____/ /_____/ /__/
+
+...
+...
+com.twitter.heron.scheduler.yarn.ReefClientSideHandlers INFO:  Topology AckingTopology is running, jobId AckingTopology.
+```
+
+**Verification**
+
+Visit YARN http console or execute `yarn application -list` on yarn client host.
+
+```
+Total number of applications (application-types: [] and states: [SUBMITTED, ACCEPTED, RUNNING]):1
+                Application-Id	    Application-Name	    Application-Type	      User	     Queue	             State	       Final-State	       Progress	                       Tracking-URL
+application_1466548964728_0004	      AckingTopology	                YARN	     heron	   default	           RUNNING	         UNDEFINED	             0%	                                N/A
+```
+
+### Topology termination
+**Command**
+
+`heron kill yarn AckingTopology`
+
+
+###Log File location###
+Assuming HDFS as the file system, Heron logs and REEF logs can be found in the following locations
+1. Logs generated when YARN AM starts:
+`<LOG_DIR>/userlogs/application_1466548964728_0004/container_1466548964728_0004_01_000001/driver.stderr`
+
+1. Scheduler logs are created on the first/AM container:
+`<NM_LOCAL_DIR>/usercache/heron/appcache/application_1466548964728_0004/container_1466548964728_0004_01_000001/log-files`
+
+1. Logs generated when TMaster starts in its container:
+`<LOG_DIR>/userlogs/application_1466548964728_0004/container_1466548964728_0004_01_000002/evaluator.stderr`
+
+1. TMaster logs are created on the second container owned by the topology app:
+`<NM_LOCAL_DIR>/usercache/heron/appcache/application_1466548964728_0004/container_1466548964728_0004_01_000002/log-files`
+
+1. Worker logs are created on the remaining containers in Node's local directory
+
+
+## Work in Progress
+
+1. YARN Scheduler will restart any failed workers and TM processes. However AM HA is not
+ supported yet. As a result AM failure will result in topology failure.
+ Issue: [#949](https://github.com/twitter/heron/issues/949)
+1. TMaster and Scheduler are started in separate containers. Increased network latency can result
+ in warning or failures. Issue: [#951] (https://github.com/twitter/heron/issues/951)

--- a/website/data/toc.yaml
+++ b/website/data/toc.yaml
@@ -43,6 +43,8 @@ sections:
 #        url: /docs/operators/deployment/schedulers/mesos
       - name: Slurm Cluster
         url: /docs/operators/deployment/schedulers/slurm
+      - name: YARN Cluster
+        url: /docs/operators/deployment/schedulers/yarn
   - name: Cluster Configuration
     sublinks:
       - name: Overview


### PR DESCRIPTION
Fixes #947 

The doc page can be seen here:
* https://github.com/ashvina/heron/blob/yarnSchedulerDoc-947/website/content/docs/operators/deployment/schedulers/yarn.md
* OR here http://ashvina.github.io/heron/docs/operators/deployment/schedulers/yarn/

On ashvin.github.com/heron, some pages are not formatted correctly. I am not sure why `make site` is generating different markdown on my machine. The first link above shows the correct format.