### PR TITLE
Add Javadocs metadata (fresh PR)

### DIFF
--- a/website/scripts/javadocs-overview.html
+++ b/website/scripts/javadocs-overview.html
@@ -1,0 +1,3 @@
+<body>
+  <p>Heron is a realtime, distributed, fault-tolerant stream processing engine built by Twitter.</p>
+</body>

--- a/website/scripts/javadocs.sh
+++ b/website/scripts/javadocs.sh
@@ -11,6 +11,9 @@ JAVADOC_OUTPUT_DIR=$HERON_ROOT_DIR/website/public/api
 JAVADOC_OUTPUT_LOCAL_DIR=$HERON_ROOT_DIR/website/static/api
 GEN_PROTO_DIR=$HERON_ROOT_DIR/bazel-bin/heron/proto/_javac
 
+# The path of the customized landing page for the Javadocs
+OVERVIEW_HTML_FILE=$HERON_ROOT_DIR/website/scripts/javadocs-overview.html
+
 # Check if this script is run with Travis flag
 if [ $# -eq 1 ] && [ $1 == "--travis" ]; then
     BAZEL_CMD="bazel --bazelrc=$HERON_ROOT_DIR/tools/travis-ci/bazel.rc build"
@@ -39,7 +42,11 @@ CLOSURE_CLASSES="$HERON_ROOT_DIR/bazel-bin/heron/storm/src/java/_javac/storm-com
 
 export CLASSPATH=$BIN_JARS:$GEN_JARS:$SCRIBE_JARS:$PROTO_JARS:$CLOSURE_CLASSES
 
-$JAVADOC $FLAGS -d $JAVADOC_OUTPUT_DIR $GEN_FILES $HERON_SRC_FILES $BACKTYPE_SRC_FILES $APACHE_SRC_FILES
+$JAVADOC $FLAGS \
+  -windowtitle "Heron Java API" \
+  -doctitle "The Heron Java API" \
+  -overview $OVERVIEW_HTML_FILE \
+  -d $JAVADOC_OUTPUT_DIR $GEN_FILES $HERON_SRC_FILES $BACKTYPE_SRC_FILES $APACHE_SRC_FILES
 
 # Generated Java API doc needs to be copied to $JAVADOC_OUTPUT_LOCAL_DIR
 # for the following two reasons:


### PR DESCRIPTION
Currently, there is no front matter on the [Javadocs API main page](http://twitter.github.io/heron/api/). This PR adds a title to the HTML page, a title that goes at the top of the overview page, and a basic description. It's incomplete but it provides a scaffolding that can be used by later contributors to produce a more fully fleshed out Javadocs landing page.

Here's the existing site:

<img width="958" alt="screen shot 2016-05-25 at 5 15 17 pm" src="https://cloud.githubusercontent.com/assets/1523104/15560036/58b5b810-229c-11e6-8014-71d51b4d48f1.png">

Here's the site with the placeholder page added in this PR:

<img width="887" alt="screen shot 2016-05-25 at 5 15 31 pm" src="https://cloud.githubusercontent.com/assets/1523104/15560039/653de738-229c-11e6-8f02-4dc9eaea5960.png">

A live version can be seen here:

http://lucperkins.github.io/heron/api/