### PR TITLE
Add Heron list of ADOPTERS

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,7 @@
+## Heron Adopters
+
+Twitter isn't the only company using Heron. We're sure the following list isn't complete, so please [let us know](https://github.com/twitter/heron) if your company should be included, or if you'd like us to feature a link to a blog post or article about how you're using Heron. Or even better, add the links yourself (please use HTTPS URLs if possible) and [submit a pull request](https://github.com/twitter/heron)!
+
+* [Twitter](https://twitter.com/)
+ * https://blog.twitter.com/2016/open-sourcing-twitter-heron
+* TODO


### PR DESCRIPTION
Start a list of Heron adopters, it's convenient to see who is using Heron in production!

See Finagle as an example: https://github.com/twitter/finagle/blob/develop/ADOPTERS.md