### PR TITLE
refactor the getMaxResource method

### DIFF
--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
@@ -31,10 +31,9 @@ import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Context;
 import com.twitter.heron.spi.common.Misc;
 import com.twitter.heron.spi.packing.PackingPlan;
-import com.twitter.heron.spi.packing.PackingPlan.ContainerPlan;
-import com.twitter.heron.spi.packing.PackingPlan.Resource;
 import com.twitter.heron.spi.scheduler.IScheduler;
 import com.twitter.heron.spi.utils.Runtime;
+import com.twitter.heron.spi.utils.SchedulerUtils;
 import com.twitter.heron.spi.utils.TopologyUtils;
 
 public class AuroraScheduler implements IScheduler {
@@ -130,8 +129,8 @@ public class AuroraScheduler implements IScheduler {
 
     TopologyAPI.Topology topology = Runtime.topology(runtime);
 
-    // Align the ram to the maximal one
-    PackingPlan.Resource containerResource = getMaxRequiredResource(packing);
+    // Align the cpu, ram, disk to the maximal one
+    PackingPlan.Resource containerResource = SchedulerUtils.getMaxRequiredResource(packing);
     // Update total topology resource requirement on Aurora clusters
     packing.resource.ram = containerResource.ram * (packing.containers.size() + 1);
 
@@ -192,22 +191,6 @@ public class AuroraScheduler implements IScheduler {
     auroraProperties.put("TOPOLOGY_PACKAGE_URI", topologyPkgURI);
 
     return auroraProperties;
-  }
-
-  /**
-   * This method finds the container with highest resource requirement and returns the resource.
-   * Currently only RAM is used for max identification.
-   */
-  private Resource getMaxRequiredResource(PackingPlan packingPlan) {
-    Resource maxResource = packingPlan.containers.values().iterator().next().resource;
-    for (ContainerPlan entry : packingPlan.containers.values()) {
-      Resource resource = entry.resource;
-      if (maxResource.ram < resource.ram) {
-        maxResource = resource;
-      }
-    }
-
-    return maxResource;
   }
 
   protected boolean isProduction() {

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/mesos/MesosScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/mesos/MesosScheduler.java
@@ -245,20 +245,12 @@ public class MesosScheduler implements IScheduler {
    */
   protected void fillResourcesRequirementForBaseContainer(
       BaseContainer container, Integer containerIndex, PackingPlan packing) {
-    double cpu = 0;
-    double disk = 0;
-    double mem = 0;
-    for (PackingPlan.ContainerPlan cp : packing.containers.values()) {
-      PackingPlan.Resource containerResource = cp.resource;
-      cpu = Math.max(cpu, containerResource.cpu);
-      disk = Math.max(disk, containerResource.disk);
-      mem = Math.max(mem, containerResource.ram);
-    }
+    PackingPlan.Resource maxResourceContainer = SchedulerUtils.getMaxRequiredResource(packing);
 
-    container.cpu = cpu;
+    container.cpu = maxResourceContainer.cpu;
     // Convert them from bytes to MB
-    container.diskInMB = disk / Constants.MB;
-    container.memInMB = mem / Constants.MB;
+    container.diskInMB = maxResourceContainer.disk / Constants.MB;
+    container.memInMB = maxResourceContainer.ram / Constants.MB;
     container.ports = SchedulerUtils.PORTS_REQUIRED_FOR_EXECUTOR;
   }
 }

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/SchedulerUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/SchedulerUtils.java
@@ -438,4 +438,20 @@ public final class SchedulerUtils {
 
     return true;
   }
+
+  /**
+   * Get a resource that requires the maximum amount of ram, cpu and disk
+   */
+  public static PackingPlan.Resource getMaxRequiredResource(PackingPlan packingPlan) {
+    PackingPlan.Resource maxResource = new PackingPlan.Resource(0, 0, 0);
+
+    for (PackingPlan.ContainerPlan entry : packingPlan.containers.values()) {
+      PackingPlan.Resource resource = entry.resource;
+      maxResource.ram = Math.max(maxResource.ram, resource.ram);
+      maxResource.cpu = Math.max(maxResource.cpu, resource.cpu);
+      maxResource.disk = Math.max(maxResource.disk, resource.disk);
+    }
+
+    return maxResource;
+  }
 }


### PR DESCRIPTION
As mentioned in #1161, put the getMaxResource refactor into a separate PR.

The new getMaxRequiredResource will find the max requirement for cpu, ram and disk from all the required container resources.

MesosScheduler and AuroraScheduler will use the new method to decide their resource allocation to each container.