### PR TITLE
Improve exception handling of heron-explorer.

### DIFF
--- a/heron/common/src/python/utils.py
+++ b/heron/common/src/python/utils.py
@@ -20,6 +20,7 @@ import sys
 import subprocess
 import tarfile
 import tempfile
+import traceback
 import tornado.gen
 import tornado.ioloop
 import yaml
@@ -352,9 +353,8 @@ def get_clusters():
   # pylint: disable=unnecessary-lambda
   try:
     return instance.run_sync(lambda: API.get_clusters())
-  except Exception as ex:
-    Log.error(str(ex))
-    Log.error('Failed to retrive clusters')
+  except Exception:
+    Log.info(traceback.format_exc())
     raise
 
 
@@ -363,10 +363,8 @@ def get_logical_plan(cluster, env, topology, role):
   instance = tornado.ioloop.IOLoop.instance()
   try:
     return instance.run_sync(lambda: API.get_logical_plan(cluster, env, topology, role))
-  except Exception as ex:
-    Log.error(str(ex))
-    Log.error('Failed to retrive logical plan info of topology \'%s\''
-              % ('/'.join([cluster, role, env, topology])))
+  except Exception:
+    Log.info(traceback.format_exc())
     raise
 
 
@@ -375,9 +373,8 @@ def get_topology_info(*args):
   instance = tornado.ioloop.IOLoop.instance()
   try:
     return instance.run_sync(lambda: API.get_topology_info(*args))
-  except Exception as ex:
-    Log.error(str(ex))
-    Log.error('Failed to get topology info')
+  except Exception:
+    Log.info(traceback.format_exc())
     raise
 
 
@@ -386,9 +383,8 @@ def get_topology_metrics(*args):
   instance = tornado.ioloop.IOLoop.instance()
   try:
     return instance.run_sync(lambda: API.get_comp_metrics(*args))
-  except Exception as ex:
-    Log.error(str(ex))
-    Log.error("Failed to retrive metrics of topology \'%s\'" % args[3])
+  except Exception:
+    Log.info(traceback.format_exc())
     raise
 
 
@@ -399,10 +395,8 @@ def get_component_metrics(component, cluster, env, topology, role):
     result = get_topology_metrics(
         cluster, env, topology, component, [], all_queries, [0, -1], role)
     return result["metrics"]
-  except Exception as ex:
-    Log.error(str(ex))
-    topology_loc = '/'.join([cluster, role, env, topology])
-    Log.error("Failed to retrive metrics of component '%s' in '%s'" % (component, topology_loc))
+  except Exception:
+    Log.info(traceback.format_exc())
     raise
 
 
@@ -411,9 +405,8 @@ def get_cluster_topologies(cluster):
   instance = tornado.ioloop.IOLoop.instance()
   try:
     return instance.run_sync(lambda: API.get_cluster_topologies(cluster))
-  except Exception as ex:
-    Log.error(str(ex))
-    Log.error('Failed to retrive topologies running in cluster \'%s\'' % cluster)
+  except Exception:
+    Log.info(traceback.format_exc())
     raise
 
 
@@ -422,10 +415,8 @@ def get_cluster_role_topologies(cluster, role):
   instance = tornado.ioloop.IOLoop.instance()
   try:
     return instance.run_sync(lambda: API.get_cluster_role_topologies(cluster, role))
-  except Exception as ex:
-    Log.error(str(ex))
-    Log.error('Failed to retrive topologies running in cluster'
-              '\'%s\' submitted by %s' % (cluster, role))
+  except Exception:
+    Log.info(traceback.format_exc())
     raise
 
 
@@ -434,8 +425,6 @@ def get_cluster_role_env_topologies(cluster, role, env):
   instance = tornado.ioloop.IOLoop.instance()
   try:
     return instance.run_sync(lambda: API.get_cluster_role_env_topologies(cluster, role, env))
-  except Exception as ex:
-    Log.error(str(ex))
-    Log.error('Failed to retrive topologies running in cluster'
-              '\'%s\' submitted by %s under environment %s' % (cluster, role, env))
+  except Exception:
+    Log.info(traceback.format_exc())
     raise

--- a/heron/common/src/python/utils.py
+++ b/heron/common/src/python/utils.py
@@ -353,7 +353,7 @@ def get_clusters():
   try:
     return instance.run_sync(lambda: API.get_clusters())
   except Exception as ex:
-    Log.error('Error: %s' % str(ex))
+    Log.error(str(ex))
     Log.error('Failed to retrive clusters')
     raise
 
