### PR TITLE
Keep argument value as list

### DIFF
--- a/heron/cli/tests/python/heronparser_unittest.py
+++ b/heron/cli/tests/python/heronparser_unittest.py
@@ -134,8 +134,6 @@ class HeronParserTest(unittest.TestCase):
     args, _ = parser.parse_known_args(["activate", "devcluster/ads/PROD",
                                        "12313", "--config-property", "a=b"])
     namespace = vars(args)
-    with open('/Users/rli/a.txt', 'w') as f:
-      f.write(str(namespace))
     self.assertEqual(['a=b', 'e=f', 'ooo=ppp', 'hi=wee', 'foo=bar'], args.config_property)
     hr_argparser.HeronArgumentParser.clear()
 

--- a/heron/cli/tests/python/heronparser_unittest.py
+++ b/heron/cli/tests/python/heronparser_unittest.py
@@ -56,7 +56,12 @@ class HeronParserTest(unittest.TestCase):
     args, _ = parser.parse_known_args(["submit", "local", "~/.heron/examples/heron-examples.jar",
                                        "com.twitter.heron.examples.ExclamationTopology",
                                        "ExclamationTopology"])
-    self.assertEqual('~/.heron/examples/heron-examples.jar', args.__dict__['topology-file-name'])
+
+    namespace = vars(args)
+    self.assertEqual('submit', namespace['subcommand'])
+    self.assertEqual('local', namespace['cluster/[role]/[env]'])
+    self.assertEqual('~/.heron/examples/heron-examples.jar', namespace['topology-file-name'])
+    self.assertEqual('com.twitter.heron.examples.ExclamationTopology', namespace['topology-class-name'])
 
 
   def test_parser_commandline_positional_withrc(self):
@@ -79,7 +84,8 @@ class HeronParserTest(unittest.TestCase):
     args, _ = parser.parse_known_args(["submit", "local", "~/.heron/examples/heron-examples.jar",
                                        "com.twitter.heron.examples.ExclamationTopology",
                                        "ExclamationTopology"])
-    self.assertEqual('True', args.__dict__['verbose'])
+    namespace = vars(args)
+    self.assertEqual('True', namespace['verbose'])
     hr_argparser.HeronArgumentParser.clear()
 
   def test_parser_commandline_positional_error(self):
@@ -126,9 +132,11 @@ class HeronParserTest(unittest.TestCase):
         metavar='<command> <options>')
     activate.create_parser(subparsers)
     args, _ = parser.parse_known_args(["activate", "devcluster/ads/PROD",
-                                       "12313", "--config-property", "this-is-it"])
-
-    self.assertEqual('this-is-it', args.config_property)
+                                       "12313", "--config-property", "a=b"])
+    namespace = vars(args)
+    with open('/Users/rli/a.txt', 'w') as f:
+      f.write(str(namespace))
+    self.assertEqual(['a=b', 'e=f', 'ooo=ppp', 'hi=wee', 'foo=bar'], args.config_property)
     hr_argparser.HeronArgumentParser.clear()
 
   def test_parser_rolecmdspecific(self):
@@ -149,7 +157,7 @@ class HeronParserTest(unittest.TestCase):
     activate.create_parser(subparsers)
     args, _ = parser.parse_known_args(["activate", "devcluster/ads/PROD",
                                        "12313"])
-    self.assertEqual('test-cmd-activate-role', args.config_property)
+    self.assertEqual(['e=f', 'ooo=ppp', 'hi=wee', 'foo=bar'], args.config_property)
     hr_argparser.HeronArgumentParser.clear()
 
   def test_parser_norcfile(self):
@@ -170,15 +178,10 @@ class HeronParserTest(unittest.TestCase):
         metavar='<command> <options>')
     activate.create_parser(subparsers)
     args, _ = parser.parse_known_args(["activate", "devcluster/ads/PROD",
-                                       "12313", "--config-property", "this-is-it"])
+                                       "12313", "--config-property", "a=b"])
 
-    self.assertEqual('this-is-it', args.config_property)
+    self.assertEqual(['a=b'], args.config_property)
     hr_argparser.HeronArgumentParser.clear()
 
   def tearDown(self):
     hr_argparser.HeronArgumentParser.clear()
-
-
-if __name__ == '__main__':
-  suite = unittest.TestLoader().loadTestsFromTestCase(HeronParserTest)
-  unittest.TextTestRunner(verbosity=2).run(suite)

--- a/heron/cli/tests/python/heronrc.test
+++ b/heron/cli/tests/python/heronrc.test
@@ -1,16 +1,16 @@
 # validate with http://pythex.org/
 #global
-*:*:* --config-property test-hello-global
+*:*:* --config-property foo=bar
 # app - global
-heron:*:* --config-property  command-global
+heron:*:* --config-property hi=wee
 
 #command specific
-heron:activate:* --config-property test-cmd-activate-*                  
+heron:activate:* --config-property ooo=ppp
 
 #role and command specific
 
-heron:submit:devcluster/ads/PROD --config-property test-cmd-submit-role
-heron:activate:devcluster/ads/PROD --config-property test-cmd-activate-role
+heron:submit:devcluster/ads/PROD --config-property a=b --config-property c=d
+heron:activate:devcluster/ads/PROD --config-property e=f
 heron:submit:local --verbose True
 
 #error for submit parser with ilocal role

--- a/heron/common/src/python/heronparser.py
+++ b/heron/common/src/python/heronparser.py
@@ -18,7 +18,6 @@ import json
 import os
 import re
 import sys
-import traceback
 import heron.common.src.python.utils.config as config
 from  heron.common.src.python.utils.log import Log
 ##########################################################################
@@ -182,18 +181,8 @@ class HeronArgumentParser(argparse.ArgumentParser):
   def parse_known_args(self, args=None, namespace=None):
     namespace, args = super(HeronArgumentParser,
                             self).parse_known_args(args, namespace)
-    dict_ns = namespace.__dict__
     positional_args_map = self.get_positional_args()
-    if self.prog == 'heron':
-      try:
-        for key in dict_ns:
-          val = dict_ns[key]
-          if val is not None and isinstance(val, list) and len(val) > 0:
-            dict_ns[key] = val[0]
-      except Exception:
-        Log.warn("heronrc: unable to clobber arguments (%s,%s ) ", namespace, args)
-        Log.debug(traceback.format_exc())
-    else:
+    if self.prog != 'heron':
       ## sub parser specific validation
       Log.debug('sub parser expansion  %s %s', self.prog, args)
       ## if the expanded args contains a optional equivalent of a positional argument


### PR DESCRIPTION
A bug introduced by https://github.com/twitter/heron/pull/1119 takes only the first element of the argument value list and destructively updates the corresponding key argument in the dictionary. See: https://github.com/twitter/heron/pull/1119/files#r74668021

This problem is blocking PyHeron integration test so this is not good. This PR fixed it.

cc: @prabhuinbarajan @taishi8117 