### PR TITLE
Refactor state manager locations to prevent #1303

### DIFF
--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/FileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/FileSystemStateManager.java
@@ -59,12 +59,12 @@ public abstract class FileSystemStateManager implements IStateManager {
       return name;
     }
 
-    public String getDirectory(String rootAddress) {
-      return concatPath(rootAddress, dir);
+    public String getDirectory(String root) {
+      return concatPath(root, dir);
     }
 
-    public String getNodePath(String rootAddress, String topology) {
-      return concatPath(getDirectory(rootAddress), topology);
+    public String getNodePath(String root, String topology) {
+      return concatPath(getDirectory(root), topology);
     }
 
     private static String concatPath(String basePath, String appendPath) {


### PR DESCRIPTION
When adding state manager locations, we shouldn't have to remember to add code in various places like `initTree`. This change makes that so by using an Enum to hold all state manager locations. The Enum allows us to do logic on all registered locations.