### PR TITLE
Clean up executor logging in LocalScheduler

### DIFF
--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -595,10 +595,10 @@ def signal_handler(signal_to_handle, frame):
   # Just catch the SIGTERM and then cleanup(), registered with atexit, would invoke
   sys.exit(signal_to_handle)
 
-def setup():
+def setup(shardid):
   # Redirect stdout and stderr to files in append mode
   # The filename format is heron-executor.stdxxx
-  log.configure(logfile='heron-executor.stdout', with_time=True)
+  log.configure(logfile='heron-executor-%s.stdout' % shardid, with_time=True)
 
   Log.info('Set up process group; executor becomes leader')
   os.setpgrp() # create new process group, become its leader
@@ -619,5 +619,5 @@ def cleanup():
   os.killpg(0, signal.SIGTERM)
 
 if __name__ == "__main__":
-  setup()
+  setup(sys.argv[1])
   main()

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalScheduler.java
@@ -66,7 +66,9 @@ public class LocalScheduler implements IScheduler {
    */
   protected Process startExecutorProcess(int container) {
     return ShellUtils.runASyncProcess(true,
-        getExecutorCommand(container), new File(LocalContext.workingDirectory(config)));
+        getExecutorCommand(container),
+        new File(LocalContext.workingDirectory(config)),
+        Integer.toString(container));
   }
 
   /**

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/HeronExecutorTaskTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/HeronExecutorTaskTest.java
@@ -98,10 +98,10 @@ public class HeronExecutorTaskTest {
     PowerMockito.doReturn(mockProcess).when(
         ShellUtils.class,
         "runASyncProcess",
-        Mockito.eq(true),
         Mockito.eq(testCmd),
         Mockito.any(File.class),
-        Mockito.eq(env));
+        Mockito.eq(env),
+        Mockito.any(String.class));
     spyTask.call(null);
     Mockito.verify(mockProcess).waitFor();
   }

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/ShellUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/ShellUtils.java
@@ -161,11 +161,12 @@ public final class ShellUtils {
     // the log file can help people to find out what happened between pb.start()
     // and the async process started
     String commandFileName = Paths.get(command[0]).getFileName().toString();
-    if (logFileUuid == null) {
-      logFileUuid = UUID.randomUUID().toString().substring(0, 8) + "-started";
+    String uuid = logFileUuid;
+    if (uuid == null) {
+      uuid = UUID.randomUUID().toString().substring(0, 8) + "-started";
     }
     String logFilePath = String.format("%s/%s-%s.stderr",
-        workingDirectory, commandFileName, logFileUuid);
+        workingDirectory, commandFileName, uuid);
     File logFile = new File(logFilePath);
 
     // For AsyncProcess, we will never inherit IO, since parent process will not

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/ShellUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/ShellUtils.java
@@ -139,20 +139,33 @@ public final class ShellUtils {
   }
 
   public static Process runASyncProcess(
+      boolean verbose, String[] command, File workingDirectory, String logFileUuid) {
+    return runASyncProcess(command, workingDirectory, new HashMap<String, String>(), logFileUuid);
+  }
+
+  public static Process runASyncProcess(
       boolean verbose, String[] command, File workingDirectory) {
     return runASyncProcess(verbose, command, workingDirectory, new HashMap<String, String>());
   }
 
   public static Process runASyncProcess(
       boolean verbose, String[] command, File workingDirectory, Map<String, String> envs) {
+    return runASyncProcess(command, workingDirectory, envs, null);
+  }
+
+  private static Process runASyncProcess(String[] command, File workingDirectory,
+      Map<String, String> envs, String logFileUuid) {
     // Log the command for debugging
     LOG.log(Level.FINE, "$> {0}", Arrays.toString(command));
 
     // the log file can help people to find out what happened between pb.start()
     // and the async process started
     String commandFileName = Paths.get(command[0]).getFileName().toString();
-    String uuid = UUID.randomUUID().toString().substring(0, 8);
-    String logFilePath = workingDirectory + "/" + commandFileName + "-" + uuid + "-started.stderr";
+    if (logFileUuid == null) {
+      logFileUuid = UUID.randomUUID().toString().substring(0, 8) + "-started";
+    }
+    String logFilePath = String.format("%s/%s-%s.stderr",
+        workingDirectory, commandFileName, logFileUuid);
     File logFile = new File(logFilePath);
 
     // For AsyncProcess, we will never inherit IO, since parent process will not


### PR DESCRIPTION
Executor log files in LocalScheduler currently look like this:
```
heron-executor-d7e5809a-started.stderr
heron-executor-dc47dc90-started.stderr
heron-executor-edd18eeb-started.stderr
heron-executor-effb081c-started.stderr
heron-executor.stdout
```
Two issues:
1. Every run of the executor makes a new stderr file which causes file bloat of mostly 0-byte sized files. Each run shares the same stdout file though, which is inconsistent.
2. When running multiple executors, they all log to the same stdout file, which makes the file contents difficult to read.

This changes executor logging to look more like the logging of the other processes. If you have two executors you'd see something like this:
```
heron-executor-0.stderr
heron-executor-0.stdout
heron-executor-1.stderr
heron-executor-1.stdout
```

If one fails and is restarted, it continues to log to the same file as the previous instance.