### PR TITLE
Make task index never negative in simulator's FieldsGrouping

### DIFF
--- a/heron/simulator/src/java/com/twitter/heron/simulator/grouping/FieldsGrouping.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/grouping/FieldsGrouping.java
@@ -47,8 +47,8 @@ public class FieldsGrouping extends Grouping {
     int taskIndex = 0;
     int primeNumber = 633910111;
     for (Integer indices : fieldsGroupingIndices) {
-      int hash = tuple.getValues(indices).hashCode();
-      taskIndex += (hash % primeNumber + primeNumber) % primeNumber;
+      int hash = tuple.getValues(indices).hashCode() % primeNumber;
+      taskIndex += hash >= 0 ? hash : hash + primeNumber;
     }
 
     taskIndex = taskIndex % taskIds.size();

--- a/heron/simulator/src/java/com/twitter/heron/simulator/grouping/FieldsGrouping.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/grouping/FieldsGrouping.java
@@ -17,8 +17,6 @@ package com.twitter.heron.simulator.grouping;
 import java.util.LinkedList;
 import java.util.List;
 
-import com.google.protobuf.ByteString;
-
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.proto.system.HeronTuples;
 
@@ -60,7 +58,7 @@ public class FieldsGrouping extends Grouping {
 
     int taskIndex = 0;
     for (Integer indices : fieldsGroupingIndices) {
-      int hash = getByteStringHashCode(tuple.getValues(indices)) % primeNumber;
+      int hash = getHashCode(tuple.getValues(indices)) % primeNumber;
       taskIndex += hash >= 0 ? hash : hash + primeNumber;
     }
 
@@ -71,13 +69,13 @@ public class FieldsGrouping extends Grouping {
   }
 
   /**
-   * Returns a hash code value for the given ByteString,
+   * Returns a hash code value for the given Object,
    * basing on customized hash method.
    *
-   * @param bs the given
-   * @return the hash code of the ByteString
+   * @param o the given
+   * @return the hash code of the Object
    */
-  protected int getByteStringHashCode(ByteString bs) {
-    return bs.hashCode();
+  protected int getHashCode(Object o) {
+    return o.hashCode();
   }
 }

--- a/heron/simulator/tests/java/com/twitter/heron/simulator/grouping/FieldsGroupingTest.java
+++ b/heron/simulator/tests/java/com/twitter/heron/simulator/grouping/FieldsGroupingTest.java
@@ -80,6 +80,7 @@ public class FieldsGroupingTest {
     Mockito.doReturn(Integer.MIN_VALUE).
         when(g).getHashCode(Mockito.any(ByteString.class));
     g.getListToSend(tuple);
+    // Assert True here to make Test Tool take this test case into account
     Assert.assertTrue(true);
   }
 

--- a/heron/simulator/tests/java/com/twitter/heron/simulator/grouping/FieldsGroupingTest.java
+++ b/heron/simulator/tests/java/com/twitter/heron/simulator/grouping/FieldsGroupingTest.java
@@ -81,17 +81,6 @@ public class FieldsGroupingTest {
         when(g).getHashCode(Mockito.any(ByteString.class));
     g.getListToSend(tuple);
     Assert.assertTrue(true);
-
-    // It will not throw exceptions though
-    // (hash code of ByteString + primeNumber) > Integer.MAX_VALUE
-    int primeNumber = Integer.MAX_VALUE - 1;
-    int mockHashCode = primeNumber - 1;
-    FieldsGrouping customizedPrimeNumberGrouping =
-        Mockito.spy(new FieldsGrouping(is, schema, taskIds, primeNumber));
-    Mockito.doReturn(mockHashCode).
-        when(customizedPrimeNumberGrouping).getHashCode(Mockito.any(ByteString.class));
-    customizedPrimeNumberGrouping.getListToSend(tuple);
-    Assert.assertTrue(true);
   }
 
   /**

--- a/heron/simulator/tests/java/com/twitter/heron/simulator/grouping/FieldsGroupingTest.java
+++ b/heron/simulator/tests/java/com/twitter/heron/simulator/grouping/FieldsGroupingTest.java
@@ -78,7 +78,7 @@ public class FieldsGroupingTest {
     FieldsGrouping g = Mockito.spy(new FieldsGrouping(is, schema, taskIds));
 
     Mockito.doReturn(Integer.MIN_VALUE).
-        when(g).getByteStringHashCode(Mockito.any(ByteString.class));
+        when(g).getHashCode(Mockito.any(ByteString.class));
     g.getListToSend(tuple);
     Assert.assertTrue(true);
 
@@ -89,7 +89,7 @@ public class FieldsGroupingTest {
     FieldsGrouping customizedPrimeNumberGrouping =
         Mockito.spy(new FieldsGrouping(is, schema, taskIds, primeNumber));
     Mockito.doReturn(mockHashCode).
-        when(customizedPrimeNumberGrouping).getByteStringHashCode(Mockito.any(ByteString.class));
+        when(customizedPrimeNumberGrouping).getHashCode(Mockito.any(ByteString.class));
     customizedPrimeNumberGrouping.getListToSend(tuple);
     Assert.assertTrue(true);
   }


### PR DESCRIPTION
1. Make the task index never be negative
As "hash % primeNumber + primeNumber" can overflow and be a negative number,
when primeNumber is greater than Integar.MAX_VALUE/2.
This PR fixed it to avoid IndexOutOfBoundsException.

2. Add unit tests

This pull request is supplementary for #1014 