### PR TITLE
Change executor to load packing plan from StateManager

### DIFF
--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 #!/usr/bin/env python2.7
+""" The Heron executor is a process that runs on a container and is responsible for starting and
+monitoring the processes of the topology and it's support services."""
 import atexit
 import base64
 import json


### PR DESCRIPTION
Change to no longer use the instance distribution passed but instead watch the state manager for packing plan updates. Will remove the instance distribution entirely in a follow-up change.