### PR TITLE
Add the command to install libtool for Mac OS X developers

### DIFF
--- a/website/content/docs/developers/compiling/mac.md
+++ b/website/content/docs/developers/compiling/mac.md
@@ -15,6 +15,7 @@ This is a step by step guide for building Heron on Mac OS (10.10 and 10.11).
 ```bash
 brew install automake
 brew install cmake
+brew install libtool
 ```
 
 #### Step 3 - Set the following environment variables


### PR DESCRIPTION
Add `brew install libtool`. The build will fail with the following error without libtool:

```
Executing genrule //config:config-srcs failed: bash failed: error executing command /bin/bash -c ... (remaining 1 argument(s) skipped): com.google.devtools.build.lib.shell.BadExitStatusException: Process exited with status 1.
Preparing the heron build system...please wait

Found GNU Autoconf version 2.69
Found GNU Automake version 1.15

Warning:  libtoolize does not appear to be available.  This means that
the automatic build preparation via autoreconf will probably not work.
Preparing the build by running each step individually, however, should
work and will be done automatically for you if autoreconf fails.

ERROR: Unable to locate GNU Libtool.

ERROR:  To prepare the heron build system from scratch,
        at least version 1.4.2 of GNU Libtool must be installed.

autogen.sh does not need to be run on the same machine that will
run configure or make.  Either the GNU Autotools will need to be installed
or upgraded on this system, or autogen.sh must be run on the source
code on another system and then transferred to here. -- Cheers!
```