@@ -364,7 +364,7 @@ def get_logical_plan(cluster, env, topology, role):
   try:
     return instance.run_sync(lambda: API.get_logical_plan(cluster, env, topology, role))
   except Exception as ex:
-    Log.error('Error: %s' % str(ex))
+    Log.error(str(ex))
     Log.error('Failed to retrive logical plan info of topology \'%s\''
               % ('/'.join([cluster, role, env, topology])))
     raise
@@ -377,6 +377,7 @@ def get_topology_info(*args):
     return instance.run_sync(lambda: API.get_topology_info(*args))
   except Exception as ex:
     Log.error(str(ex))
+    Log.error('Failed to get topology info')
     raise
 
 
@@ -387,7 +388,7 @@ def get_topology_metrics(*args):
     return instance.run_sync(lambda: API.get_comp_metrics(*args))
   except Exception as ex:
     Log.error(str(ex))
-    Log.error("Failed to retrive metrics of component \'%s\'" % args[3])
+    Log.error("Failed to retrive metrics of topology \'%s\'" % args[3])
     raise
 
 
@@ -398,7 +399,10 @@ def get_component_metrics(component, cluster, env, topology, role):
     result = get_topology_metrics(
         cluster, env, topology, component, [], all_queries, [0, -1], role)
     return result["metrics"]
-  except:
+  except Exception as ex:
+    Log.error(str(ex))
+    topology_loc = '/'.join([cluster, role, env, topology])
+    Log.error("Failed to retrive metrics of component '%s' in '%s'" % (component, topology_loc))
     raise
 
 

--- a/heron/explorer/src/python/clusters.py
+++ b/heron/explorer/src/python/clusters.py
@@ -16,6 +16,7 @@ import heron.explorer.src.python.args as args
 # from heron.common.src.python.color import Log
 # from tabulate import tabulate
 import heron.common.src.python.utils as utils
+from heron.common.src.python.color import Log
 
 
 def create_parser(subparsers):
@@ -36,6 +37,7 @@ def run(command, parser, cl_args, unknown_args):
   try:
     clusters = utils.get_clusters()
   except:
+    Log.error("Fail to connect to tracker: \'%s\'", cl_args["tracker_url"])
     return False
   print 'Available clusters:'
   for cluster in clusters:

--- a/heron/explorer/src/python/clusters.py
+++ b/heron/explorer/src/python/clusters.py
@@ -33,7 +33,10 @@ def create_parser(subparsers):
 # pylint: disable=unused-argument
 def run(command, parser, cl_args, unknown_args):
   """ run command """
-  clusters = utils.get_clusters()
+  try:
+    clusters = utils.get_clusters()
+  except:
+    return False
   print 'Available clusters:'
   for cluster in clusters:
     print '  %s' % cluster

--- a/heron/explorer/src/python/logicalplan.py
+++ b/heron/explorer/src/python/logicalplan.py
@@ -117,6 +117,7 @@ def run(cl_args, compo_type):
       print tabulate(table, headers=header)
     return True
   except:
+    Log.error("Fail to connect to tracker: \'%s\'", cl_args["tracker_url"])
     return False
 
 

--- a/heron/explorer/src/python/physicalplan.py
+++ b/heron/explorer/src/python/physicalplan.py
@@ -156,7 +156,10 @@ def run_containers(command, parser, cl_args, unknown_args):
   cluster, role, env = cl_args['cluster'], cl_args['role'], cl_args['environ']
   topology = cl_args['topology-name']
   container_id = cl_args['id']
-  result = utils.get_topology_info(cluster, env, topology, role)
+  try:
+    result = utils.get_topology_info(cluster, env, topology, role)
+  except:
+    return False
   containers = result['physical_plan']['stmgrs']
   all_bolts, all_spouts = set(), set()
   for _, bolts in result['physical_plan']['bolts'].items():

--- a/heron/explorer/src/python/physicalplan.py
+++ b/heron/explorer/src/python/physicalplan.py
@@ -107,10 +107,11 @@ def run_metrics(command, parser, cl_args, unknown_args):
   for comp in components:
     try:
       metrics = utils.get_component_metrics(comp, cluster, env, topology, role)
-      stat, header = to_table(metrics)
-      cresult.append((comp, stat, header))
     except:
+      Log.error("Fail to connect to tracker: \'%s\'", cl_args["tracker_url"])
       return False
+    stat, header = to_table(metrics)
+    cresult.append((comp, stat, header))
   for i, (comp, stat, header) in enumerate(cresult):
     if i != 0:
       print ''

