### PR TITLE
Print a random word with exclamation points as the tutorial explains

### DIFF
--- a/heron/examples/src/java/com/twitter/heron/examples/ExclamationTopology.java
+++ b/heron/examples/src/java/com/twitter/heron/examples/ExclamationTopology.java
@@ -83,11 +83,9 @@ public final class ExclamationTopology {
 
     @Override
     public void execute(Tuple tuple) {
-      // System.out.println(tuple.getString(0));
-      // collector.emit(tuple, new Values(tuple.getString(0) + "!!!"));
-      // collector.ack(tuple);
       if (++nItems % 100000 == 0) {
         long latency = System.currentTimeMillis() - startTime;
+        System.out.println(tuple.getString(0) + "!!!");
         System.out.println("Bolt processed " + nItems + " tuples in " + latency + " ms");
         GlobalMetrics.incr("selected_items");
       }


### PR DESCRIPTION
The website says that the ExclamationTopology prints a random word with an exclamation point added, but the example didn't actually do that.  This does that at the same frequency that it prints the number of items processed to keep the log size reasonable. 