### PR TITLE
Pex without interpreter cache disabled

### DIFF
--- a/third_party/pex/_pex.py
+++ b/third_party/pex/_pex.py
@@ -88,7 +88,7 @@ def main():
     parser = optparse.OptionParser(usage="usage: %prog [options] output")
     parser.add_option('--entry-point', default='__main__')
     parser.add_option('--no-pypi', action='store_false', dest='pypi', default=True)
-    parser.add_option('--disable-cache', action='store_true', dest='pypi', default=False)
+    parser.add_option('--disable-cache', action='store_true', dest='disable_cache', default=False)
     parser.add_option('--not-zip-safe', action='store_false', dest='zip_safe', default=True)
     parser.add_option('--python', default="/usr/bin/python2.7")
     parser.add_option('--find-links', dest='find_links', default='')

--- a/third_party/pex/_pex.py
+++ b/third_party/pex/_pex.py
@@ -88,6 +88,7 @@ def main():
     parser = optparse.OptionParser(usage="usage: %prog [options] output")
     parser.add_option('--entry-point', default='__main__')
     parser.add_option('--no-pypi', action='store_false', dest='pypi', default=True)
+    parser.add_option('--disable-cache', action='store_true', dest='pypi', default=False)
     parser.add_option('--not-zip-safe', action='store_false', dest='zip_safe', default=True)
     parser.add_option('--python', default="/usr/bin/python2.7")
     parser.add_option('--find-links', dest='find_links', default='')
@@ -128,6 +129,8 @@ def main():
         poptions.pypi = options.pypi
         poptions.python = options.python
         poptions.zip_safe = options.zip_safe
+        poptions.disable_cache = options.disable_cache
+
 
         print("pex options: %s" % poptions)
         os.environ["PATH"] = ".:%s:/bin:/usr/bin" % poptions.python

--- a/third_party/pex/pex/resolver.py
+++ b/third_party/pex/pex/resolver.py
@@ -259,10 +259,7 @@ class CachingResolver(Resolver):
     # if distribution is not in cache, copy
     target = os.path.join(self.__cache, os.path.basename(dist.location))
     if not os.path.exists(target):
-      print(target)
       shutil.copyfile(dist.location, target + '~')
-      print(dist.location)
-      print(target + '~')
       os.rename(target + '~', target)
     os.utime(target, None)
 

--- a/third_party/pex/pex/resolver.py
+++ b/third_party/pex/pex/resolver.py
@@ -259,7 +259,10 @@ class CachingResolver(Resolver):
     # if distribution is not in cache, copy
     target = os.path.join(self.__cache, os.path.basename(dist.location))
     if not os.path.exists(target):
+      print(target)
       shutil.copyfile(dist.location, target + '~')
+      print(dist.location)
+      print(target + '~')
       os.rename(target + '~', target)
     os.utime(target, None)
 

--- a/tools/rules/pex_rules.bzl
+++ b/tools/rules/pex_rules.bzl
@@ -98,7 +98,8 @@ def make_manifest(ctx, output):
     command = ('touch %s && echo "%s" > %s' % (output.path, manifest_text, output.path)))
 
 def common_pex_arguments(entry_point, deploy_pex_path, manifest_file_path):
-  arguments = ['--entry-point', entry_point]
+  arguments = ['--disable-cache']
+  arguments += ['--entry-point', entry_point]
 
   # Our internal build environment requires extra args injected and this is a brutal hack. Ideally
   # bazel would provide a mechanism to swap in env-specific global params here
@@ -129,8 +130,7 @@ def pex_binary_impl(ctx):
   pexbuilder = ctx.executable._pexbuilder
 
   # form the arguments to pex builder
-  arguments = ["--disable-cache"]
-  arguments +=  [] if ctx.attr.zip_safe else ["--not-zip-safe"]
+  arguments = [] if ctx.attr.zip_safe else ["--not-zip-safe"]
   arguments += common_pex_arguments(main_pkg, deploy_pex.path, manifest_file.path)
 
   # form the inputs to pex builder
@@ -170,8 +170,7 @@ def pex_test_impl(ctx):
   pex_test_files = pex_test_file_types.filter(pex_file_types.filter(transitive_sources))
   test_run_args = ' '.join([f.path for f in pex_test_files])
 
-  arguments = ["--disable-cache"]
-  arguments += common_pex_arguments('pytest', deploy_pex.path, manifest_file.path)
+  arguments = common_pex_arguments('pytest', deploy_pex.path, manifest_file.path)
 
   ctx.action(
       inputs = [manifest_file] + list(transitive_sources) + list(transitive_eggs) + list(transitive_resources),

--- a/tools/rules/pex_rules.bzl
+++ b/tools/rules/pex_rules.bzl
@@ -129,7 +129,8 @@ def pex_binary_impl(ctx):
   pexbuilder = ctx.executable._pexbuilder
 
   # form the arguments to pex builder
-  arguments =  [] if ctx.attr.zip_safe else ["--not-zip-safe"]
+  arguments = ["--disable-cache"]
+  arguments +=  [] if ctx.attr.zip_safe else ["--not-zip-safe"]
   arguments += common_pex_arguments(main_pkg, deploy_pex.path, manifest_file.path)
 
   # form the inputs to pex builder

--- a/tools/rules/pex_rules.bzl
+++ b/tools/rules/pex_rules.bzl
@@ -170,12 +170,15 @@ def pex_test_impl(ctx):
   pex_test_files = pex_test_file_types.filter(pex_file_types.filter(transitive_sources))
   test_run_args = ' '.join([f.path for f in pex_test_files])
 
+  arguments = ["--disable-cache"]
+  arguments += common_pex_arguments('pytest', deploy_pex.path, manifest_file.path)
+
   ctx.action(
       inputs = [manifest_file] + list(transitive_sources) + list(transitive_eggs) + list(transitive_resources),
       executable = pexbuilder,
       outputs = [ deploy_pex ],
       mnemonic = "PexPython",
-      arguments = common_pex_arguments('pytest', deploy_pex.path, manifest_file.path))
+      arguments = arguments)
 
   executable = ctx.outputs.executable
   ctx.action(


### PR DESCRIPTION
This lovely PR disables interpreter cache because [resolver.py L260-L263](https://github.com/twitter/heron/blob/master/third_party/pex/pex/resolver.py#L260-L263) is known to fail build due to some caching problem.

cf. https://github.com/pantsbuild/pex/issues/293


cc @kramasamy @billonahill 