### PR TITLE
Make system config global (singleton as a module).

### DIFF
--- a/heron/common/src/python/config/__init__.py
+++ b/heron/common/src/python/config/__init__.py
@@ -1,0 +1,2 @@
+''' config module: various singleton configuration modules for PyHeron '''
+__all__ = ['system_config']

--- a/heron/common/src/python/config/system_config.py
+++ b/heron/common/src/python/config/system_config.py
@@ -1,0 +1,23 @@
+# Copyright 2016 Twitter. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+''' sys_config '''
+# pylint: disable=global-statement
+sys_config = None
+
+def set_sys_config(config):
+  global sys_config
+  sys_config = config
+
+def get_sys_config():
+  return sys_config

--- a/heron/common/src/python/config/system_config.py
+++ b/heron/common/src/python/config/system_config.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 ''' sys_config '''
 # pylint: disable=global-statement
-sys_config = None
+sys_config = {}
 
 def set_sys_config(config):
   global sys_config

--- a/heron/common/src/python/network/socket_options.py
+++ b/heron/common/src/python/network/socket_options.py
@@ -16,14 +16,15 @@
 from collections import namedtuple
 from heron.common.src.python.utils.log import Log
 import heron.common.src.python.constants as const
+from heron.common.src.python.config import system_config
 
 SocketOptions = namedtuple('Options', 'nw_write_batch_size_bytes, nw_write_batch_time_ms, '
                                       'nw_read_batch_size_bytes, nw_read_batch_time_ms, '
                                       'sock_send_buf_size_bytes, sock_recv_buf_size_bytes')
 
-
-def create_socket_options(sys_config):
+def create_socket_options():
   """Creates SocketOptions object from a given sys_config dict"""
+  sys_config = system_config.get_sys_config()
   opt_list = [const.INSTANCE_NETWORK_WRITE_BATCH_SIZE_BYTES,
               const.INSTANCE_NETWORK_WRITE_BATCH_TIME_MS,
               const.INSTANCE_NETWORK_READ_BATCH_SIZE_BYTES,

--- a/heron/common/src/python/utils/metrics/metrics_helper.py
+++ b/heron/common/src/python/utils/metrics/metrics_helper.py
@@ -14,6 +14,7 @@
 '''metrics_helper: helper classes for managing common metrics'''
 
 from heron.common.src.python.utils.log import Log
+from heron.common.src.python.config import system_config
 from heron.proto import metrics_pb2
 import heron.common.src.python.constants as constants
 
@@ -111,7 +112,8 @@ class GatewayMetrics(BaseMetricsHelper):
              IN_STREAM_QUEUE_EXPECTED_CAPACITY: MeanReducedMetric(),
              OUT_STREAM_QUEUE_EXPECTED_CAPACITY: MeanReducedMetric()}
 
-  def __init__(self, metrics_collector, sys_config):
+  def __init__(self, metrics_collector):
+    sys_config = system_config.get_sys_config()
     super(GatewayMetrics, self).__init__(self.metrics)
     interval = float(sys_config[constants.HERON_METRICS_EXPORT_INTERVAL_SEC])
     self.register_metrics(metrics_collector, interval)
@@ -155,12 +157,13 @@ class ComponentMetrics(BaseMetricsHelper):
     metrics.update(additional_metrics)
     super(ComponentMetrics, self).__init__(metrics)
 
-  def register_metrics(self, context, sys_config):
+  # pylint: disable=arguments-differ
+  def register_metrics(self, context):
     """Registers metrics to context
 
     :param context: Topology Context
-    :param sys_config: System config
     """
+    sys_config = system_config.get_sys_config()
     interval = float(sys_config[constants.HERON_METRICS_EXPORT_INTERVAL_SEC])
     collector = context.get_metrics_collector()
     super(ComponentMetrics, self).register_metrics(collector, interval)

--- a/heron/common/src/python/utils/misc/outgoing_tuple_helper.py
+++ b/heron/common/src/python/utils/misc/outgoing_tuple_helper.py
@@ -14,6 +14,7 @@
 '''outgoing_tuple_helper.py: module to provide a helper class for preparing and pushing tuples'''
 import sys
 
+from heron.common.src.python.config import system_config
 from heron.common.src.python.utils.log import Log
 from heron.proto import tuple_pb2, topology_pb2
 
