### PR TITLE
Modified checkstyle for python topology support

### DIFF
--- a/tools/python/checkstyle.ini
+++ b/tools/python/checkstyle.ini
@@ -371,7 +371,7 @@ callbacks=cb_,_cb
 [CLASSES]
 
 # List of method names used to declare (i.e. assign) instance attributes.
-defining-attr-methods=__init__,__new__,setUp
+defining-attr-methods=__init__,__new__,setUp,initialize,prepare
 
 # List of valid names for the first argument in a class method.
 valid-classmethod-first-arg=cls


### PR DESCRIPTION
This PR is necessary for python topology support, as defining attributes in ``initialize()`` is necessary when defining python components (bolt and spout, refer to #1196 and #1198), whereas defining attributes in ``prepare()`` is necessary for implementing [ITaskHook](https://github.com/twitter/heron/blob/master/heron/common/src/python/utils/topology/task_hook.py).