### PR TITLE
Add java_tests to make adding java unit tests easier

### DIFF
--- a/heron/common/tests/java/BUILD
+++ b/heron/common/tests/java/BUILD
@@ -1,106 +1,33 @@
-java_test(
-    name = "CommunicatorTest",
-    srcs = glob(["**/CommunicatorTest.java"]),
-    deps = [
-        "//heron/common/src/java:common-java",
-        "//third_party/java:junit4",
-    ],
-    size = "small",
-)
+load("/tools/rules/java_tests", "java_tests")
 
-java_test(
-    name = "SysUtilsTest",
-    srcs = glob(["**/SysUtilsTest.java"]),
+java_library(
+    name = "common-tests",
+    srcs = glob(["**/*.java"]),
     deps = [
         "//heron/common/src/java:common-java",
-        "//third_party/java:junit4",
-    ],
-    size = "small",
-)
-
-java_test(
-    name = "WakeableLooperTest",
-    srcs = glob(["**/WakeableLooperTest.java"]),
-    deps = [
-        "//heron/common/src/java:common-java",
-        "//third_party/java:junit4",
-    ],
-    size = "small",
-)
-
-java_test(
-    name = "FileUtilsTest",
-    srcs = glob(["**/FileUtilsTest.java"]),
-    deps = [
-        "//heron/common/src/java:common-java",
+        "//heron/proto:proto_networktests_java",
         "//third_party/java:powermock",
+        "@com_google_protobuf_protobuf_java//jar",
         "//third_party/java:mockito",
         "//third_party/java:junit4",
     ],
-    size = "small",
 )
 
-java_test(
-    name = "EchoTest",
-    srcs = glob(["**/EchoTest.java"]),
-    deps = [
-        "//heron/common/src/java:common-java",
-        "//heron/proto:proto_networktests_java",
-        "@com_google_protobuf_protobuf_java//jar",
-        "//third_party/java:junit4",
+java_tests(
+    test_classes = [
+        "com.twitter.heron.common.basics.CommunicatorTest",
+        "com.twitter.heron.common.basics.SysUtilsTest",
+        "com.twitter.heron.common.basics.WakeableLooperTest",
+        "com.twitter.heron.common.basics.FileUtilsTest",
+        "com.twitter.heron.common.network.EchoTest",
+        "com.twitter.heron.common.network.HeronServerTest",
+        "com.twitter.heron.common.config.ConfigReaderTest",
+        "com.twitter.heron.common.config.ClusterConfigReaderTest",
+        "com.twitter.heron.common.config.SystemConfigTest",
     ],
-    size = "small",
-)
-
-java_test(
-    name = "HeronServerTest",
-    srcs = glob(["**/HeronServerTest.java"]),
-    deps = [
-        "//heron/common/src/java:common-java",
-        "//heron/proto:proto_networktests_java",
-        "@com_google_protobuf_protobuf_java//jar",
-        "//third_party/java:junit4",
-    ],
-    size = "small",
-)
-
-java_library(
-    name = "config-test-java",
-    srcs = glob(["**/config/Constants.java"]),
-)
-
-java_test(
-    name = "ConfigReaderTest",
-    srcs = glob(["**/config/ConfigReaderTest.java"]),
-    deps = [
-        ":config-test-java",
-        "//heron/common/src/java:config-java",
-        "//third_party/java:junit4",
+    runtime_deps = [
+        ":common-tests",
     ],
     data = glob(["**/config/testdata/**/*.yaml"]),
-    size = "small",
-)
-
-java_test(
-    name = "ClusterConfigReaderTest",
-    srcs = glob(["**/config/ClusterConfigReaderTest.java"]),
-    deps = [
-        ":config-test-java",
-        "//heron/common/src/java:config-java",
-        "//third_party/java:junit4",
-    ],
-    data = glob(["**/config/testdata/**/*.yaml"]),
-    size = "small",
-)
-
-java_test(
-    name = "SystemConfigTest",
-    srcs = glob(["**/config/SystemConfigTest.java"]),
-    deps = [
-        ":config-test-java",
-        "//heron/common/src/java:config-java",
-        "//third_party/java:junit4",
-    ],
-    data = glob(["**/config/testdata/sysconfig.yaml"]),
     size = "small",
 )

--- a/heron/instance/tests/java/BUILD
+++ b/heron/instance/tests/java/BUILD
@@ -1,4 +1,4 @@
-
+load("/tools/rules/java_tests", "java_tests")
 load("/tools/rules/heron_deps", "heron_java_proto_files")
 
 test_deps_files = \
@@ -9,101 +9,27 @@ test_deps_files = \
         "//third_party/java:junit4",
     ]
 
-java_test(
-    name = "CustomGroupingTest",
-    srcs = glob(
-        ["**/CustomGroupingTest.java"] +
-        ["**/resource/*.java"]
-    ),
+java_library(
+    name = "instance-tests",
+    srcs = glob(["**/*.java"]),
     deps = test_deps_files,
-    data = ["//heron/config/src/yaml:test-config-internals-yaml"],
-    size = "small",
 )
 
-java_test(
-    name = "BoltInstanceTest",
-    srcs = glob(
-        ["**/BoltInstanceTest.java"] +
-        ["**/resource/*.java"]
-    ),
-    deps = test_deps_files,
-    data = ["//heron/config/src/yaml:test-config-internals-yaml"],
-    size = "small",
-)
-
-java_test(
-    name = "ActivateDeactivateTest",
-    srcs = glob(
-        ["**/ActivateDeactivateTest.java"] +
-        ["**/resource/*.java"]
-    ),
-    deps = test_deps_files,
-    data = ["//heron/config/src/yaml:test-config-internals-yaml"],
-    size = "small",
-)
-
-java_test(
-    name = "SpoutInstanceTest",
-    srcs = glob(
-        ["**/SpoutInstanceTest.java"] +
-        ["**/resource/*.java"]
-    ),
-    deps = test_deps_files,
-    data = ["//heron/config/src/yaml:test-config-internals-yaml"],
-    size = "small",
-)
-
-java_test(
-    name = "GlobalMetricsTest",
-    srcs = glob(
-        ["**/GlobalMetricsTest.java"] +
-        ["**/resource/*.java"]
-    ),
-    deps = test_deps_files,
-    data = ["//heron/config/src/yaml:test-config-internals-yaml"],
-    size = "small",
-)
-
-java_test(
-    name = "MultiAssignableMetricTest",
-    srcs = glob(
-        ["**/MultiAssignableMetricTest.java"] +
-        ["**/resource/*.java"]
-    ),
-    deps = test_deps_files,
-    data = ["//heron/config/src/yaml:test-config-internals-yaml"],
-    size = "small",
-)
-
-java_test(
-    name = "ConnectTest",
-    srcs = glob(
-        ["**/ConnectTest.java"] +
-        ["**/resource/*.java"]
-    ),
-    deps = test_deps_files,
-    data = ["//heron/config/src/yaml:test-config-internals-yaml"],
-    size = "small",
-)
-
-java_test(
-    name = "HandleReadTest",
-    srcs = glob(
-        ["**/HandleReadTest.java"] +
-        ["**/resource/*.java"]
-    ),
-    deps = test_deps_files,
-    data = ["//heron/config/src/yaml:test-config-internals-yaml"],
-    size = "small",
-)
-
-java_test(
-    name = "HandleWriteTest",
-    srcs = glob(
-        ["**/HandleWriteTest.java"] +
-        ["**/resource/*.java"]
-    ),
-    deps = test_deps_files,
+java_tests(
+    test_classes = [
+        "com.twitter.heron.grouping.CustomGroupingTest",
+        "com.twitter.heron.instance.bolt.BoltInstanceTest",
+        "com.twitter.heron.instance.spout.ActivateDeactivateTest",
+        "com.twitter.heron.instance.spout.SpoutInstanceTest",
+        "com.twitter.heron.metrics.GlobalMetricsTest",
+        "com.twitter.heron.metrics.MultiAssignableMetricTest",
+        "com.twitter.heron.network.ConnectTest",
+        "com.twitter.heron.network.HandleReadTest",
+        "com.twitter.heron.network.HandleWriteTest",
+    ],
+    runtime_deps = [
+        ":instance-tests",
+    ],
     data = ["//heron/config/src/yaml:test-config-internals-yaml"],
     size = "small",
 )

--- a/heron/metricsmgr/tests/java/BUILD
+++ b/heron/metricsmgr/tests/java/BUILD
@@ -1,10 +1,13 @@
-java_test(
-    name = "HandleTMasterLocationTest",
-    srcs = glob(["**/HandleTMasterLocationTest.java"]),
+load("/tools/rules/java_tests", "java_tests")
+
+java_library(
+    name = "metricsmgr-tests",
+    srcs = glob(["**/*.java"]),
     deps = [
-        "//heron/api/src/java:api-java", 
-        "//heron/common/src/java:common-java", 
-        "//heron/metricsmgr/src/java:metricsmgr-java", 
+        "//heron/api/src/java:api-java",
+        "//heron/common/src/java:common-java",
+        "//heron/metricsmgr/src/java:metricsmgr-java",
+        "//heron/spi/src/java:metricsmgr-spi-java",
         "//heron/proto:proto_common_java",
         "//heron/proto:proto_metrics_java",
         "//heron/proto:proto_tmaster_java",
@@ -12,67 +15,18 @@ java_test(
         "//third_party/java:mockito",
         "//third_party/java:junit4",
     ],
-    size = "small",
 )
 
-java_test(
-    name = "MetricsManagerServerTest",
-    srcs = glob(["**/MetricsManagerServerTest.java"]),
-    deps = [
-        "//heron/api/src/java:api-java", 
-        "//heron/common/src/java:common-java", 
-        "//heron/spi/src/java:metricsmgr-spi-java", 
-        "//heron/metricsmgr/src/java:metricsmgr-java", 
-        "//heron/proto:proto_common_java",
-        "//heron/proto:proto_metrics_java", 
-        "@com_google_protobuf_protobuf_java//jar",
-        "//third_party/java:junit4",
+java_tests(
+    test_classes = [
+        "com.twitter.heron.metricsmgr.HandleTMasterLocationTest",
+        "com.twitter.heron.metricsmgr.MetricsManagerServerTest",
+        "com.twitter.heron.metricsmgr.executor.SinkExecutorTest",
+        "com.twitter.heron.metricsmgr.sink.tmaster.TMasterSinkTest",
+        "com.twitter.heron.metricsmgr.sink.FileSinkTest",
     ],
-    size = "small",
-)
-
-java_test(
-    name = "SinkExecutorTest",
-    srcs = glob(["**/SinkExecutorTest.java"]),
-    deps = [
-        "//heron/api/src/java:api-java", 
-        "//heron/common/src/java:common-java", 
-        "//heron/spi/src/java:metricsmgr-spi-java", 
-        "//heron/metricsmgr/src/java:metricsmgr-java", 
-        "//heron/proto:proto-java",
-        "@com_google_protobuf_protobuf_java//jar",
-        "//third_party/java:junit4",
-    ],
-    size = "small",
-)
-
-java_test(
-    name = "TMasterSinkTest",
-    srcs = glob(["**/TMasterSinkTest.java"]),
-    deps = [
-        "//heron/api/src/java:api-java", 
-        "//heron/common/src/java:common-java", 
-        "//heron/spi/src/java:metricsmgr-spi-java", 
-        "//heron/metricsmgr/src/java:metricsmgr-java", 
-        "//heron/proto:proto_tmaster_java",
-        "@com_google_protobuf_protobuf_java//jar",
-        "//third_party/java:junit4",
-    ],
-    size = "small",
-)
-
-java_test(
-    name = "FileSinkTest",
-    srcs = glob(["**/FileSinkTest.java"]),
-    deps = [
-        "//heron/api/src/java:api-java",
-        "//heron/common/src/java:common-java",
-        "//heron/spi/src/java:metricsmgr-spi-java",
-        "//heron/metricsmgr/src/java:metricsmgr-java",
-        "//heron/proto:proto_tmaster_java",
-        "@com_google_protobuf_protobuf_java//jar",
-        "//third_party/java:junit4",
-        "//third_party/java:mockito",
+    runtime_deps = [
+        ":metricsmgr-tests",
     ],
     size = "small",
 )

--- a/heron/scheduler-core/tests/java/BUILD
+++ b/heron/scheduler-core/tests/java/BUILD
@@ -1,3 +1,4 @@
+load("/tools/rules/java_tests", "java_tests")
 load("/tools/rules/heron_deps", "heron_java_proto_files")
 
 common_deps_files = [
@@ -24,95 +25,27 @@ scheduler_deps_files = \
   heron_java_proto_files() + \
   spi_deps_files
 
-# Following unit tests are for classes under package com.twitter.heron.scheduler
-java_test(
-  name="LaunchRunnerTest",
-  srcs=glob(
-    ["**/LaunchRunnerTest.java"] +
-    ["**/util/TopologyUtilityTest.java"]
-  ),
-  deps=scheduler_deps_files,
-  size="small",
+java_library(
+  name = "scheduler-core-tests",
+  srcs = glob(["**/*.java"]),
+  deps = scheduler_deps_files + [
+    "//heron/statemgrs/src/java:null-statemgr-java",
+    "//heron/schedulers/src/java:null-scheduler-java",
+  ],
 )
 
-java_test(
-  name="RuntimeManagerRunnerTest",
-  srcs=glob(
-    ["**/RuntimeManagerRunnerTest.java"] +
-    ["**/util/TopologyUtilityTest.java"]
-  ),
-  deps=scheduler_deps_files,
-  size="small",
-)
-
-java_test(
-  name="RuntimeManagerMainTest",
-  srcs=glob(
-    ["**/RuntimeManagerMainTest.java"] +
-    ["**/util/TopologyUtilityTest.java"]
-  ),
-  deps=scheduler_deps_files  +
-    ["//heron/statemgrs/src/java:null-statemgr-java"],
-  size="small",
-)
-
-java_test(
-  name="SubmitterMainTest",
-  srcs=glob(
-    ["**/SubmitterMainTest.java"] +
-    ["**/util/TopologyUtilityTest.java"]
-  ),
-  deps=scheduler_deps_files,
-  size="small",
-)
-
-java_test(
-  name="SchedulerMainTest",
-  srcs=glob(
-    ["**/SchedulerMainTest.java"] +
-    ["**/util/TopologyUtilityTest.java"]
-  ),
-  deps=scheduler_deps_files,
-  size="small",
-)
-
-# Following unit tests are for classes under package com.twitter.heron.scheduler.server
-java_test(
-  name="SchedulerServerTest",
-  srcs=glob(
-    ["**/SchedulerServerTest.java"]
-  ),
-  deps=scheduler_deps_files,
-  size="small",
-)
-
-
-# Following unit tests are for class under package com.twitter.heron.scheduler.client
-
-java_test(
-  name="LibrarySchedulerClientTest",
-  srcs=glob(
-    ["**/LibrarySchedulerClientTest.java"]
-  ),
-  deps=scheduler_deps_files,
-  size="small",
-)
-
-java_test(
-  name="HttpServiceSchedulerClientTest",
-  srcs=glob(
-    ["**/HttpServiceSchedulerClientTest.java"]
-  ),
-  deps=scheduler_deps_files,
-  size="small",
-)
-
-java_test(
-  name="SchedulerClientFactoryTest",
-  srcs=glob(
-    ["**/SchedulerClientFactoryTest.java"]
-  ),
-  deps=scheduler_deps_files +
-    ["//heron/schedulers/src/java:null-scheduler-java"],
-  size="small",
+java_tests(
+  test_classes = [
+    "com.twitter.heron.scheduler.LaunchRunnerTest",
+    "com.twitter.heron.scheduler.RuntimeManagerRunnerTest",
+    "com.twitter.heron.scheduler.RuntimeManagerMainTest",
+    "com.twitter.heron.scheduler.SubmitterMainTest",
+    "com.twitter.heron.scheduler.SchedulerMainTest",
+    "com.twitter.heron.scheduler.server.SchedulerServerTest",
+    "com.twitter.heron.scheduler.client.LibrarySchedulerClientTest",
+    "com.twitter.heron.scheduler.client.HttpServiceSchedulerClientTest",
+    "com.twitter.heron.scheduler.client.SchedulerClientFactoryTest",
+  ],
+  runtime_deps = [ ":scheduler-core-tests" ],
+  size = "small",
 )

--- a/heron/schedulers/tests/java/BUILD
+++ b/heron/schedulers/tests/java/BUILD
@@ -1,3 +1,4 @@
+load("/tools/rules/java_tests", "java_tests")
 load("/tools/rules/heron_deps", "heron_java_proto_files")
 
 common_deps_files = [
@@ -49,106 +50,66 @@ slurm_deps_files = [
     "//heron/schedulers/src/java:slurm-scheduler-java",
 ]
 
-java_test(
-  name="AuroraSchedulerTest",
-  srcs=glob(
-    ["**/AuroraSchedulerTest.java"]
-  ),
-  deps=scheduler_deps_files + aurora_deps_files,
-  size="small",
+java_library(
+  name = "aurora-tests",
+  srcs = glob(["**/aurora/*.java"]),
+  deps = scheduler_deps_files + aurora_deps_files,
 )
 
-java_test(
-  name="AuroraLauncherTest",
-  srcs=glob(
-    ["**/AuroraLauncherTest.java"]
-  ),
-  deps=scheduler_deps_files + aurora_deps_files,
-  size="small",
+java_tests(
+  test_classes = [
+    "com.twitter.heron.scheduler.aurora.AuroraSchedulerTest",
+    "com.twitter.heron.scheduler.aurora.AuroraLauncherTest",
+    "com.twitter.heron.scheduler.aurora.AuroraControllerTest",
+  ],
+  runtime_deps = [ ":aurora-tests" ],
+  size = "small",
 )
 
-java_test(
-  name="AuroraControllerTest",
-  srcs=glob(
-    ["**/AuroraControllerTest.java"]
-  ),
-  deps=scheduler_deps_files + aurora_deps_files,
-  size="small",
+java_library(
+  name = "yarn-tests",
+  srcs = glob(["**/yarn/*.java"]),
+  deps = scheduler_deps_files + yarn_deps_files,
 )
 
-java_test(
-  name="YarnSchedulerTest",
-  srcs=glob(["**/YarnSchedulerTest.java"]
-  ),
-  deps=scheduler_deps_files + yarn_deps_files,
-  size="small",
+java_tests(
+  test_classes = [
+    "com.twitter.heron.scheduler.yarn.YarnSchedulerTest",
+    "com.twitter.heron.scheduler.yarn.HeronMasterDriverTest",
+    "com.twitter.heron.scheduler.yarn.DriverOnLocalReefTest",
+    "com.twitter.heron.scheduler.yarn.HeronExecutorTaskTest",
+  ],
+  runtime_deps = [ ":yarn-tests" ],
+  size = "small",
 )
 
-java_test(
-  name="HeronMasterDriverTest",
-  srcs=glob(["**/HeronMasterDriverTest.java"]
-  ),
-  deps=scheduler_deps_files + yarn_deps_files,
-  size="small",
+java_library(
+  name = "local-tests",
+  srcs = glob(["**/local/*.java"]),
+  deps = scheduler_deps_files + local_deps_files,
 )
 
-java_test(
-  name="DriverOnLocalReefTest",
-  srcs=glob(["**/DriverOnLocalReefTest.java"]
-  ),
-  deps=scheduler_deps_files + yarn_deps_files,
-  size="small",
+java_tests(
+  test_classes = [
+    "com.twitter.heron.scheduler.local.LocalLauncherTest",
+    "com.twitter.heron.scheduler.local.LocalSchedulerTest",
+  ],
+  runtime_deps = [ ":local-tests" ],
+  size = "small",
 )
 
-java_test(
-  name="HeronExecutorTaskTest",
-  srcs=glob(["**/HeronExecutorTaskTest.java"]
-  ),
-  deps=scheduler_deps_files + yarn_deps_files,
-  size="small",
+java_library(
+  name = "slurm-tests",
+  srcs = glob(["**/slurm/*.java"]),
+  deps = scheduler_deps_files + slurm_deps_files,
 )
 
-java_test(
-  name="LocalLauncherTest",
-  srcs=glob(
-    ["**/LocalLauncherTest.java"]
-  ),
-  deps=scheduler_deps_files + local_deps_files,
-  size="small",
-)
-
-java_test(
-  name="LocalSchedulerTest",
-  srcs=glob(
-    ["**/LocalSchedulerTest.java"]
-  ),
-  deps=scheduler_deps_files + local_deps_files,
-  size="small",
-)
-
-java_test(
-  name="SlurmLauncherTest",
-  srcs=glob(
-    ["**/SlurmLauncherTest.java"]
-  ),
-  deps=scheduler_deps_files + slurm_deps_files,
-  size="small",
-)
-
-java_test(
-  name="SlurmSchedulerTest",
-  srcs=glob(
-    ["**/SlurmSchedulerTest.java"]
-  ),
-  deps=scheduler_deps_files + slurm_deps_files,
-  size="small",
-)
-
-java_test(
-  name="SlurmControllerTest",
-  srcs=glob(
-    ["**/SlurmControllerTest.java"]
-  ),
-  deps=scheduler_deps_files + slurm_deps_files,
-  size="small",
+java_tests(
+  test_classes = [
+    "com.twitter.heron.scheduler.slurm.SlurmLauncherTest",
+    "com.twitter.heron.scheduler.slurm.SlurmSchedulerTest",
+    "com.twitter.heron.scheduler.slurm.SlurmControllerTest",
+  ],
+  runtime_deps = [ ":slurm-tests" ],
+  size = "small",
 )

--- a/heron/simulator/tests/java/BUILD
+++ b/heron/simulator/tests/java/BUILD
@@ -1,103 +1,35 @@
+load("/tools/rules/java_tests", "java_tests")
 load("/tools/rules/heron_deps", "heron_java_proto_files")
 
-test_deps_files = \
-    heron_java_proto_files() + [
-        "//heron/api/src/java:api-java", 
+java_library(
+    name = "simulator-tests",
+    srcs = glob(["**/*.java"]),
+    deps =  heron_java_proto_files() + [
+        "//heron/api/src/java:api-java",
         "//heron/common/src/java:common-java",
         "//heron/simulator/src/java:simulator-java",
         "//third_party/java:mockito",
         "//third_party/java:junit4",
-    ]
-
-java_test(
-    name = "InstanceExecutorTest",
-    srcs = glob(
-        ["**/InstanceExecutorTest.java"] +
-        ["**/PhysicalPlanUtilTest.java"],
-    ),
-    deps = test_deps_files,
-    size = "small",
+    ],
 )
 
-java_test(
-    name = "AllGroupingTest",
-    srcs = glob(["**/AllGroupingTest.java"]),
-    deps = test_deps_files, 
-    size = "small",
-)
-
-java_test(
-    name = "CustomGroupingTest",
-    srcs = glob(["**/CustomGroupingTest.java"]),
-    deps = test_deps_files, 
-    size = "small",
-)
-
-java_test(
-    name = "FieldsGroupingTest",
-    srcs = glob(["**/FieldsGroupingTest.java"]),
-    deps = test_deps_files, 
-    size = "small",
-)
-
-java_test(
-    name = "LowestGroupingTest",
-    srcs = glob(["**/LowestGroupingTest.java"]),
-    deps = test_deps_files, 
-    size = "small",
-)
-
-java_test(
-    name = "ShuffleGroupingTest",
-    srcs = glob(["**/ShuffleGroupingTest.java"]),
-    deps = test_deps_files, 
-    size = "small",
-)
-
-java_test(
-    name = "PhysicalPlanUtilTest",
-    srcs = glob(["**/PhysicalPlanUtilTest.java"]),
-    deps = test_deps_files, 
-    size = "small",
-)
-
-java_test(
-    name = "RotatingMapTest",
-    srcs = glob(["**/RotatingMapTest.java"]),
-    deps = test_deps_files, 
-    size = "small",
-)
-
-java_test(
-    name = "StreamConsumersTest",
-    srcs = glob(
-        ["**/StreamConsumersTest.java"] +
-        ["**/PhysicalPlanUtilTest.java"],
-    ),
-    deps = test_deps_files, 
-    size = "small",
-)
-
-java_test(
-    name = "TupleCacheTest",
-    srcs = glob(["**/TupleCacheTest.java"]),
-    deps = test_deps_files, 
-    size = "small",
-)
-
-java_test(
-    name = "XORManagerTest",
-    srcs = glob(
-        ["**/XORManagerTest.java"] +
-        ["**/PhysicalPlanUtilTest.java"],
-    ),
-    deps = test_deps_files, 
-    size = "small",
-)
-
-java_test(
-    name = "SimulatorTest",
-    srcs = glob(["**/SimulatorTest.java"]),
-    deps = test_deps_files,
+java_tests(
+    test_classes = [
+        "com.twitter.heron.simulator.executors.InstanceExecutorTest",
+        "com.twitter.heron.simulator.grouping.AllGroupingTest",
+        "com.twitter.heron.simulator.grouping.CustomGroupingTest",
+        "com.twitter.heron.simulator.grouping.FieldsGroupingTest",
+        "com.twitter.heron.simulator.grouping.LowestGroupingTest",
+        "com.twitter.heron.simulator.grouping.ShuffleGroupingTest",
+        "com.twitter.heron.simulator.utils.PhysicalPlanUtilTest",
+        "com.twitter.heron.simulator.utils.RotatingMapTest",
+        "com.twitter.heron.simulator.utils.StreamConsumersTest",
+        "com.twitter.heron.simulator.utils.TupleCacheTest",
+        "com.twitter.heron.simulator.utils.XORManagerTest",
+        "com.twitter.heron.simulator.SimulatorTest",
+    ],
+    runtime_deps = [
+        ":simulator-tests",
+    ],
     size = "small",
 )

--- a/heron/spi/tests/java/BUILD
+++ b/heron/spi/tests/java/BUILD
@@ -1,4 +1,4 @@
-
+load("/tools/rules/java_tests", "java_tests")
 load("/tools/rules/heron_deps", "heron_java_proto_files")
 
 common_deps_files = [
@@ -29,10 +29,21 @@ api_deps_files = proto_deps_files + [
 ]
 
 java_library(
-    name = "test-utils-java",
-    srcs = glob([
-        "**/TestConstants.java",
-    ]),
+    name = "utils-tests",
+    srcs = glob(["**/utils/*.java"]),
+    deps = api_deps_files
+)
+
+java_tests(
+    test_classes = [
+        "com.twitter.heron.spi.utils.ShellUtilsTest",
+        "com.twitter.heron.spi.utils.NetworkUtilsTest",
+        "com.twitter.heron.spi.utils.SchedulerUtilsTest",
+        "com.twitter.heron.spi.utils.TopologyUtilsTest",
+        "com.twitter.heron.spi.utils.UploaderUtilsTest",
+    ],
+    runtime_deps = [ ":utils-tests" ],
+    size = "small",
 )
 
 java_test(
@@ -42,110 +53,41 @@ java_test(
     size = "small",
 )
 
-java_test(
-    name = "ShellUtilsTest",
-    srcs = glob(["**/utils/ShellUtilsTest.java"]),
-    deps = util_deps_files,
-    size = "small",
-)
-
-java_test(
-    name = "NetworkUtilsTest",
-    srcs = glob(["**/utils/NetworkUtilsTest.java"]),
-    deps = util_deps_files,
-    size = "small",
-)
-
-java_test(
-    name = "SchedulerUtilsTest",
-    srcs = glob(["**/utils/SchedulerUtilsTest.java"]),
-    deps = proto_deps_files, 
-    size = "small",
-)
-
-java_test(
-    name = "TopologyUtilsTest",
-    srcs = glob(["**/utils/TopologyUtilsTest.java"]),
-    deps = api_deps_files, 
-    size = "small",
-)
-
-java_test(
-    name = "ExceptionInfoTest",
-    srcs = glob(["**/ExceptionInfoTest.java"]),
+java_library(
+    name = "metrics-tests",
+    srcs = glob(["**/metrics/*.java"]),
     deps = [
-        "//heron/spi/src/java:metricsmgr-spi-java", 
+        "//heron/spi/src/java:metricsmgr-spi-java",
         "//third_party/java:junit4",
     ],
-    size = "small",
 )
 
-java_test(
-    name = "MetricsInfoTest",
-    srcs = glob(["**/MetricsInfoTest.java"]),
-    deps = [
-        "//heron/spi/src/java:metricsmgr-spi-java", 
-        "//third_party/java:junit4",
+java_tests(
+    test_classes = [
+        "com.twitter.heron.spi.metricsmgr.metrics.ExceptionInfoTest",
+        "com.twitter.heron.spi.metricsmgr.metrics.MetricsInfoTest",
+        "com.twitter.heron.spi.metricsmgr.metrics.MetricsRecordTest",
     ],
+    runtime_deps = [ ":metrics-tests" ],
     size = "small",
 )
 
-java_test(
-    name = "MetricsRecordTest",
-    srcs = glob(["**/MetricsRecordTest.java"]),
-    deps = [
-        "//heron/spi/src/java:metricsmgr-spi-java", 
-        "//third_party/java:junit4",
+java_library(
+    name = "common-tests",
+    srcs = glob(["**/common/*.java"]),
+    deps = common_deps_files,
+)
+
+java_tests(
+    test_classes = [
+        "com.twitter.heron.spi.common.ConfigKeysTest",
+        "com.twitter.heron.spi.common.ConfigDefaultsTest",
+        "com.twitter.heron.spi.common.ConfigKeysDefaultsTest",
+        "com.twitter.heron.spi.common.MiscTest",
+        "com.twitter.heron.spi.common.ClusterDefaultsTest",
+        "com.twitter.heron.spi.common.ClusterConfigTest",
     ],
-    size = "small",
-)
-
-java_test(
-    name = "ConfigKeysTest",
-    srcs = glob(["**/ConfigKeysTest.java"]),
-    deps = [":test-utils-java"] + common_deps_files,
-    size = "small",
-)
-
-java_test(
-    name = "ConfigDefaultsTest",
-    srcs = glob(["**/ConfigDefaultsTest.java"]),
-    deps = [":test-utils-java"] + common_deps_files,
-    size = "small",
-)
-
-java_test(
-    name = "ConfigKeysDefaultsTest",
-    srcs = glob(["**/ConfigKeysDefaultsTest.java"]),
-    deps = [":test-utils-java"] + common_deps_files,
-    size = "small",
-)
-
-java_test(
-    name = "MiscTest",
-    srcs = glob(["**/MiscTest.java"]),
-    deps = [":test-utils-java"] + common_deps_files,
-    size = "small",
-)
-
-java_test(
-    name = "ClusterDefaultsTest",
-    srcs = glob(["**/ClusterDefaultsTest.java"]),
-    deps = [":test-utils-java"] + common_deps_files,
-    size = "small",
-)
-
-java_test(
-    name = "ClusterConfigTest",
-    srcs = glob(["**/ClusterConfigTest.java"]),
-    deps = [":test-utils-java"] + common_deps_files,
+    runtime_deps = [ ":common-tests" ],
     data = glob(["**/testdata/**/*.yaml"]),
-    size = "small",
-)
-
-java_test(
-    name = "UploaderUtilsTest",
-    srcs = glob(["**/utils/UploaderUtilsTest.java"]),
-    deps = util_deps_files,
     size = "small",
 )

--- a/heron/uploaders/tests/java/BUILD
+++ b/heron/uploaders/tests/java/BUILD
@@ -1,3 +1,4 @@
+load("/tools/rules/java_tests", "java_tests")
 load("/tools/rules/heron_deps", "heron_java_proto_files")
 
 common_deps_files = [
@@ -16,7 +17,6 @@ spi_deps_files = [
 localfs_deps_files = \
     common_deps_files + \
     spi_deps_files + [
-        ":local-filesystem-constants-java",
         "//heron/uploaders/src/java:localfs-uploader-java",
     ]
 
@@ -27,23 +27,19 @@ hdfs_deps_files = \
     ]
 
 java_library(
-    name = "local-filesystem-constants-java",
-    srcs = glob(["**/localfs/LocalFileSystemConstantsTest.java"]),
+    name = "localfs-tests",
+    srcs = glob(["**/localfs/*.java"]),
+    deps = localfs_deps_files,
 )
 
-java_test(
-    name = "LocalFileSystemConfigTest",
-    srcs = glob(["**/localfs/LocalFileSystemConfigTest.java"]),
-    deps = localfs_deps_files,
-    size = "small",
-)
-
-java_test(
-    name = "LocalFileSystemUploaderTest",
-    srcs = glob(["**/localfs/LocalFileSystemUploaderTest.java"]),
-    deps = localfs_deps_files,
-    size = "small",
-    data = glob(["**/localfs/testdata/*.tar"]),
+java_tests(
+  test_classes = [
+    "com.twitter.heron.uploader.localfs.LocalFileSystemConfigTest",
+    "com.twitter.heron.uploader.localfs.LocalFileSystemUploaderTest",
+  ],
+  runtime_deps = [ ":localfs-tests" ],
+  data = glob(["**/localfs/testdata/*.tar"]),
+  size = "small",
 )
 
 java_test(

--- a/tools/rules/java_tests.bzl
+++ b/tools/rules/java_tests.bzl
@@ -1,0 +1,9 @@
+def java_tests(test_classes, runtime_deps=[], data=[], size="medium"):
+    for test_class in test_classes:
+        native.java_test(
+            name = test_class.split(".")[-1],
+            runtime_deps = runtime_deps,
+            size = size,
+            test_class = test_class,
+            data = data,
+        )


### PR DESCRIPTION
This PR adds a Bazel rule `java_tests` to generate `java_test` according to the specified `test_classes`. It reduces a lot of build codes and it's pretty easy to add a new unit test: just add the full class name and there will be a new `java_test` target created automatically. E.g., `com.twitter.heron.common.basics.CommunicatorTest` will have a target named `CommunicatorTest`.
