### PR TITLE
Add reflectasm as a require dependency for kryo

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -162,6 +162,11 @@ maven_jar(
 )
 
 maven_jar(
+  name = "com_esotericsoftware_reflectasm",
+  artifact = "com.esotericsoftware:reflectasm:1.11.3",
+)
+
+maven_jar(
   name = "org_apache_mesos_mesos",
   artifact = "org.apache.mesos:mesos:0.22.0",
 )

--- a/third_party/java/BUILD
+++ b/third_party/java/BUILD
@@ -78,6 +78,7 @@ java_library(
     exports = [ "@com_esotericsoftware_kryo//jar" ],
     deps = [
         "@com_esotericsoftware_kryo//jar",
+        "@com_esotericsoftware_reflectasm//jar",
         "@com_esotericsoftware_minlog//jar",
         "@org_objenesis_objenesis//jar",
     ],


### PR DESCRIPTION
This dependency is required for kryo to properly determine how to
serialize or deserialize data tuples. This fixes #1165