### PR TITLE
Apply override config on scheduler

### DIFF
--- a/heron/spi/src/java/com/twitter/heron/spi/common/ClusterConfig.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/ClusterConfig.java
@@ -90,7 +90,9 @@ public final class ClusterConfig {
         .put(Keys.systemSandboxFile(),
             Misc.substituteSandbox(heronSandboxHome, configPath, Defaults.systemSandboxFile()))
         .put(Keys.uploaderSandboxFile(),
-            Misc.substituteSandbox(heronSandboxHome, configPath, Defaults.uploaderSandboxFile()));
+            Misc.substituteSandbox(heronSandboxHome, configPath, Defaults.uploaderSandboxFile()))
+        .put(Keys.overrideSandboxFile(),
+            Misc.substituteSandbox(heronSandboxHome, configPath, Defaults.overrideSandboxFile()));
     return cb.build();
   }
 
@@ -179,6 +181,10 @@ public final class ClusterConfig {
         .putAll(loadSchedulerConfig(Context.schedulerSandboxFile(sandboxConfig)))
         .putAll(loadStateManagerConfig(Context.stateManagerSandboxFile(sandboxConfig)))
         .putAll(loadUploaderConfig(Context.uploaderSandboxFile(sandboxConfig)));
+
+    // Add the override config at the end to replace any exisiting configs
+    cb.putAll(loadOverrideConfig(Context.overrideSandboxFile(sandboxConfig)));
+
     return cb.build();
   }
 }

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Context.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Context.java
@@ -275,6 +275,10 @@ public class Context {
     return cfg.getStringValue(Keys.packingSandboxFile());
   }
 
+  public static String overrideSandboxFile(Config cfg) {
+    return cfg.getStringValue(Keys.overrideSandboxFile());
+  }
+
   public static String schedulerSandboxFile(Config cfg) {
     return cfg.getStringValue(Keys.schedulerSandboxFile());
   }

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Defaults.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Defaults.java
@@ -255,6 +255,10 @@ public class Defaults {
     return ConfigDefaults.get("SANDBOX_UPLOADER_YAML");
   }
 
+  public static String overrideSandboxFile() {
+    return ConfigDefaults.get("SANDBOX_OVERRIDE_YAML");
+  }
+
   public static String executorSandboxBinary() {
     return ConfigDefaults.get("SANDBOX_EXECUTOR_BINARY");
   }

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Keys.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Keys.java
@@ -323,6 +323,10 @@ public class Keys {
     return ConfigKeys.get("SANDBOX_PACKING_YAML");
   }
 
+  public static String overrideSandboxFile() {
+    return ConfigKeys.get("SANDBOX_OVERRIDE_YAML");
+  }
+
   public static String schedulerSandboxFile() {
     return ConfigKeys.get("SANDBOX_SCHEDULER_YAML");
   }

--- a/heron/spi/src/java/com/twitter/heron/spi/common/defaults.yaml
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/defaults.yaml
@@ -82,6 +82,7 @@ SANDBOX_SCHEDULER_YAML:       ${HERON_SANDBOX_CONF}/scheduler.yaml
 SANDBOX_STATEMGR_YAML:        ${HERON_SANDBOX_CONF}/statemgr.yaml
 SANDBOX_SYSTEM_YAML:          ${HERON_SANDBOX_CONF}/heron_internals.yaml
 SANDBOX_UPLOADER_YAML:        ${HERON_SANDBOX_CONF}/uploader.yaml
+SANDBOX_OVERRIDE_YAML:        ${HERON_SANDBOX_CONF}/override.yaml
 
 ################################################################################
 # Default values for heron sandbox binaries and jars

--- a/heron/spi/src/java/com/twitter/heron/spi/common/keys.yaml
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/keys.yaml
@@ -160,6 +160,7 @@ SANDBOX_SCHEDULER_YAML:              heron.config.sandbox.file.scheduler.yaml
 SANDBOX_STATEMGR_YAML:               heron.config.sandbox.file.statemgr.yaml
 SANDBOX_SYSTEM_YAML:                 heron.config.sandbox.file.system.yaml
 SANDBOX_UPLOADER_YAML:               heron.config.sandbox.file.uploader.yaml
+SANDBOX_OVERRIDE_YAML:               heron.config.sandbox.file.override.yaml
 
 ################################################################################
 # keys for sandbox config provided user binaries

--- a/integration-test/src/python/test_runner/main.py
+++ b/integration-test/src/python/test_runner/main.py
@@ -111,8 +111,11 @@ def submitTopology(heronCliPath, cluster, role, env, jarPath, classPath, pkgUri,
   # Form the command to submit a topology.
   # Note the single quote around the arg for heron.package.core.uri.
   # This is needed to prevent shell expansion.
-  cmd = "%s submit %s/%s/%s --config-property heron.package.core.uri='%s' %s %s %s --verbose" % (
-    heronCliPath, cluster, role, env, pkgUri, jarPath, classPath, args)
+  cmd = "%s submit %s/%s/%s %s %s %s --verbose" % (
+    heronCliPath, cluster, role, env, jarPath, classPath, args)
+
+  if pkgUri is not None:
+    cmd = "%s --config-property heron.package.core.uri='%s'" %(cmd, pkgUri)
 
   logging.info("Submitting command: %s" % (cmd))
 
@@ -184,7 +187,7 @@ def main():
   parser.add_argument('-rh', '--results-server-hostname', dest='resultsServerHostname')
   parser.add_argument('-rp', '--results-server-port', dest='resultsServerPort', default=conf['resultsServerPort'])
   parser.add_argument('-tp', '--topologies-path', dest='topologiesPath')
-  parser.add_argument('-pi', '--release-package-uri', dest='releasePackageUri', default=conf['releasePackageUri'])
+  parser.add_argument('-pi', '--release-package-uri', dest='releasePackageUri', default=None)
 
   #TODO: Enable this option
   #parser.add_argument('-dt', '--disable-topologies', dest='disabledTopologies', default='',

--- a/scripts/travis/test.sh
+++ b/scripts/travis/test.sh
@@ -36,7 +36,7 @@ trap "kill -9 $http_server_id" SIGINT SIGTERM EXIT
   -hc heron -tj bazel-genfiles/integration-test/src/java/integration-tests.jar \
   -rh localhost -rp 8080\
   -tp integration-test/src/java/com/twitter/heron/integration_test/topology/ \
-  -cl local -rl heron-staging -ev devel -pi 'file://${HERON_DIST}/heron-core.tar.gz'
+  -cl local -rl heron-staging -ev devel
 end_timer "$T"
 
 print_timer_summary


### PR DESCRIPTION
Currently any override config passed to heron-cli would apply on client side, i.e. SubmitterMain or RuntimeManagerMain only.
This pull request would apply the override config on server side, for instance, SchedulerMain, too.