### PR TITLE
Run docker compilation without pseudo-tty

### DIFF
--- a/docker/compile-docker.sh
+++ b/docker/compile-docker.sh
@@ -47,4 +47,4 @@ docker run \
     -e HERON_TREE_STATUS="${HERON_TREE_STATUS}" \
     -v "$SOURCE_TARBALL:/src.tar.gz:ro" \
     -v "$OUTPUT_DIRECTORY:/dist" \
-    -it heron-compiler:$TARGET_PLATFORM /compile-platform.sh
+    heron-compiler:$TARGET_PLATFORM /compile-platform.sh


### PR DESCRIPTION
In order to run the artifact compilation in docker in a ci environment
we need to run without allocating a pseudo-tty or the compilation will
fail to run the container with `cannot enable tty mode on non tty input`

This will require people to do `docker ps` and then `docker kill $containerid` to actually stop mid-run if they want to. An alternative approach here could be to include a flag or an environmental variable to switch off the psuedo-tty in CI environments.