### PR TITLE
Add more default metrics for Python topology

### DIFF
--- a/heron/common/src/python/utils/metrics/metrics_helper.py
+++ b/heron/common/src/python/utils/metrics/metrics_helper.py
@@ -75,25 +75,6 @@ class BaseMetricsHelper(object):
     else:
       Log.error("In update_count(): %s is registered but not supported with this method" % name)
 
-  def update_mean_reduced_metric(self, name, value, key=None):
-    """Update the value of MeanReducedMetric or MultiMeanReducedMetric
-
-    :type name: str
-    :param name: name of the registered metric to be updated.
-    :param value: specifies a value to be reduced.
-    :type key: str or None
-    :param key: specifies a key for MeanMultiReducedMetric. Needs to be `None` for updating
-                MeanReducedMetric.
-    """
-    if name not in self.metrics:
-      Log.error("In update_reduced_metric(): %s is not registered in the metric" % name)
-
-    if key is None and isinstance(self.metrics[name], MeanReducedMetric):
-      self.metrics[name].update(value)
-    elif key is not None and isinstance(self.metrics[name], MultiMeanReducedMetric):
-      self.metrics[name].update(key, value)
-    else:
-      Log.error("In update_count(): %s is registered but not supported with this method" % name)
 
 class GatewayMetrics(BaseMetricsHelper):
   """Metrics helper class for Gateway metric"""
@@ -149,10 +130,10 @@ class GatewayMetrics(BaseMetricsHelper):
     self.update_count(self.SENT_EXCEPTION_COUNT, exceptions_count)
 
   def update_in_out_stream_metrics(self, in_size, out_size, in_expect_size, out_expect_size):
-    self.update_mean_reduced_metric(self.IN_STREAM_QUEUE_SIZE, in_size)
-    self.update_mean_reduced_metric(self.OUT_STREAM_QUEUE_SIZE, out_size)
-    self.update_mean_reduced_metric(self.IN_STREAM_QUEUE_EXPECTED_CAPACITY, in_expect_size)
-    self.update_mean_reduced_metric(self.OUT_STREAM_QUEUE_EXPECTED_CAPACITY, out_expect_size)
+    self.update_reduced_metric(self.IN_STREAM_QUEUE_SIZE, in_size)
+    self.update_reduced_metric(self.OUT_STREAM_QUEUE_SIZE, out_size)
+    self.update_reduced_metric(self.IN_STREAM_QUEUE_EXPECTED_CAPACITY, in_expect_size)
+    self.update_reduced_metric(self.OUT_STREAM_QUEUE_EXPECTED_CAPACITY, out_expect_size)
 
 
 class ComponentMetrics(BaseMetricsHelper):

--- a/heron/common/src/python/utils/metrics/metrics_helper.py
+++ b/heron/common/src/python/utils/metrics/metrics_helper.py
@@ -32,8 +32,8 @@ class BaseMetricsHelper(object):
 
   def register_metrics(self, metrics_collector, interval):
     """Registers its metrics to a given metrics collector with a given interval"""
