### PR TITLE
Protect against failures when killing a running topology.

### DIFF
--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/LaunchRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/LaunchRunner.java
@@ -160,9 +160,10 @@ public class LaunchRunner implements Callable<Boolean> {
 
     // launch the topology, clear the state if it fails
     if (!launcher.launch(packedPlan)) {
-      statemgr.deleteExecutionState(topologyName);
-      statemgr.deletePackingPlan(topologyName);
-      statemgr.deleteTopology(topologyName);
+      if (!statemgr.cleanState(topologyName)) {
+        LOG.severe("Failed to clean topology state");
+      }
+
       LOG.log(Level.SEVERE, "Failed to launch topology");
       return false;
     }

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/LaunchRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/LaunchRunner.java
@@ -160,10 +160,7 @@ public class LaunchRunner implements Callable<Boolean> {
 
     // launch the topology, clear the state if it fails
     if (!launcher.launch(packedPlan)) {
-      if (!statemgr.cleanState(topologyName)) {
-        LOG.severe("Failed to clean topology state");
-      }
-
+      statemgr.cleanState(topologyName);
       LOG.log(Level.SEVERE, "Failed to launch topology");
       return false;
     }

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
@@ -347,18 +347,14 @@ public class RuntimeManagerMain {
       return false;
     }
 
-    // Check whether cluster/role/environ matched. It is possible to get into a state where some of
-    // the data does not actually exist in zookeeper. If we are in this state them assume the
-    // runtime is valid.
-    if (adaptor.doesExecutionStateExist(topologyName)) {
-      ExecutionEnvironment.ExecutionState executionState = adaptor.getExecutionState(topologyName);
-      if (executionState == null
-          || !executionState.getCluster().equals(Context.cluster(config))
-          || !executionState.getRole().equals(Context.role(config))
-          || !executionState.getEnviron().equals(Context.environ(config))) {
-        LOG.severe("cluster/role/environ not matched");
-        return false;
-      }
+    // Check whether cluster/role/environ matched
+    ExecutionEnvironment.ExecutionState executionState = adaptor.getExecutionState(topologyName);
+    if (executionState == null
+        || !executionState.getCluster().equals(Context.cluster(config))
+        || !executionState.getRole().equals(Context.role(config))
+        || !executionState.getEnviron().equals(Context.environ(config))) {
+      LOG.severe("cluster/role/environ not matched");
+      return false;
     }
 
     return true;

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
@@ -303,7 +303,8 @@ public class RuntimeManagerMain {
       // TODO(mfu): timeout should read from config
       SchedulerStateManagerAdaptor adaptor = new SchedulerStateManagerAdaptor(statemgr, 5000);
 
-      boolean isValid = (Command.KILL.equals(command)) || validateRuntimeManage(adaptor, topologyName);
+      boolean isValid = (Command.KILL.equals(command))
+          || validateRuntimeManage(adaptor, topologyName);
 
       // 2. Try to manage topology if valid
       if (isValid) {

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
@@ -347,14 +347,18 @@ public class RuntimeManagerMain {
       return false;
     }
 
-    // Check whether cluster/role/environ matched
-    ExecutionEnvironment.ExecutionState executionState = adaptor.getExecutionState(topologyName);
-    if (executionState == null
-        || !executionState.getCluster().equals(Context.cluster(config))
-        || !executionState.getRole().equals(Context.role(config))
-        || !executionState.getEnviron().equals(Context.environ(config))) {
-      LOG.severe("cluster/role/environ not matched");
-      return false;
+    // Check whether cluster/role/environ matched. It is possible to get into a state where some of
+    // the data does not actually exist in zookeeper. If we are in this state them assume the
+    // runtime is valid.
+    if (adaptor.doesExecutionStateExist(topologyName)) {
+      ExecutionEnvironment.ExecutionState executionState = adaptor.getExecutionState(topologyName);
+      if (executionState == null
+          || !executionState.getCluster().equals(Context.cluster(config))
+          || !executionState.getRole().equals(Context.role(config))
+          || !executionState.getEnviron().equals(Context.environ(config))) {
+        LOG.severe("cluster/role/environ not matched");
+        return false;
+      }
     }
 
     return true;
@@ -365,7 +369,7 @@ public class RuntimeManagerMain {
     RuntimeManagerRunner runtimeManagerRunner =
         new RuntimeManagerRunner(config, runtime, command, schedulerClient);
 
-    // invoke the appropriate handlers based on command
+    S// invoke the appropriate handlers based on command
     boolean ret = runtimeManagerRunner.call();
 
     return ret;

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
@@ -369,7 +369,7 @@ public class RuntimeManagerMain {
     RuntimeManagerRunner runtimeManagerRunner =
         new RuntimeManagerRunner(config, runtime, command, schedulerClient);
 
-    S// invoke the appropriate handlers based on command
+    // invoke the appropriate handlers based on command
     boolean ret = runtimeManagerRunner.call();
 
     return ret;

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
@@ -303,7 +303,7 @@ public class RuntimeManagerMain {
       // TODO(mfu): timeout should read from config
       SchedulerStateManagerAdaptor adaptor = new SchedulerStateManagerAdaptor(statemgr, 5000);
 
-      boolean isValid = validateRuntimeManage(adaptor, topologyName);
+      boolean isValid = (Command.KILL.equals(command)) || validateRuntimeManage(adaptor, topologyName);
 
       // 2. Try to manage topology if valid
       if (isValid) {

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
@@ -138,10 +138,7 @@ public class RuntimeManagerRunner implements Callable<Boolean> {
 
     // clean up the state of the topology in state manager
     SchedulerStateManagerAdaptor statemgr = Runtime.schedulerStateManagerAdaptor(runtime);
-    if (!statemgr.cleanState(topologyName)) {
-      LOG.severe("Failed to clean topology state");
-      return false;
-    }
+    statemgr.cleanState(topologyName);
 
     // Clean the connection when we are done.
     LOG.fine("Scheduler killed topology successfully.");

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
@@ -137,63 +137,14 @@ public class RuntimeManagerRunner implements Callable<Boolean> {
     }
 
     // clean up the state of the topology in state manager
-    if (!cleanState(topologyName, Runtime.schedulerStateManagerAdaptor(runtime))) {
+    SchedulerStateManagerAdaptor statemgr = Runtime.schedulerStateManagerAdaptor(runtime);
+    if (!statemgr.cleanState(topologyName)) {
       LOG.severe("Failed to clean topology state");
       return false;
     }
 
     // Clean the connection when we are done.
     LOG.fine("Scheduler killed topology successfully.");
-    return true;
-  }
-
-  /**
-   * Clean all states of a heron topology
-   * 1. Topology def and ExecutionState are required to exist to delete
-   * 2. TMasterLocation, SchedulerLocation and PhysicalPlan may not exist to delete
-   */
-  protected boolean cleanState(
-      String topologyName,
-      SchedulerStateManagerAdaptor statemgr) {
-    LOG.fine("Cleaning up topology state");
-
-    Boolean result;
-
-    // It is possible that  TMasterLocation, PhysicalPlan and SchedulerLocation are not set
-    // Just log but don't consider them failure
-    result = statemgr.deleteTMasterLocation(topologyName);
-    if (result == null || !result) {
-      // We would not return false since it is possible that TMaster didn't write physical plan
-      LOG.warning("Failed to clear TMaster location. Check whether TMaster set it correctly.");
-    }
-
-    result = statemgr.deletePhysicalPlan(topologyName);
-    if (result == null || !result) {
-      // We would not return false since it is possible that TMaster didn't write physical plan
-      LOG.warning("Failed to clear physical plan. Check whether TMaster set it correctly.");
-    }
-
-    result = statemgr.deleteSchedulerLocation(topologyName);
-    if (result == null || !result) {
-      // We would not return false since it is possible that TMaster didn't write physical plan
-      LOG.warning("Failed to clear scheduler location. Check whether Scheduler set it correctly.");
-    }
-
-    result = statemgr.deleteExecutionState(topologyName);
-    if (result == null || !result) {
-      LOG.severe("Failed to clear execution state");
-      return false;
-    }
-
-    // Set topology def at last since we determine whether a topology is running
-    // by checking the existence of topology def
-    result = statemgr.deleteTopology(topologyName);
-    if (result == null || !result) {
-      LOG.severe("Failed to clear topology definition");
-      return false;
-    }
-
-    LOG.fine("Cleaned up topology state");
     return true;
   }
 }

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/LaunchRunnerTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/LaunchRunnerTest.java
@@ -257,8 +257,7 @@ public class LaunchRunnerTest {
         Mockito.any(TopologyAPI.Topology.class), Mockito.eq(TOPOLOGY_NAME));
     Mockito.verify(statemgr).setExecutionState(
         Mockito.any(ExecutionEnvironment.ExecutionState.class), Mockito.eq(TOPOLOGY_NAME));
-    Mockito.verify(statemgr).deleteExecutionState(Mockito.eq(TOPOLOGY_NAME));
-    Mockito.verify(statemgr).deleteTopology(Mockito.eq(TOPOLOGY_NAME));
+    Mockito.verify(statemgr).cleanState(Mockito.eq(TOPOLOGY_NAME));
   }
 
   @Test

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/RuntimeManagerRunnerTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/RuntimeManagerRunnerTest.java
@@ -101,6 +101,9 @@ public class RuntimeManagerRunnerTest {
     RuntimeManagerRunner runner =
         Mockito.spy(new RuntimeManagerRunner(config, runtime, Command.KILL, client));
 
+    SchedulerStateManagerAdaptor adaptor = Mockito.mock(SchedulerStateManagerAdaptor.class);
+    Mockito.when(runtime.get(Keys.schedulerStateManagerAdaptor())).thenReturn(adaptor);
+
     // Failed to invoke client's killTopology
     Mockito.when(client.killTopology(killTopologyRequest)).thenReturn(false);
     Assert.assertFalse(runner.killTopologyHandler(TOPOLOGY_NAME));
@@ -108,14 +111,12 @@ public class RuntimeManagerRunnerTest {
 
     // Failed to clean states
     Mockito.when(client.killTopology(killTopologyRequest)).thenReturn(true);
-    Mockito.doReturn(false).when(runner).cleanState(
-        Mockito.eq(TOPOLOGY_NAME), Mockito.any(SchedulerStateManagerAdaptor.class));
+    Mockito.doReturn(false).when(adaptor).cleanState(Mockito.eq(TOPOLOGY_NAME));
     Assert.assertFalse(runner.killTopologyHandler(TOPOLOGY_NAME));
     Mockito.verify(client, Mockito.times(2)).killTopology(killTopologyRequest);
 
     // Success case
-    Mockito.doReturn(true).when(runner).cleanState(
-        Mockito.eq(TOPOLOGY_NAME), Mockito.any(SchedulerStateManagerAdaptor.class));
+    Mockito.doReturn(true).when(adaptor).cleanState(Mockito.eq(TOPOLOGY_NAME));
     Assert.assertTrue(runner.killTopologyHandler(TOPOLOGY_NAME));
     Mockito.verify(client, Mockito.times(3)).killTopology(killTopologyRequest);
   }

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/RuntimeManagerRunnerTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/RuntimeManagerRunnerTest.java
@@ -109,15 +109,9 @@ public class RuntimeManagerRunnerTest {
     Assert.assertFalse(runner.killTopologyHandler(TOPOLOGY_NAME));
     Mockito.verify(client).killTopology(killTopologyRequest);
 
-    // Failed to clean states
-    Mockito.when(client.killTopology(killTopologyRequest)).thenReturn(true);
-    Mockito.doReturn(false).when(adaptor).cleanState(Mockito.eq(TOPOLOGY_NAME));
-    Assert.assertFalse(runner.killTopologyHandler(TOPOLOGY_NAME));
-    Mockito.verify(client, Mockito.times(2)).killTopology(killTopologyRequest);
-
     // Success case
-    Mockito.doReturn(true).when(adaptor).cleanState(Mockito.eq(TOPOLOGY_NAME));
+    Mockito.doReturn(true).when(client).killTopology(killTopologyRequest);
     Assert.assertTrue(runner.killTopologyHandler(TOPOLOGY_NAME));
-    Mockito.verify(client, Mockito.times(3)).killTopology(killTopologyRequest);
+    Mockito.verify(client, Mockito.times(2)).killTopology(killTopologyRequest);
   }
 }

--- a/heron/spi/src/java/com/twitter/heron/spi/statemgr/IStateManager.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/statemgr/IStateManager.java
@@ -79,6 +79,12 @@ public interface IStateManager extends AutoCloseable {
       return concatPath(getDirectory(root), topology);
     }
 
+    public static void deleteAll(IStateManager stateManager, String topology) {
+      for (IStateManager.StateLocation stateLocation : IStateManager.StateLocation.values()) {
+        stateLocation.delete(stateManager, topology);
+      }
+    }
+
     public void delete(IStateManager stateManager, String topology) {
       switch(this) {
         case TMASTER_LOCATION:

--- a/heron/spi/src/java/com/twitter/heron/spi/statemgr/IStateManager.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/statemgr/IStateManager.java
@@ -51,6 +51,64 @@ import com.twitter.heron.spi.common.Config;
  */
 
 public interface IStateManager extends AutoCloseable {
+  enum StateLocation {
+    TMASTER_LOCATION("tmasters", "TMaster location"),
+    TOPOLOGY("topologies", "Topologies"),
+    PACKING_PLAN("packingplans", "Packing plan"),
+    PHYSICAL_PLAN("pplans", "Physical plan"),
+    EXECUTION_STATE("executionstate", "Execution state"),
+    SCHEDULER_LOCATION("schedulers", "Scheduler location");
+
+    private final String dir;
+    private final String name;
+
+    StateLocation(String dir, String name) {
+      this.dir = dir;
+      this.name = name;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getDirectory(String root) {
+      return concatPath(root, dir);
+    }
+
+    public String getNodePath(String root, String topology) {
+      return concatPath(getDirectory(root), topology);
+    }
+
+    public void delete(IStateManager stateManager, String topology) {
+      switch(this) {
+        case TMASTER_LOCATION:
+          stateManager.deleteTMasterLocation(topology);
+          break;
+        case TOPOLOGY:
+          stateManager.deleteTopology(topology);
+          break;
+        case PACKING_PLAN:
+          stateManager.deletePackingPlan(topology);
+          break;
+        case PHYSICAL_PLAN:
+          stateManager.deletePhysicalPlan(topology);
+          break;
+        case EXECUTION_STATE:
+          stateManager.deleteExecutionState(topology);
+          break;
+        case SCHEDULER_LOCATION:
+          stateManager.deleteSchedulerLocation(topology);
+          break;
+        default:
+          // This should never be reached, nothing to do.
+      }
+    }
+
+    private static String concatPath(String basePath, String appendPath) {
+      return String.format("%s/%s", basePath, appendPath);
+    }
+  }
+
   /**
    * Initialize StateManager with the incoming context.
    */
@@ -138,6 +196,8 @@ public interface IStateManager extends AutoCloseable {
    * @return Boolean - Success or Failure
    */
   ListenableFuture<Boolean> deleteSchedulerLocation(String topologyName);
+
+
 
   /**
    * Get the tmaster location for the given topology

--- a/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
@@ -226,39 +226,20 @@ public class SchedulerStateManagerAdaptor {
   public void cleanState(String topologyName) {
     LOG.fine("Cleaning up topology state");
 
-    Boolean result;
-
-    result = deleteTMasterLocation(topologyName);
-    if (result == null || !result) {
-      LOG.warning("Failed to clear TMaster location.");
-    }
-
-    result = deletePackingPlan(topologyName);
-    if (result == null || !result) {
-      LOG.warning("Failed to clear packing plan.");
-    }
-
-    result = deletePhysicalPlan(topologyName);
-    if (result == null || !result) {
-      LOG.warning("Failed to clear physical plan.");
-    }
-
-    result = deleteSchedulerLocation(topologyName);
-    if (result == null || !result) {
-      LOG.warning("Failed to clear scheduler location.");
-    }
-
-    result = deleteExecutionState(topologyName);
-    if (result == null || !result) {
-      LOG.severe("Failed to clear execution state");
-    }
-
-    result = deleteTopology(topologyName);
-    if (result == null || !result) {
-      LOG.severe("Failed to clear topology definition");
-    }
+    logDeleteStatus(deleteTMasterLocation(topologyName), "topology master");
+    logDeleteStatus(deletePackingPlan(topologyName), "packing plan");
+    logDeleteStatus(deletePhysicalPlan(topologyName), "physical plan");
+    logDeleteStatus(deleteSchedulerLocation(topologyName), "scheduler");
+    logDeleteStatus(deleteExecutionState(topologyName), "execution state");
+    logDeleteStatus(deleteTopology(topologyName), "topology definition");
 
     LOG.fine("Cleaned up topology state");
+  }
+
+  private void logDeleteStatus(Boolean success, String name) {
+    if (success == null || !success) {
+      LOG.warning("Failed to clear state for " + name);
+    }
   }
 
   /**

--- a/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
@@ -217,9 +217,7 @@ public class SchedulerStateManagerAdaptor {
   public void cleanState(String topologyName) {
     LOG.fine("Cleaning up topology state");
 
-    for (IStateManager.StateLocation stateLocation : IStateManager.StateLocation.values()) {
-      stateLocation.delete(delegate, topologyName);
-    }
+    IStateManager.StateLocation.deleteAll(delegate, topologyName);
 
     LOG.fine("Cleaned up topology state");
   }

--- a/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
@@ -217,20 +217,11 @@ public class SchedulerStateManagerAdaptor {
   public void cleanState(String topologyName) {
     LOG.fine("Cleaning up topology state");
 
-    logDeleteStatus(deleteTMasterLocation(topologyName), "topology master");
-    logDeleteStatus(deletePackingPlan(topologyName), "packing plan");
-    logDeleteStatus(deletePhysicalPlan(topologyName), "physical plan");
-    logDeleteStatus(deleteSchedulerLocation(topologyName), "scheduler");
-    logDeleteStatus(deleteExecutionState(topologyName), "execution state");
-    logDeleteStatus(deleteTopology(topologyName), "topology definition");
+    for (IStateManager.StateLocation stateLocation : IStateManager.StateLocation.values()) {
+      stateLocation.delete(delegate, topologyName);
+    }
 
     LOG.fine("Cleaned up topology state");
-  }
-
-  private void logDeleteStatus(Boolean success, String name) {
-    if (success == null || !success) {
-      LOG.warning("Failed to clear state for " + name);
-    }
   }
 
   /**

--- a/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
@@ -209,15 +209,6 @@ public class SchedulerStateManagerAdaptor {
   }
 
   /**
-   * Checks to see if the execution state exists
-   *
-   * @return a boolean indicating whether the execution state exists or not
-   */
-  public boolean doesExecutionStateExist(String topologyName) {
-    return awaitResult(delegate.executionStateExists(topologyName));
-  }
-
-  /**
    * Clean all states of a heron topology. This goes through each piece of state that needs
    * to be cleaned up and will log out a warning if it could not be cleaned up properly.
    * TMasterLocation, PackingPlan, PhysicalPlan, SchedulerLocation, ExecutionState, and Topology

--- a/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
@@ -218,56 +218,47 @@ public class SchedulerStateManagerAdaptor {
   }
 
   /**
-   * Clean all states of a heron topology.
+   * Clean all states of a heron topology. This goes through each piece of state that needs
+   * to be cleaned up and will log out a warning if it could not be cleaned up properly.
    * TMasterLocation, PackingPlan, PhysicalPlan, SchedulerLocation, ExecutionState, and Topology
+   * @param topologyName the name of the topology that we should clean the state for
    */
-  public Boolean cleanState(String topologyName) {
+  public void cleanState(String topologyName) {
     LOG.fine("Cleaning up topology state");
 
     Boolean result;
 
-    // It is possible that  TMasterLocation, PhysicalPlan and SchedulerLocation are not set
-    // Just log but don't consider them failure
     result = deleteTMasterLocation(topologyName);
     if (result == null || !result) {
-      // We would not return false since it is possible that TMaster didn't write physical plan
       LOG.warning("Failed to clear TMaster location.");
     }
 
     result = deletePackingPlan(topologyName);
     if (result == null || !result) {
-      // We would not return false since it is possible that TMaster didn't write physical plan
       LOG.warning("Failed to clear packing plan.");
     }
 
     result = deletePhysicalPlan(topologyName);
     if (result == null || !result) {
-      // We would not return false since it is possible that TMaster didn't write physical plan
       LOG.warning("Failed to clear physical plan.");
     }
 
     result = deleteSchedulerLocation(topologyName);
     if (result == null || !result) {
-      // We would not return false since it is possible that TMaster didn't write physical plan
       LOG.warning("Failed to clear scheduler location.");
     }
 
     result = deleteExecutionState(topologyName);
     if (result == null || !result) {
       LOG.severe("Failed to clear execution state");
-      return false;
     }
 
-    // Set topology def at last since we determine whether a topology is running
-    // by checking the existence of topology def
     result = deleteTopology(topologyName);
     if (result == null || !result) {
       LOG.severe("Failed to clear topology definition");
-      return false;
     }
 
     LOG.fine("Cleaned up topology state");
-    return true;
   }
 
   /**

--- a/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
@@ -133,7 +133,7 @@ public class SchedulerStateManagerAdaptor {
    * @return Boolean - Success or Failure
    */
   public Boolean deleteTMasterLocation(String topologyName) {
-    return awaitResult(delegate.doesTMasterLocationExists(topologyName))
+    return awaitResult(delegate.tmasterLocationExists(topologyName))
         ? awaitResult(delegate.deleteTMasterLocation(topologyName))
         : true;
   }
@@ -144,7 +144,7 @@ public class SchedulerStateManagerAdaptor {
    * @return Boolean - Success or Failure
    */
   public Boolean deleteExecutionState(String topologyName) {
-    return awaitResult(delegate.doesExecutionStateExists(topologyName))
+    return awaitResult(delegate.executionStateExists(topologyName))
         ? awaitResult(delegate.deleteExecutionState(topologyName))
         : true;
   }
@@ -155,7 +155,7 @@ public class SchedulerStateManagerAdaptor {
    * @return Boolean - Success or Failure
    */
   public Boolean deleteTopology(String topologyName) {
-    return awaitResult(delegate.doesTopologyExists(topologyName))
+    return awaitResult(delegate.topologyExists(topologyName))
         ? awaitResult(delegate.deleteTopology(topologyName))
         : true;
   }
@@ -175,7 +175,7 @@ public class SchedulerStateManagerAdaptor {
    * @return Boolean - Success or Failure
    */
   public Boolean deletePhysicalPlan(String topologyName) {
-    return awaitResult(delegate.doesPhysicalPlanExists(topologyName))
+    return awaitResult(delegate.physicalPlanExists(topologyName))
         ? awaitResult(delegate.deletePhysicalPlan(topologyName))
         : true;
   }
@@ -186,7 +186,7 @@ public class SchedulerStateManagerAdaptor {
    * @return Boolean - Success or Failure
    */
   public Boolean deleteSchedulerLocation(String topologyName) {
-    return awaitResult(delegate.doesSchedulerLocationExists(topologyName))
+    return awaitResult(delegate.schedulerLocationExists(topologyName))
         ? awaitResult(delegate.deleteSchedulerLocation(topologyName))
         : true;
   }
@@ -224,7 +224,7 @@ public class SchedulerStateManagerAdaptor {
    * @return a boolean indicating whether the execution state exists or not
    */
   public boolean doesExecutionStateExist(String topologyName) {
-    return awaitResult(delegate.doesExecutionStateExists(topologyName));
+    return awaitResult(delegate.executionStateExists(topologyName));
   }
 
   /**

--- a/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
@@ -133,9 +133,7 @@ public class SchedulerStateManagerAdaptor {
    * @return Boolean - Success or Failure
    */
   public Boolean deleteTMasterLocation(String topologyName) {
-    return awaitResult(delegate.tmasterLocationExists(topologyName))
-        ? awaitResult(delegate.deleteTMasterLocation(topologyName))
-        : true;
+    return awaitResult(delegate.deleteTMasterLocation(topologyName));
   }
 
   /**
@@ -144,9 +142,7 @@ public class SchedulerStateManagerAdaptor {
    * @return Boolean - Success or Failure
    */
   public Boolean deleteExecutionState(String topologyName) {
-    return awaitResult(delegate.executionStateExists(topologyName))
-        ? awaitResult(delegate.deleteExecutionState(topologyName))
-        : true;
+    return awaitResult(delegate.deleteExecutionState(topologyName));
   }
 
   /**
@@ -155,9 +151,7 @@ public class SchedulerStateManagerAdaptor {
    * @return Boolean - Success or Failure
    */
   public Boolean deleteTopology(String topologyName) {
-    return awaitResult(delegate.topologyExists(topologyName))
-        ? awaitResult(delegate.deleteTopology(topologyName))
-        : true;
+    return awaitResult(delegate.deleteTopology(topologyName));
   }
 
   /**
@@ -175,9 +169,7 @@ public class SchedulerStateManagerAdaptor {
    * @return Boolean - Success or Failure
    */
   public Boolean deletePhysicalPlan(String topologyName) {
-    return awaitResult(delegate.physicalPlanExists(topologyName))
-        ? awaitResult(delegate.deletePhysicalPlan(topologyName))
-        : true;
+     return awaitResult(delegate.deletePhysicalPlan(topologyName));
   }
 
   /**
@@ -186,9 +178,7 @@ public class SchedulerStateManagerAdaptor {
    * @return Boolean - Success or Failure
    */
   public Boolean deleteSchedulerLocation(String topologyName) {
-    return awaitResult(delegate.schedulerLocationExists(topologyName))
-        ? awaitResult(delegate.deleteSchedulerLocation(topologyName))
-        : true;
+    return awaitResult(delegate.deleteSchedulerLocation(topologyName));
   }
 
   /**

--- a/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
@@ -169,7 +169,7 @@ public class SchedulerStateManagerAdaptor {
    * @return Boolean - Success or Failure
    */
   public Boolean deletePhysicalPlan(String topologyName) {
-     return awaitResult(delegate.deletePhysicalPlan(topologyName));
+    return awaitResult(delegate.deletePhysicalPlan(topologyName));
   }
 
   /**

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/FileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/FileSystemStateManager.java
@@ -39,39 +39,6 @@ public abstract class FileSystemStateManager implements IStateManager {
   // Store the root address of the hierarchical file system
   protected String rootAddress;
 
-  protected enum StateLocation {
-    TMASTER_LOCATION("tmasters", "TMaster location"),
-    TOPOLOGY("topologies", "Topologies"),
-    PACKING_PLAN("packingplans", "Packing plan"),
-    PHYSICAL_PLAN("pplans", "Physical plan"),
-    EXECUTION_STATE("executionstate", "Execution state"),
-    SCHEDULER_LOCATION("schedulers", "Scheduler location");
-
-    private final String dir;
-    private final String name;
-
-    StateLocation(String dir, String name) {
-      this.dir = dir;
-      this.name = name;
-    }
-
-    public String getName() {
-      return name;
-    }
-
-    public String getDirectory(String root) {
-      return concatPath(root, dir);
-    }
-
-    public String getNodePath(String root, String topology) {
-      return concatPath(getDirectory(root), topology);
-    }
-
-    private static String concatPath(String basePath, String appendPath) {
-      return String.format("%s/%s", basePath, appendPath);
-    }
-  }
-
   protected abstract ListenableFuture<Boolean> nodeExists(String path);
 
   protected abstract ListenableFuture<Boolean> deleteNode(String path);

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/FileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/FileSystemStateManager.java
@@ -182,6 +182,10 @@ public abstract class FileSystemStateManager implements IStateManager {
     return getNodeData(watcher, getStatePath(location, topologyName), builder);
   }
 
+  private static String concatPath(String basePath, String appendPath) {
+    return String.format("%s/%s", basePath, appendPath);
+  }
+
   /**
    * Returns all information stored in the StateManager. This is a utility method used for debugging
    * while developing. To invoke, run:

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/NullStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/NullStateManager.java
@@ -158,4 +158,29 @@ public class NullStateManager implements IStateManager {
       String topologyName) {
     return SettableFuture.create();
   }
+
+  @Override
+  public ListenableFuture<Boolean> tmasterLocationExists(String topologyName) {
+    return nullFuture;
+  }
+
+  @Override
+  public ListenableFuture<Boolean> schedulerLocationExists(String topologyName) {
+    return nullFuture;
+  }
+
+  @Override
+  public ListenableFuture<Boolean> topologyExists(String topologyName) {
+    return nullFuture;
+  }
+
+  @Override
+  public ListenableFuture<Boolean> executionStateExists(String topologyName) {
+    return nullFuture;
+  }
+
+  @Override
+  public ListenableFuture<Boolean> physicalPlanExists(String topologyName) {
+    return nullFuture;
+  }
 }

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/NullStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/NullStateManager.java
@@ -158,29 +158,4 @@ public class NullStateManager implements IStateManager {
       String topologyName) {
     return SettableFuture.create();
   }
-
-  @Override
-  public ListenableFuture<Boolean> tmasterLocationExists(String topologyName) {
-    return nullFuture;
-  }
-
-  @Override
-  public ListenableFuture<Boolean> schedulerLocationExists(String topologyName) {
-    return nullFuture;
-  }
-
-  @Override
-  public ListenableFuture<Boolean> topologyExists(String topologyName) {
-    return nullFuture;
-  }
-
-  @Override
-  public ListenableFuture<Boolean> executionStateExists(String topologyName) {
-    return nullFuture;
-  }
-
-  @Override
-  public ListenableFuture<Boolean> physicalPlanExists(String topologyName) {
-    return nullFuture;
-  }
 }

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
@@ -218,7 +218,8 @@ public class CuratorStateManager extends FileSystemStateManager {
       result.set(true);
 
     } catch (KeeperException.NoNodeException e) {
-      LOG.warning(path + " does not exist so there's nothing to delete");
+      LOG.warning("deleteNode called for " + path
+          + " but it does not exist so there's nothing to delete");
       result.set(true);
 
       // Suppress it since forPath() throws Exception

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
@@ -31,6 +31,7 @@ import org.apache.curator.framework.api.BackgroundCallback;
 import org.apache.curator.framework.api.CuratorEvent;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.Watcher;
 
 import com.twitter.heron.api.generated.TopologyAPI;
@@ -214,6 +215,10 @@ public class CuratorStateManager extends FileSystemStateManager {
     try {
       client.delete().withVersion(-1).forPath(path);
       LOG.info("Deleted node for path: " + path);
+      result.set(true);
+
+    } catch (KeeperException.NoNodeException e) {
+      LOG.info(path + " does not exist so there's nothing to delete");
       result.set(true);
 
       // Suppress it since forPath() throws Exception

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
@@ -218,7 +218,7 @@ public class CuratorStateManager extends FileSystemStateManager {
       result.set(true);
 
     } catch (KeeperException.NoNodeException e) {
-      LOG.info(path + " does not exist so there's nothing to delete");
+      LOG.warning(path + " does not exist so there's nothing to delete");
       result.set(true);
 
       // Suppress it since forPath() throws Exception


### PR DESCRIPTION
I believe that this is functionally complete, I need to write some tests but wanted to get some feedback on the approach first.

If any of the state in zookeeper is deleted while others are left in
tact the topology will become undeployable because the cli will fail to
clean up the leftover state. The exception looks like:

```
[2016-07-21 13:42:23 +0000] com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor SEVERE:  Exception processing future
java.util.concurrent.ExecutionException: java.lang.RuntimeException: Failed to fetch data from path: /heron/executionstate/foo
        at com.google.common.util.concurrent.AbstractFuture$Sync.getValue(AbstractFuture.java:299)
        at com.google.common.util.concurrent.AbstractFuture$Sync.get(AbstractFuture.java:272)
        at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:96)
        at com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor.awaitResult(SchedulerStateManagerAdaptor.java:71)
        at com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor.awaitResult(SchedulerStateManagerAdaptor.java:63)
        at com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor.getExecutionState(SchedulerStateManagerAdaptor.java:198)
        at com.twitter.heron.scheduler.RuntimeManagerMain.validateRuntimeManage(RuntimeManagerMain.java:351)
        at com.twitter.heron.scheduler.RuntimeManagerMain.manageTopology(RuntimeManagerMain.java:306)
        at com.twitter.heron.scheduler.RuntimeManagerMain.main(RuntimeManagerMain.java:251)
```

This change makes it so the kill command is more robust and will treat
instances where the state does not exist as a no-op and continue its
clean up.

This fixes: https://github.com/twitter/heron/issues/1126