@@ -41,7 +42,7 @@ class OutgoingTupleHelper(object):
   make_tuple_set = lambda _: tuple_pb2.HeronTupleSet()
   make_stream_id = lambda _: topology_pb2.StreamId()
 
-  def __init__(self, pplan_helper, out_stream, sys_config):
+  def __init__(self, pplan_helper, out_stream):
     self.out_stream = out_stream
     self.pplan_helper = pplan_helper
 
@@ -51,11 +52,13 @@ class OutgoingTupleHelper(object):
     self.current_data_tuple_size_in_bytes = 0
     self.total_data_emitted_in_bytes = 0
 
+    self.sys_config = system_config.get_sys_config()
+
     # read the config values
-    self.data_tuple_set_capacity = sys_config[constants.INSTANCE_SET_DATA_TUPLE_CAPACITY]
-    self.max_data_tuple_size_in_bytes = sys_config.get(constants.INSTANCE_SET_DATA_TUPLE_SIZE_BYTES,
-                                                       sys.maxint)
-    self.control_tuple_set_capacity = sys_config[constants.INSTANCE_SET_CONTROL_TUPLE_CAPACITY]
+    self.data_tuple_set_capacity = self.sys_config[constants.INSTANCE_SET_DATA_TUPLE_CAPACITY]
+    self.max_data_tuple_size_in_bytes =\
+      self.sys_config.get(constants.INSTANCE_SET_DATA_TUPLE_SIZE_BYTES, sys.maxint)
+    self.control_tuple_set_capacity = self.sys_config[constants.INSTANCE_SET_CONTROL_TUPLE_CAPACITY]
 
   def send_out_tuples(self):
     """Sends out currently buffered tuples into the Out-Stream"""

--- a/heron/common/tests/python/utils/BUILD
+++ b/heron/common/tests/python/utils/BUILD
@@ -1,11 +1,23 @@
 package(default_visibility = ["//visibility:public"])
 load("/tools/rules/pex_rules", "pex_library", "pex_test")
 
