### PR TITLE
Creating main method to make it easy to inspect local state manager contents

### DIFF
--- a/heron/statemgrs/src/java/BUILD
+++ b/heron/statemgrs/src/java/BUILD
@@ -54,14 +54,15 @@ java_library(
     name = "localfs-statemgr-java",
     srcs = glob(["**/FileSystemStateManager.java"]) + glob(["**/localfs/**/*.java"]),
     resources = glob(["**/localfs/**/*.yaml"]),
-    deps = localfs_deps_files, 
+    deps = localfs_deps_files,
 )
 
 java_binary(
     name = "localfs-statemgr-unshaded",
     srcs = glob(["**/FileSystemStateManager.java"]) + glob(["**/localfs/**/*.java"]),
     resources = glob(["**/localfs/**/*.yaml"]),
-    deps = localfs_deps_files, 
+    deps = localfs_deps_files,
+    main_class="com.twitter.heron.statemgr.localfs.LocalFileSystemStateManager"
 )
 
 genrule(

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/FileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/FileSystemStateManager.java
@@ -34,42 +34,46 @@ public abstract class FileSystemStateManager implements IStateManager {
   }
 
   protected String getTMasterLocationDir() {
-    return rootAddress + "/tmasters";
+    return concatPath(rootAddress, "tmasters");
   }
 
   protected String getTopologyDir() {
-    return rootAddress + "/topologies";
+    return concatPath(rootAddress, "topologies");
   }
 
   protected String getPhysicalPlanDir() {
-    return rootAddress + "/pplans";
+    return concatPath(rootAddress, "pplans");
   }
 
   protected String getExecutionStateDir() {
-    return rootAddress + "/executionstate";
+    return concatPath(rootAddress, "executionstate");
   }
 
   protected String getSchedulerLocationDir() {
-    return rootAddress + "/schedulers";
+    return concatPath(rootAddress, "schedulers");
   }
 
   protected String getTMasterLocationPath(String topologyName) {
-    return getTMasterLocationDir() + "/" + topologyName;
+    return concatPath(getTMasterLocationDir(), topologyName);
   }
 
   protected String getTopologyPath(String topologyName) {
-    return String.format("%s/%s", getTopologyDir(), topologyName);
+    return concatPath(getTopologyDir(), topologyName);
   }
 
   protected String getPhysicalPlanPath(String topologyName) {
-    return String.format("%s/%s", getPhysicalPlanDir(), topologyName);
+    return concatPath(getPhysicalPlanDir(), topologyName);
   }
 
   protected String getExecutionStatePath(String topologyName) {
-    return String.format("%s/%s", getExecutionStateDir(), topologyName);
+    return concatPath(getExecutionStateDir(), topologyName);
   }
 
   protected String getSchedulerLocationPath(String topologyName) {
-    return String.format("%s/%s", getSchedulerLocationDir(), topologyName);
+    return concatPath(getSchedulerLocationDir(), topologyName);
+  }
+
+  private static String concatPath(String basePath, String appendPath) {
+    return String.format("%s/%s", basePath, appendPath);
   }
 }

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
@@ -74,8 +74,8 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
     boolean schedulerLocationDir = FileUtils.isDirectoryExists(getSchedulerLocationDir())
         || FileUtils.createDirectory(getSchedulerLocationDir());
 
-    return (topologyDir && tmasterLocationDir && physicalPlanDir && executionStateDir
-        && schedulerLocationDir);
+    return topologyDir && tmasterLocationDir && physicalPlanDir && executionStateDir
+        && schedulerLocationDir;
   }
 
   // Make utils class protected for easy unit testing
