### PR TITLE
Modified topology.proto to support for Python topology

### DIFF
--- a/heron/api/src/java/com/twitter/heron/api/topology/BaseComponentDeclarer.java
+++ b/heron/api/src/java/com/twitter/heron/api/topology/BaseComponentDeclarer.java
@@ -59,7 +59,7 @@ public abstract class BaseComponentDeclarer<T extends ComponentConfigurationDecl
 
   public void dump(TopologyAPI.Component.Builder bldr) {
     bldr.setName(name);
-    bldr.setLang(TopologyAPI.Language.JAVA);
+    bldr.setSpec(TopologyAPI.ComponentObjectSpec.JAVA_SERIALIZED_OBJECT);
     bldr.setSerializedObject(ByteString.copyFrom(Utils.serialize(component)));
 
     TopologyAPI.Config.Builder cBldr = TopologyAPI.Config.newBuilder();

--- a/heron/api/src/java/com/twitter/heron/api/topology/BaseComponentDeclarer.java
+++ b/heron/api/src/java/com/twitter/heron/api/topology/BaseComponentDeclarer.java
@@ -59,7 +59,8 @@ public abstract class BaseComponentDeclarer<T extends ComponentConfigurationDecl
 
   public void dump(TopologyAPI.Component.Builder bldr) {
     bldr.setName(name);
-    bldr.setJavaObject(ByteString.copyFrom(Utils.serialize(component)));
+    bldr.setLang(TopologyAPI.Language.JAVA);
+    bldr.setSerializedObject(ByteString.copyFrom(Utils.serialize(component)));
 
     TopologyAPI.Config.Builder cBldr = TopologyAPI.Config.newBuilder();
     for (Map.Entry<String, Object> entry : componentConfiguration.entrySet()) {

--- a/heron/common/src/cpp/config/topology-config-helper.cpp
+++ b/heron/common/src/cpp/config/topology-config-helper.cpp
@@ -144,13 +144,13 @@ proto::api::Topology* TopologyConfigHelper::StripComponentObjects(
   proto::api::Topology* ret = new proto::api::Topology();
   ret->CopyFrom(_topology);
   for (sp_int32 i = 0; i < ret->spouts_size(); ++i) {
-    if (ret->mutable_spouts(i)->mutable_comp()->has_java_object()) {
-      ret->mutable_spouts(i)->mutable_comp()->clear_java_object();
+    if (ret->mutable_spouts(i)->mutable_comp()->has_serialized_object()) {
+      ret->mutable_spouts(i)->mutable_comp()->clear_serialized_object();
     }
   }
   for (sp_int32 i = 0; i < ret->bolts_size(); ++i) {
-    if (ret->mutable_bolts(i)->mutable_comp()->has_java_object()) {
-      ret->mutable_bolts(i)->mutable_comp()->clear_java_object();
+    if (ret->mutable_bolts(i)->mutable_comp()->has_serialized_object()) {
+      ret->mutable_bolts(i)->mutable_comp()->clear_serialized_object();
     }
   }
   return ret;

--- a/heron/common/tests/python/mock_protobuf.py
+++ b/heron/common/tests/python/mock_protobuf.py
@@ -32,7 +32,8 @@ def get_mock_component(name="component_name",
   """Returns a mock protobuf Component object from topology_pb2"""
   component = topology_pb2.Component()
   component.name = name
-  component.python_class_name = python_cls
+  component.spec = topology_pb2.ComponentObjectSpec.Value("PYTHON_CLASS_NAME")
+  component.class_name = python_cls
   component.config.CopyFrom(config)
   return component
 

--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
@@ -78,7 +78,8 @@ public class BoltInstance implements IInstance {
 
     // Get the bolt. Notice, in fact, we will always use the deserialization way to get bolt.
     if (helper.getMyBolt().getComp().hasSerializedObject()) {
-      bolt = (IBolt) Utils.deserialize(helper.getMyBolt().getComp().getSerializedObject().toByteArray());
+      bolt = (IBolt) Utils.deserialize(
+          helper.getMyBolt().getComp().getSerializedObject().toByteArray());
     } else if (helper.getMyBolt().getComp().hasClassName()) {
       try {
         String boltClassName = helper.getMyBolt().getComp().getClassName();

--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
@@ -77,11 +77,11 @@ public class BoltInstance implements IInstance {
         SystemConfig.HERON_SYSTEM_CONFIG);
 
     // Get the bolt. Notice, in fact, we will always use the deserialization way to get bolt.
-    if (helper.getMyBolt().getComp().hasJavaObject()) {
-      bolt = (IBolt) Utils.deserialize(helper.getMyBolt().getComp().getJavaObject().toByteArray());
-    } else if (helper.getMyBolt().getComp().hasJavaClassName()) {
+    if (helper.getMyBolt().getComp().hasSerializedObject()) {
+      bolt = (IBolt) Utils.deserialize(helper.getMyBolt().getComp().getSerializedObject().toByteArray());
+    } else if (helper.getMyBolt().getComp().hasClassName()) {
       try {
-        String boltClassName = helper.getMyBolt().getComp().getJavaClassName();
+        String boltClassName = helper.getMyBolt().getComp().getClassName();
         bolt = (IBolt) Class.forName(boltClassName).newInstance();
       } catch (ClassNotFoundException ex) {
         throw new RuntimeException(ex + " Bolt class must be in class path.");

--- a/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutInstance.java
@@ -92,11 +92,11 @@ public class SpoutInstance implements IInstance {
     }
     serializer = SerializeDeSerializeHelper.getSerializer(config);
     // Get the spout. Notice, in fact, we will always use the deserialization way to get bolt.
-    if (helper.getMySpout().getComp().hasJavaObject()) {
+    if (helper.getMySpout().getComp().hasSerializedObject()) {
       spout = (ISpout) Utils.deserialize(
-          helper.getMySpout().getComp().getJavaObject().toByteArray());
-    } else if (helper.getMySpout().getComp().hasJavaClassName()) {
-      String spoutClassName = helper.getMySpout().getComp().getJavaClassName();
+          helper.getMySpout().getComp().getSerializedObject().toByteArray());
+    } else if (helper.getMySpout().getComp().hasClassName()) {
+      String spoutClassName = helper.getMySpout().getComp().getClassName();
       try {
         spout = (ISpout) Class.forName(spoutClassName).newInstance();
       } catch (ClassNotFoundException ex) {

--- a/heron/proto/topology.proto
+++ b/heron/proto/topology.proto
@@ -77,7 +77,11 @@ message Config {
 message Component {
   // The name of the component. Like Tail-FlatMap
   required string name = 1;
-  // Only one of the below two are set
+  // Only one of the below two is set, whose meaning is determined
+  // by the value of spec. For example, when spec is JAVA_CLASS_NAME,
+  // `class_name` is set and contains Java's class name.
+  // When spec is JAVA_SERIALIZED_OBJECT, `serialized_object` is set and
+  // contains a serialized Java object.
   optional string class_name = 2;
   optional bytes serialized_object = 4;
 

--- a/heron/proto/topology.proto
+++ b/heron/proto/topology.proto
@@ -33,9 +33,10 @@ enum Type {
   OBJECT = 1; // generic type
 }
 
-enum Language {
-  JAVA = 1;
-  PYTHON = 2;
+enum ComponentObjectSpec {
+  JAVA_CLASS_NAME = 1;
+  JAVA_SERIALIZED_OBJECT = 2;
+  PYTHON_CLASS_NAME = 3;
 }
 
 message StreamSchema {
@@ -76,11 +77,12 @@ message Config {
 message Component {
   // The name of the component. Like Tail-FlatMap
   required string name = 1;
-  required Language lang = 5;
-  // Only one of the below three are set
+  // Only one of the below two are set
   optional string class_name = 2;
   optional bytes serialized_object = 4;
+
   required Config config = 3;
+  required ComponentObjectSpec spec = 5;
 }
 
 message Spout {

--- a/heron/proto/topology.proto
+++ b/heron/proto/topology.proto
@@ -33,6 +33,11 @@ enum Type {
   OBJECT = 1; // generic type
 }
 
+enum Language {
+  JAVA = 1;
+  PYTHON = 2;
+}
+
 message StreamSchema {
   message KeyType {
     required string key = 1;
@@ -71,10 +76,10 @@ message Config {
 message Component {
   // The name of the component. Like Tail-FlatMap
   required string name = 1;
+  required Language lang = 5;
   // Only one of the below three are set
-  optional string java_class_name = 2;
-  optional bytes java_object = 4;
-  optional string python_class_name = 5;
+  optional string class_name = 2;
+  optional bytes serialized_object = 4;
   required Config config = 3;
 }
 

--- a/heron/proto/topology.proto
+++ b/heron/proto/topology.proto
@@ -71,9 +71,10 @@ message Config {
 message Component {
   // The name of the component. Like Tail-FlatMap
   required string name = 1;
-  // Only one of the below two are set
+  // Only one of the below three are set
   optional string java_class_name = 2;
   optional bytes java_object = 4;
+  optional string python_class_name = 5;
   required Config config = 3;
 }
 

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/LaunchRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/LaunchRunner.java
@@ -99,12 +99,12 @@ public class LaunchRunner implements Callable<Boolean> {
 
     // clear the state of user spout java objects - which can be potentially huge
     for (TopologyAPI.Spout.Builder spout : builder.getSpoutsBuilderList()) {
-      spout.getCompBuilder().clearJavaObject();
+      spout.getCompBuilder().clearSerializedObject();
     }
 
     // clear the state of user spout java objects - which can be potentially huge
     for (TopologyAPI.Bolt.Builder bolt : builder.getBoltsBuilderList()) {
-      bolt.getCompBuilder().clearJavaObject();
+      bolt.getCompBuilder().clearSerializedObject();
     }
 
     return builder.build();

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/LaunchRunnerTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/LaunchRunnerTest.java
@@ -132,19 +132,19 @@ public class LaunchRunnerTest {
     TopologyAPI.Topology topologyAfterTrimmed = launchRunner.trimTopology(topologyBeforeTrimmed);
 
     for (TopologyAPI.Spout spout : topologyBeforeTrimmed.getSpoutsList()) {
-      Assert.assertTrue(spout.getComp().hasJavaObject());
+      Assert.assertTrue(spout.getComp().hasSerializedObject());
     }
 
     for (TopologyAPI.Bolt bolt : topologyBeforeTrimmed.getBoltsList()) {
-      Assert.assertTrue(bolt.getComp().hasJavaObject());
+      Assert.assertTrue(bolt.getComp().hasSerializedObject());
     }
 
     for (TopologyAPI.Spout spout : topologyAfterTrimmed.getSpoutsList()) {
-      Assert.assertFalse(spout.getComp().hasJavaObject());
+      Assert.assertFalse(spout.getComp().hasSerializedObject());
     }
 
     for (TopologyAPI.Bolt bolt : topologyAfterTrimmed.getBoltsList()) {
-      Assert.assertFalse(bolt.getComp().hasJavaObject());
+      Assert.assertFalse(bolt.getComp().hasSerializedObject());
     }
   }
 

--- a/heron/simulator/src/java/com/twitter/heron/simulator/instance/BoltInstance.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/instance/BoltInstance.java
@@ -76,11 +76,12 @@ public class BoltInstance implements IInstance {
         SystemConfig.HERON_SYSTEM_CONFIG);
 
     // Get the bolt. Notice, in fact, we will always use the deserialization way to get bolt.
-    if (helper.getMyBolt().getComp().hasJavaObject()) {
-      bolt = (IBolt) Utils.deserialize(helper.getMyBolt().getComp().getJavaObject().toByteArray());
-    } else if (helper.getMyBolt().getComp().hasJavaClassName()) {
+    if (helper.getMyBolt().getComp().hasSerializedObject()) {
+      bolt = (IBolt) Utils.deserialize(
+          helper.getMyBolt().getComp().getSerializedObject().toByteArray());
+    } else if (helper.getMyBolt().getComp().hasClassName()) {
       try {
-        String boltClassName = helper.getMyBolt().getComp().getJavaClassName();
+        String boltClassName = helper.getMyBolt().getComp().getClassName();
         bolt = (IBolt) Class.forName(boltClassName).newInstance();
       } catch (ClassNotFoundException ex) {
         throw new RuntimeException(ex + " Bolt class must be in class path.");

--- a/heron/simulator/src/java/com/twitter/heron/simulator/instance/SpoutInstance.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/instance/SpoutInstance.java
@@ -91,11 +91,11 @@ public class SpoutInstance implements IInstance {
     }
     serializer = SerializeDeSerializeHelper.getSerializer(config);
     // Get the spout. Notice, in fact, we will always use the deserialization way to get bolt.
-    if (helper.getMySpout().getComp().hasJavaObject()) {
+    if (helper.getMySpout().getComp().hasSerializedObject()) {
       spout = (ISpout) Utils.deserialize(
-          helper.getMySpout().getComp().getJavaObject().toByteArray());
-    } else if (helper.getMySpout().getComp().hasJavaClassName()) {
-      String spoutClassName = helper.getMySpout().getComp().getJavaClassName();
+          helper.getMySpout().getComp().getSerializedObject().toByteArray());
+    } else if (helper.getMySpout().getComp().hasClassName()) {
+      String spoutClassName = helper.getMySpout().getComp().getClassName();
       try {
         spout = (ISpout) Class.forName(spoutClassName).newInstance();
       } catch (ClassNotFoundException ex) {

--- a/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
@@ -71,6 +71,8 @@ static heron::proto::api::Topology* GenerateDummyTopology(
     sp_string compname = SPOUT_NAME;
     compname += std::to_string(i);
     component->set_name(compname);
+    heron::proto::api::ComponentObjectSpec compspec = heron::proto::api::JAVA_CLASS_NAME;
+    component->set_spec(compspec);
     // Set the stream information
     heron::proto::api::OutputStream* ostream = spout->add_outputs();
     heron::proto::api::StreamId* tstream = ostream->mutable_stream();

--- a/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
@@ -98,6 +98,8 @@ static heron::proto::api::Topology* GenerateDummyTopology(
     sp_string compname = BOLT_NAME;
     compname += std::to_string(i);
     component->set_name(compname);
+    heron::proto::api::ComponentObjectSpec compspec = heron::proto::api::JAVA_CLASS_NAME;
+    component->set_spec(compspec);
     // Set the stream information
     heron::proto::api::InputStream* istream = bolt->add_inputs();
     heron::proto::api::StreamId* tstream = istream->mutable_stream();

--- a/heron/tmaster/tests/cpp/server/tmaster_unittest.cpp
+++ b/heron/tmaster/tests/cpp/server/tmaster_unittest.cpp
@@ -94,6 +94,8 @@ static heron::proto::api::Topology* GenerateDummyTopology(
     sp_string compname = BOLT_NAME;
     compname += std::to_string(i);
     component->set_name(compname);
+    heron::proto::api::ComponentObjectSpec compspec = heron::proto::api::JAVA_CLASS_NAME;
+    component->set_spec(compspec);
     // Set the stream information
     heron::proto::api::InputStream* istream = bolt->add_inputs();
     heron::proto::api::StreamId* tstream = istream->mutable_stream();

--- a/heron/tmaster/tests/cpp/server/tmaster_unittest.cpp
+++ b/heron/tmaster/tests/cpp/server/tmaster_unittest.cpp
@@ -67,6 +67,8 @@ static heron::proto::api::Topology* GenerateDummyTopology(
     sp_string compname = SPOUT_NAME;
     compname += std::to_string(i);
     component->set_name(compname);
+    heron::proto::api::ComponentObjectSpec compspec = heron::proto::api::JAVA_CLASS_NAME;
+    component->set_spec(compspec);
     // Set the stream information
     heron::proto::api::OutputStream* ostream = spout->add_outputs();
     heron::proto::api::StreamId* tstream = ostream->mutable_stream();

--- a/heron/tracker/src/python/topology_helpers.py
+++ b/heron/tracker/src/python/topology_helpers.py
@@ -195,8 +195,8 @@ def strip_java_objects(topology):
   stripped_topology.CopyFrom(topology)
   components = list(stripped_topology.spouts) + list(stripped_topology.bolts)
   for component in components:
-    if component.comp.HasField("java_object"):
-      component.comp.ClearField("java_object")
+    if component.comp.HasField("serialized_object"):
+      component.comp.ClearField("serialized_object")
 
   return stripped_topology
 


### PR DESCRIPTION
Modified topology.proto so a component object can be defined in java or python. 
It is backward-compatible and easily extensible to add a support for another language.

This change is necessary for #1138 