### PR TITLE
Made Config message in topology.proto generic

### DIFF
--- a/heron/api/src/java/com/twitter/heron/api/HeronTopology.java
+++ b/heron/api/src/java/com/twitter/heron/api/HeronTopology.java
@@ -44,9 +44,11 @@ public class HeronTopology {
       TopologyAPI.Config.KeyValue.Builder b = TopologyAPI.Config.KeyValue.newBuilder();
       b.setKey(entry.getKey());
       if (apiVars.contains(entry.getKey())) {
+        b.setType(TopologyAPI.ConfigValueType.STRING_VALUE);
         b.setValue(entry.getValue().toString());
       } else {
-        b.setJavaSerializedValue(ByteString.copyFrom(Utils.serialize(entry.getValue())));
+        b.setType(TopologyAPI.ConfigValueType.JAVA_SERIALIZED_VALUE);
+        b.setSerializedValue(ByteString.copyFrom(Utils.serialize(entry.getValue())));
       }
       cBldr.addKvs(b);
     }

--- a/heron/api/src/java/com/twitter/heron/api/topology/BaseComponentDeclarer.java
+++ b/heron/api/src/java/com/twitter/heron/api/topology/BaseComponentDeclarer.java
@@ -67,6 +67,7 @@ public abstract class BaseComponentDeclarer<T extends ComponentConfigurationDecl
       TopologyAPI.Config.KeyValue.Builder kvBldr = TopologyAPI.Config.KeyValue.newBuilder();
       kvBldr.setKey(entry.getKey());
       kvBldr.setValue(entry.getValue().toString());
+      kvBldr.setType(TopologyAPI.ConfigValueType.STRING_VALUE);
       cBldr.addKvs(kvBldr);
     }
     bldr.setConfig(cBldr);

--- a/heron/common/src/java/com/twitter/heron/common/utils/misc/PhysicalPlanHelper.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/misc/PhysicalPlanHelper.java
@@ -201,19 +201,17 @@ public class PhysicalPlanHelper {
     for (TopologyAPI.Config.KeyValue kv : config.getKvsList()) {
       if (kv.hasValue()) {
         retval.put(kv.getKey(), kv.getValue());
-      } else if (kv.getType().equals(TopologyAPI.ConfigValueType.JAVA_SERIALIZED_VALUE)){
+      } else {
         retval.put(kv.getKey(), Utils.deserialize(kv.getSerializedValue().toByteArray()));
       }
-      // non-Java serialized value is simply ignored
     }
     // Override any component specific configs
     for (TopologyAPI.Config.KeyValue kv : acomponent.getConfig().getKvsList()) {
       if (kv.hasValue()) {
         retval.put(kv.getKey(), kv.getValue());
-      } else if (kv.getType().equals(TopologyAPI.ConfigValueType.JAVA_SERIALIZED_VALUE)){
+      } else {
         retval.put(kv.getKey(), Utils.deserialize(kv.getSerializedValue().toByteArray()));
       }
-      // non-Java serialized value is simply ignored
     }
     return retval;
   }

--- a/heron/common/src/java/com/twitter/heron/common/utils/misc/PhysicalPlanHelper.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/misc/PhysicalPlanHelper.java
@@ -201,17 +201,19 @@ public class PhysicalPlanHelper {
     for (TopologyAPI.Config.KeyValue kv : config.getKvsList()) {
       if (kv.hasValue()) {
         retval.put(kv.getKey(), kv.getValue());
-      } else {
-        retval.put(kv.getKey(), Utils.deserialize(kv.getJavaSerializedValue().toByteArray()));
+      } else if (kv.getType().equals(TopologyAPI.ConfigValueType.JAVA_SERIALIZED_VALUE)){
+        retval.put(kv.getKey(), Utils.deserialize(kv.getSerializedValue().toByteArray()));
       }
+      // non-Java serialized value is simply ignored
     }
     // Override any component specific configs
     for (TopologyAPI.Config.KeyValue kv : acomponent.getConfig().getKvsList()) {
       if (kv.hasValue()) {
         retval.put(kv.getKey(), kv.getValue());
-      } else {
-        retval.put(kv.getKey(), Utils.deserialize(kv.getJavaSerializedValue().toByteArray()));
+      } else if (kv.getType().equals(TopologyAPI.ConfigValueType.JAVA_SERIALIZED_VALUE)){
+        retval.put(kv.getKey(), Utils.deserialize(kv.getSerializedValue().toByteArray()));
       }
+      // non-Java serialized value is simply ignored
     }
     return retval;
   }