@@ -231,9 +231,9 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
    */
   public static void main(String[] args) throws ExecutionException, InterruptedException {
     if (args.length < 1) {
-      print("Usage: java %s <topology_name> - view state manager details for a topology",
-          LocalFileSystemStateManager.class.getCanonicalName());
-      System.exit(1);
+      throw new RuntimeException(String.format(
+          "Usage: java %s <topology_name> - view state manager details for a topology",
+          LocalFileSystemStateManager.class.getCanonicalName()));
     }
 
     String topologyName = args[0];
@@ -249,12 +249,17 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
 
     if (stateManager.isTopologyRunning(topologyName).get()) {
       print("==> Topology %s found", topologyName);
-      print("==> ExecutionState:\n%s",    stateManager.getExecutionState(null, topologyName).get());
-      print("==> SchedulerLocation:\n%s", stateManager.getSchedulerLocation(null, topologyName).get());
-      print("==> TMasterLocation:\n%s",   stateManager.getTMasterLocation(null, topologyName).get());
-      print("==> PhysicalPlan:\n%s",      stateManager.getPhysicalPlan(null, topologyName).get());
+      print("==> ExecutionState:\n%s",
+          stateManager.getExecutionState(null, topologyName).get());
+      print("==> SchedulerLocation:\n%s",
+          stateManager.getSchedulerLocation(null, topologyName).get());
+      print("==> TMasterLocation:\n%s",
+          stateManager.getTMasterLocation(null, topologyName).get());
+      print("==> PhysicalPlan:\n%s",
+          stateManager.getPhysicalPlan(null, topologyName).get());
     } else {
-      print("==> Topology %s not found under %s", topologyName, config.get(Keys.stateManagerRootPath()));
+      print("==> Topology %s not found under %s",
+          topologyName, config.get(Keys.stateManagerRootPath()));
     }
   }
 

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
@@ -227,7 +227,7 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
    * Returns all information stored in the StateManager. This is a utility method used for debugging
    * while developing. To invoke, run:
    *
-   *   bazel run heron/statemgrs/src/java:localfs-statemgr-unshaded -- &lt;topology-name>
+   *   bazel run heron/statemgrs/src/java:localfs-statemgr-unshaded -- &lt;topology-name&gt;
    */
   public static void main(String[] args) throws ExecutionException, InterruptedException {
     if (args.length < 1) {

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
@@ -254,7 +254,7 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
       print("==> TMasterLocation:\n%s",   stateManager.getTMasterLocation(null, topologyName).get());
       print("==> PhysicalPlan:\n%s",      stateManager.getPhysicalPlan(null, topologyName).get());
     } else {
-      print("==> Topology %s is not running", topologyName);
+      print("==> Topology %s not found under %s", topologyName, config.get(Keys.stateManagerRootPath()));
     }
   }
 

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
@@ -14,6 +14,7 @@
 
 package com.twitter.heron.statemgr.localfs;
 
+import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -29,22 +30,20 @@ import com.twitter.heron.proto.system.ExecutionEnvironment;
 import com.twitter.heron.proto.system.PhysicalPlans;
 import com.twitter.heron.proto.tmaster.TopologyMaster;
 import com.twitter.heron.spi.common.Config;
