### PR TITLE
Fix flaky SpoutInstanceTest

### DIFF
--- a/heron/instance/tests/java/com/twitter/heron/instance/spout/SpoutInstanceTest.java
+++ b/heron/instance/tests/java/com/twitter/heron/instance/spout/SpoutInstanceTest.java
@@ -275,9 +275,9 @@ public class SpoutInstanceTest {
         setNewPhysicalPlanHelper(physicalPlanHelper).
         build();
 
-    inControlQueue.offer(instanceControlMsg);
-
     SingletonRegistry.INSTANCE.registerSingleton(Constants.ACK_COUNT, ackCount);
+
+    inControlQueue.offer(instanceControlMsg);
 
     Runnable task = new Runnable() {
       @Override
@@ -323,9 +323,9 @@ public class SpoutInstanceTest {
         setNewPhysicalPlanHelper(physicalPlanHelper).
         build();
 
-    inControlQueue.offer(instanceControlMsg);
-
     SingletonRegistry.INSTANCE.registerSingleton(Constants.FAIL_COUNT, failCount);
+
+    inControlQueue.offer(instanceControlMsg);
 
     Runnable task = new Runnable() {
       @Override
@@ -361,11 +361,10 @@ public class SpoutInstanceTest {
         setNewPhysicalPlanHelper(physicalPlanHelper).
         build();
 
-    inControlQueue.offer(instanceControlMsg);
-
     SingletonRegistry.INSTANCE.registerSingleton(Constants.ACK_COUNT, ackCount);
     SingletonRegistry.INSTANCE.registerSingleton(Constants.FAIL_COUNT, failCount);
 
+    inControlQueue.offer(instanceControlMsg);
 
     Runnable task = new Runnable() {
       @Override


### PR DESCRIPTION
SpoutInstanceTest should register the singleton objects before offering the message. Otherwise, TestBolt maybe has already processed several tuples before the singleton objects are registered.