### PR TITLE
Adjust explorer's logging level

### DIFF
--- a/heron/common/src/python/utils.py
+++ b/heron/common/src/python/utils.py
@@ -354,7 +354,7 @@ def get_clusters():
   try:
     return instance.run_sync(lambda: API.get_clusters())
   except Exception:
-    Log.info(traceback.format_exc())
+    Log.debug(traceback.format_exc())
     raise
 
 
@@ -364,7 +364,7 @@ def get_logical_plan(cluster, env, topology, role):
   try:
     return instance.run_sync(lambda: API.get_logical_plan(cluster, env, topology, role))
   except Exception:
-    Log.info(traceback.format_exc())
+    Log.debug(traceback.format_exc())
     raise
 
 
@@ -374,7 +374,7 @@ def get_topology_info(*args):
   try:
     return instance.run_sync(lambda: API.get_topology_info(*args))
   except Exception:
-    Log.info(traceback.format_exc())
+    Log.debug(traceback.format_exc())
     raise
 
 
@@ -384,7 +384,7 @@ def get_topology_metrics(*args):
   try:
     return instance.run_sync(lambda: API.get_comp_metrics(*args))
   except Exception:
-    Log.info(traceback.format_exc())
+    Log.debug(traceback.format_exc())
     raise
 
 
@@ -396,7 +396,7 @@ def get_component_metrics(component, cluster, env, topology, role):
         cluster, env, topology, component, [], all_queries, [0, -1], role)
     return result["metrics"]
   except Exception:
-    Log.info(traceback.format_exc())
+    Log.debug(traceback.format_exc())
     raise
 
 
@@ -406,7 +406,7 @@ def get_cluster_topologies(cluster):
   try:
     return instance.run_sync(lambda: API.get_cluster_topologies(cluster))
   except Exception:
-    Log.info(traceback.format_exc())
+    Log.debug(traceback.format_exc())
     raise
 
 
@@ -416,7 +416,7 @@ def get_cluster_role_topologies(cluster, role):
   try:
     return instance.run_sync(lambda: API.get_cluster_role_topologies(cluster, role))
   except Exception:
-    Log.info(traceback.format_exc())
+    Log.debug(traceback.format_exc())
     raise
 
 
@@ -426,5 +426,5 @@ def get_cluster_role_env_topologies(cluster, role, env):
   try:
     return instance.run_sync(lambda: API.get_cluster_role_env_topologies(cluster, role, env))
   except Exception:
-    Log.info(traceback.format_exc())
+    Log.debug(traceback.format_exc())
     raise

--- a/heron/explorer/src/python/opts.py
+++ b/heron/explorer/src/python/opts.py
@@ -20,9 +20,9 @@ from tornado.options import define
 def set_verbose(cl_args):
   """ set verbose level """
   if cl_args['verbose']:
-    Log.setLevel(logging.INFO)
+    Log.setLevel(logging.DEBUG)
   else:
-    Log.setLevel(logging.WARNING)
+    Log.setLevel(logging.INFO)
 
 
 def set_tracker_url(cl_args):


### PR DESCRIPTION
Adjust logging level of verbose to debug so that elapsing time gets printed out.

resolves #1153 