+import com.twitter.heron.spi.common.Keys;
 import com.twitter.heron.spi.statemgr.WatchCallback;
 import com.twitter.heron.statemgr.FileSystemStateManager;
 
 public class LocalFileSystemStateManager extends FileSystemStateManager {
   private static final Logger LOG = Logger.getLogger(LocalFileSystemStateManager.class.getName());
 
-  private Config config;
-
   @Override
   public void initialize(Config ipconfig) {
 
     super.initialize(ipconfig);
-    this.config = ipconfig;
 
     // By default, we would init the file tree if it is not there
-    boolean isInitLocalFileTree = LocalFileSystemContext.initLocalFileTree(config);
+    boolean isInitLocalFileTree = LocalFileSystemContext.initLocalFileTree(ipconfig);
 
     if (isInitLocalFileTree && !initTree()) {
       throw new IllegalArgumentException("Failed to initialize Local State manager. "
@@ -75,12 +74,8 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
     boolean schedulerLocationDir = FileUtils.isDirectoryExists(getSchedulerLocationDir())
         || FileUtils.createDirectory(getSchedulerLocationDir());
 
-    if (topologyDir && tmasterLocationDir && physicalPlanDir && executionStateDir
-        && schedulerLocationDir) {
-      return true;
-    }
-
-    return false;
+    return (topologyDir && tmasterLocationDir && physicalPlanDir && executionStateDir
+        && schedulerLocationDir);
   }
 
   // Make utils class protected for easy unit testing
@@ -226,5 +221,44 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
   public void close() {
     // We would not clear anything here
     // Scheduler kill interface should take care of the cleaning
+  }
+
+  /**
+   * Returns all information stored in the StateManager. This is a utility method used for debugging
+   * while developing. To invoke, run:
+   *
+   *   bazel run heron/statemgrs/src/java:localfs-statemgr-unshaded -- &lt;topology-name>
+   */
+  public static void main(String[] args) throws ExecutionException, InterruptedException {
+    if (args.length < 1) {
+      print("Usage: java %s <topology_name> - view state manager details for a topology",
+          LocalFileSystemStateManager.class.getCanonicalName());
+      System.exit(1);
+    }
+
+    String topologyName = args[0];
+    Config config = Config.newBuilder()
+        .put(Keys.stateManagerRootPath(),
+            System.getProperty("user.home") + "/.herondata/repository/state/local")
+        .build();
+
+    print("==> State Manager root path: %s", config.get(Keys.stateManagerRootPath()));
+
+    com.twitter.heron.spi.statemgr.IStateManager stateManager = new LocalFileSystemStateManager();
+    stateManager.initialize(config);
+
+    if (stateManager.isTopologyRunning(topologyName).get()) {
+      print("==> Topology %s found", topologyName);
+      print("==> ExecutionState:\n%s",    stateManager.getExecutionState(null, topologyName).get());
+      print("==> SchedulerLocation:\n%s", stateManager.getSchedulerLocation(null, topologyName).get());
+      print("==> TMasterLocation:\n%s",   stateManager.getTMasterLocation(null, topologyName).get());
+      print("==> PhysicalPlan:\n%s",      stateManager.getPhysicalPlan(null, topologyName).get());
+    } else {
+      print("==> Topology %s is not running", topologyName);
+    }
+  }
+
+  private static void print(String format, Object... values) {
+    System.out.println(String.format(format, values));
   }
 }


### PR DESCRIPTION
This has been helpful during development to inspect what's in the state manager. If this proves useful we could follow up with a generalized version that works with ZK as well. Output looks like this:

```
$ bazel run heron/statemgrs/src/java:localfs-statemgr-unshaded -- ExclamationTopology
INFO: Found 1 target...
Target //heron/statemgrs/src/java:localfs-statemgr-unshaded up-to-date:
  bazel-bin/heron/statemgrs/src/java/localfs-statemgr-unshaded.jar
  bazel-bin/heron/statemgrs/src/java/localfs-statemgr-unshaded
INFO: Elapsed time: 1.875s, Critical Path: 1.65s

INFO: Running command line: bazel-bin/heron/statemgrs/src/java/localfs-statemgr-unshaded ExclamationTopology
==> State Manager root path: /Users/billg/.herondata/repository/state/local
==> Topology ExclamationTopology found
==> ExecutionState:
topology_name: "ExclamationTopology"
topology_id: "ExclamationTopology9002dca6-6129-4674-b7a5-90af730e26ab"
submission_time: 1468354233
submission_user: "billg"
cluster: "local"
environ: "default"
role: "billg"
release_state {
  release_username: "billg"
  release_tag: ""
  release_version: "master"
}

==> SchedulerLocation:
topology_name: "ExclamationTopology"
http_endpoint: "XXXXXX:52629"

==> TMasterLocation:
topology_name: "ExclamationTopology"
topology_id: "ExclamationTopology9002dca6-6129-4674-b7a5-90af730e26ab"
host: "XXXXXX"
controller_port: 52631
master_port: 52630
stats_port: 52632

==> PhysicalPlan:
topology {
  id: "ExclamationTopology9002dca6-6129-4674-b7a5-90af730e26ab"
  name: "ExclamationTopology"
  spouts {
    comp {
      name: "word"
      config {
        kvs {
          key: "topology.component.parallelism"
          value: "1"
        }
      }
    }
    outputs {
      stream {
        id: "default"
        component_name: "word"
      }
      schema {
        keys {
          key: "word"
          type: OBJECT
        }
      }
    }
  }
  bolts {
    comp {
      name: "exclaim1"
      config {
        kvs {
          key: "topology.component.parallelism"
          value: "1"
        }
      }
    }
    inputs {
      stream {
        id: "default"
        component_name: "word"
      }
      gtype: SHUFFLE
    }
  }
  state: PAUSED
  topology_config {
    kvs {
      key: "topology.component.rammap"
      value: "word:536870912,exclaim1:536870912"
    }
    kvs {
      key: "topology.auto.task.hooks"
      java_serialized_value: "\254\355\000\005sr\000\024java.util.LinkedList\f)S]J`\210\"\003\000\000xpw\004\000\000\000\001t\000&backtype.storm.hooks.ITaskHookDelegatex"
    }
    kvs {
      key: "topology.skip.missing.kryo.registrations"
      java_serialized_value: "\254\355\000\005sr\000\021java.lang.Boolean\315 r\200\325\234\372\356\002\000\001Z\000\005valuexp\000"
    }
    kvs {
      key: "topology.container.disk"
      value: "1073741824"
    }
    kvs {
      key: "topology.enable.message.timeouts"
      value: "true"
    }
    kvs {
      key: "topology.serializer.classname"
      value: "backtype.storm.serialization.HeronPluggableSerializerDelegate"
    }
    kvs {
      key: "topology.debug"
      value: "true"
    }
    kvs {
      key: "topology.max.spout.pending"
      value: "10"
    }
    kvs {
      key: "topology.kryo.factory"
      java_serialized_value: "\254\355\000\005t\000/backtype.storm.serialization.DefaultKryoFactory"
    }
    kvs {
      key: "topology.container.cpu"
      value: "1.0"
    }
    kvs {
      key: "topology.fall.back.on.java.serialization"
      java_serialized_value: "\254\355\000\005sr\000\021java.lang.Boolean\315 r\200\325\234\372\356\002\000\001Z\000\005valuexp\000"
    }
    kvs {
      key: "topology.name"
      value: "ExclamationTopology"
    }
    kvs {
      key: "topology.component.parallelism"
      value: "1"
    }
    kvs {
      key: "stormcompat.topology.auto.task.hooks"
      java_serialized_value: "\254\355\000\005sr\000\023java.util.ArrayListx\201\322\035\231\307a\235\003\000\001I\000\004sizexp\000\000\000\000w\004\000\000\000\000x"
    }
    kvs {
      key: "topology.stmgrs"
      value: "1"
    }
    kvs {
      key: "topology.worker.childopts"
      value: "-XX:+HeapDumpOnOutOfMemoryError"
    }
    kvs {
      key: "topology.message.timeout.secs"
      value: "30"
    }
    kvs {
      key: "topology.acking"
      value: "false"
    }
  }
}
stmgrs {
  id: "stmgr-1"
  host_name: "XXXXXX"
  data_port: 52636
  local_endpoint: "/unused"
  cwd: "/Users/billg/.herondata/topologies/local/billg/ExclamationTopology"
  pid: 38625
  shell_port: 52639
}
instances {
  instance_id: "container_1_exclaim1_1"
  stmgr_id: "stmgr-1"
  info {
    task_id: 1
    component_index: 0
    component_name: "exclaim1"
  }
}
instances {
  instance_id: "container_1_word_2"
  stmgr_id: "stmgr-1"
  info {
    task_id: 2
    component_index: 0
    component_name: "word"
  }
}
```