+pex_library(
+    name = "common-utils-mock",
+    srcs = ["mock_generator.py"],
+    deps = [
+        "//heron/common/tests/python:pytest-py",
+    ],
+    reqs = [
+        "mock==1.0.1"
+    ]
+)
+
 pex_test(
     name = "communicator_unittest",
-    srcs = ["communicator_unittest.py", "mock_generator.py"],
+    srcs = ["communicator_unittest.py"],
     deps = [
-        "//heron/common/tests/python:pytest-py"
+        "//heron/common/tests/python:pytest-py",
+        "//heron/common/tests/python/utils:common-utils-mock"
     ],
     reqs = [
         "py==1.4.27",
@@ -17,9 +29,10 @@ pex_test(
 
 pex_test(
     name = "custom_grouping_unittest",
-    srcs = ["custom_grouping_unittest.py", "mock_generator.py"],
+    srcs = ["custom_grouping_unittest.py"],
     deps = [
-        "//heron/common/tests/python:pytest-py"
+        "//heron/common/tests/python:pytest-py",
+        "//heron/common/tests/python/utils:common-utils-mock"
     ],
     reqs = [
         "py==1.4.27",
@@ -31,9 +44,10 @@ pex_test(
 
 pex_test(
     name = "metrics_helper_unittest",
-    srcs = ["metrics_helper_unittest.py", "mock_generator.py"],
+    srcs = ["metrics_helper_unittest.py"],
     deps = [
-        "//heron/common/tests/python:pytest-py"
+        "//heron/common/tests/python:pytest-py",
+        "//heron/common/tests/python/utils:common-utils-mock"
     ],
     reqs = [
         "py==1.4.27",
@@ -47,7 +61,8 @@ pex_test(
     name = "metrics_unittest",
     srcs = ["metrics_unittest.py"],
     deps = [
-        "//heron/common/tests/python:pytest-py"
+        "//heron/common/tests/python:pytest-py",
+        "//heron/common/tests/python/utils:common-utils-mock"
     ],
     reqs = [
         "py==1.4.27",
@@ -59,9 +74,10 @@ pex_test(
 
 pex_test(
     name = "outgoing_tuple_helper_unittest",
-    srcs = ["outgoing_tuple_helper_unittest.py", "mock_generator.py"],
+    srcs = ["outgoing_tuple_helper_unittest.py"],
     deps = [
-        "//heron/common/tests/python:pytest-py"
+        "//heron/common/tests/python:pytest-py",
+        "//heron/common/tests/python/utils:common-utils-mock"
     ],
     reqs = [
         "py==1.4.27",
@@ -73,9 +89,10 @@ pex_test(
 
 pex_test(
     name = "serializer_unittest",
-    srcs = ["serializer_unittest.py", "mock_generator.py"],
+    srcs = ["serializer_unittest.py"],
     deps = [
-        "//heron/common/tests/python:pytest-py"
+        "//heron/common/tests/python:pytest-py",
+        "//heron/common/tests/python/utils:common-utils-mock"
     ],
     reqs = [
         "py==1.4.27",
@@ -87,9 +104,10 @@ pex_test(
 
 pex_test(
     name = "pplan_helper_unittest",
-    srcs = ["pplan_helper_unittest.py", "mock_generator.py"],
+    srcs = ["pplan_helper_unittest.py"],
     deps = [
-        "//heron/common/tests/python:pytest-py"
+        "//heron/common/tests/python:pytest-py",
+        "//heron/common/tests/python/utils:common-utils-mock"
     ],
     reqs = [
         "py==1.4.27",
@@ -101,9 +119,10 @@ pex_test(
 
 pex_test(
     name = "topology_context_unittest",
-    srcs = ["topology_context_unittest.py", "mock_generator.py"],
+    srcs = ["topology_context_unittest.py"],
     deps = [
-        "//heron/common/tests/python:pytest-py"
+        "//heron/common/tests/python:pytest-py",
+        "//heron/common/tests/python/utils:common-utils-mock"
     ],
     reqs = [
         "py==1.4.27",
@@ -115,9 +134,10 @@ pex_test(
 
 pex_test(
     name = "tuple_helper_unittest",
-    srcs = ["tuple_helper_unittest.py", "mock_generator.py"],
+    srcs = ["tuple_helper_unittest.py"],
     deps = [
-        "//heron/common/tests/python:pytest-py"
+        "//heron/common/tests/python:pytest-py",
+        "//heron/common/tests/python/utils:common-utils-mock"
     ],
     reqs = [
         "py==1.4.27",

--- a/heron/common/tests/python/utils/BUILD
+++ b/heron/common/tests/python/utils/BUILD
@@ -8,7 +8,7 @@ pex_library(
         "//heron/common/tests/python:pytest-py",
     ],
     reqs = [
-        "mock==1.0.1"
+        "mock==1.0.1",
     ]
 )
 
@@ -149,9 +149,10 @@ pex_test(
 
 pex_test(
     name = "global_metrics_unittest",
-    srcs = ["global_metrics_unittest.py", "mock_generator.py"],
+    srcs = ["global_metrics_unittest.py"],
     deps = [
-        "//heron/common/tests/python:pytest-py"
+        "//heron/common/tests/python:pytest-py",
+        "//heron/common/tests/python/utils:common-utils-mock"
     ],
     reqs = [
         "py==1.4.27",

--- a/heron/common/tests/python/utils/mock_generator.py
+++ b/heron/common/tests/python/utils/mock_generator.py
@@ -17,6 +17,7 @@
 # pylint: disable=unused-argument
 # pylint: disable=missing-docstring
 import random
+from mock import patch
 
 from heron.common.src.python.utils.metrics import MetricsCollector
 from heron.common.src.python.utils.misc import (OutgoingTupleHelper, PhysicalPlanHelper,
@@ -111,7 +112,9 @@ class MockOutgoingTupleHelper(OutgoingTupleHelper):
 
     if mode == MockOutgoingTupleHelper.SAMPLE_SUCCESS:
       pplan_helper, out_stream = self._prepare_sample_success()
-      super(MockOutgoingTupleHelper, self).__init__(pplan_helper, out_stream)
+      with patch("heron.common.src.python.config.system_config.get_sys_config",
+                 side_effect=lambda: sample_sys_config):
+        super(MockOutgoingTupleHelper, self).__init__(pplan_helper, out_stream)
 
   @staticmethod
   def _prepare_sample_success():

--- a/heron/common/tests/python/utils/mock_generator.py
+++ b/heron/common/tests/python/utils/mock_generator.py
@@ -111,7 +111,7 @@ class MockOutgoingTupleHelper(OutgoingTupleHelper):
 
     if mode == MockOutgoingTupleHelper.SAMPLE_SUCCESS:
       pplan_helper, out_stream = self._prepare_sample_success()
-      super(MockOutgoingTupleHelper, self).__init__(pplan_helper, out_stream, sample_sys_config)
+      super(MockOutgoingTupleHelper, self).__init__(pplan_helper, out_stream)
 
   @staticmethod
   def _prepare_sample_success():

--- a/heron/instance/src/python/basics/base_instance.py
+++ b/heron/instance/src/python/basics/base_instance.py
@@ -17,6 +17,7 @@ import logging
 import traceback
 from abc import abstractmethod
 
+from heron.common.src.python.config import system_config
 from heron.common.src.python.utils.misc import OutgoingTupleHelper
 from heron.proto import tuple_pb2
 
@@ -36,12 +37,12 @@ class BaseInstance(object):
   """
   make_data_tuple = lambda _: tuple_pb2.HeronDataTuple()
 
-  def __init__(self, pplan_helper, in_stream, out_stream, looper, sys_config):
+  def __init__(self, pplan_helper, in_stream, out_stream, looper):
     self.pplan_helper = pplan_helper
     self.in_stream = in_stream
-    self.output_helper = OutgoingTupleHelper(self.pplan_helper, out_stream, sys_config)
+    self.output_helper = OutgoingTupleHelper(self.pplan_helper, out_stream)
     self.looper = looper
-    self.sys_config = sys_config
+    self.sys_config = system_config.get_sys_config()
 
     # will set a root logger here
     self.logger = logging.getLogger()

--- a/heron/instance/src/python/basics/bolt_instance.py
+++ b/heron/instance/src/python/basics/bolt_instance.py
@@ -51,7 +51,7 @@ class BoltInstance(BaseInstance):
 
   def start(self):
     context = self.pplan_helper.context
-    self.bolt_metrics.register_metrics(context, self.sys_config)
+    self.bolt_metrics.register_metrics(context)
     self.bolt_impl.initialize(config=context.get_cluster_config(), context=context)
     context.invoke_hook_prepare()
 

--- a/heron/instance/src/python/basics/bolt_instance.py
+++ b/heron/instance/src/python/basics/bolt_instance.py
@@ -30,8 +30,8 @@ from .base_instance import BaseInstance
 class BoltInstance(BaseInstance):
   """The base class for all heron bolts in Python"""
 
-  def __init__(self, pplan_helper, in_stream, out_stream, looper, sys_config):
-    super(BoltInstance, self).__init__(pplan_helper, in_stream, out_stream, looper, sys_config)
+  def __init__(self, pplan_helper, in_stream, out_stream, looper):
+    super(BoltInstance, self).__init__(pplan_helper, in_stream, out_stream, looper)
 
     if self.pplan_helper.is_spout:
       raise RuntimeError("No bolt in physical plan")

--- a/heron/instance/src/python/basics/spout_instance.py
+++ b/heron/instance/src/python/basics/spout_instance.py
@@ -61,7 +61,7 @@ class SpoutInstance(BaseInstance):
 
   def start(self):
     context = self.pplan_helper.context
-    self.spout_metrics.register_metrics(context, self.sys_config)
+    self.spout_metrics.register_metrics(context)
     self.spout_impl.initialize(config=context.get_cluster_config(), context=context)
     context.invoke_hook_prepare()
 

--- a/heron/instance/src/python/basics/spout_instance.py
+++ b/heron/instance/src/python/basics/spout_instance.py
@@ -32,8 +32,8 @@ from .base_instance import BaseInstance
 class SpoutInstance(BaseInstance):
   """The base class for all heron spouts in Python"""
 
-  def __init__(self, pplan_helper, in_stream, out_stream, looper, sys_config):
-    super(SpoutInstance, self).__init__(pplan_helper, in_stream, out_stream, looper, sys_config)
+  def __init__(self, pplan_helper, in_stream, out_stream, looper):
+    super(SpoutInstance, self).__init__(pplan_helper, in_stream, out_stream, looper)
     self.topology_state = topology_pb2.TopologyState.Value("PAUSED")
 
     if not self.pplan_helper.is_spout:

--- a/heron/instance/src/python/instance/st_heron_instance.py
+++ b/heron/instance/src/python/instance/st_heron_instance.py
@@ -21,6 +21,7 @@ import signal
 import yaml
 
 from heron.common.src.python.basics import GatewayLooper
+from heron.common.src.python.config import system_config
 from heron.common.src.python.utils import log
 from heron.common.src.python.utils.metrics import GatewayMetrics, MetricsCollector
 from heron.common.src.python.utils.misc import HeronCommunicator
@@ -41,7 +42,7 @@ class SingleThreadHeronInstance(object):
   STREAM_MGR_HOST = "127.0.0.1"
   METRICS_MGR_HOST = "127.0.0.1"
   def __init__(self, topology_name, topology_id, instance,
-               stream_port, metrics_port, topo_pex_file_path, sys_config):
+               stream_port, metrics_port, topo_pex_file_path):
     # Basic information about this heron instance
     self.topology_name = topology_name
     self.topology_id = topology_id
@@ -49,7 +50,7 @@ class SingleThreadHeronInstance(object):
     self.stream_port = stream_port
     self.metrics_port = metrics_port
     self.topo_pex_file_abs_path = os.path.abspath(topo_pex_file_path)
-    self.sys_config = sys_config
+    self.sys_config = system_config.get_sys_config()
 
     self.in_stream = HeronCommunicator(producer_cb=None, consumer_cb=None)
     self.out_stream = HeronCommunicator(producer_cb=None, consumer_cb=None)
@@ -62,19 +63,18 @@ class SingleThreadHeronInstance(object):
     self.out_metrics.\
       register_capacity(self.sys_config[constants.INSTANCE_INTERNAL_METRICS_WRITE_QUEUE_CAPACITY])
     self.metrics_collector = MetricsCollector(self.looper, self.out_metrics)
-    self.gateway_metrics = GatewayMetrics(self.metrics_collector, sys_config)
+    self.gateway_metrics = GatewayMetrics(self.metrics_collector)
 
     # Create socket options and socket clients
-    socket_options = create_socket_options(self.sys_config)
+    socket_options = create_socket_options()
     self._stmgr_client = \
       SingleThreadStmgrClient(self.looper, self, self.STREAM_MGR_HOST, stream_port,
                               topology_name, topology_id, instance, self.socket_map,
-                              self.gateway_metrics, socket_options, self.sys_config)
+                              self.gateway_metrics, socket_options)
     self._metrics_client = \
       MetricsManagerClient(self.looper, self.METRICS_MGR_HOST, metrics_port, instance,
                            self.out_metrics, self.in_stream, self.out_stream,
-                           self.socket_map, socket_options, self.gateway_metrics,
-                           self.sys_config)
+                           self.socket_map, socket_options, self.gateway_metrics)
     self.my_pplan_helper = None
 
     # my_instance is a AssignedInstance tuple
@@ -160,7 +160,7 @@ class SingleThreadHeronInstance(object):
         register_capacity(self.sys_config[constants.INSTANCE_INTERNAL_SPOUT_WRITE_QUEUE_CAPACITY])
 
       py_spout_instance = SpoutInstance(self.my_pplan_helper, self.in_stream, self.out_stream,
-                                        self.looper, self.sys_config)
+                                        self.looper)
       self.my_instance = AssignedInstance(is_spout=True,
                                           protobuf=my_spout,
                                           py_class=py_spout_instance)
@@ -176,7 +176,7 @@ class SingleThreadHeronInstance(object):
         register_capacity(self.sys_config[constants.INSTANCE_INTERNAL_BOLT_WRITE_QUEUE_CAPACITY])
 
       py_bolt_instance = BoltInstance(self.my_pplan_helper, self.in_stream, self.out_stream,
-                                      self.looper, self.sys_config)
+                                      self.looper)
       self.my_instance = AssignedInstance(is_spout=False,
                                           protobuf=my_bolt,
                                           py_class=py_bolt_instance)
@@ -232,8 +232,10 @@ def main():
   stmgr_id = sys.argv[7]
   stmgr_port = sys.argv[8]
   metrics_port = sys.argv[9]
-  system_config = yaml_config_reader(sys.argv[10])
+  sys_config = yaml_config_reader(sys.argv[10])
   topology_pex_file_path = sys.argv[11]
+
+  system_config.set_sys_config(sys_config)
 
   # create the protobuf instance
   instance_info = physical_plan_pb2.InstanceInfo()
@@ -247,9 +249,9 @@ def main():
   instance.info.MergeFrom(instance_info)
 
   # Logging init
-  log_dir = os.path.abspath(system_config[constants.HERON_LOGGING_DIRECTORY])
-  max_log_files = system_config[constants.HERON_LOGGING_MAXIMUM_FILES]
-  max_log_bytes = system_config[constants.HERON_LOGGING_MAXIMUM_SIZE_MB] * constants.MB
+  log_dir = os.path.abspath(sys_config[constants.HERON_LOGGING_DIRECTORY])
+  max_log_files = sys_config[constants.HERON_LOGGING_MAXIMUM_FILES]
+  max_log_bytes = sys_config[constants.HERON_LOGGING_MAXIMUM_SIZE_MB] * constants.MB
 
   log_file = os.path.join(log_dir, instance_id + ".log.0")
   log.init_rotating_logger(level=logging.INFO, logfile=log_file,
@@ -261,10 +263,10 @@ def main():
            " and stmgrId: " + stmgr_id + " and stmgrPort: " + stmgr_port +
            " and metricsManagerPort: " + metrics_port +
            "\n **Topology Pex file located at: " + topology_pex_file_path)
-  Log.debug("System config: " + str(system_config))
+  Log.debug("System config: " + str(sys_config))
 
   heron_instance = SingleThreadHeronInstance(topology_name, topology_id, instance, stmgr_port,
-                                             metrics_port, topology_pex_file_path, system_config)
+                                             metrics_port, topology_pex_file_path)
   heron_instance.start()
 
 if __name__ == '__main__':

--- a/heron/instance/src/python/network/metricsmgr_client.py
+++ b/heron/instance/src/python/network/metricsmgr_client.py
@@ -14,6 +14,7 @@
 '''metrics manager client'''
 import socket
 
+from heron.common.src.python.config import system_config
 from heron.common.src.python.utils.log import Log
 from heron.common.src.python.network import HeronClient, StatusCode
 from heron.proto import metrics_pb2, common_pb2
@@ -25,14 +26,14 @@ class MetricsManagerClient(HeronClient):
   # pylint: disable=too-many-arguments
   def __init__(self, looper, metrics_host, port, instance,
                out_metrics, in_stream, out_stream, sock_map, socket_options,
-               gateway_metrics, sys_config):
+               gateway_metrics):
     HeronClient.__init__(self, looper, metrics_host, port, sock_map, socket_options)
     self.instance = instance
     self.out_queue = out_metrics
     self.in_stream = in_stream
     self.out_stream = out_stream
     self.gateway_metrics = gateway_metrics
-    self.sys_config = sys_config
+    self.sys_config = system_config.get_sys_config()
 
     self._add_metrics_client_tasks()
     Log.debug('start updating in and out stream metrics')

--- a/heron/instance/src/python/network/st_stmgr_client.py
+++ b/heron/instance/src/python/network/st_stmgr_client.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 '''Stream Manager client for single-thread heron instance in python'''
+from heron.common.src.python.config import system_config
 from heron.common.src.python.utils.log import Log
 from heron.common.src.python.utils.misc import PhysicalPlanHelper
 from heron.common.src.python.network import HeronClient, StatusCode
@@ -31,7 +32,7 @@ class SingleThreadStmgrClient(HeronClient):
   3. Handle relative response for requests
   """
   def __init__(self, looper, heron_instance_cls, strmgr_host, port, topology_name, topology_id,
-               instance, sock_map, gateway_metrics, socket_options, sys_config):
+               instance, sock_map, gateway_metrics, socket_options):
     HeronClient.__init__(self, looper, strmgr_host, port, sock_map, socket_options)
     self.heron_instance_cls = heron_instance_cls
     self.topology_name = topology_name
@@ -40,7 +41,7 @@ class SingleThreadStmgrClient(HeronClient):
     self.instance = instance
     self.gateway_metrics = gateway_metrics
     self._pplan_helper = None
-    self.sys_config = sys_config
+    self.sys_config = system_config.get_sys_config()
 
   # send register request
   def on_connect(self, status):

--- a/heron/instance/tests/python/network/BUILD
+++ b/heron/instance/tests/python/network/BUILD
@@ -2,11 +2,11 @@ package(default_visibility = ["//visibility:public"])
 
 load("/tools/rules/pex_rules", "pex_library", "pex_test")
 
-
 pex_library(
     name = "instance-network-mock",
     srcs = ["mock_generator.py"],
     deps = [
+        "//heron/common/tests/python:pytest-py",
         "//heron/instance/src/python/network:pyheron-network-py",
     ],
     reqs = [
@@ -19,6 +19,7 @@ pex_test(
     srcs = ["st_stmgr_client_unittest.py"],
     deps = [
         "//heron/common/tests/python:pytest-py",
+        "//heron/instance/src/python/network:pyheron-network-py",
         "//heron/instance/tests/python/network:instance-network-mock",
     ],
     reqs = [
@@ -34,6 +35,7 @@ pex_test(
     srcs = ["metricsmgr_client_unittest.py"],
     deps = [
         "//heron/common/tests/python:pytest-py",
+        "//heron/instance/src/python/network:pyheron-network-py",
         "//heron/instance/tests/python/network:instance-network-mock",
     ],
     reqs = [

--- a/heron/instance/tests/python/network/mock_generator.py
+++ b/heron/instance/tests/python/network/mock_generator.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 '''mock_generator for instance/network'''
 # pylint : disable=missing-docstring
-import heron.common.src.python.constants as constants
 from heron.common.src.python.basics import EventLooper
 from heron.common.src.python.network import SocketOptions
 from heron.common.src.python.utils.misc import HeronCommunicator
@@ -22,9 +21,7 @@ import heron.common.src.python.constants as constants
 import heron.common.tests.python.mock_protobuf as mock_protobuf
 from mock import Mock
 
-
-def mocked_get_sys_config():
-  return {constants.INSTANCE_RECONNECT_STREAMMGR_INTERVAL_SEC: 10}
+from mock import patch
 
 class MockSTStmgrClient(SingleThreadStmgrClient):
   HOST = '127.0.0.1'
@@ -33,7 +30,7 @@ class MockSTStmgrClient(SingleThreadStmgrClient):
   def __init__(self):
     socket_options = SocketOptions(32768, 16, 32768, 16, 1024000, 1024000)
     with patch("heron.common.src.python.config.system_config.get_sys_config",
-               side_effect={constants.INSTANCE_RECONNECT_STREAMMGR_INTERVAL_SEC: 10}):
+               side_effect=lambda: {constants.INSTANCE_RECONNECT_STREAMMGR_INTERVAL_SEC: 10}):
       SingleThreadStmgrClient.__init__(self, EventLooper(), None, self.HOST, self.PORT,
                                        "topology_name", "topology_id",
                                        mock_protobuf.get_mock_instance(), {},
@@ -56,8 +53,8 @@ class MockMetricsManagerClient(MetricsManagerClient):
     with patch("heron.common.src.python.config.system_config.get_sys_config",
                side_effect=lambda: {constants.INSTANCE_RECONNECT_METRICSMGR_INTERVAL_SEC: 10,
                                     constants.INSTANCE_METRICS_SYSTEM_SAMPLE_INTERVAL_SEC: 10}):
-    stream = HeronCommunicator(producer_cb=None, consumer_cb=None)
-    MetricsManagerClient.__init__(self, EventLooper(), self.HOST, self.PORT,
+      stream = HeronCommunicator(producer_cb=None, consumer_cb=None)
+      MetricsManagerClient.__init__(self, EventLooper(), self.HOST, self.PORT,
                                   mock_protobuf.get_mock_instance(), HeronCommunicator(),
                                   stream, stream, {}, socket_options, Mock())
     self.register_req_called = False

--- a/integration-test/src/python/test_runner/main.py
+++ b/integration-test/src/python/test_runner/main.py
@@ -116,7 +116,7 @@ def submitTopology(heronCliPath, cluster, role, env, jarPath, classPath, pkgUri,
   # Form the command to submit a topology.
   # Note the single quote around the arg for heron.package.core.uri.
   # This is needed to prevent shell expansion.
-  cmd = "%s submit %s/%s/%s %s %s %s --verbose" % (
+  cmd = "%s submit %s/%s/%s %s %s %s" % (
       heronCliPath, cluster, role, env, jarPath, classPath, args)
 
   if pkgUri is not None:


### PR DESCRIPTION
This PR makes system config global by putting system configuration into a single module. This corresponds to [what Java instance does](https://github.com/twitter/heron/blob/master/heron/instance/src/java/com/twitter/heron/instance/HeronInstance.java) and we don't need to pass `sys_config` around in different initialization functions.

Related to #1264.

#1309 should go first