### PR TITLE
Add double quote to support spaces in envionment variables

### DIFF
--- a/bazel_configure.py
+++ b/bazel_configure.py
@@ -289,7 +289,7 @@ def discover_tool_default(program, msg, envvar, defvalue):
 
 def export_env_to_file(out_file, env):
   if env in os.environ:
-    out_file.write('export %s=%s\n' % (env, os.environ[env]))
+    out_file.write('export %s="%s"\n' % (env, os.environ[env]))
 
 ######################################################################
 # Generate the shell script that recreates the environment


### PR DESCRIPTION
This PR adds double quote for environment variables to avoid crash when some existing variable (e.g., CFLAGS) contains spaces.