### PR TITLE
Sort containers by id in the UI so they are easier to find

### DIFF
--- a/heron/ui/resources/static/js/physical-plan.js
+++ b/heron/ui/resources/static/js/physical-plan.js
@@ -42,6 +42,12 @@
       // make ordering of instances the same in each container
       container.children = _.sortBy(container.children, 'name');
     });
+
+    // Sort the containers by their id so they are easier to find in the UI.
+    auroraContainers = _.sortBy(auroraContainers, function(container) {
+      return parseInt(container.id.split('-')[1]);
+    });
+
     var maxInstances = d3.max(auroraContainers, function (d) {
       return d.children.length;
     });


### PR DESCRIPTION
Sorting the containers by the id makes it easier to find a specific container in the UI without having to hunt around by hovering over the boxes. If you know that there is a problem with a component in container 5 you will now be able to easy go straight to it.

Before:
![screen shot 2016-07-18 at 2 32 51 pm](https://cloud.githubusercontent.com/assets/509779/16925928/898caf3e-4cf4-11e6-98c6-40dfe956da8e.png)

After:
![screen shot 2016-07-18 at 2 33 59 pm](https://cloud.githubusercontent.com/assets/509779/16925960/b237367a-4cf4-11e6-899f-3731a3f512d2.png)

