### PR TITLE
Fix corner cases for FileSink.flush

### DIFF
--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/FileSink.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/FileSink.java
@@ -55,7 +55,7 @@ public class FileSink implements IMetricsSink {
 
   // We would convert a file's metrics into a JSON object, i.e. array
   // So we need to add "[" at the start and "]" at the end
-  private static boolean isFileStart = true;
+  private boolean isFileStart = true;
   private PrintStream writer;
   private String filenamePrefix;
   private int fileMaximum = 1;
@@ -64,15 +64,12 @@ public class FileSink implements IMetricsSink {
 
   @Override
   public void init(Map<String, Object> conf, SinkContext context) {
-    filenamePrefix = (String) conf.get(FILENAME_KEY) + "." + context.getMetricsMgrId();
+    filenamePrefix = conf.get(FILENAME_KEY) + "." + context.getMetricsMgrId();
     fileMaximum = TypeUtils.getInteger(conf.get(MAXIMUM_FILE_COUNT_KEY));
     sinkContext = context;
-
-    // We set System.out as writer's default value here to avoid null object
-    writer = System.out;
   }
 
-  private void openNewFile(String filename) {
+  private PrintStream openNewFile(String filename) {
     // If the file already exists, set it Writable to avoid permission denied
     File f = new File(filename);
     if (f.exists() && !f.isDirectory()) {
@@ -80,9 +77,7 @@ public class FileSink implements IMetricsSink {
     }
 
     try {
-      writer = filename == null ? System.out
-          : new PrintStream(new FileOutputStream(filename, false),
-          true, "UTF-8");
+      return new PrintStream(new FileOutputStream(filename, false), true, "UTF-8");
     } catch (FileNotFoundException | UnsupportedEncodingException e) {
       throw new RuntimeException("Error creating " + filename, e);
     }
@@ -139,7 +134,7 @@ public class FileSink implements IMetricsSink {
   @Override
   public void processRecord(MetricsRecord record) {
     if (isFileStart) {
-      openNewFile(String.format("%s.%s", filenamePrefix, currentFileIndex));
+      writer = openNewFile(String.format("%s.%d", filenamePrefix, currentFileIndex));
 
       writer.print("[");
       isFileStart = false;
@@ -156,6 +151,12 @@ public class FileSink implements IMetricsSink {
 
   @Override
   public void flush() {
+    if (isFileStart) {
+      // No record has been processed since the previous flush, so create a new file
+      // and output an empty JSON array.
+      writer = openNewFile(String.format("%s.%d", filenamePrefix, currentFileIndex));
+      writer.print("[");
+    }
     writer.print("]");
     writer.flush();
     writer.close();
@@ -171,6 +172,8 @@ public class FileSink implements IMetricsSink {
 
   @Override
   public void close() {
-    writer.close();
+    if (writer != null) {
+      writer.close();
+    }
   }
 }

--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/FileSink.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/FileSink.java
@@ -64,9 +64,19 @@ public class FileSink implements IMetricsSink {
 
   @Override
   public void init(Map<String, Object> conf, SinkContext context) {
+    verifyConf(conf);
     filenamePrefix = conf.get(FILENAME_KEY) + "." + context.getMetricsMgrId();
     fileMaximum = TypeUtils.getInteger(conf.get(MAXIMUM_FILE_COUNT_KEY));
     sinkContext = context;
+  }
+
+  private void verifyConf(Map<String, Object> conf) {
+    if (!conf.containsKey(FILENAME_KEY)) {
+      throw new IllegalArgumentException("Require: " + FILENAME_KEY);
+    }
+    if (!conf.containsKey(MAXIMUM_FILE_COUNT_KEY)) {
+      throw new IllegalArgumentException("Require: " + MAXIMUM_FILE_COUNT_KEY);
+    }
   }
 
   private PrintStream openNewFile(String filename) {

--- a/heron/metricsmgr/tests/java/BUILD
+++ b/heron/metricsmgr/tests/java/BUILD
@@ -60,3 +60,19 @@ java_test(
     ],
     size = "small",
 )
+
+java_test(
+    name = "FileSinkTest",
+    srcs = glob(["**/FileSinkTest.java"]),
+    deps = [
+        "//heron/api/src/java:api-java",
+        "//heron/common/src/java:common-java",
+        "//heron/spi/src/java:metricsmgr-spi-java",
+        "//heron/metricsmgr/src/java:metricsmgr-java",
+        "//heron/proto:proto_tmaster_java",
+        "@com_google_protobuf_protobuf_java//jar",
+        "@bazel_tools//third_party:junit4",
+        "@bazel_tools//third_party:mockito",
+    ],
+    size = "small",
+)

--- a/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/FileSinkTest.java
+++ b/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/FileSinkTest.java
@@ -1,0 +1,113 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.twitter.heron.metricsmgr.sink;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.twitter.heron.common.basics.FileUtils;
+import com.twitter.heron.spi.metricsmgr.sink.SinkContext;
+
+/**
+ * FileSink Tester.
+ */
+public class FileSinkTest {
+
+  private FileSink fileSink;
+  private File tmpDir;
+
+  @Before
+  public void before() throws IOException {
+    fileSink = new FileSink();
+    Map<String, Object> conf = new HashMap<>();
+    tmpDir = Files.createTempDirectory("filesink").toFile();
+    conf.put("filename-output", tmpDir.getAbsolutePath() + "/filesink");
+    conf.put("file-maximum", 100);
+    SinkContext context = Mockito.mock(SinkContext.class);
+    Mockito.when(context.getMetricsMgrId()).thenReturn("test");
+    fileSink.init(conf, context);
+  }
+
+  @After
+  public void after() {
+    fileSink.close();
+    for (File file: tmpDir.listFiles()) {
+      file.delete();
+    }
+    tmpDir.delete();
+  }
+
+  /**
+   * Method: flush()
+   */
+  @Test
+  public void testFirstFlushWithoutRecords() {
+    fileSink.flush();
+    String content = new String(FileUtils.readFromFile(
+        new File(tmpDir, "/filesink.test.0").getAbsolutePath()), StandardCharsets.UTF_8);
+    Assert.assertEquals("[]", content);
+  }
+
+  /**
+   * Method: flush()
+   */
+  @Test
+  public void testSuccessiveFlushWithoutRecords() throws UnsupportedEncodingException {
+    fileSink.flush();
+    fileSink.flush();
+    String content = new String(FileUtils.readFromFile(
+        new File(tmpDir, "/filesink.test.0").getAbsolutePath()), StandardCharsets.UTF_8);
+    Assert.assertEquals("[]", content);
+    content = new String(FileUtils.readFromFile(
+        new File(tmpDir, "/filesink.test.1").getAbsolutePath()), StandardCharsets.UTF_8);
+    Assert.assertEquals("[]", content);
+  }
+
+  /**
+   * Method: init()
+   */
+  @Test
+  public void testIllegalConf() throws IOException {
+    FileSink sink = new FileSink();
+    Map<String, Object> conf = new HashMap<>();
+    SinkContext context = Mockito.mock(SinkContext.class);
+    try {
+      sink.init(conf, context);
+      Assert.fail("Expected IllegalArgumentException.");
+    } catch (IllegalArgumentException e) {
+      Assert.assertEquals("Require: filename-output", e.getMessage());
+    }
+
+    sink = new FileSink();
+    conf.put("filename-output", tmpDir.getAbsolutePath() + "/filesink");
+    try {
+      sink.init(conf, context);
+      Assert.fail("Expected IllegalArgumentException.");
+    } catch (IllegalArgumentException e) {
+      Assert.assertEquals("Require: file-maximum", e.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
There are two corner cases for `flush`:

- No record has been processed before the first `flush`: it will output "]" to the stdout and close it.
- No record has been processed between two `flush`s: it will write "]" to a closed writer. Currently it's silent as PrintStream always swallows IOException.

This PR fixed `flush` by creating a new file for these corner cases.