### PR TITLE
Make taskIndex never be negative

### DIFF
--- a/heron/simulator/src/java/com/twitter/heron/simulator/grouping/FieldsGrouping.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/grouping/FieldsGrouping.java
@@ -47,7 +47,8 @@ public class FieldsGrouping extends Grouping {
     int taskIndex = 0;
     int primeNumber = 633910111;
     for (Integer indices : fieldsGroupingIndices) {
-      taskIndex += Math.abs(tuple.getValues(indices).hashCode()) % primeNumber;
+      int hash = tuple.getValues(indices).hashCode();
+      taskIndex += (hash % primeNumber + primeNumber) % primeNumber;
     }
 
     taskIndex = taskIndex % taskIds.size();


### PR DESCRIPTION
As `Math.abs(Integer.MIN_VALUE)` returns a negative value, taskIndex may be negative. This PR fixed it to avoid IndexOutOfBoundsException.