--- a/heron/explorer/src/python/physicalplan.py
+++ b/heron/explorer/src/python/physicalplan.py
@@ -101,6 +101,7 @@ def run_metrics(command, parser, cl_args, unknown_args):
         Log.error('Unknown component: \'%s\'' % cname)
         raise
   except Exception:
+    Log.error("Fail to connect to tracker: \'%s\'", cl_args["tracker_url"])
     return False
   cresult = []
   for comp in components:
@@ -134,6 +135,7 @@ def run_bolts(command, parser, cl_args, unknown_args):
         Log.error('Unknown bolt: \'%s\'' % bolt_name)
         raise
   except Exception:
+    Log.error("Fail to connect to tracker: \'%s\'", cl_args["tracker_url"])
     return False
   bolts_result = []
   for bolt in bolts:
@@ -142,6 +144,7 @@ def run_bolts(command, parser, cl_args, unknown_args):
       stat, header = to_table(metrics)
       bolts_result.append((bolt, stat, header))
     except Exception:
+      Log.error("Fail to connect to tracker: \'%s\'", cl_args["tracker_url"])
       return False
   for i, (bolt, stat, header) in enumerate(bolts_result):
     if i != 0:
@@ -159,6 +162,7 @@ def run_containers(command, parser, cl_args, unknown_args):
   try:
     result = utils.get_topology_info(cluster, env, topology, role)
   except:
+    Log.error("Fail to connect to tracker: \'%s\'", cl_args["tracker_url"])
     return False
   containers = result['physical_plan']['stmgrs']
   all_bolts, all_spouts = set(), set()

--- a/heron/explorer/src/python/topologies.py
+++ b/heron/explorer/src/python/topologies.py
@@ -50,7 +50,7 @@ def to_table(result):
   return table, header, rest_count
 
 
-def show_cluster(cluster):
+def show_cluster(cl_args, cluster):
   ''' print topologies information to stdout '''
   try:
     result = utils.get_cluster_topologies(cluster)
@@ -59,6 +59,7 @@ def show_cluster(cluster):
       return False
     result = result[cluster]
   except Exception:
+    Log.error("Fail to connect to tracker: \'%s\'", cl_args["tracker_url"])
     return False
   table, header, rest_count = to_table(result)
   print 'Topologies running in cluster \'%s\'' % cluster
@@ -68,7 +69,7 @@ def show_cluster(cluster):
   return True
 
 
-def show_cluster_role(cluster, role):
+def show_cluster_role(cl_args, cluster, role):
   ''' print topologies information to stdout '''
   try:
     result = utils.get_cluster_role_topologies(cluster, role)
@@ -77,6 +78,7 @@ def show_cluster_role(cluster, role):
       return False
     result = result[cluster]
   except Exception:
+    Log.error("Fail to connect to tracker: \'%s\'", cl_args["tracker_url"])
     return False
   table, header, rest_count = to_table(result)
   print 'Topologies running in cluster \'%s\' submitted by \'%s\':' % (cluster, role)
@@ -86,7 +88,7 @@ def show_cluster_role(cluster, role):
   return True
 
 
-def show_cluster_role_env(cluster, role, env):
+def show_cluster_role_env(cl_args, cluster, role, env):
   ''' print topologies information to stdout '''
   try:
     result = utils.get_cluster_role_env_topologies(cluster, role, env)
@@ -95,6 +97,7 @@ def show_cluster_role_env(cluster, role, env):
       return False
     result = result[cluster]
   except Exception:
+    Log.error("Fail to connect to tracker: \'%s\'", cl_args["tracker_url"])
     return False
   table, header, rest_count = to_table(result)
   print 'Topologies running in cluster \'%s\', submitted by \'%s\', and\
@@ -109,11 +112,11 @@ def run(command, parser, cl_args, unknown_args):
   """ run command """
   location = cl_args['cluster/[role]/[env]'].split('/')
   if len(location) == 1:
-    return show_cluster(*location)
+    return show_cluster(cl_args, *location)
   elif len(location) == 2:
-    return show_cluster_role(*location)
+    return show_cluster_role(cl_args, *location)
   elif len(location) == 3:
-    return show_cluster_role_env(*location)
+    return show_cluster_role_env(cl_args, *location)
   else:
     Log.error('Invalid topologies selection')
     return False


### PR DESCRIPTION
1. unify format of error message when exception is raised
2. fix two places where exception will not be caught and traceback will be printed out.  
    This is ugly so I fixed it. (resolves #1117)