--- a/heron/proto/topology.proto
+++ b/heron/proto/topology.proto
@@ -39,6 +39,12 @@ enum ComponentObjectSpec {
   PYTHON_CLASS_NAME = 3;
 }
 
+enum ConfigValueType {
+  STRING_VALUE = 1; //normal string
+  JAVA_SERIALIZED_VALUE = 2;
+  PYTHON_SERIALIZED_VALUE = 3;
+}
+
 message StreamSchema {
   message KeyType {
     required string key = 1;
@@ -69,7 +75,10 @@ message Config {
     required string key = 1;
     // Only one of the below are set
     optional string value = 2;
-    optional bytes java_serialized_value = 3;
+    //optional bytes java_serialized_value = 3;
+    optional bytes serialized_value = 3;
+
+    required ConfigValueType type = 4;
   }
   repeated KeyValue kvs = 1;
 }

--- a/heron/proto/topology.proto
+++ b/heron/proto/topology.proto
@@ -75,10 +75,10 @@ message Config {
     required string key = 1;
     // Only one of the below are set
     optional string value = 2;
-    //optional bytes java_serialized_value = 3;
     optional bytes serialized_value = 3;
 
-    required ConfigValueType type = 4;
+    // This is made optional for backward compatibility (#1179)
+    optional ConfigValueType type = 4;
   }
   repeated KeyValue kvs = 1;
 }

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/LaunchRunnerTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/LaunchRunnerTest.java
@@ -52,7 +52,8 @@ public class LaunchRunnerTest {
   private static final String BUILD_USER = "user";
 
   private static TopologyAPI.Config.KeyValue getConfig(String key, String value) {
-    return TopologyAPI.Config.KeyValue.newBuilder().setKey(key).setValue(value).build();
+    return TopologyAPI.Config.KeyValue.newBuilder().setKey(key).setValue(value).
+        setType(TopologyAPI.ConfigValueType.STRING_VALUE).build();
   }
 
   public static TopologyAPI.Topology createTopology(com.twitter.heron.api.Config heronConfig) {

--- a/heron/tracker/src/python/tracker.py
+++ b/heron/tracker/src/python/tracker.py
@@ -333,20 +333,22 @@ class Tracker(object):
       for kvs in topology.physical_plan.topology.topology_config.kvs:
         if kvs.value:
           physicalPlan["config"][kvs.key] = kvs.value
-        elif kvs.java_serialized_value:
-          # Hexadecimal byte array for Serialized objects
-          try:
-            pobj = javaobj.loads(kvs.java_serialized_value)
-            physicalPlan["config"][kvs.key] = {
-                'value' : json.dumps(pobj,
-                                     default=lambda custom_field: custom_field.__dict__,
-                                     sort_keys=True,
-                                     indent=2),
-                'raw' : utils.hex_escape(kvs.java_serialized_value)}
-          except Exception:
-            physicalPlan["config"][kvs.key] = {
-                'value' : 'A Java Object',
-                'raw' : utils.hex_escape(kvs.java_serialized_value)}
+        elif kvs.serialized_value:
+          # non-Java serialized value is simply ignored for now
+          if kvs.type == topology_pb2.ConfigValueType.Value('JAVA_SERIALIZED_VALUE'):
+            # Hexadecimal byte array for Serialized objects
+            try:
+              pobj = javaobj.loads(kvs.serialized_value)
+              physicalPlan["config"][kvs.key] = {
+                  'value' : json.dumps(pobj,
+                                       default=lambda custom_field: custom_field.__dict__,
+                                       sort_keys=True,
+                                       indent=2),
+                  'raw' : utils.hex_escape(kvs.serialized_value)}
+            except Exception:
+              physicalPlan["config"][kvs.key] = {
+                  'value' : 'A Java Object',
+                  'raw' : utils.hex_escape(kvs.serialized_value)}
     for spout in spouts:
       spout_name = spout.comp.name
       physicalPlan["spouts"][spout_name] = []

--- a/heron/tracker/src/python/tracker.py
+++ b/heron/tracker/src/python/tracker.py
@@ -334,21 +334,22 @@ class Tracker(object):
         if kvs.value:
           physicalPlan["config"][kvs.key] = kvs.value
         elif kvs.serialized_value:
-          # non-Java serialized value is simply ignored for now
-          if kvs.type == topology_pb2.ConfigValueType.Value('JAVA_SERIALIZED_VALUE'):
-            # Hexadecimal byte array for Serialized objects
-            try:
-              pobj = javaobj.loads(kvs.serialized_value)
-              physicalPlan["config"][kvs.key] = {
-                  'value' : json.dumps(pobj,
-                                       default=lambda custom_field: custom_field.__dict__,
-                                       sort_keys=True,
-                                       indent=2),
-                  'raw' : utils.hex_escape(kvs.serialized_value)}
-            except Exception:
-              physicalPlan["config"][kvs.key] = {
-                  'value' : 'A Java Object',
-                  'raw' : utils.hex_escape(kvs.serialized_value)}
+          # currently assumes that serialized_value is Java serialization
+          # when multi-language support is added later, ConfigValueType should be checked
+
+          # Hexadecimal byte array for Serialized objects
+          try:
+            pobj = javaobj.loads(kvs.serialized_value)
+            physicalPlan["config"][kvs.key] = {
+                'value' : json.dumps(pobj,
+                                     default=lambda custom_field: custom_field.__dict__,
+                                     sort_keys=True,
+                                     indent=2),
+                'raw' : utils.hex_escape(kvs.serialized_value)}
+          except Exception:
+            physicalPlan["config"][kvs.key] = {
+                'value' : 'A Java Object',
+                'raw' : utils.hex_escape(kvs.serialized_value)}
     for spout in spouts:
       spout_name = spout.comp.name
       physicalPlan["spouts"][spout_name] = []

--- a/heron/tracker/tests/python/mock_proto.py
+++ b/heron/tracker/tests/python/mock_proto.py
@@ -22,6 +22,7 @@ class MockProto(object):
     spout.comp.name = spout_name
     kv = spout.comp.config.kvs.add()
     kv.key = constants.TOPOLOGY_COMPONENT_PARALLELISM
+    kv.type = protoTopology.ConfigValueType.Value('STRING_VALUE')
     kv.value = str(spout_parallelism)
     for stream in output_streams:
       spout.outputs.add().stream.CopyFrom(stream)
@@ -36,6 +37,7 @@ class MockProto(object):
     bolt.comp.name = bolt_name
     kv = bolt.comp.config.kvs.add()
     kv.key = constants.TOPOLOGY_COMPONENT_PARALLELISM
+    kv.type = protoTopology.ConfigValueType.Value('STRING_VALUE')
     kv.value = str(bolt_parallelism)
     for stream in input_streams:
       bolt.inputs.add().stream.CopyFrom(stream)
@@ -166,4 +168,5 @@ class MockProto(object):
   def add_topology_config(self, topology, key, value):
     kv = topology.topology_config.kvs.add()
     kv.key = key
+    kv.type = protoTopology.ConfigValueType.Value('STRING_VALUE')
     kv.value = str(value)


### PR DESCRIPTION
Modified Config message's serialized field so it's more generic and extensible.
This PR is necessary for adding a support for python topology.

This change should be backward compatible.