### PR TITLE
Improving logging and retries of local int test runner

### DIFF
--- a/integration-test/README
+++ b/integration-test/README
@@ -1,7 +1,7 @@
 This directory (integration-test) contains all the source code and scripts for the
 integration test framework and tests.
 
-The main components are,
+The main components are:
 
  * Test framework (src/java/.../(core, common))
    - this forms the core framework which ensures the output of the topology is
@@ -21,12 +21,12 @@ The main components are,
      Test topologies `post` the result, and test runner `get`s the result.
 
  * Local test runner (src/python/local_test_runner)
-   - Local test runner launches topology locally, and polls for the actual results (from local file
-     system).
+   - Local test runner launches topologies locally, and polls for the actual results (from the
+     local file system).
 
-To run the local integration tests on your mac, at heron repo's top dir:
+To run the local integration tests on your mac run the following from the heron repo's top dir:
 
-  bazel build --config=dawrin integration-test/src/...
+  bazel build --config=darwin integration-test/src/...
 
   bazel run --config=darwin -- scripts/packages:heron-client-install.sh --user
 

--- a/integration-test/src/python/local_test_runner/main.py
+++ b/integration-test/src/python/local_test_runner/main.py
@@ -68,6 +68,9 @@ def runTest(test, topologyName, params):
   while not processExists(processList, HERON_STMGR_CMD):
     processList = getProcesses()
 
+  _safe_delete_file(params['readFile'])
+  _safe_delete_file(params['outputFile'])
+
   # insert lines into temp file and then move to read file
   try:
     with open('temp.txt', 'w') as f:
@@ -132,12 +135,8 @@ def runTest(test, topologyName, params):
       return False
 
     # delete test files
-    try:
-      os.remove(params['readFile'])
-      os.remove(params['outputFile'])
-    except Exception as e:
-      logging.error("Failed to delete test files")
-      return False
+    _safe_delete_file(params['readFile'])
+    _safe_delete_file(params['outputFile'])
 
   # get actual and expected result
   # retry if results are not equal a predesignated amount of times
@@ -298,6 +297,14 @@ def processExists(processList, processCmd):
     if processCmd in process.cmd:
       return True
   return False
+
+def _safe_delete_file(file):
+  if os.path.isfile(file) and os.path.exists(file):
+    try:
+      os.remove(file)
+    except Exception as e:
+      logging.error("Failed to delete file: %s: %s", file, e)
+      return False
 
 def main():
   ''' main '''

--- a/integration-test/src/python/local_test_runner/main.py
+++ b/integration-test/src/python/local_test_runner/main.py
@@ -196,7 +196,6 @@ def submitTopology(heronCliPath, testCluster, testJarPath, topologyClassPath,
       '%d' % (len(TEST_INPUT))
   ]
   logging.info("Submitting topology: %s", splitcmd)
-  logging.info(splitcmd)
   p = subprocess.Popen(splitcmd)
   p.wait()
   logging.info("Submitted topology %s", topologyName)
@@ -211,7 +210,6 @@ def killTopology(heronCliPath, testCluster, topologyName):
       '%s' % (topologyName),
   ]
   logging.info("Killing topology: %s", splitcmd)
-  logging.info(splitcmd)
   # this call can be blocking, no need for subprocess
   if subprocess.call(splitcmd) != 0:
     raise RuntimeError("Unable to kill the topology: %s" % topologyName)
@@ -241,7 +239,6 @@ def restartShard(heronCliPath, testCluster, topologyName, shardNum):
       '%d' % shardNum
   ]
   logging.info("Killing TMaster: %s", splitcmd)
-  logging.info(splitcmd)
   if subprocess.call(splitcmd) != 0:
     raise RuntimeError("Unable to kill TMaster")
   logging.info("Killed TMaster")

--- a/integration-test/src/python/local_test_runner/main.py
+++ b/integration-test/src/python/local_test_runner/main.py
@@ -81,7 +81,7 @@ def runTest(test, topologyName, params):
     return False
 
   # extra time to start up, write to .pid file, connect to tmaster, etc.
-  seconds = 10
+  seconds = 30
   logging.info("Sleeping for %s seconds to allow time for startup", seconds)
   time.sleep(seconds)
 
@@ -89,7 +89,7 @@ def runTest(test, topologyName, params):
   if test == 'KILL_TMASTER':
     restartShard(params['cliPath'], params['cluster'], params['topologyName'], TMASTER_SHARD)
   elif test == 'KILL_STMGR':
-    logging.info("Executing kill stmgr")
+    logging.info("Executing kill stream manager")
     stmgrPid = getPid('%s-%d' % (STMGR, NON_TMASTER_SHARD), params['workingDirectory'])
     killProcess(stmgrPid)
   elif test == 'KILL_METRICSMGR':
