### PR TITLE
Load HTTPS JQuery.

### DIFF
--- a/website/layouts/docs/single.ace
+++ b/website/layouts/docs/single.ace
@@ -14,5 +14,5 @@ html lang={{.Site.LanguageCode}}
             {{partial "sidenav.html" .}}
           section.hn-docs-main.col-sm-8.col-md-9.col-lg-10.col-sm-offset-4.col-md-offset-3.col-lg-offset-2
             {{partial "docs/main.html" .}}
-    script src=http://code.jquery.com/jquery-2.2.1.min.js
+    script src=https://code.jquery.com/jquery-2.2.1.min.js
     script src=/js/app.min.js

--- a/website/layouts/index.ace
+++ b/website/layouts/index.ace
@@ -72,5 +72,5 @@ html lang={{.Site.LanguageCode}}
       {{partial "index/twitter-timeline.html" .}}
       {{partial "index/google-analytics.html" .}}
 
-      script src=http://code.jquery.com/jquery-2.2.1.min.js
+      script src=https://code.jquery.com/jquery-2.2.1.min.js
       script src=/js/app.min.js


### PR DESCRIPTION
HTTPS requires all resources to be loaded using HTTPS. This PR will make sure navigation bar works fine with HTTPS. This change still works fine with HTTP.

cc @lucperkins @billonahill 