### PR TITLE
Add utils method schedulerCommandArgs

### DIFF
--- a/heron/spi/src/java/com/twitter/heron/spi/utils/SchedulerUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/SchedulerUtils.java
@@ -89,18 +89,6 @@ public final class SchedulerUtils {
       Config config,
       Config runtime,
       List<Integer> freePorts) {
-    // First let us have some safe checks
-    if (freePorts.size() < PORTS_REQUIRED_FOR_SCHEDULER) {
-      throw new RuntimeException("Failed to find enough ports for executor");
-    }
-    for (int port : freePorts) {
-      if (port == -1) {
-        throw new RuntimeException("Failed to find available ports for executor");
-      }
-    }
-
-    int httpPort = freePorts.get(0);
-
     List<String> commands = new ArrayList<>();
 
     // The java executable should be "{JAVA_HOME}/bin/java"
@@ -116,7 +104,36 @@ public final class SchedulerUtils {
         .toString();
     commands.add(completeSchedulerProcessClassPath);
 
-    commands.add("com.twitter.heron.scheduler.SchedulerMain");
+    String[] commandArgs = schedulerCommandArgs(config, runtime, freePorts);
+    commands.addAll(Arrays.asList(commandArgs));
+
+    return commands.toArray(new String[0]);
+  }
+
+  /**
+   * Util method to get the arguments to the heron scheduler.
+   *
+   * @param config The static Config
+   * @param runtime The runtime Config
+   * @param freePorts list of free ports
+   * @return String[] representing the arguments to start heron-scheduler
+   */
+  public static String[] schedulerCommandArgs(
+      Config config, Config runtime, List<Integer> freePorts) {
+    // First let us have some safe checks
+    if (freePorts.size() < PORTS_REQUIRED_FOR_SCHEDULER) {
+      throw new RuntimeException("Failed to find enough ports for executor");
+    }
+    for (int port : freePorts) {
+      if (port == -1) {
+        throw new RuntimeException("Failed to find available ports for executor");
+      }
+    }
+
+    int httpPort = freePorts.get(0);
+
+    List<String> commands = new ArrayList<>();
+
     commands.add("--cluster");
     commands.add(Context.cluster(config));
     commands.add("--role");

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/SchedulerUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/SchedulerUtils.java
@@ -103,6 +103,7 @@ public final class SchedulerUtils {
         .append(Context.stateManagerSandboxClassPath(config))
         .toString();
     commands.add(completeSchedulerProcessClassPath);
+    commands.add("com.twitter.heron.scheduler.SchedulerMain");
 
     String[] commandArgs = schedulerCommandArgs(config, runtime, freePorts);
     commands.addAll(Arrays.asList(commandArgs));

--- a/heron/spi/tests/java/com/twitter/heron/spi/utils/SchedulerUtilsTest.java
+++ b/heron/spi/tests/java/com/twitter/heron/spi/utils/SchedulerUtilsTest.java
@@ -14,6 +14,9 @@
 
 package com.twitter.heron.spi.utils;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,6 +27,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.twitter.heron.common.basics.FileUtils;
 import com.twitter.heron.proto.system.Common;
+import com.twitter.heron.spi.common.Config;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({FileUtils.class, ShellUtils.class, SchedulerUtils.class})
@@ -147,5 +151,18 @@ public class SchedulerUtilsTest {
         setupWorkingDirectory(
             WORKING_DIR, CORE_RELEASE_URI, CORE_RELEASE_DEST,
             TOPOLOGY_URI, TOPOLOGY_DEST, isVerbose));
+  }
+
+  @Test
+  public void testSchedulerCommandArgs() throws Exception {
+    List<Integer> freePorts = new ArrayList();
+
+    freePorts.add(1);
+    String[] expectedArgs =
+        {"--cluster", null, "--role", null,
+            "--environment", null, "--topology_name", null,
+            "--topology_jar", null, "--http_port", "1"};
+    Assert.assertArrayEquals(expectedArgs,SchedulerUtils.schedulerCommandArgs(
+        Mockito.mock(Config.class), Mockito.mock(Config.class), freePorts) );
   }
 }

--- a/heron/spi/tests/java/com/twitter/heron/spi/utils/SchedulerUtilsTest.java
+++ b/heron/spi/tests/java/com/twitter/heron/spi/utils/SchedulerUtilsTest.java
@@ -155,14 +155,14 @@ public class SchedulerUtilsTest {
 
   @Test
   public void testSchedulerCommandArgs() throws Exception {
-    List<Integer> freePorts = new ArrayList();
+    List<Integer> freePorts = new ArrayList<>();
 
     freePorts.add(1);
     String[] expectedArgs =
         {"--cluster", null, "--role", null,
             "--environment", null, "--topology_name", null,
             "--topology_jar", null, "--http_port", "1"};
-    Assert.assertArrayEquals(expectedArgs,SchedulerUtils.schedulerCommandArgs(
-        Mockito.mock(Config.class), Mockito.mock(Config.class), freePorts) );
+    Assert.assertArrayEquals(expectedArgs, SchedulerUtils.schedulerCommandArgs(
+        Mockito.mock(Config.class), Mockito.mock(Config.class), freePorts));
   }
 }


### PR DESCRIPTION
Add utils method schedulerCommandArgs
    
Add utils method schedulerCommandArgs, allowing people to get only the args
of scheduler command. This could provide more flexibility when trying to invoke SchedulerMain.
Add unit tests.