@@ -98,7 +98,7 @@ def runTest(test, topologyName, params):
                            params['workingDirectory'])
     killProcess(metricsmgrPid)
   elif test == 'KILL_STMGR_METRICSMGR':
-    logging.info("Executing kill stmgr metrics manager")
+    logging.info("Executing kill stream manager and metrics manager")
     stmgrPid = getPid('%s-%d' % (STMGR, NON_TMASTER_SHARD), params['workingDirectory'])
     killProcess(stmgrPid)
 

--- a/integration-test/src/python/local_test_runner/main.py
+++ b/integration-test/src/python/local_test_runner/main.py
@@ -349,7 +349,6 @@ def main():
     logging.error("Fail: %s/%s test failed:", len(failures), total)
     for test in failures:
       logging.error("  - %s", test)
-      logging.info("\n".join(failures))
     sys.exit(1)
 
 if __name__ == '__main__':

--- a/integration-test/src/python/local_test_runner/main.py
+++ b/integration-test/src/python/local_test_runner/main.py
@@ -298,12 +298,12 @@ def processExists(processList, processCmd):
       return True
   return False
 
-def _safe_delete_file(file):
-  if os.path.isfile(file) and os.path.exists(file):
+def _safe_delete_file(file_name):
+  if os.path.isfile(file_name) and os.path.exists(file_name):
     try:
-      os.remove(file)
+      os.remove(file_name)
     except Exception as e:
-      logging.error("Failed to delete file: %s: %s", file, e)
+      logging.error("Failed to delete file: %s: %s", file_name, e)
       return False
 
 def main():

--- a/integration-test/src/python/local_test_runner/main.py
+++ b/integration-test/src/python/local_test_runner/main.py
@@ -140,41 +140,43 @@ def runTest(test, topologyName, params):
 
   # get actual and expected result
   # retry if results are not equal a predesignated amount of times
-  expectedResult = ""
-  actualResult = ""
+  expected_result = ""
+  actual_result = ""
   retriesLeft = RETRY_COUNT
   while retriesLeft > 0:
     retriesLeft -= 1
-    expectedResult = ""
-    actualResult = ""
     try:
       with open(params['readFile'], 'r') as f:
-        expectedResult = f.read()
+        expected_result = f.read()
       with open(params['outputFile'], 'r') as g:
-        actualResult = g.read()
+        actual_result = g.read()
     except Exception as e:
-      logging.error("Failed to read expected or actual results from file: %s", e)
+      logging.error("Failed to read expected or actual results from file for test %s: %s", test, e)
       cleanup_test()
       return False
     # if we get expected result, no need to retry
-    if expectedResult == actualResult:
+    if expected_result == actual_result:
       break
     if retriesLeft > 0:
-      logging.info("Failed to get expected results, retrying after %s seconds", RETRY_INTERVAL)
+      expected_result = ""
+      actual_result = ""
+      logging.info("Failed to get expected results for test %s (attempt %s/%s), "\
+                   + "retrying after %s seconds",
+                   test, RETRY_COUNT - retriesLeft, RETRY_COUNT, RETRY_INTERVAL)
       time.sleep(RETRY_INTERVAL)
 
   cleanup_test()
 
   # Compare the actual and expected result
-  if actualResult == expectedResult:
-    logging.info("Actual result matched expected result")
-    logging.info("Actual result ---------- \n" + actualResult)
-    logging.info("Expected result ---------- \n" + expectedResult)
+  if actual_result == expected_result:
+    logging.info("Actual result matched expected result for test %s", test)
+    logging.info("Actual result ---------- \n" + actual_result)
+    logging.info("Expected result ---------- \n" + expected_result)
     return True
   else:
-    logging.error("Actual result did not match expected result")
-    logging.info("Actual result ---------- \n" + actualResult)
-    logging.info("Expected result ---------- \n" + expectedResult)
+    logging.error("Actual result did not match expected result for test %s", test)
+    logging.info("Actual result ---------- \n" + actual_result)
+    logging.info("Expected result ---------- \n" + expected_result)
     return False
 
 def submitTopology(heronCliPath, testCluster, testJarPath, topologyClassPath,

--- a/integration-test/src/python/local_test_runner/resources/test.conf
+++ b/integration-test/src/python/local_test_runner/resources/test.conf
@@ -5,7 +5,7 @@
   "topology" : {
     "topologyName" : "IntegrationTest_LocalReadWriteTopology",
     "topologyClassPath" : "com.twitter.heron.local_integration_test.topology.local_readwrite.LocalReadWriteTopology",
-    "readFile" : "testing.txt",
-    "outputFile" : "testing2.txt"
+    "readFile" : "test_input.txt",
+    "outputFile" : "test_output.txt"
   }
 }


### PR DESCRIPTION
When a local integration test fails to get the test result it needs to also kill the topology. Otherwise retries will fail with "topology already exists" errors.