### PR TITLE
#1048 print verbose test failure output when test failed

### DIFF
--- a/tools/travis-ci/bazel.rc
+++ b/tools/travis-ci/bazel.rc
@@ -8,7 +8,7 @@ test --ram_utilization_factor=10 --test_output=errors
 build --verbose_failures
 
 build --show_timestamps
-test --show_timestamps --test_output=errors
+test --show_timestamps
 
 # Limits the jobs to 25 since the resources are limited
 build --jobs 25
@@ -31,7 +31,7 @@ build --crosstool_top //tools/travis-ci/toolchain:CROSSTOOL
 # in a container (unless you require sudo in your .travis.yml) this
 # fails to run tests.
 build --spawn_strategy=standalone --genrule_strategy=standalone
-test --test_strategy=standalone --test_output=errors
+test --test_strategy=standalone
 
 # Ignore unsupported warning for sandboxing
 build --ignore_unsupported_sandboxing

--- a/tools/travis-ci/bazel.rc
+++ b/tools/travis-ci/bazel.rc
@@ -2,13 +2,13 @@
 startup --host_jvm_args=-Xmx2500m
 startup --host_jvm_args=-Xms2500m
 startup --batch
-test --ram_utilization_factor=10
+test --ram_utilization_factor=10 --test_output=errors
 
 # This is so we understand failures better
 build --verbose_failures
 
 build --show_timestamps
-test --show_timestamps
+test --show_timestamps --test_output=errors
 
 # Limits the jobs to 25 since the resources are limited
 build --jobs 25
@@ -31,7 +31,7 @@ build --crosstool_top //tools/travis-ci/toolchain:CROSSTOOL
 # in a container (unless you require sudo in your .travis.yml) this
 # fails to run tests.
 build --spawn_strategy=standalone --genrule_strategy=standalone
-test --test_strategy=standalone
+test --test_strategy=standalone --test_output=errors
 
 # Ignore unsupported warning for sandboxing
 build --ignore_unsupported_sandboxing

--- a/tools/travis-ci/bazel.rc
+++ b/tools/travis-ci/bazel.rc
@@ -2,7 +2,8 @@
 startup --host_jvm_args=-Xmx2500m
 startup --host_jvm_args=-Xms2500m
 startup --batch
-test --ram_utilization_factor=10 --test_output=errors
+test --ram_utilization_factor=10
+test --test_output=errors
 
 # This is so we understand failures better
 build --verbose_failures


### PR DESCRIPTION
* Before 
```
➜  myproject git:(master) ✗ cat bazel.rc 
test --show_timestamps
➜  myproject git:(master) ✗ bazel --bazelrc=./bazel.rc test :fail
INFO: (07-08 13:00:10.878) Found 1 test target...
FAIL: (07-08 13:00:11.962) //examples/java-native/src/test/java/com/example/myproject:fail (see /home/ablecao/.cache/bazel/_bazel_ablecao/e7a4f3e889214213e3acc228637ac701/bazel/bazel-out/local-fastbuild/testlogs/examples/java-native/src/test/java/com/example/myproject/fail/test.log).
Target //examples/java-native/src/test/java/com/example/myproject:fail up-to-date:
  bazel-bin/examples/java-native/src/test/java/com/example/myproject/fail.jar
  bazel-bin/examples/java-native/src/test/java/com/example/myproject/fail
INFO: (07-08 13:00:11.971) Elapsed time: 1.435s, Critical Path: 0.95s
//examples/java-native/src/test/java/com/example/myproject:fail          FAILED in 0.9s
  /home/ablecao/.cache/bazel/_bazel_ablecao/e7a4f3e889214213e3acc228637ac701/bazel/bazel-out/local-fastbuild/testlogs/examples/java-native/src/test/java/com/example/myproject/fail/test.log

Executed 1 out of 1 tests: 1 fails locally.
```
* when use ``` --test_output=errors```
```
➜  myproject git:(master) ✗ cat bazel.rc 
test --show_timestamps --test_output=errors
➜  myproject git:(master) ✗ bazel --bazelrc=./bazel.rc test :fail
INFO: (07-08 13:04:59.830) Found 1 test target...
FAIL: (07-08 13:05:00.709) //examples/java-native/src/test/java/com/example/myproject:fail (see /home/ablecao/.cache/bazel/_bazel_ablecao/e7a4f3e889214213e3acc228637ac701/bazel/bazel-out/local-fastbuild/testlogs/examples/java-native/src/test/java/com/example/myproject/fail/test.log).
INFO: (07-08 13:05:00.710) From Testing //examples/java-native/src/test/java/com/example/myproject:fail:
==================== Test output for //examples/java-native/src/test/java/com/example/myproject:fail:
JUnit4 Test Runner
.E
Time: 0.065
There was 1 failure:
1) testFail(com.example.myproject.Fail)
java.lang.AssertionError: This is an expected test failure.
	at org.junit.Assert.fail(Assert.java:88)
	at com.example.myproject.Fail.testFail(Fail.java:12)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at com.google.testing.junit.runner.junit4.CancellableRequestFactory$CancellableRunner.run(CancellableRequestFactory.java:84)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:160)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:138)
	at com.google.testing.junit.runner.junit4.JUnit4Runner.run(JUnit4Runner.java:103)
	at com.google.testing.junit.runner.BazelTestRunner.runTestsInSuite(BazelTestRunner.java:149)
	at com.google.testing.junit.runner.BazelTestRunner.main(BazelTestRunner.java:90)

FAILURES!!!
Tests run: 1,  Failures: 1


BazelTestRunner exiting with a return value of 1
JVM shutdown hooks (if any) will run now.
The JVM will exit once they complete.

-- JVM shutdown starting at 2016-07-08 05:05:00 --

================================================================================
Target //examples/java-native/src/test/java/com/example/myproject:fail up-to-date:
  bazel-bin/examples/java-native/src/test/java/com/example/myproject/fail.jar
  bazel-bin/examples/java-native/src/test/java/com/example/myproject/fail
INFO: (07-08 13:05:00.754) Elapsed time: 1.100s, Critical Path: 0.84s
//examples/java-native/src/test/java/com/example/myproject:fail          FAILED in 0.8s
  /home/ablecao/.cache/bazel/_bazel_ablecao/e7a4f3e889214213e3acc228637ac701/bazel/bazel-out/local-fastbuild/testlogs/examples/java-native/src/test/java/com/example/myproject/fail/test.log

Executed 1 out of 1 tests: 1 fails locally.
```