### PR TITLE
package all files in spi directory for publishing

### DIFF
--- a/heron/spi/src/java/BUILD
+++ b/heron/spi/src/java/BUILD
@@ -171,7 +171,13 @@ java_library(
 java_binary(
     name = "spi-unshaded",
     srcs = glob([
-        "**/spi/**/*.java",
+        "**/spi/common/**/*.java",
+        "**/spi/metricsmgr/**/*.java",
+        "**/spi/packing/**/*.java",
+        "**/spi/scheduler/**/*.java",
+        "**/spi/statemgr/**/*.java",
+        "**/spi/uploader/**/*.java",
+        "**/spi/utils/**/*.java",
     ]),
     deps = utils_deps_files,
 )

--- a/heron/spi/src/java/BUILD
+++ b/heron/spi/src/java/BUILD
@@ -171,8 +171,7 @@ java_library(
 java_binary(
     name = "spi-unshaded",
     srcs = glob([
-        "**/spi/utils/**/*.java",
-        "**/spi/common/**/*.java",
+        "**/spi/**/*.java",
     ]),
     deps = utils_deps_files,
 )


### PR DESCRIPTION
As mentioned in #1130, currently only java files under `common` and `utils` are published in spi.jar. We need to publish all files under `spi` directory.