### PR TITLE
Fix HeronMasterDriverTest.createsContextConfigForExecutorId

### DIFF
--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/HeronMasterDriverTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/HeronMasterDriverTest.java
@@ -221,11 +221,14 @@ public class HeronMasterDriverTest {
   @Test
   public void createsContextConfigForExecutorId() {
     Configuration config = driver.createContextConfig("4");
+    boolean found = false;
     for (NamedParameterNode<?> namedParameterNode : config.getNamedParameters()) {
-      if (namedParameterNode.getName().equals(ContextIdentifier.class.getName())) {
-        Assert.assertEquals(4, config.getNamedParameter(namedParameterNode));
+      if (namedParameterNode.getName().equals(ContextIdentifier.class.getSimpleName())) {
+        Assert.assertEquals("4", config.getNamedParameter(namedParameterNode));
+        found = true;
       }
     }
+    Assert.assertTrue("\"ContextIdentifier\" didn't exist.", found);
   }
 
   @Test


### PR DESCRIPTION
`Assert.assertEquals(4, config.getNamedParameter(namedParameterNode));` compares the int `4` with a String, but it doesn't fail because this line has never been called.

This PR fixes this issue and also makes sure the test will fail if the above assertion is not called.