### PR TITLE
Move duplicate get/delete code up into FileSystemStateManager

### DIFF
--- a/heron/statemgrs/src/java/BUILD
+++ b/heron/statemgrs/src/java/BUILD
@@ -54,14 +54,15 @@ java_library(
     name = "localfs-statemgr-java",
     srcs = glob(["**/FileSystemStateManager.java"]) + glob(["**/localfs/**/*.java"]),
     resources = glob(["**/localfs/**/*.yaml"]),
-    deps = localfs_deps_files, 
+    deps = localfs_deps_files,
 )
 
 java_binary(
     name = "localfs-statemgr-unshaded",
     srcs = glob(["**/FileSystemStateManager.java"]) + glob(["**/localfs/**/*.java"]),
     resources = glob(["**/localfs/**/*.yaml"]),
-    deps = localfs_deps_files, 
+    deps = localfs_deps_files,
+    main_class="com.twitter.heron.statemgr.localfs.LocalFileSystemStateManager"
 )
 
 genrule(

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/FileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/FileSystemStateManager.java
@@ -34,42 +34,46 @@ public abstract class FileSystemStateManager implements IStateManager {
   }
 
   protected String getTMasterLocationDir() {
-    return rootAddress + "/tmasters";
+    return concatPath(rootAddress, "tmasters");
   }
 
   protected String getTopologyDir() {
-    return rootAddress + "/topologies";
+    return concatPath(rootAddress, "topologies");
   }
 
   protected String getPhysicalPlanDir() {
-    return rootAddress + "/pplans";
+    return concatPath(rootAddress, "pplans");
   }
 
   protected String getExecutionStateDir() {
-    return rootAddress + "/executionstate";
+    return concatPath(rootAddress, "executionstate");
   }
 
   protected String getSchedulerLocationDir() {
-    return rootAddress + "/schedulers";
+    return concatPath(rootAddress, "schedulers");
   }
 
   protected String getTMasterLocationPath(String topologyName) {
-    return getTMasterLocationDir() + "/" + topologyName;
+    return concatPath(getTMasterLocationDir(), topologyName);
   }
 
   protected String getTopologyPath(String topologyName) {
-    return String.format("%s/%s", getTopologyDir(), topologyName);
+    return concatPath(getTopologyDir(), topologyName);
   }
 
   protected String getPhysicalPlanPath(String topologyName) {
-    return String.format("%s/%s", getPhysicalPlanDir(), topologyName);
+    return concatPath(getPhysicalPlanDir(), topologyName);
   }
 
   protected String getExecutionStatePath(String topologyName) {
-    return String.format("%s/%s", getExecutionStateDir(), topologyName);
+    return concatPath(getExecutionStateDir(), topologyName);
   }
 
   protected String getSchedulerLocationPath(String topologyName) {
-    return String.format("%s/%s", getSchedulerLocationDir(), topologyName);
+    return concatPath(getSchedulerLocationDir(), topologyName);
+  }
+
+  private static String concatPath(String basePath, String appendPath) {
+    return String.format("%s/%s", basePath, appendPath);
   }
 }

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/FileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/FileSystemStateManager.java
@@ -17,9 +17,18 @@ package com.twitter.heron.statemgr;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.protobuf.Message;
+
+import com.twitter.heron.api.generated.TopologyAPI;
+import com.twitter.heron.proto.scheduler.Scheduler;
+import com.twitter.heron.proto.system.ExecutionEnvironment;
+import com.twitter.heron.proto.system.PhysicalPlans;
+import com.twitter.heron.proto.tmaster.TopologyMaster;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Context;
 import com.twitter.heron.spi.statemgr.IStateManager;