-    for key, value in self.metrics.iteritems():
-      metrics_collector.register_metric(key, value, interval)
+    for field, metrics in self.metrics.iteritems():
+      metrics_collector.register_metric(field, metrics, interval)
 
   def update_count(self, name, incr_by=1, key=None):
     """Update the value of CountMetric or MultiCountMetric
@@ -75,6 +75,26 @@ class BaseMetricsHelper(object):
     else:
       Log.error("In update_count(): %s is registered but not supported with this method" % name)
 
+  def update_mean_reduced_metric(self, name, value, key=None):
+    """Update the value of MeanReducedMetric or MultiMeanReducedMetric
+
+    :type name: str
+    :param name: name of the registered metric to be updated.
+    :param value: specifies a value to be reduced.
+    :type key: str or None
+    :param key: specifies a key for MeanMultiReducedMetric. Needs to be `None` for updating
+                MeanReducedMetric.
+    """
+    if name not in self.metrics:
+      Log.error("In update_reduced_metric(): %s is not registered in the metric" % name)
+
+    if key is None and isinstance(self.metrics[name], MeanReducedMetric):
+      self.metrics[name].update(value)
+    elif key is not None and isinstance(self.metrics[name], MultiMeanReducedMetric):
+      self.metrics[name].update(key, value)
+    else:
+      Log.error("In update_count(): %s is registered but not supported with this method" % name)
+
 class GatewayMetrics(BaseMetricsHelper):
   """Metrics helper class for Gateway metric"""
   RECEIVED_PKT_SIZE = '__gateway-received-packets-size'
@@ -82,10 +102,33 @@ class GatewayMetrics(BaseMetricsHelper):
   RECEIVED_PKT_COUNT = '__gateway-received-packets-count'
   SENT_PKT_COUNT = '__gateway-sent-packets-count'
 
+  SENT_METRICS_SIZE = '__gateway-sent-metrics-size'
+  SENT_METRICS_PKT_COUNT = '__gateway-sent-metrics-packets-count'
+  SENT_METRICS_COUNT = '__gateway-sent-metrics-count'
+  SENT_EXCEPTION_COUNT = '__gateway-sent-exceptions-count'
+
+  IN_STREAM_QUEUE_SIZE = '__gateway-in-stream-queue-size'
+  OUT_STREAM_QUEUE_SIZE = '__gateway-out-stream-queue-size'
+
+  IN_STREAM_QUEUE_EXPECTED_CAPACITY = '__gateway-in-stream-queue-expected-capacity'
+  OUT_STREAM_QUEUE_EXPECTED_CAPACITY = '__gateway-out-stream-queue-expected-capacity'
+
+  IN_QUEUE_FULL_COUNT = '__gateway-in-queue-full-count'
+
   metrics = {RECEIVED_PKT_SIZE: CountMetric(),
              SENT_PKT_SIZE: CountMetric(),
              RECEIVED_PKT_COUNT: CountMetric(),
-             SENT_PKT_COUNT: CountMetric()}
+             SENT_PKT_COUNT: CountMetric(),
+
+             SENT_METRICS_SIZE: CountMetric(),
+             SENT_METRICS_PKT_COUNT: CountMetric(),
+             SENT_METRICS_COUNT: CountMetric(),
+             SENT_EXCEPTION_COUNT: CountMetric(),
+
+             IN_STREAM_QUEUE_SIZE: MeanReducedMetric(),
+             OUT_STREAM_QUEUE_SIZE: MeanReducedMetric(),
+             IN_STREAM_QUEUE_EXPECTED_CAPACITY: MeanReducedMetric(),
+             OUT_STREAM_QUEUE_EXPECTED_CAPACITY: MeanReducedMetric()}
 
   def __init__(self, metrics_collector, sys_config):
     super(GatewayMetrics, self).__init__(self.metrics)
@@ -96,6 +139,21 @@ class GatewayMetrics(BaseMetricsHelper):
     """Apply updates to received packet metrics"""
     self.update_count(self.RECEIVED_PKT_COUNT)
     self.update_count(self.RECEIVED_PKT_SIZE, incr_by=received_pkt_size_bytes)
+
+  def update_sent_metrics_size(self, size):
+    self.update_count(self.SENT_METRICS_SIZE, size)
+
+  def update_sent_metrics(self, metrics_count, exceptions_count):
+    self.update_count(self.SENT_METRICS_PKT_COUNT)
+    self.update_count(self.SENT_METRICS_COUNT, metrics_count)
+    self.update_count(self.SENT_EXCEPTION_COUNT, exceptions_count)
+
+  def update_in_out_stream_metrics(self, in_size, out_size, in_expect_size, out_expect_size):
+    self.update_mean_reduced_metric(self.IN_STREAM_QUEUE_SIZE, in_size)
+    self.update_mean_reduced_metric(self.OUT_STREAM_QUEUE_SIZE, out_size)
+    self.update_mean_reduced_metric(self.IN_STREAM_QUEUE_EXPECTED_CAPACITY, in_expect_size)
+    self.update_mean_reduced_metric(self.OUT_STREAM_QUEUE_EXPECTED_CAPACITY, out_expect_size)
+
 
 class ComponentMetrics(BaseMetricsHelper):
   """Metrics to be collected for both Bolt and Spout"""

--- a/heron/examples/src/python/BUILD
+++ b/heron/examples/src/python/BUILD
@@ -23,6 +23,12 @@ pex_binary(
     deps = [":example-py"],
 )
 
+pex_binary(
+    name = "half_acking",
+    srcs = ["half_acking_topology.py"],
+    deps = [":example-py"],
+)
+
 # without main method
 pex_binary(
     name = "custom_grouping",
@@ -35,3 +41,5 @@ pex_binary(
     srcs = ["multi_stream_topology.py"],
     deps = [":example-py"],
 )
+
+

--- a/heron/examples/src/python/half_acking_topology.py
+++ b/heron/examples/src/python/half_acking_topology.py
@@ -36,7 +36,7 @@ if __name__ == '__main__':
   topology_config = {constants.TOPOLOGY_ENABLE_ACKING: True,
                      constants.TOPOLOGY_MAX_SPOUT_PENDING: 100000000,
                      constants.TOPOLOGY_MESSAGE_TIMEOUT_SECS: 300}
-  
+
   builder.set_config(topology_config)
 
   builder.build_and_submit()

--- a/heron/examples/src/python/half_acking_topology.py
+++ b/heron/examples/src/python/half_acking_topology.py
@@ -30,8 +30,8 @@ if __name__ == '__main__':
 
   word_spout = builder.add_spout("word_spout", WordSpout, par=2)
   half_ack_bolt = builder.add_bolt("half_ack_bolt", HalfAckBolt, par=2,
-                                inputs={word_spout: Grouping.fields('word')},
-                                config={constants.TOPOLOGY_TICK_TUPLE_FREQ_SECS: 10})
+                                   inputs={word_spout: Grouping.fields('word')},
+                                   config={constants.TOPOLOGY_TICK_TUPLE_FREQ_SECS: 10})
 
   topology_config = {constants.TOPOLOGY_ENABLE_ACKING: True,
                      constants.TOPOLOGY_MAX_SPOUT_PENDING: 100000000,

--- a/heron/examples/src/python/half_acking_topology.py
+++ b/heron/examples/src/python/half_acking_topology.py
@@ -35,8 +35,8 @@ if __name__ == '__main__':
 
   topology_config = {constants.TOPOLOGY_ENABLE_ACKING: True,
                      constants.TOPOLOGY_MAX_SPOUT_PENDING: 100000000,
-                     constants.TOPOLOGY_MESSAGE_TIMEOUT_SECS: 300,
-                     constants.INSTANCE_METRICS_SYSTEM_SAMPLE_INTERVAL_SEC: 2}
+                     constants.TOPOLOGY_MESSAGE_TIMEOUT_SECS: 300}
+  
   builder.set_config(topology_config)
 
   builder.build_and_submit()

--- a/heron/examples/src/python/half_acking_topology.py
+++ b/heron/examples/src/python/half_acking_topology.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':
   builder = TopologyBuilder(name=sys.argv[1])
 
   word_spout = builder.add_spout("word_spout", WordSpout, par=2)
-  count_bolt = builder.add_bolt("half_ack_bolt", HalfAckBolt, par=2,
+  half_ack_bolt = builder.add_bolt("half_ack_bolt", HalfAckBolt, par=2,
                                 inputs={word_spout: Grouping.fields('word')},
                                 config={constants.TOPOLOGY_TICK_TUPLE_FREQ_SECS: 10})
 

--- a/heron/examples/src/python/half_acking_topology.py
+++ b/heron/examples/src/python/half_acking_topology.py
@@ -1,0 +1,42 @@
+# copyright 2016 twitter. all rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+'''Example HalfAckingTopology'''
+import sys
+
+from heron.pyheron.src.python import Grouping, TopologyBuilder, constants
+
+from heron.examples.src.python.spout import WordSpout
+from heron.examples.src.python.bolt import HalfAckBolt
+
+# Topology is defined using a topology builder
+# Refer to multi_stream_topology for defining a topology by subclassing Topology
+if __name__ == '__main__':
+  if len(sys.argv) != 2:
+    print "Topology's name is not specified"
+    sys.exit(1)
+
+  builder = TopologyBuilder(name=sys.argv[1])
+
+  word_spout = builder.add_spout("word_spout", WordSpout, par=2)
+  count_bolt = builder.add_bolt("half_ack_bolt", HalfAckBolt, par=2,
+                                inputs={word_spout: Grouping.fields('word')},
+                                config={constants.TOPOLOGY_TICK_TUPLE_FREQ_SECS: 10})
+
+  topology_config = {constants.TOPOLOGY_ENABLE_ACKING: True,
+                     constants.TOPOLOGY_MAX_SPOUT_PENDING: 100000000,
+                     constants.TOPOLOGY_MESSAGE_TIMEOUT_SECS: 300,
+                     constants.INSTANCE_METRICS_SYSTEM_SAMPLE_INTERVAL_SEC: 2}
+  builder.set_config(topology_config)
+
+  builder.build_and_submit()

--- a/heron/instance/src/python/instance/st_heron_instance.py
+++ b/heron/instance/src/python/instance/st_heron_instance.py
@@ -72,7 +72,8 @@ class SingleThreadHeronInstance(object):
                               self.gateway_metrics, socket_options, self.sys_config)
     self._metrics_client = \
       MetricsManagerClient(self.looper, self.METRICS_MGR_HOST, metrics_port, instance,
-                           self.out_metrics, self.socket_map, socket_options, self.gateway_metrics,
+                           self.out_metrics, self.in_stream, self.out_stream,
+                           self.socket_map, socket_options, self.gateway_metrics,
                            self.sys_config)
     self.my_pplan_helper = None
 

--- a/heron/instance/src/python/instance/st_heron_instance.py
+++ b/heron/instance/src/python/instance/st_heron_instance.py
@@ -72,7 +72,8 @@ class SingleThreadHeronInstance(object):
                               self.gateway_metrics, socket_options, self.sys_config)
     self._metrics_client = \
       MetricsManagerClient(self.looper, self.METRICS_MGR_HOST, metrics_port, instance,
-                           self.out_metrics, self.socket_map, socket_options, self.sys_config)
+                           self.out_metrics, self.socket_map, socket_options, self.gateway_metrics,
+                           self.sys_config)
     self.my_pplan_helper = None
 
     # my_instance is a AssignedInstance tuple
@@ -250,7 +251,7 @@ def main():
   max_log_bytes = system_config[constants.HERON_LOGGING_MAXIMUM_SIZE_MB] * constants.MB
 
   log_file = os.path.join(log_dir, instance_id + ".log.0")
-  log.init_rotating_logger(level=logging.INFO, logfile=log_file,
+  log.init_rotating_logger(level=logging.DEBUG, logfile=log_file,
                            max_files=max_log_files, max_bytes=max_log_bytes)
 
   Log.info("\nStarting instance: " + instance_id + " for topology: " + topology_name +

--- a/heron/instance/src/python/instance/st_heron_instance.py
+++ b/heron/instance/src/python/instance/st_heron_instance.py
@@ -252,7 +252,7 @@ def main():
   max_log_bytes = system_config[constants.HERON_LOGGING_MAXIMUM_SIZE_MB] * constants.MB
 
   log_file = os.path.join(log_dir, instance_id + ".log.0")
-  log.init_rotating_logger(level=logging.DEBUG, logfile=log_file,
+  log.init_rotating_logger(level=logging.INFO, logfile=log_file,
                            max_files=max_log_files, max_bytes=max_log_bytes)
 
   Log.info("\nStarting instance: " + instance_id + " for topology: " + topology_name +

--- a/heron/instance/src/python/network/metricsmgr_client.py
+++ b/heron/instance/src/python/network/metricsmgr_client.py
@@ -35,6 +35,7 @@ class MetricsManagerClient(HeronClient):
     self.sys_config = sys_config
 
     self._add_metrics_client_tasks()
+    Log.info('start updating in and out stream metrics')
     self._update_in_out_stream_metrics_tasks()
 
   def _add_metrics_client_tasks(self):
@@ -42,7 +43,7 @@ class MetricsManagerClient(HeronClient):
 
   def _update_in_out_stream_metrics_tasks(self):
     in_size, out_size = self.in_stream.get_size(), self.out_stream.get_size()
-    Log.debug("updating in out stream metrics, %d, %d", in_size, out_size)
+    Log.info("updating in and out stream metrics, %d, %d", in_size, out_size)
     self.gateway_metrics.update_in_out_stream_metrics(in_size, out_size, in_size, out_size)
     interval = float(self.sys_config[constants.INSTANCE_METRICS_SYSTEM_SAMPLE_INTERVAL_SEC])
     self.looper.register_timer_task_in_sec(self._update_in_out_stream_metrics_tasks, interval)
@@ -52,7 +53,7 @@ class MetricsManagerClient(HeronClient):
       while not self.out_queue.is_empty():
         message = self.out_queue.poll()
         assert isinstance(message, metrics_pb2.MetricPublisherPublishMessage)
-        Log.debug("Sending metric message: %s" % str(message))
+        Log.info("Sending metric message: %s" % str(message))
         self.send_message(message)
         self.gateway_metrics.update_sent_metrics_size(message.ByteSize())
         self.gateway_metrics.update_sent_metrics(len(message.metrics), len(message.exceptions))

--- a/heron/instance/src/python/network/metricsmgr_client.py
+++ b/heron/instance/src/python/network/metricsmgr_client.py
@@ -35,7 +35,7 @@ class MetricsManagerClient(HeronClient):
     self.sys_config = sys_config
 
     self._add_metrics_client_tasks()
-    Log.info('start updating in and out stream metrics')
+    Log.debug('start updating in and out stream metrics')
     self._update_in_out_stream_metrics_tasks()
 
   def _add_metrics_client_tasks(self):
@@ -43,7 +43,7 @@ class MetricsManagerClient(HeronClient):
 
   def _update_in_out_stream_metrics_tasks(self):
     in_size, out_size = self.in_stream.get_size(), self.out_stream.get_size()
-    Log.info("updating in and out stream metrics, %d, %d", in_size, out_size)
+    Log.debug("updating in and out stream metrics, %d, %d", in_size, out_size)
     self.gateway_metrics.update_in_out_stream_metrics(in_size, out_size, in_size, out_size)
     interval = float(self.sys_config[constants.INSTANCE_METRICS_SYSTEM_SAMPLE_INTERVAL_SEC])
     self.looper.register_timer_task_in_sec(self._update_in_out_stream_metrics_tasks, interval)
@@ -53,7 +53,7 @@ class MetricsManagerClient(HeronClient):
       while not self.out_queue.is_empty():
         message = self.out_queue.poll()
         assert isinstance(message, metrics_pb2.MetricPublisherPublishMessage)
-        Log.info("Sending metric message: %s" % str(message))
+        Log.debug("Sending metric message: %s" % str(message))
         self.send_message(message)
         self.gateway_metrics.update_sent_metrics_size(message.ByteSize())
         self.gateway_metrics.update_sent_metrics(len(message.metrics), len(message.exceptions))

--- a/heron/instance/tests/python/network/BUILD
+++ b/heron/instance/tests/python/network/BUILD
@@ -2,12 +2,24 @@ package(default_visibility = ["//visibility:public"])
 
 load("/tools/rules/pex_rules", "pex_library", "pex_test")
 
+
+pex_library(
+    name = "instance-network-mock",
+    srcs = ["mock_generator.py"],
+    deps = [
+        "//heron/instance/src/python/network:pyheron-network-py",
+    ],
+    reqs = [
+        "mock==1.0.1"
+    ]
+)
+
 pex_test(
     name = "st_stmgrcli_unittest",
-    srcs = ["st_stmgr_client_unittest.py", "mock_generator.py"],
+    srcs = ["st_stmgr_client_unittest.py"],
     deps = [
         "//heron/common/tests/python:pytest-py",
-        "//heron/instance/src/python/network:pyheron-network-py",
+        "//heron/instance/tests/python/network:instance-network-mock",
     ],
     reqs = [
         "py==1.4.27",
@@ -19,10 +31,10 @@ pex_test(
 
 pex_test(
     name = "metricsmgr_client_unittest",
-    srcs = ["metricsmgr_client_unittest.py", "mock_generator.py"],
+    srcs = ["metricsmgr_client_unittest.py"],
     deps = [
         "//heron/common/tests/python:pytest-py",
-        "//heron/instance/src/python/network:pyheron-network-py",
+        "//heron/instance/tests/python/network:instance-network-mock",
     ],
     reqs = [
         "py==1.4.27",

--- a/heron/instance/tests/python/network/metricsmgr_client_unittest.py
+++ b/heron/instance/tests/python/network/metricsmgr_client_unittest.py
@@ -37,10 +37,10 @@ class MetricsMgrClientTest(unittest.TestCase):
 
   def test_on_connect_error(self):
     self.metrics_client.on_connect(StatusCode.CONNECT_ERROR)
-    self.assertEqual(len(self.metrics_client.looper.timer_tasks), 1)
-    self.assertEqual(self.metrics_client.looper.timer_tasks[0][1].__name__, 'start_connect')
+    self.assertEqual(len(self.metrics_client.looper.timer_tasks), 2)
+    self.assertEqual(self.metrics_client.looper.timer_tasks[1][1].__name__, 'start_connect')
 
   def test_on_error(self):
     self.metrics_client.on_error()
-    self.assertEqual(len(self.metrics_client.looper.timer_tasks), 1)
-    self.assertEqual(self.metrics_client.looper.timer_tasks[0][1].__name__, 'start_connect')
+    self.assertEqual(len(self.metrics_client.looper.timer_tasks), 2)
+    self.assertEqual(self.metrics_client.looper.timer_tasks[1][1].__name__, 'start_connect')

--- a/heron/instance/tests/python/network/mock_generator.py
+++ b/heron/instance/tests/python/network/mock_generator.py
@@ -20,6 +20,7 @@ from heron.common.src.python.utils.misc import HeronCommunicator
 from heron.instance.src.python.network import SingleThreadStmgrClient, MetricsManagerClient
 import heron.common.src.python.constants as constants
 import heron.common.tests.python.mock_protobuf as mock_protobuf
+from mock import Mock
 
 class MockSTStmgrClient(SingleThreadStmgrClient):
   HOST = '127.0.0.1'
@@ -48,10 +49,12 @@ class MockMetricsManagerClient(MetricsManagerClient):
   PORT = 9000
   def __init__(self):
     socket_options = SocketOptions(32768, 16, 32768, 16, 1024000, 1024000)
-    sys_config = {constants.INSTANCE_RECONNECT_METRICSMGR_INTERVAL_SEC: 10}
+    sys_config = {constants.INSTANCE_RECONNECT_METRICSMGR_INTERVAL_SEC: 10,
+                  constants.INSTANCE_METRICS_SYSTEM_SAMPLE_INTERVAL_SEC: 10}
+    stream = HeronCommunicator(producer_cb=None, consumer_cb=None)
     MetricsManagerClient.__init__(self, EventLooper(), self.HOST, self.PORT,
-                                  mock_protobuf.get_mock_instance(), HeronCommunicator(), {},
-                                  socket_options, sys_config)
+                                  mock_protobuf.get_mock_instance(), HeronCommunicator(),
+                                  stream, stream, {}, socket_options, Mock(), sys_config)
     self.register_req_called = False
 
   def _send_register_req(self):


### PR DESCRIPTION
This patch adds more default metrics for Python topology, namely:

```
'__gateway-sent-metrics-size'
'__gateway-sent-metrics-packets-count'
'__gateway-sent-metrics-count'
'__gateway-sent-exceptions-count'
'__gateway-in-stream-queue-size'
'__gateway-out-stream-queue-size'
'__gateway-in-stream-queue-expected-capacity'
'__gateway-out-stream-queue-expected-capacity'
'__gateway-in-queue-full-count'
```

This PR also adds a half-acking topology example.

related to #1264 