### PR TITLE
Revert UI with version

### DIFF
--- a/heron/ui/src/python/BUILD
+++ b/heron/ui/src/python/BUILD
@@ -29,4 +29,5 @@ pex_binary(
         "//heron/ui/resources:templates",
         "//heron/ui/resources:static",
     ],
+    zip_safe = False,
 )

--- a/heron/ui/src/python/main.py
+++ b/heron/ui/src/python/main.py
@@ -16,7 +16,6 @@
 ''' main.py '''
 import os
 import socket
-import sys
 
 import tornado.ioloop
 import tornado.options
@@ -127,14 +126,10 @@ def main():
   (parser, child_parser) = args.create_parsers()
   (parsed_args, remaining) = parser.parse_known_args()
 
-  if remaining == ['help']:
+  if remaining:
     child_parser.parse_args(args=remaining, namespace=parsed_args)
     parser.print_help()
     parser.exit()
-
-  elif remaining != []:
-    LOG.error('Invalid subcommand')
-    sys.exit(1)
 
   # log additional information
   command_line_args = vars(parsed_args)

--- a/heron/ui/src/python/main.py
+++ b/heron/ui/src/python/main.py
@@ -30,7 +30,6 @@ from heron.ui.src.python import handlers
 from heron.ui.src.python import args
 from heron.ui.src.python import log
 from heron.ui.src.python.log import Log as LOG
-import heron.common.src.python.utils as utils
 
 class Application(tornado.web.Application):
   ''' Application '''
@@ -131,10 +130,6 @@ def main():
   if remaining == ['help']:
     child_parser.parse_args(args=remaining, namespace=parsed_args)
     parser.print_help()
-    parser.exit()
-
-  elif remaining == ['version']:
-    utils.print_version()
     parser.exit()
 
   elif remaining != []:


### PR DESCRIPTION
This PR reverts UI part of the change in #1163 to make UI works on master. To make `heron-ui` has `version` subcommand, further investigation is needed because of some complicated issues which I had discussed with @kramasamy, @billonahill and @nlu90.


**I'm very sorry about merging #1163 into master which makes `heron-ui` break**