### PR TITLE
YARN: Kill and request new container(s) on restart

### DIFF
--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/HeronExecutorTask.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/HeronExecutorTask.java
@@ -130,6 +130,7 @@ public class HeronExecutorTask implements Task {
     LOG.log(Level.INFO, "Started heron executor-id: {0}", heronExecutorId);
     try {
       regularExecutor.waitFor();
+      LOG.log(Level.WARNING, "Heron executor process terminate");
     } catch (InterruptedException e) {
       LOG.log(Level.INFO, "Destroy heron executor-id: {0}", heronExecutorId);
       regularExecutor.destroy();

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/HeronExecutorTask.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/HeronExecutorTask.java
@@ -130,7 +130,7 @@ public class HeronExecutorTask implements Task {
     LOG.log(Level.INFO, "Started heron executor-id: {0}", heronExecutorId);
     try {
       regularExecutor.waitFor();
-      LOG.log(Level.WARNING, "Heron executor process terminate");
+      LOG.log(Level.WARNING, "Heron executor process terminated");
     } catch (InterruptedException e) {
       LOG.log(Level.INFO, "Destroy heron executor-id: {0}", heronExecutorId);
       regularExecutor.destroy();

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/YarnLauncher.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/YarnLauncher.java
@@ -31,12 +31,13 @@ import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.annotations.Unit;
 import org.apache.reef.tang.exceptions.InjectionException;
 
-import com.twitter.heron.scheduler.yarn.HeronMasterDriver.HeronCompletedTaskHandler;
-import com.twitter.heron.scheduler.yarn.HeronMasterDriver.HeronContainerAllocationHandler;
-import com.twitter.heron.scheduler.yarn.HeronMasterDriver.HeronExecutorContainerErrorHandler;
-import com.twitter.heron.scheduler.yarn.HeronMasterDriver.HeronExecutorLauncher;
-import com.twitter.heron.scheduler.yarn.HeronMasterDriver.HeronRunningTaskHandler;
+import com.twitter.heron.scheduler.yarn.HeronMasterDriver.ContainerAllocationHandler;
+import com.twitter.heron.scheduler.yarn.HeronMasterDriver.FailedContainerHandler;
 import com.twitter.heron.scheduler.yarn.HeronMasterDriver.HeronSchedulerLauncher;
+import com.twitter.heron.scheduler.yarn.HeronMasterDriver.HeronWorkerLauncher;
+import com.twitter.heron.scheduler.yarn.HeronMasterDriver.HeronWorkerStartHandler;
+import com.twitter.heron.scheduler.yarn.HeronMasterDriver.HeronWorkerTaskCompletedErrorHandler;
+import com.twitter.heron.scheduler.yarn.HeronMasterDriver.HeronWorkerTaskFailureHandler;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Context;
 import com.twitter.heron.spi.packing.PackingPlan;
@@ -131,11 +132,12 @@ public class YarnLauncher implements ILauncher {
         .setMultiple(DriverConfiguration.GLOBAL_LIBRARIES, libJars)
         .set(DriverConfiguration.DRIVER_IDENTIFIER, topologyName)
         .set(DriverConfiguration.ON_DRIVER_STARTED, HeronSchedulerLauncher.class)
-        .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, HeronContainerAllocationHandler.class)
-        .set(DriverConfiguration.ON_EVALUATOR_FAILED, HeronExecutorContainerErrorHandler.class)
-        .set(DriverConfiguration.ON_CONTEXT_ACTIVE, HeronExecutorLauncher.class)
-        .set(DriverConfiguration.ON_TASK_RUNNING, HeronRunningTaskHandler.class)
-        .set(DriverConfiguration.ON_TASK_COMPLETED, HeronCompletedTaskHandler.class)
+        .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, ContainerAllocationHandler.class)
+        .set(DriverConfiguration.ON_EVALUATOR_FAILED, FailedContainerHandler.class)
+        .set(DriverConfiguration.ON_CONTEXT_ACTIVE, HeronWorkerLauncher.class)
+        .set(DriverConfiguration.ON_TASK_RUNNING, HeronWorkerStartHandler.class)
+        .set(DriverConfiguration.ON_TASK_COMPLETED, HeronWorkerTaskCompletedErrorHandler.class)
+        .set(DriverConfiguration.ON_TASK_FAILED, HeronWorkerTaskFailureHandler.class)
         .set(DriverConfiguration.GLOBAL_FILES, topologyPackageLocation)
         .set(DriverConfiguration.GLOBAL_FILES, coreReleasePackage)
         .set(HeronDriverConfiguration.TOPOLOGY_NAME, topologyName)

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/YarnScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/YarnScheduler.java
@@ -41,9 +41,12 @@ public class YarnScheduler implements IScheduler {
   public boolean onSchedule(PackingPlan packing) {
     LOG.log(Level.INFO, "Launching topology master for packing: {0}", packing.id);
     HeronMasterDriver driver = HeronMasterDriverProvider.getInstance();
-    driver.scheduleTMasterContainer();
-    driver.scheduleHeronWorkers(packing);
-    return true;
+
+    if (!driver.scheduleTMasterContainer()) {
+      return false;
+    }
+
+    return driver.scheduleHeronWorkers(packing);
   }
 
   @Override
@@ -63,15 +66,14 @@ public class YarnScheduler implements IScheduler {
     int containerId = request.getContainerIndex();
 
     if (containerId == -1) {
-      HeronMasterDriverProvider.getInstance().restartTopology();
+      return HeronMasterDriverProvider.getInstance().restartTopology();
     } else {
-      HeronMasterDriverProvider.getInstance().restartWorker(String.valueOf(containerId));
+      return HeronMasterDriverProvider.getInstance().restartWorker(String.valueOf(containerId));
     }
-
-    return true;
   }
 
   @Override
   public void close() {
+    HeronMasterDriverProvider.getInstance().killTopology();
   }
 }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/YarnScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/YarnScheduler.java
@@ -65,7 +65,7 @@ public class YarnScheduler implements IScheduler {
     if (containerId == -1) {
       HeronMasterDriverProvider.getInstance().restartTopology();
     } else {
-      HeronMasterDriverProvider.getInstance().restartContainer(String.valueOf(containerId));
+      HeronMasterDriverProvider.getInstance().restartWorker(String.valueOf(containerId));
     }
 
     return true;

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/DriverOnLocalReefTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/DriverOnLocalReefTest.java
@@ -127,7 +127,7 @@ public class DriverOnLocalReefTest {
     class Allocated implements EventHandler<AllocatedEvaluator> {
       @Override
       public void onNext(AllocatedEvaluator evaluator) {
-        driver.new HeronContainerAllocationHandler().onNext(evaluator);
+        driver.new ContainerAllocationHandler().onNext(evaluator);
       }
     }
 

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/DriverOnLocalReefTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/DriverOnLocalReefTest.java
@@ -110,15 +110,17 @@ public class DriverOnLocalReefTest {
     class DriverStarter implements EventHandler<StartTime> {
       @Override
       public void onNext(StartTime startTime) {
-        counter = new CountDownLatch(2);
-        driver.scheduleTMasterContainer();
-        Map<String, PackingPlan.ContainerPlan> containers = new HashMap<>();
-        addContainer("1", 1.0, 512L, containers);
-        PackingPlan packing = new PackingPlan("packingId", containers, null);
-        driver.scheduleHeronWorkers(packing);
         try {
+          counter = new CountDownLatch(2);
+          driver.scheduleTMasterContainer();
+          Map<String, PackingPlan.ContainerPlan> containers = new HashMap<>();
+          addContainer("1", 1.0, 512L, containers);
+          PackingPlan packing = new PackingPlan("packingId", containers, null);
+          driver.scheduleHeronWorkers(packing);
           counter.await(1, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        } catch (HeronMasterDriver.ContainerAllocationException e) {
           throw new RuntimeException(e);
         }
       }

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/HeronMasterDriverTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/HeronMasterDriverTest.java
@@ -23,7 +23,6 @@ import org.apache.reef.driver.evaluator.AllocatedEvaluator;
 import org.apache.reef.driver.evaluator.EvaluatorRequest;
 import org.apache.reef.driver.evaluator.EvaluatorRequestor;
 import org.apache.reef.driver.evaluator.FailedEvaluator;
-import org.apache.reef.driver.task.RunningTask;
 import org.apache.reef.evaluator.context.parameters.ContextIdentifier;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.types.NamedParameterNode;
@@ -55,6 +54,8 @@ public class HeronMasterDriverTest {
         0,
         false);
     spyDriver = Mockito.spy(driver);
+    Mockito.doReturn("").when(spyDriver).getPackingAsString();
+    Mockito.doReturn("").when(spyDriver).getComponentRamMap();
   }
 
   @Test
@@ -111,11 +112,8 @@ public class HeronMasterDriverTest {
     ActiveContext mockContext2 = Mockito.mock(ActiveContext.class);
     Mockito.when(mockContext2.getId()).thenReturn("1"); // worker
 
-    Mockito.doReturn("").when(spyDriver).getPackingAsString();
-    Mockito.doReturn("").when(spyDriver).getComponentRamMap();
-
-    spyDriver.new HeronExecutorLauncher().onNext(mockContext1);
-    spyDriver.new HeronExecutorLauncher().onNext(mockContext2);
+    spyDriver.new HeronWorkerLauncher().onNext(mockContext1);
+    spyDriver.new HeronWorkerLauncher().onNext(mockContext2);
 
     spyDriver.killTopology();
 
@@ -123,64 +121,56 @@ public class HeronMasterDriverTest {
     Mockito.verify(mockContext2).close();
   }
 
+  /**
+   * Tests if all workers are killed and restarted
+   */
   @Test
-  public void onRestartKillsAndStartsTasks() throws Exception {
-    Mockito.doReturn("").when(spyDriver).getPackingAsString();
-    Mockito.doReturn("").when(spyDriver).getComponentRamMap();
-
-    ActiveContext mockContext1 = Mockito.mock(ActiveContext.class);
-    Mockito.when(mockContext1.getId()).thenReturn("0"); // TM
-    RunningTask mockTaskTM = Mockito.mock(RunningTask.class);
-    Mockito.when(mockTaskTM.getActiveContext()).thenReturn(mockContext1);
-
-    ActiveContext mockContext2 = Mockito.mock(ActiveContext.class);
-    Mockito.when(mockContext2.getId()).thenReturn("1"); // worker
-    RunningTask mockTaskWorker = Mockito.mock(RunningTask.class);
-    Mockito.when(mockTaskWorker.getActiveContext()).thenReturn(mockContext2);
-
-    spyDriver.new HeronRunningTaskHandler().onNext(mockTaskTM);
-    spyDriver.new HeronRunningTaskHandler().onNext(mockTaskWorker);
+  public void onRestartClosesAndStartsContainers() throws Exception {
+    int numContainers = 3;
+    AllocatedEvaluator[] mockEvaluators = new AllocatedEvaluator[numContainers];
+    for (int id = 0; id < numContainers; id++) {
+      AllocatedEvaluator mockEvaluator = Mockito.mock(AllocatedEvaluator.class);
+      Mockito.when(mockEvaluator.getId()).thenReturn("container-" + id);
+      Mockito.doReturn(mockEvaluator).when(spyDriver).allocateContainer("" + id, id + 1, id + 1);
+      spyDriver.launchContainerForExecutor("" + id, id + 1, id + 1);
+      Mockito.verify(mockEvaluator, Mockito.timeout(1000).times(1))
+          .submitContext(Mockito.any(Configuration.class));
+      mockEvaluators[id] = mockEvaluator;
+    }
 
     spyDriver.restartTopology();
 
-    Mockito.verify(mockTaskTM).close();
-    Mockito.verify(mockTaskWorker).close();
-
-    Mockito.verify(mockContext1).submitTask(Mockito.any(Configuration.class));
-    Mockito.verify(mockContext1, Mockito.never()).close();
-    Mockito.verify(mockContext2).submitTask(Mockito.any(Configuration.class));
-    Mockito.verify(mockContext2, Mockito.never()).close();
+    for (int id = 0; id < numContainers; id++) {
+      Mockito.verify(mockEvaluators[id]).close();
+      Mockito.verify(mockEvaluators[id], Mockito.timeout(1000).times(2))
+          .submitContext(Mockito.any(Configuration.class));
+    }
   }
 
+  /**
+   * Tests if a specific worker can be killed and restarted
+   */
   @Test
-  public void restartsSpecificTask() throws Exception {
-    Mockito.doReturn("").when(spyDriver).getPackingAsString();
-    Mockito.doReturn("").when(spyDriver).getComponentRamMap();
+  public void restartsSpecificWorker() throws Exception {
+    int numContainers = 3;
+    AllocatedEvaluator[] mockEvaluators = new AllocatedEvaluator[numContainers];
+    for (int id = 0; id < numContainers; id++) {
+      AllocatedEvaluator mockEvaluator = Mockito.mock(AllocatedEvaluator.class);
+      Mockito.when(mockEvaluator.getId()).thenReturn("container-" + id);
+      Mockito.doReturn(mockEvaluator).when(spyDriver).allocateContainer("" + id, id + 1, id + 1);
+      spyDriver.launchContainerForExecutor("" + id, id + 1, id + 1);
+      Mockito.verify(mockEvaluator, Mockito.timeout(1000).times(1))
+          .submitContext(Mockito.any(Configuration.class));
+      mockEvaluators[id] = mockEvaluator;
+    }
 
-    ActiveContext mockContextTM = Mockito.mock(ActiveContext.class);
-    Mockito.when(mockContextTM.getId()).thenReturn("0"); // TM
-    RunningTask mockTaskTM = Mockito.mock(RunningTask.class);
-    Mockito.when(mockTaskTM.getActiveContext()).thenReturn(mockContextTM);
-    Mockito.when(mockTaskTM.getId()).thenReturn("0");
+    spyDriver.restartWorker("1");
 
-    ActiveContext mockContextWorker = Mockito.mock(ActiveContext.class);
-    Mockito.when(mockContextWorker.getId()).thenReturn("1"); // worker
-    RunningTask mockTaskWorker = Mockito.mock(RunningTask.class);
-    Mockito.when(mockTaskWorker.getActiveContext()).thenReturn(mockContextWorker);
-    Mockito.when(mockTaskWorker.getId()).thenReturn("1");
-
-    spyDriver.new HeronRunningTaskHandler().onNext(mockTaskTM);
-    spyDriver.new HeronRunningTaskHandler().onNext(mockTaskWorker);
-
-    spyDriver.restartContainer("0");
-
-    Mockito.verify(mockTaskTM).close();
-    Mockito.verify(mockTaskTM, Mockito.timeout(2)).getActiveContext();
-    Mockito.verify(mockContextTM).submitTask(Mockito.any(Configuration.class));
-
-    Mockito.verify(mockTaskWorker, Mockito.never()).close();
-    Mockito.verify(mockTaskWorker, Mockito.timeout(1)).getActiveContext();
-    Mockito.verify(mockContextWorker, Mockito.never()).submitTask(Mockito.any(Configuration.class));
+    Mockito.verify(mockEvaluators[1]).close();
+    Mockito.verify(mockEvaluators[1], Mockito.timeout(1000).times(2))
+        .submitContext(Mockito.any(Configuration.class));
+    Mockito.verify(mockEvaluators[0], Mockito.never()).close();
+    Mockito.verify(mockEvaluators[2], Mockito.never()).close();
   }
 
   @Test
@@ -195,7 +185,7 @@ public class HeronMasterDriverTest {
 
     FailedEvaluator mockFailedContainer = Mockito.mock(FailedEvaluator.class);
     Mockito.when(mockFailedContainer.getId()).thenReturn("tMaster");
-    spyDriver.new HeronExecutorContainerErrorHandler().onNext(mockFailedContainer);
+    spyDriver.new FailedContainerHandler().onNext(mockFailedContainer);
 
     Mockito.verify(spyDriver, Mockito.timeout(1000).times(2)).allocateContainer("0", 1, 1024);
   }
@@ -215,7 +205,7 @@ public class HeronMasterDriverTest {
 
     FailedEvaluator mockFailedContainer = Mockito.mock(FailedEvaluator.class);
     Mockito.when(mockFailedContainer.getId()).thenReturn("worker");
-    spyDriver.new HeronExecutorContainerErrorHandler().onNext(mockFailedContainer);
+    spyDriver.new FailedContainerHandler().onNext(mockFailedContainer);
 
     Mockito.verify(spyDriver, Mockito.timeout(1000).times(2)).allocateContainer("1", 1, 1024);
   }
@@ -240,7 +230,7 @@ public class HeronMasterDriverTest {
 
     AllocatedEvaluator mockEvaluator = Mockito.mock(AllocatedEvaluator.class);
     Mockito.when(mockEvaluator.getId()).thenReturn("testEvaluatorId");
-    spyDriver.new HeronContainerAllocationHandler().onNext(mockEvaluator);
+    spyDriver.new ContainerAllocationHandler().onNext(mockEvaluator);
 
     AllocatedEvaluator evaluator = spyDriver.allocateContainer("5", 7, 234);
     Mockito.verify(mockRequestor).submit(evaluatorRequest);

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/YarnSchedulerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/YarnSchedulerTest.java
@@ -23,10 +23,10 @@ import com.twitter.heron.spi.scheduler.IScheduler;
 
 public class YarnSchedulerTest {
   @Test
-  public void delegatesToDriverOnSchedule() {
+  public void delegatesToDriverOnSchedule() throws Exception {
     HeronMasterDriver mockHeronDriver = Mockito.mock(HeronMasterDriver.class);
     HeronMasterDriverProvider.setInstance(mockHeronDriver);
-    Mockito.when(mockHeronDriver.scheduleTMasterContainer()).thenReturn(true);
+    Mockito.doNothing().when(mockHeronDriver).scheduleTMasterContainer();
 
     IScheduler scheduler = new YarnScheduler();
     PackingPlan mockPacking = Mockito.mock(PackingPlan.class);

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/YarnSchedulerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/YarnSchedulerTest.java
@@ -17,17 +17,16 @@ package com.twitter.heron.scheduler.yarn;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.scheduler.IScheduler;
 
 public class YarnSchedulerTest {
   @Test
-  @PrepareForTest(HeronMasterDriverProvider.class)
   public void delegatesToDriverOnSchedule() {
     HeronMasterDriver mockHeronDriver = Mockito.mock(HeronMasterDriver.class);
     HeronMasterDriverProvider.setInstance(mockHeronDriver);
+    Mockito.when(mockHeronDriver.scheduleTMasterContainer()).thenReturn(true);
 
     IScheduler scheduler = new YarnScheduler();
     PackingPlan mockPacking = Mockito.mock(PackingPlan.class);
@@ -39,7 +38,6 @@ public class YarnSchedulerTest {
   }
 
   @Test
-  @PrepareForTest(HeronMasterDriverProvider.class)
   public void delegatesToDriverOnKill() {
     HeronMasterDriver mockHeronDriver = Mockito.mock(HeronMasterDriver.class);
     HeronMasterDriverProvider.setInstance(mockHeronDriver);


### PR DESCRIPTION
Fixes #1244 
Instead of restarting executor process in the same container, restart kills
current container and requests for a new one.