### PR TITLE
add some useful information when run async process

### DIFF
--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/HeronExecutorTask.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/HeronExecutorTask.java
@@ -109,7 +109,12 @@ public class HeronExecutorTask implements Task {
 
     processTarget = Thread.currentThread();
 
-    final Process regularExecutor = ShellUtils.runASyncProcess(true, executorCmd, new File("."));
+    // Log the working directory, this will make people fast locate the
+    // directory to find the log files
+    File workingDirectory = new File(".");
+    LOG.log(Level.INFO, "working dir: {0}", workingDirectory.getAbsolutePath());
+
+    final Process regularExecutor = ShellUtils.runASyncProcess(true, executorCmd, workingDirectory);
     LOG.log(Level.INFO, "Started heron executor-id: {0}", heronExecutorId);
     try {
       regularExecutor.waitFor();

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/ShellUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/ShellUtils.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.StringTokenizer;
+import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -127,10 +128,20 @@ public final class ShellUtils {
     // Log the command for debugging
     LOG.log(Level.FINE, "$> {0}", Arrays.toString(command));
 
+    // the log file can help people to find out what happened between pb.start()
+    // and the async process started
+    String commandFileName = Paths.get(command[0]).getFileName().toString();
+    String uuid = UUID.randomUUID().toString().substring(0, 8);
+    String logFilePath = workingDirectory + "/" + commandFileName + "-" + uuid + "-started.stderr";
+    File logFile = new File(logFilePath);
+
     // For AsyncProcess, we will never inherit IO, since parent process will not
     // be guaranteed alive when children processing trying to flush to
     // parent processes's IO.
     ProcessBuilder pb = getProcessBuilder(false, command, workingDirectory, envs);
+    pb.redirectErrorStream(true);
+    pb.redirectOutput(ProcessBuilder.Redirect.appendTo(logFile));
+
     Process process = null;
     try {
       process = pb.start();


### PR DESCRIPTION
in runASyncProcess method:

- add a log for working directory which can help people locate the working directory to debug in some scheduler like yarn scheduler
- add a log file which can help people to find out what happened between pb.start() and the async process started (maybe some system error occurred)

These information will be very useful for people to solve the problem when deploying the multi-node heron cluster.

Extra information: #1010 