### PR TITLE
Made ComponentObjectSpec optional for backward compatibility

### DIFF
--- a/heron/proto/topology.proto
+++ b/heron/proto/topology.proto
@@ -86,7 +86,9 @@ message Component {
   optional bytes serialized_object = 4;
 
   required Config config = 3;
-  required ComponentObjectSpec spec = 5;
+
+  // This is made optional for backward compatibility
+  optional ComponentObjectSpec spec = 5;
 }
 
 message Spout {


### PR DESCRIPTION
Made ComponentObjectSpec field for Component message in topology.proto optional to be safe with the backward compatibility. See discussion in https://github.com/twitter/heron/pull/1179#discussion-diff-72712681.