+import com.twitter.heron.spi.statemgr.WatchCallback;
 
 public abstract class FileSystemStateManager implements IStateManager {
   private static final Logger LOG = Logger.getLogger(FileSystemStateManager.class.getName());
@@ -27,31 +36,19 @@ public abstract class FileSystemStateManager implements IStateManager {
   // Store the root address of the hierarchical file system
   protected String rootAddress;
 
-  @Override
-  public void initialize(Config config) {
-    this.rootAddress = Context.stateManagerRootPath(config);
-    LOG.log(Level.FINE, "File system state manager root address: {0}", rootAddress);
-  }
+  abstract protected ListenableFuture<Boolean> nodeExists(String path);
 
-  protected String getTMasterLocationDir() {
-    return concatPath(rootAddress, "tmasters");
-  }
+  abstract protected ListenableFuture<Boolean> deleteNode(String path);
 
-  protected String getTopologyDir() {
-    return concatPath(rootAddress, "topologies");
-  }
+  abstract protected <M extends Message> ListenableFuture<M> getNodeData(WatchCallback watcher,
+                                                                         String path,
+                                                                         Message.Builder builder);
 
-  protected String getPhysicalPlanDir() {
-    return concatPath(rootAddress, "pplans");
-  }
-
-  protected String getExecutionStateDir() {
-    return concatPath(rootAddress, "executionstate");
-  }
-
-  protected String getSchedulerLocationDir() {
-    return concatPath(rootAddress, "schedulers");
-  }
+  protected String getTMasterLocationDir() { return concatPath(rootAddress, "tmasters"); }
+  protected String getTopologyDir() { return concatPath(rootAddress, "topologies"); }
+  protected String getPhysicalPlanDir() { return concatPath(rootAddress, "pplans"); }
+  protected String getExecutionStateDir() { return concatPath(rootAddress, "executionstate"); }
+  protected String getSchedulerLocationDir() { return concatPath(rootAddress, "schedulers"); }
 
   protected String getTMasterLocationPath(String topologyName) {
     return concatPath(getTMasterLocationDir(), topologyName);
@@ -71,6 +68,76 @@ public abstract class FileSystemStateManager implements IStateManager {
 
   protected String getSchedulerLocationPath(String topologyName) {
     return concatPath(getSchedulerLocationDir(), topologyName);
+  }
+
+  @Override
+  public void initialize(Config config) {
+    this.rootAddress = Context.stateManagerRootPath(config);
+    LOG.log(Level.FINE, "File system state manager root address: {0}", rootAddress);
+  }
+
+  @Override
+  public ListenableFuture<Boolean> deleteTMasterLocation(String topologyName) {
+    return deleteNode(getTMasterLocationPath(topologyName));
+  }
+
+  @Override
+  public ListenableFuture<Boolean> deleteSchedulerLocation(String topologyName) {
+    return deleteNode(getSchedulerLocationPath(topologyName));
+  }
+
+  @Override
+  public ListenableFuture<Boolean> deleteExecutionState(String topologyName) {
+    return deleteNode(getExecutionStatePath(topologyName));
+  }
+
+  @Override
+  public ListenableFuture<Boolean> deleteTopology(String topologyName) {
+    return deleteNode(getTopologyPath(topologyName));
+  }
+
+  @Override
+  public ListenableFuture<Boolean> deletePhysicalPlan(String topologyName) {
+    return deleteNode(getPhysicalPlanPath(topologyName));
+  }
+
+  @Override
+  public ListenableFuture<Scheduler.SchedulerLocation> getSchedulerLocation(
+      WatchCallback watcher, String topologyName) {
+    return getNodeData(watcher, getSchedulerLocationPath(topologyName),
+        Scheduler.SchedulerLocation.newBuilder());
+  }
+
+  @Override
+  public ListenableFuture<TopologyAPI.Topology> getTopology(
+      WatchCallback watcher, String topologyName) {
+    return getNodeData(watcher, getTopologyPath(topologyName), TopologyAPI.Topology.newBuilder());
+  }
+
+  @Override
+  public ListenableFuture<ExecutionEnvironment.ExecutionState> getExecutionState(
+      WatchCallback watcher, String topologyName) {
+    return getNodeData(watcher, getExecutionStatePath(topologyName),
+        ExecutionEnvironment.ExecutionState.newBuilder());
+  }
+
+  @Override
+  public ListenableFuture<PhysicalPlans.PhysicalPlan> getPhysicalPlan(
+      WatchCallback watcher, String topologyName) {
+    return getNodeData(watcher, getPhysicalPlanPath(topologyName),
+        PhysicalPlans.PhysicalPlan.newBuilder());
+  }
+
+  @Override
+  public ListenableFuture<TopologyMaster.TMasterLocation> getTMasterLocation(
+      WatchCallback watcher, String topologyName) {
+    return getNodeData(watcher, getTMasterLocationPath(topologyName),
+        TopologyMaster.TMasterLocation.newBuilder());
+  }
+
+  @Override
+  public ListenableFuture<Boolean> isTopologyRunning(String topologyName) {
+    return nodeExists(getTopologyPath(topologyName));
   }
 
   private static String concatPath(String basePath, String appendPath) {

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/FileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/FileSystemStateManager.java
@@ -36,19 +36,37 @@ public abstract class FileSystemStateManager implements IStateManager {
   // Store the root address of the hierarchical file system
   protected String rootAddress;
 
-  abstract protected ListenableFuture<Boolean> nodeExists(String path);
+  protected abstract ListenableFuture<Boolean> nodeExists(String path);
 
-  abstract protected ListenableFuture<Boolean> deleteNode(String path);
+  protected abstract ListenableFuture<Boolean> deleteNode(String path);
 
-  abstract protected <M extends Message> ListenableFuture<M> getNodeData(WatchCallback watcher,
+  protected abstract <M extends Message> ListenableFuture<M> getNodeData(WatchCallback watcher,
                                                                          String path,
                                                                          Message.Builder builder);
 
-  protected String getTMasterLocationDir() { return concatPath(rootAddress, "tmasters"); }
-  protected String getTopologyDir() { return concatPath(rootAddress, "topologies"); }
-  protected String getPhysicalPlanDir() { return concatPath(rootAddress, "pplans"); }
-  protected String getExecutionStateDir() { return concatPath(rootAddress, "executionstate"); }
-  protected String getSchedulerLocationDir() { return concatPath(rootAddress, "schedulers"); }
+  protected String getTMasterLocationDir() {
+    return concatPath(rootAddress, "tmasters");
+  }
+
+  protected String getTopologyDir() {
+    return concatPath(rootAddress, "topologies");
+  }
+
+  protected String getPackingPlanDir() {
+    return concatPath(rootAddress, "packingplans");
+  }
+
+  protected String getPhysicalPlanDir() {
+    return concatPath(rootAddress, "pplans");
+  }
+
+  protected String getExecutionStateDir() {
+    return concatPath(rootAddress, "executionstate");
+  }
+
+  protected String getSchedulerLocationDir() {
+    return concatPath(rootAddress, "schedulers");
+  }
 
   protected String getTMasterLocationPath(String topologyName) {
     return concatPath(getTMasterLocationDir(), topologyName);

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
@@ -107,7 +107,9 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
 
   @Override
   @SuppressWarnings("unchecked") // we don't know what M is until runtime
-  protected <M extends Message> ListenableFuture<M> getNodeData(WatchCallback watcher, String path, Message.Builder builder) {
+  protected <M extends Message> ListenableFuture<M> getNodeData(WatchCallback watcher,
+                                                                String path,
+                                                                Message.Builder builder) {
     final SettableFuture<M> future = SettableFuture.create();
     byte[] data = FileUtils.readFromFile(path);
     if (data.length == 0) {

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
@@ -74,8 +74,8 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
     boolean schedulerLocationDir = FileUtils.isDirectoryExists(getSchedulerLocationDir())
         || FileUtils.createDirectory(getSchedulerLocationDir());
 
-    return (topologyDir && tmasterLocationDir && physicalPlanDir && executionStateDir
-        && schedulerLocationDir);
+    return topologyDir && tmasterLocationDir && physicalPlanDir && executionStateDir
+        && schedulerLocationDir;
   }
 
   // Make utils class protected for easy unit testing
@@ -231,9 +231,9 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
    */
   public static void main(String[] args) throws ExecutionException, InterruptedException {
     if (args.length < 1) {
-      print("Usage: java %s <topology_name> - view state manager details for a topology",
-          LocalFileSystemStateManager.class.getCanonicalName());
-      System.exit(1);
+      throw new RuntimeException(String.format(
+          "Usage: java %s <topology_name> - view state manager details for a topology",
+          LocalFileSystemStateManager.class.getCanonicalName()));
     }
 
     String topologyName = args[0];
@@ -249,12 +249,17 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
 
     if (stateManager.isTopologyRunning(topologyName).get()) {
       print("==> Topology %s found", topologyName);
-      print("==> ExecutionState:\n%s",    stateManager.getExecutionState(null, topologyName).get());
-      print("==> SchedulerLocation:\n%s", stateManager.getSchedulerLocation(null, topologyName).get());
-      print("==> TMasterLocation:\n%s",   stateManager.getTMasterLocation(null, topologyName).get());
-      print("==> PhysicalPlan:\n%s",      stateManager.getPhysicalPlan(null, topologyName).get());
+      print("==> ExecutionState:\n%s",
+          stateManager.getExecutionState(null, topologyName).get());
+      print("==> SchedulerLocation:\n%s",
+          stateManager.getSchedulerLocation(null, topologyName).get());
+      print("==> TMasterLocation:\n%s",
+          stateManager.getTMasterLocation(null, topologyName).get());
+      print("==> PhysicalPlan:\n%s",
+          stateManager.getPhysicalPlan(null, topologyName).get());
     } else {
-      print("==> Topology %s not found under %s", topologyName, config.get(Keys.stateManagerRootPath()));
+      print("==> Topology %s not found under %s",
+          topologyName, config.get(Keys.stateManagerRootPath()));
     }
   }
 

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
@@ -227,7 +227,7 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
    * Returns all information stored in the StateManager. This is a utility method used for debugging
    * while developing. To invoke, run:
    *
-   *   bazel run heron/statemgrs/src/java:localfs-statemgr-unshaded -- &lt;topology-name>
+   *   bazel run heron/statemgrs/src/java:localfs-statemgr-unshaded -- &lt;topology-name&gt;
    */
   public static void main(String[] args) throws ExecutionException, InterruptedException {
     if (args.length < 1) {

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
@@ -254,7 +254,7 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
       print("==> TMasterLocation:\n%s",   stateManager.getTMasterLocation(null, topologyName).get());
       print("==> PhysicalPlan:\n%s",      stateManager.getPhysicalPlan(null, topologyName).get());
     } else {
-      print("==> Topology %s is not running", topologyName);
+      print("==> Topology %s not found under %s", topologyName, config.get(Keys.stateManagerRootPath()));
     }
   }
 

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
@@ -87,7 +87,17 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
     return future;
   }
 
-  protected ListenableFuture<Boolean> deleteData(String path) {
+  @Override
+  protected ListenableFuture<Boolean> nodeExists(String path) {
+    SettableFuture<Boolean> future = SettableFuture.create();
+    boolean ret = FileUtils.isFileExists(path);
+    future.set(ret);
+
+    return future;
+  }
+
+  @Override
+  protected ListenableFuture<Boolean> deleteNode(String path) {
     final SettableFuture<Boolean> future = SettableFuture.create();
     boolean ret = FileUtils.deleteFile(path);
     future.set(ret);
@@ -95,8 +105,9 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
     return future;
   }
 
+  @Override
   @SuppressWarnings("unchecked") // we don't know what M is until runtime
-  protected <M extends Message> ListenableFuture<M> getData(String path, Message.Builder builder) {
+  protected <M extends Message> ListenableFuture<M> getNodeData(WatchCallback watcher, String path, Message.Builder builder) {
     final SettableFuture<M> future = SettableFuture.create();
     byte[] data = FileUtils.readFromFile(path);
     if (data.length == 0) {
@@ -147,74 +158,6 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
     // This is because when running in simulator we control when a scheduler dies and
     // comes up deterministically.
     return setData(getSchedulerLocationPath(topologyName), location.toByteArray(), true);
-  }
-
-  @Override
-  public ListenableFuture<Boolean> deleteTMasterLocation(String topologyName) {
-    return deleteData(getTMasterLocationPath(topologyName));
-  }
-
-  @Override
-  public ListenableFuture<Boolean> deleteSchedulerLocation(String topologyName) {
-    return deleteData(getSchedulerLocationPath(topologyName));
-  }
-
-  @Override
-  public ListenableFuture<Boolean> deleteExecutionState(String topologyName) {
-    return deleteData(getExecutionStatePath(topologyName));
-  }
-
-  @Override
-  public ListenableFuture<Boolean> deleteTopology(String topologyName) {
-    return deleteData(getTopologyPath(topologyName));
-  }
-
-  @Override
-  public ListenableFuture<Boolean> deletePhysicalPlan(String topologyName) {
-    return deleteData(getPhysicalPlanPath(topologyName));
-  }
-
-  @Override
-  public ListenableFuture<Scheduler.SchedulerLocation> getSchedulerLocation(
-      WatchCallback watcher, String topologyName) {
-    return getData(getSchedulerLocationPath(topologyName),
-        Scheduler.SchedulerLocation.newBuilder());
-  }
-
-  @Override
-  public ListenableFuture<TopologyAPI.Topology> getTopology(
-      WatchCallback watcher, String topologyName) {
-    return getData(getTopologyPath(topologyName), TopologyAPI.Topology.newBuilder());
-  }
-
-  @Override
-  public ListenableFuture<ExecutionEnvironment.ExecutionState> getExecutionState(
-      WatchCallback watcher, String topologyName) {
-    return getData(getExecutionStatePath(topologyName),
-        ExecutionEnvironment.ExecutionState.newBuilder());
-  }
-
-  @Override
-  public ListenableFuture<PhysicalPlans.PhysicalPlan> getPhysicalPlan(
-      WatchCallback watcher, String topologyName) {
-    return getData(getPhysicalPlanPath(topologyName),
-        PhysicalPlans.PhysicalPlan.newBuilder());
-  }
-
-  @Override
-  public ListenableFuture<TopologyMaster.TMasterLocation> getTMasterLocation(
-      WatchCallback watcher, String topologyName) {
-    return getData(getTMasterLocationPath(topologyName),
-        TopologyMaster.TMasterLocation.newBuilder());
-  }
-
-  @Override
-  public ListenableFuture<Boolean> isTopologyRunning(String topologyName) {
-    SettableFuture<Boolean> future = SettableFuture.create();
-    boolean ret = FileUtils.isFileExists(getTopologyPath(topologyName));
-    future.set(ret);
-
-    return future;
   }
 
   @Override

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
@@ -14,6 +14,7 @@
 
 package com.twitter.heron.statemgr.localfs;
 
+import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -29,22 +30,20 @@ import com.twitter.heron.proto.system.ExecutionEnvironment;
 import com.twitter.heron.proto.system.PhysicalPlans;
 import com.twitter.heron.proto.tmaster.TopologyMaster;
 import com.twitter.heron.spi.common.Config;
+import com.twitter.heron.spi.common.Keys;
 import com.twitter.heron.spi.statemgr.WatchCallback;
 import com.twitter.heron.statemgr.FileSystemStateManager;
 
 public class LocalFileSystemStateManager extends FileSystemStateManager {
   private static final Logger LOG = Logger.getLogger(LocalFileSystemStateManager.class.getName());
 
-  private Config config;
-
   @Override
   public void initialize(Config ipconfig) {
 
     super.initialize(ipconfig);
-    this.config = ipconfig;
 
     // By default, we would init the file tree if it is not there
-    boolean isInitLocalFileTree = LocalFileSystemContext.initLocalFileTree(config);
+    boolean isInitLocalFileTree = LocalFileSystemContext.initLocalFileTree(ipconfig);
 
     if (isInitLocalFileTree && !initTree()) {
       throw new IllegalArgumentException("Failed to initialize Local State manager. "
@@ -75,12 +74,8 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
     boolean schedulerLocationDir = FileUtils.isDirectoryExists(getSchedulerLocationDir())
         || FileUtils.createDirectory(getSchedulerLocationDir());
 
-    if (topologyDir && tmasterLocationDir && physicalPlanDir && executionStateDir
-        && schedulerLocationDir) {
-      return true;
-    }
-
-    return false;
+    return (topologyDir && tmasterLocationDir && physicalPlanDir && executionStateDir
+        && schedulerLocationDir);
   }
 
   // Make utils class protected for easy unit testing
@@ -226,5 +221,44 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
   public void close() {
     // We would not clear anything here
     // Scheduler kill interface should take care of the cleaning
+  }
+
+  /**
+   * Returns all information stored in the StateManager. This is a utility method used for debugging
+   * while developing. To invoke, run:
+   *
+   *   bazel run heron/statemgrs/src/java:localfs-statemgr-unshaded -- &lt;topology-name>
+   */
+  public static void main(String[] args) throws ExecutionException, InterruptedException {
+    if (args.length < 1) {
+      print("Usage: java %s <topology_name> - view state manager details for a topology",
+          LocalFileSystemStateManager.class.getCanonicalName());
+      System.exit(1);
+    }
+
+    String topologyName = args[0];
+    Config config = Config.newBuilder()
+        .put(Keys.stateManagerRootPath(),
+            System.getProperty("user.home") + "/.herondata/repository/state/local")
+        .build();
+
+    print("==> State Manager root path: %s", config.get(Keys.stateManagerRootPath()));
+
+    com.twitter.heron.spi.statemgr.IStateManager stateManager = new LocalFileSystemStateManager();
+    stateManager.initialize(config);
+
+    if (stateManager.isTopologyRunning(topologyName).get()) {
+      print("==> Topology %s found", topologyName);
+      print("==> ExecutionState:\n%s",    stateManager.getExecutionState(null, topologyName).get());
+      print("==> SchedulerLocation:\n%s", stateManager.getSchedulerLocation(null, topologyName).get());
+      print("==> TMasterLocation:\n%s",   stateManager.getTMasterLocation(null, topologyName).get());
+      print("==> PhysicalPlan:\n%s",      stateManager.getPhysicalPlan(null, topologyName).get());
+    } else {
+      print("==> Topology %s is not running", topologyName);
+    }
+  }
+
+  private static void print(String format, Object... values) {
+    System.out.println(String.format(format, values));
   }
 }

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
@@ -209,48 +209,4 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
   private static void print(String format, Object... values) {
     System.out.println(String.format(format, values));
   }
-
-  /**
-   * Returns all information stored in the StateManager. This is a utility method used for debugging
-   * while developing. To invoke, run:
-   *
-   *   bazel run heron/statemgrs/src/java:localfs-statemgr-unshaded -- &lt;topology-name&gt;
-   */
-  public static void main(String[] args) throws ExecutionException, InterruptedException {
-    if (args.length < 1) {
-      throw new RuntimeException(String.format(
-          "Usage: java %s <topology_name> - view state manager details for a topology",
-          LocalFileSystemStateManager.class.getCanonicalName()));
-    }
-
-    String topologyName = args[0];
-    Config config = Config.newBuilder()
-        .put(Keys.stateManagerRootPath(),
-            System.getProperty("user.home") + "/.herondata/repository/state/local")
-        .build();
-
-    print("==> State Manager root path: %s", config.get(Keys.stateManagerRootPath()));
-
-    com.twitter.heron.spi.statemgr.IStateManager stateManager = new LocalFileSystemStateManager();
-    stateManager.initialize(config);
-
-    if (stateManager.isTopologyRunning(topologyName).get()) {
-      print("==> Topology %s found", topologyName);
-      print("==> ExecutionState:\n%s",
-          stateManager.getExecutionState(null, topologyName).get());
-      print("==> SchedulerLocation:\n%s",
-          stateManager.getSchedulerLocation(null, topologyName).get());
-      print("==> TMasterLocation:\n%s",
-          stateManager.getTMasterLocation(null, topologyName).get());
-      print("==> PhysicalPlan:\n%s",
-          stateManager.getPhysicalPlan(null, topologyName).get());
-    } else {
-      print("==> Topology %s not found under %s",
-          topologyName, config.get(Keys.stateManagerRootPath()));
-    }
-  }
-
-  private static void print(String format, Object... values) {
-    System.out.println(String.format(format, values));
-  }
 }

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
@@ -161,7 +161,8 @@ public class CuratorStateManager extends FileSystemStateManager {
   }
 
   // Make utils class protected for easy unit testing
-  protected ListenableFuture<Boolean> existNode(String path) {
+  @Override
+  protected ListenableFuture<Boolean> nodeExists(String path) {
     final SettableFuture<Boolean> result = SettableFuture.create();
 
     try {
@@ -198,6 +199,7 @@ public class CuratorStateManager extends FileSystemStateManager {
     return result;
   }
 
+  @Override
   protected ListenableFuture<Boolean> deleteNode(String path) {
     final SettableFuture<Boolean> result = SettableFuture.create();
 
@@ -215,6 +217,7 @@ public class CuratorStateManager extends FileSystemStateManager {
     return result;
   }
 
+  @Override
   protected <M extends Message> ListenableFuture<M> getNodeData(
       WatchCallback watcher,
       String path,
@@ -244,7 +247,7 @@ public class CuratorStateManager extends FileSystemStateManager {
       // Suppress it since forPath() throws Exception
       // SUPPRESS CHECKSTYLE IllegalCatch
     } catch (Exception e) {
-      future.setException(new RuntimeException("Could not getData", e));
+      future.setException(new RuntimeException("Could not getNodeData", e));
     }
 
     return future;
@@ -297,21 +300,6 @@ public class CuratorStateManager extends FileSystemStateManager {
   }
 
   @Override
-  public ListenableFuture<Boolean> deleteExecutionState(String topologyName) {
-    return deleteNode(getExecutionStatePath(topologyName));
-  }
-
-  @Override
-  public ListenableFuture<Boolean> deleteTopology(String topologyName) {
-    return deleteNode(getTopologyPath(topologyName));
-  }
-
-  @Override
-  public ListenableFuture<Boolean> deletePhysicalPlan(String topologyName) {
-    return deleteNode(getPhysicalPlanPath(topologyName));
-  }
-
-  @Override
   public ListenableFuture<Boolean> deleteSchedulerLocation(String topologyName) {
     // if scheduler is service, the znode is ephemeral and it's deleted automatically
     if (isSchedulerService) {
@@ -321,50 +309,5 @@ public class CuratorStateManager extends FileSystemStateManager {
     } else {
       return deleteNode(getSchedulerLocationPath(topologyName));
     }
-  }
-
-  @Override
-  public ListenableFuture<TopologyMaster.TMasterLocation> getTMasterLocation(
-      WatchCallback watcher,
-      String topologyName) {
-    return getNodeData(watcher, getTMasterLocationPath(topologyName),
-        TopologyMaster.TMasterLocation.newBuilder());
-  }
-
-  @Override
-  public ListenableFuture<Scheduler.SchedulerLocation> getSchedulerLocation(
-      WatchCallback watcher,
-      String topologyName) {
-    return getNodeData(watcher, getSchedulerLocationPath(topologyName),
-        Scheduler.SchedulerLocation.newBuilder());
-  }
-
-  @Override
-  public ListenableFuture<TopologyAPI.Topology> getTopology(
-      WatchCallback watcher,
-      String topologyName) {
-    return getNodeData(watcher, getTopologyPath(topologyName),
-        TopologyAPI.Topology.newBuilder());
-  }
-
-  @Override
-  public ListenableFuture<ExecutionEnvironment.ExecutionState> getExecutionState(
-      WatchCallback watcher,
-      String topologyName) {
-    return getNodeData(watcher, getExecutionStatePath(topologyName),
-        ExecutionEnvironment.ExecutionState.newBuilder());
-  }
-
-  @Override
-  public ListenableFuture<PhysicalPlans.PhysicalPlan> getPhysicalPlan(
-      WatchCallback watcher,
-      String topologyName) {
-    return getNodeData(watcher, getPhysicalPlanPath(topologyName),
-        PhysicalPlans.PhysicalPlan.newBuilder());
-  }
-
-  @Override
-  public ListenableFuture<Boolean> isTopologyRunning(String topologyName) {
-    return existNode(getTopologyPath(topologyName));
   }
 }

--- a/heron/statemgrs/tests/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManagerTest.java
+++ b/heron/statemgrs/tests/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManagerTest.java
@@ -145,7 +145,7 @@ public class CuratorStateManagerTest {
   }
 
   /**
-   * Test existNode method
+   * Test nodeExists method
    * @throws Exception
    */
   @Test
@@ -171,12 +171,12 @@ public class CuratorStateManagerTest {
     spyStateManager.initialize(config);
 
     // Verify the result is true when path is correct
-    ListenableFuture<Boolean> result1 = spyStateManager.existNode(correctPath);
+    ListenableFuture<Boolean> result1 = spyStateManager.nodeExists(correctPath);
     Mockito.verify(mockExistsBuilder).forPath(correctPath);
     Assert.assertTrue(result1.get());
 
     // Verify the result is false when path is wrong
-    ListenableFuture<Boolean> result2 = spyStateManager.existNode(wrongPath);
+    ListenableFuture<Boolean> result2 = spyStateManager.nodeExists(wrongPath);
     Mockito.verify(mockExistsBuilder).forPath(wrongPath);
     Assert.assertFalse(result2.get());
   }


### PR DESCRIPTION
This diff is rendering messy but basically all get/delete/exists interface methods do the same thing across curator and local filesystem if we abstract out the following:
```
abstract protected ListenableFuture<Boolean> nodeExists(String path);
abstract protected ListenableFuture<Boolean> deleteNode(String path);
abstract protected <M extends Message> ListenableFuture<M> getNodeData(WatchCallback watcher,
                                                                         String path,
                                                                         Message.Builder builder);
```

This removes duplicate code and makes it easier to add new state manager methods. Creates are handled differently since ZK has the notion of ephemeral nodes and local FS has the notion of overwrites.