### PR TITLE
Add extension when generating filename

### DIFF
--- a/heron/spi/src/java/com/twitter/heron/spi/utils/UploaderUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/UploaderUtils.java
@@ -20,6 +20,8 @@ import java.util.Random;
  * Utility used by Uploader
  */
 public final class UploaderUtils {
+  public static final String DEFAULT_FILENAME_EXTENSION = ".tar.gz";
+
   private UploaderUtils() {
 
   }
@@ -35,7 +37,7 @@ public final class UploaderUtils {
       String topologyName,
       String role) {
     // By default, we have empty tag info and version 0
-    return generateFilename(topologyName, role, "tag", 0);
+    return generateFilename(topologyName, role, "tag", 0, DEFAULT_FILENAME_EXTENSION);
   }
 
   /**
@@ -45,14 +47,16 @@ public final class UploaderUtils {
    * @param role role owns the topology
    * @param version version of the job, put 0 if not needed
    * @param tag extra info to tag the file
+   * @param extension file extension
    * @return a unique filename
    */
   public static String generateFilename(
       String topologyName,
       String role,
       String tag,
-      int version) {
-    return String.format("%s-%s-%s-%d-%d",
-        topologyName, role, tag, version, new Random().nextLong());
+      int version,
+      String extension) {
+    return String.format("%s-%s-%s-%d-%d%s",
+        topologyName, role, tag, version, new Random().nextLong(), extension);
   }
 }

--- a/heron/spi/tests/java/com/twitter/heron/spi/utils/UploaderUtilsTest.java
+++ b/heron/spi/tests/java/com/twitter/heron/spi/utils/UploaderUtilsTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 public class UploaderUtilsTest {
 
   @Test
-  public void testGenerateFilename() {
+  public void testGenerateFilename() throws Exception {
     int expectedUniqueFilename = 10000;
     String topologyName = "topologyName";
     String role = "role";
@@ -33,10 +33,26 @@ public class UploaderUtilsTest {
     Set<String> filenames = new HashSet<>();
     for (int i = 0; i < expectedUniqueFilename; i++) {
       filenames.add(UploaderUtils.generateFilename(
-          topologyName, role, tag, version));
+          topologyName, role, tag, version, ""));
     }
 
     // All filenames should be unique
     Assert.assertEquals(expectedUniqueFilename, filenames.size());
+  }
+
+  @Test
+  public void testFilenameFormat() throws Exception {
+    String topologyName = "topologyName";
+    String role = "role";
+    String filename = UploaderUtils.generateFilename(topologyName, role);
+
+    Assert.assertTrue(filename.endsWith(UploaderUtils.DEFAULT_FILENAME_EXTENSION));
+
+    String tag = "";
+    int version = -1;
+    String extension = ".extension";
+    String customizedFilename =
+        UploaderUtils.generateFilename(topologyName, role, tag, version, extension);
+    Assert.assertTrue(customizedFilename.endsWith(extension));
   }
 }


### PR DESCRIPTION
Currently UploaderUtils.generateFilename() returns filename without extension.
This can lead to file-type mis-parsing, for instance, MesosFetcher.

This pull request adds filename extension.