### PR TITLE
Change PackingPlan model objects to be immutable

### DIFF
--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
@@ -342,13 +342,13 @@ public class RoundRobinPacking implements IPacking {
    * @return true if it is valid. Otherwise return false
    */
   protected boolean isValidPackingPlan(PackingPlan plan) {
-    for (PackingPlan.ContainerPlan containerPlan : plan.containers.values()) {
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.instances.values()) {
+    for (PackingPlan.ContainerPlan containerPlan : plan.getContainers().values()) {
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
         // Safe check
-        if (instancePlan.resource.ram < MIN_RAM_PER_INSTANCE) {
+        if (instancePlan.getResource().ram < MIN_RAM_PER_INSTANCE) {
           LOG.severe(String.format(
               "Require at least %dMB ram. Given on %d MB",
-              MIN_RAM_PER_INSTANCE / Constants.MB, instancePlan.resource.ram / Constants.MB));
+              MIN_RAM_PER_INSTANCE / Constants.MB, instancePlan.getResource().ram / Constants.MB));
 
           return false;
         }

--- a/heron/packing/tests/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPackingTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPackingTest.java
@@ -45,7 +45,7 @@ public class FirstFitDecreasingPackingTest {
   private int countComponent(String component, Map<String, PackingPlan.InstancePlan> instances) {
     int count = 0;
     for (PackingPlan.InstancePlan pair : instances.values()) {
-      if (component.equals(FirstFitDecreasingPacking.getComponentName(pair.id))) {
+      if (component.equals(FirstFitDecreasingPacking.getComponentName(pair.getId()))) {
         count++;
       }
     }
@@ -126,14 +126,14 @@ public class FirstFitDecreasingPackingTest {
     PackingPlan packingPlan =
         getFirstFitDecreasingPackingPlan(topology);
 
-    Assert.assertEquals(packingPlan.containers.size(), 2);
+    Assert.assertEquals(packingPlan.getContainers().size(), 2);
 
     long totalRam = (totalInstances + HERON_INTERNAL_CONTAINERS)
         * instanceRamDefault
         + (long) ((DEFAULT_CONTAINER_PADDING / 100.0
         * totalInstances * instanceRamDefault));
 
-    Assert.assertEquals(packingPlan.resource.ram, totalRam);
+    Assert.assertEquals(packingPlan.getResource().ram, totalRam);
 
     double totalCpu = Math.round(spoutParallelism * instanceCpuDefault
         + (DEFAULT_CONTAINER_PADDING / 100.0 * spoutParallelism * instanceCpuDefault))
@@ -141,14 +141,14 @@ public class FirstFitDecreasingPackingTest {
         + (DEFAULT_CONTAINER_PADDING / 100.0 * boltParallelism * instanceCpuDefault))
         + instanceCpuDefault;
 
-    Assert.assertEquals((long) packingPlan.resource.cpu, (long) totalCpu);
+    Assert.assertEquals((long) packingPlan.getResource().cpu, (long) totalCpu);
 
     long totalDisk = (totalInstances + HERON_INTERNAL_CONTAINERS)
         * instanceDiskDefault
         + (long) ((DEFAULT_CONTAINER_PADDING / 100.0
         * totalInstances * instanceDiskDefault));
 
-    Assert.assertEquals(packingPlan.resource.disk, totalDisk);
+    Assert.assertEquals(packingPlan.getResource().disk, totalDisk);
   }
 
   /**
@@ -170,13 +170,13 @@ public class FirstFitDecreasingPackingTest {
     PackingPlan packingPlan =
         getFirstFitDecreasingPackingPlan(topology);
 
-    Assert.assertEquals(packingPlan.containers.size(), 2);
+    Assert.assertEquals(packingPlan.getContainers().size(), 2);
 
     long totalRam = (totalInstances + HERON_INTERNAL_CONTAINERS)
         * instanceRamDefault
         + ((long) (padding / 100.0 * totalInstances * instanceRamDefault));
 
-    Assert.assertEquals(packingPlan.resource.ram, totalRam);
+    Assert.assertEquals(packingPlan.getResource().ram, totalRam);
 
     double totalCpu = Math.round(spoutParallelism * instanceCpuDefault
         + (padding / 100.0 * spoutParallelism * instanceCpuDefault))
@@ -184,13 +184,13 @@ public class FirstFitDecreasingPackingTest {
         + (padding / 100.0 * boltParallelism * instanceCpuDefault))
         + instanceCpuDefault;
 
-    Assert.assertEquals((long) packingPlan.resource.cpu, (long) totalCpu);
+    Assert.assertEquals((long) packingPlan.getResource().cpu, (long) totalCpu);
 
     long totalDisk = (totalInstances + HERON_INTERNAL_CONTAINERS)
         * instanceDiskDefault
         + (long) (padding / 100.0 * totalInstances * instanceDiskDefault);
 
-    Assert.assertEquals(packingPlan.resource.disk, totalDisk);
+    Assert.assertEquals(packingPlan.getResource().disk, totalDisk);
   }
 
 
@@ -220,43 +220,43 @@ public class FirstFitDecreasingPackingTest {
     PackingPlan packingPlanExplicitResourcesConfig =
         getFirstFitDecreasingPackingPlan(topologyExplicitResourcesConfig);
 
-    Assert.assertEquals(packingPlanExplicitResourcesConfig.containers.size(), 1);
+    Assert.assertEquals(packingPlanExplicitResourcesConfig.getContainers().size(), 1);
 
 
     Assert.assertEquals(Math.round(totalInstances * instanceCpuDefault
             + (DEFAULT_CONTAINER_PADDING / 100.0 * totalInstances * instanceCpuDefault)
             + instanceCpuDefault),
-        (long) packingPlanExplicitResourcesConfig.resource.cpu);
+        (long) packingPlanExplicitResourcesConfig.getResource().cpu);
 
     Assert.assertEquals(totalInstances * instanceRamDefault
             + (long) (DEFAULT_CONTAINER_PADDING / 100.0 * totalInstances * instanceRamDefault)
             + instanceRamDefault,
-        packingPlanExplicitResourcesConfig.resource.ram);
+        packingPlanExplicitResourcesConfig.getResource().ram);
 
     Assert.assertEquals(totalInstances * instanceDiskDefault
             + (long) (DEFAULT_CONTAINER_PADDING / 100.0 * totalInstances * instanceDiskDefault)
             + instanceDiskDefault,
-        packingPlanExplicitResourcesConfig.resource.disk);
+        packingPlanExplicitResourcesConfig.getResource().disk);
 
     for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitResourcesConfig.containers.values()) {
+        : packingPlanExplicitResourcesConfig.getContainers().values()) {
       Assert.assertEquals(Math.round(totalInstances * instanceCpuDefault
               + (DEFAULT_CONTAINER_PADDING / 100.0 * totalInstances * instanceCpuDefault)),
-          (long) containerPlan.resource.cpu);
+          (long) containerPlan.getResource().cpu);
 
       Assert.assertEquals(totalInstances * instanceRamDefault
               + (long) (DEFAULT_CONTAINER_PADDING / 100.0 * totalInstances * instanceRamDefault),
-          containerPlan.resource.ram);
+          containerPlan.getResource().ram);
 
       Assert.assertEquals(totalInstances * instanceDiskDefault
               + (long) (DEFAULT_CONTAINER_PADDING / 100.0 * totalInstances * instanceDiskDefault),
-          containerPlan.resource.disk);
+          containerPlan.getResource().disk);
 
       // All instances' resource requirement should be equal
       // So the size of set should be 1
       Set<Resource> resources = new HashSet<>();
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.instances.values()) {
-        resources.add(instancePlan.resource);
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+        resources.add(instancePlan.getResource());
       }
 
       Assert.assertEquals(1, resources.size());
@@ -297,34 +297,34 @@ public class FirstFitDecreasingPackingTest {
     PackingPlan packingPlanExplicitRamMap =
         getFirstFitDecreasingPackingPlan(topologyExplicitRamMap);
 
-    Assert.assertEquals(packingPlanExplicitRamMap.containers.size(), 1);
+    Assert.assertEquals(packingPlanExplicitRamMap.getContainers().size(), 1);
 
     Assert.assertEquals(Math.round(totalInstances * instanceCpuDefault
             + DEFAULT_CONTAINER_PADDING / 100.0 * (totalInstances * instanceCpuDefault)
             + instanceCpuDefault),
-        (long) packingPlanExplicitRamMap.resource.cpu);
+        (long) packingPlanExplicitRamMap.getResource().cpu);
 
     Assert.assertEquals(spoutParallelism * spoutRam + boltParallelism * boltRam
             + (long) (DEFAULT_CONTAINER_PADDING / 100.0 * (spoutParallelism * spoutRam
             + boltParallelism * boltRam))
             + instanceRamDefault,
-        packingPlanExplicitRamMap.resource.ram);
+        packingPlanExplicitRamMap.getResource().ram);
 
     Assert.assertEquals(totalInstances * instanceDiskDefault
             + (long) (DEFAULT_CONTAINER_PADDING / 100.0 * (totalInstances * instanceDiskDefault))
             + instanceDiskDefault,
-        packingPlanExplicitRamMap.resource.disk);
+        packingPlanExplicitRamMap.getResource().disk);
 
     // Ram for bolt should be the value in component ram map
     for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitRamMap.containers.values()) {
-      Assert.assertNotEquals(maxContainerRam, containerPlan.resource.ram);
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.instances.values()) {
-        if (instancePlan.componentName.equals(BOLT_NAME)) {
-          Assert.assertEquals(boltRam, instancePlan.resource.ram);
+        : packingPlanExplicitRamMap.getContainers().values()) {
+      Assert.assertNotEquals(maxContainerRam, containerPlan.getResource().ram);
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+        if (instancePlan.getComponentName().equals(BOLT_NAME)) {
+          Assert.assertEquals(boltRam, instancePlan.getResource().ram);
         }
-        if (instancePlan.componentName.equals(SPOUT_NAME)) {
-          Assert.assertEquals(spoutRam, instancePlan.resource.ram);
+        if (instancePlan.getComponentName().equals(SPOUT_NAME)) {
+          Assert.assertEquals(spoutRam, instancePlan.getResource().ram);
         }
       }
     }
@@ -356,38 +356,38 @@ public class FirstFitDecreasingPackingTest {
     PackingPlan packingPlanExplicitRamMap =
         getFirstFitDecreasingPackingPlan(topologyExplicitRamMap);
 
-    Assert.assertEquals(packingPlanExplicitRamMap.containers.size(), 2);
+    Assert.assertEquals(packingPlanExplicitRamMap.getContainers().size(), 2);
 
     Assert.assertEquals((long) (Math.round(spoutParallelism * instanceCpuDefault
             + DEFAULT_CONTAINER_PADDING / 100.0 * (spoutParallelism * instanceCpuDefault))
             + Math.round(boltParallelism * instanceCpuDefault
             + DEFAULT_CONTAINER_PADDING / 100.0 * (boltParallelism * instanceCpuDefault))
             + instanceCpuDefault),
-        (long) packingPlanExplicitRamMap.resource.cpu);
+        (long) packingPlanExplicitRamMap.getResource().cpu);
 
     Assert.assertEquals((spoutParallelism * spoutRam)
             + (long) (DEFAULT_CONTAINER_PADDING / 100.0 * (spoutParallelism * spoutRam))
             + boltParallelism * boltRam
             + (long) (DEFAULT_CONTAINER_PADDING / 100.0 * (boltParallelism * boltRam))
             + instanceRamDefault,
-        packingPlanExplicitRamMap.resource.ram);
+        packingPlanExplicitRamMap.getResource().ram);
 
     Assert.assertEquals(spoutParallelism * instanceDiskDefault
             + (long) (DEFAULT_CONTAINER_PADDING / 100.0 * (spoutParallelism * instanceDiskDefault))
             + boltParallelism * instanceDiskDefault
             + (long) (DEFAULT_CONTAINER_PADDING / 100.0 * (boltParallelism * instanceDiskDefault))
             + instanceDiskDefault,
-        packingPlanExplicitRamMap.resource.disk);
+        packingPlanExplicitRamMap.getResource().disk);
 
     // Ram for bolt/spout should be the value in component ram map
     for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitRamMap.containers.values()) {
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.instances.values()) {
-        if (instancePlan.componentName.equals(BOLT_NAME)) {
-          Assert.assertEquals(boltRam, instancePlan.resource.ram);
+        : packingPlanExplicitRamMap.getContainers().values()) {
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+        if (instancePlan.getComponentName().equals(BOLT_NAME)) {
+          Assert.assertEquals(boltRam, instancePlan.getResource().ram);
         }
-        if (instancePlan.componentName.equals(SPOUT_NAME)) {
-          Assert.assertEquals(spoutRam, instancePlan.resource.ram);
+        if (instancePlan.getComponentName().equals(SPOUT_NAME)) {
+          Assert.assertEquals(spoutRam, instancePlan.getResource().ram);
         }
       }
     }
@@ -418,38 +418,38 @@ public class FirstFitDecreasingPackingTest {
     PackingPlan packingPlanExplicitRamMap =
         getFirstFitDecreasingPackingPlan(topologyExplicitRamMap);
 
-    Assert.assertEquals(packingPlanExplicitRamMap.containers.size(), 2);
+    Assert.assertEquals(packingPlanExplicitRamMap.getContainers().size(), 2);
 
     Assert.assertEquals((long) (Math.round(4 * instanceCpuDefault
             + DEFAULT_CONTAINER_PADDING / 100.0 * (4 * instanceCpuDefault))
             + Math.round(3 * instanceCpuDefault
             + DEFAULT_CONTAINER_PADDING / 100.0 * (3 * instanceCpuDefault))
             + instanceCpuDefault),
-        (long) packingPlanExplicitRamMap.resource.cpu);
+        (long) packingPlanExplicitRamMap.getResource().cpu);
 
     Assert.assertEquals(2 * boltRam + 2 * instanceRamDefault
             + (long) (DEFAULT_CONTAINER_PADDING / 100.0 * (2 * boltRam + 2 * instanceRamDefault))
             + boltRam + 2 * instanceRamDefault
             + (long) (DEFAULT_CONTAINER_PADDING / 100.0 * (boltRam + 2 * instanceRamDefault))
             + instanceRamDefault,
-        packingPlanExplicitRamMap.resource.ram);
+        packingPlanExplicitRamMap.getResource().ram);
 
     Assert.assertEquals(4 * instanceDiskDefault
             + (long) (DEFAULT_CONTAINER_PADDING / 100.0 * (4 * instanceDiskDefault))
             + 3 * instanceDiskDefault
             + (long) (DEFAULT_CONTAINER_PADDING / 100.0 * (3 * instanceDiskDefault))
             + instanceDiskDefault,
-        packingPlanExplicitRamMap.resource.disk);
+        packingPlanExplicitRamMap.getResource().disk);
 
     for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitRamMap.containers.values()) {
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.instances.values()) {
+        : packingPlanExplicitRamMap.getContainers().values()) {
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
         // Ram for bolt should be the value in component ram map
-        if (instancePlan.componentName.equals(BOLT_NAME)) {
-          Assert.assertEquals(boltRam, instancePlan.resource.ram);
+        if (instancePlan.getComponentName().equals(BOLT_NAME)) {
+          Assert.assertEquals(boltRam, instancePlan.getResource().ram);
         }
-        if (instancePlan.componentName.equals(SPOUT_NAME)) {
-          Assert.assertEquals(instanceRamDefault, instancePlan.resource.ram);
+        if (instancePlan.getComponentName().equals(SPOUT_NAME)) {
+          Assert.assertEquals(instanceRamDefault, instancePlan.getResource().ram);
         }
       }
     }
@@ -481,38 +481,38 @@ public class FirstFitDecreasingPackingTest {
     PackingPlan packingPlanExplicitRamMap =
         getFirstFitDecreasingPackingPlan(topologyExplicitRamMap);
 
-    Assert.assertEquals(packingPlanExplicitRamMap.containers.size(), 2);
+    Assert.assertEquals(packingPlanExplicitRamMap.getContainers().size(), 2);
 
     Assert.assertEquals((long) (Math.round(4 * instanceCpuDefault
             + padding / 100.0 * (4 * instanceCpuDefault))
             + Math.round(3 * instanceCpuDefault
             + padding / 100.0 * (3 * instanceCpuDefault))
             + instanceCpuDefault),
-        (long) packingPlanExplicitRamMap.resource.cpu);
+        (long) packingPlanExplicitRamMap.getResource().cpu);
 
     Assert.assertEquals(2 * boltRam + 2 * instanceRamDefault
             + (long) (padding / 100.0 * (2 * boltRam + 2 * instanceRamDefault))
             + boltRam + 2 * instanceRamDefault
             + (long) (padding / 100.0 * (boltRam + 2 * instanceRamDefault))
             + instanceRamDefault,
-        packingPlanExplicitRamMap.resource.ram);
+        packingPlanExplicitRamMap.getResource().ram);
 
     Assert.assertEquals(4 * instanceDiskDefault
             + (long) (padding / 100.0 * (4 * instanceDiskDefault))
             + 3 * instanceDiskDefault
             + (long) (padding / 100.0 * (3 * instanceDiskDefault))
             + instanceDiskDefault,
-        packingPlanExplicitRamMap.resource.disk);
+        packingPlanExplicitRamMap.getResource().disk);
 
     for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitRamMap.containers.values()) {
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.instances.values()) {
+        : packingPlanExplicitRamMap.getContainers().values()) {
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
         // Ram for bolt should be the value in component ram map
-        if (instancePlan.componentName.equals(BOLT_NAME)) {
-          Assert.assertEquals(boltRam, instancePlan.resource.ram);
+        if (instancePlan.getComponentName().equals(BOLT_NAME)) {
+          Assert.assertEquals(boltRam, instancePlan.getResource().ram);
         }
-        if (instancePlan.componentName.equals(SPOUT_NAME)) {
-          Assert.assertEquals(instanceRamDefault, instancePlan.resource.ram);
+        if (instancePlan.getComponentName().equals(SPOUT_NAME)) {
+          Assert.assertEquals(instanceRamDefault, instancePlan.getResource().ram);
         }
       }
     }

--- a/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPackingTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPackingTest.java
@@ -47,7 +47,7 @@ public class ResourceCompliantRRPackingTest {
   private int countComponent(String component, Map<String, PackingPlan.InstancePlan> instances) {
     int count = 0;
     for (PackingPlan.InstancePlan pair : instances.values()) {
-      if (component.equals(RoundRobinPacking.getComponentName(pair.id))) {
+      if (component.equals(RoundRobinPacking.getComponentName(pair.getId()))) {
         count++;
       }
     }
@@ -135,7 +135,7 @@ public class ResourceCompliantRRPackingTest {
     PackingPlan packingPlanNoExplicitResourcesConfig =
         getResourceCompliantRRPackingPlan(topologyNoExplicitResourcesConfig);
 
-    Assert.assertEquals(packingPlanNoExplicitResourcesConfig.containers.size(), numContainers);
+    Assert.assertEquals(packingPlanNoExplicitResourcesConfig.getContainers().size(), numContainers);
 
     //The first container consists 2 spouts and 2 bolts (4 instances) and the second container
     //consists of 2 spouts and 1 bolt (3 instances)
@@ -144,21 +144,21 @@ public class ResourceCompliantRRPackingTest {
             + Math.round(3 * instanceCpuDefault
             + DEFAULT_CONTAINER_PADDING / 100.0 * (3 * instanceCpuDefault))
             + instanceCpuDefault),
-        (long) packingPlanNoExplicitResourcesConfig.resource.cpu);
+        (long) packingPlanNoExplicitResourcesConfig.getResource().cpu);
 
     Assert.assertEquals((4 * instanceRamDefault)
             + (long) ((DEFAULT_CONTAINER_PADDING / 100.0) * (4 * instanceRamDefault))
             + 3 * instanceRamDefault
             + (long) ((DEFAULT_CONTAINER_PADDING / 100.0) * (3 * instanceRamDefault))
             + instanceRamDefault,
-        packingPlanNoExplicitResourcesConfig.resource.ram);
+        packingPlanNoExplicitResourcesConfig.getResource().ram);
 
     Assert.assertEquals(4 * instanceDiskDefault
             + (long) ((DEFAULT_CONTAINER_PADDING / 100.0) * (4 * instanceDiskDefault))
             + 3 * instanceDiskDefault
             + (long) ((DEFAULT_CONTAINER_PADDING / 100.0) * (3 * instanceDiskDefault))
             + instanceDiskDefault,
-        packingPlanNoExplicitResourcesConfig.resource.disk);
+        packingPlanNoExplicitResourcesConfig.getResource().disk);
   }
 
   /**
@@ -181,7 +181,7 @@ public class ResourceCompliantRRPackingTest {
     PackingPlan packingPlan =
         getResourceCompliantRRPackingPlan(topology);
 
-    Assert.assertEquals(packingPlan.containers.size(), numContainers);
+    Assert.assertEquals(packingPlan.getContainers().size(), numContainers);
 
     //The first container consists 2 spouts and 2 bolts (4 instances) and the second container
     //consists of 2 spouts and 1 bolt (3 instances)
@@ -190,21 +190,21 @@ public class ResourceCompliantRRPackingTest {
             + Math.round(3 * instanceCpuDefault
             + padding / 100.0 * (3 * instanceCpuDefault))
             + instanceCpuDefault),
-        (long) packingPlan.resource.cpu);
+        (long) packingPlan.getResource().cpu);
 
     Assert.assertEquals((4 * instanceRamDefault)
             + (long) ((padding / 100.0) * (4 * instanceRamDefault))
             + 3 * instanceRamDefault
             + (long) ((padding / 100.0) * (3 * instanceRamDefault))
             + instanceRamDefault,
-        packingPlan.resource.ram);
+        packingPlan.getResource().ram);
 
     Assert.assertEquals(4 * instanceDiskDefault
             + (long) ((padding / 100.0) * (4 * instanceDiskDefault))
             + 3 * instanceDiskDefault
             + (long) ((padding / 100.0) * (3 * instanceDiskDefault))
             + instanceDiskDefault,
-        packingPlan.resource.disk);
+        packingPlan.getResource().disk);
   }
 
   /**
@@ -233,42 +233,42 @@ public class ResourceCompliantRRPackingTest {
     PackingPlan packingPlanExplicitResourcesConfig =
         getResourceCompliantRRPackingPlan(topologyExplicitResourcesConfig);
 
-    Assert.assertEquals(packingPlanExplicitResourcesConfig.containers.size(), numContainers);
+    Assert.assertEquals(packingPlanExplicitResourcesConfig.getContainers().size(), numContainers);
 
     Assert.assertEquals(Math.round(totalInstances * instanceCpuDefault
             + (DEFAULT_CONTAINER_PADDING / 100.0) * totalInstances * instanceCpuDefault
             + instanceCpuDefault),
-        (long) packingPlanExplicitResourcesConfig.resource.cpu);
+        (long) packingPlanExplicitResourcesConfig.getResource().cpu);
 
     Assert.assertEquals(totalInstances * instanceRamDefault
             + (long) ((DEFAULT_CONTAINER_PADDING / 100.0) * totalInstances * instanceRamDefault)
             + instanceRamDefault,
-        packingPlanExplicitResourcesConfig.resource.ram);
+        packingPlanExplicitResourcesConfig.getResource().ram);
 
     Assert.assertEquals(totalInstances * instanceDiskDefault
             + (long) ((DEFAULT_CONTAINER_PADDING / 100.0) * totalInstances * instanceDiskDefault)
             + instanceDiskDefault,
-        packingPlanExplicitResourcesConfig.resource.disk);
+        packingPlanExplicitResourcesConfig.getResource().disk);
 
     for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitResourcesConfig.containers.values()) {
+        : packingPlanExplicitResourcesConfig.getContainers().values()) {
       Assert.assertEquals(Math.round(totalInstances * instanceCpuDefault
               + (DEFAULT_CONTAINER_PADDING / 100.0) * totalInstances * instanceCpuDefault),
-          (long) containerPlan.resource.cpu);
+          (long) containerPlan.getResource().cpu);
 
       Assert.assertEquals(totalInstances * instanceRamDefault
               + (long) ((DEFAULT_CONTAINER_PADDING / 100.0) * totalInstances * instanceRamDefault),
-          containerPlan.resource.ram);
+          containerPlan.getResource().ram);
 
       Assert.assertEquals(totalInstances * instanceDiskDefault
               + (long) ((DEFAULT_CONTAINER_PADDING / 100.0) * totalInstances * instanceDiskDefault),
-          containerPlan.resource.disk);
+          containerPlan.getResource().disk);
 
       // All instances' resource requirement should be equal
       // So the size of set should be 1
       Set<Resource> resources = new HashSet<>();
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.instances.values()) {
-        resources.add(instancePlan.resource);
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+        resources.add(instancePlan.getResource());
       }
 
       Assert.assertEquals(1, resources.size());
@@ -301,7 +301,7 @@ public class ResourceCompliantRRPackingTest {
     PackingPlan packingPlanExplicitResourcesConfig =
         getResourceCompliantRRPackingPlan(topologyExplicitResourcesConfig);
 
-    Assert.assertEquals(packingPlanExplicitResourcesConfig.containers.size(), numContainers);
+    Assert.assertEquals(packingPlanExplicitResourcesConfig.getContainers().size(), numContainers);
 
     //The first container consists 2 spouts and 2 bolts (4 instances) and the second container
     //consists of 2 spouts and 1 bolt (3 instances)
@@ -310,27 +310,27 @@ public class ResourceCompliantRRPackingTest {
             + Math.round(3 * instanceCpuDefault
             + DEFAULT_CONTAINER_PADDING / 100.0 * (3 * instanceCpuDefault))
             + instanceCpuDefault),
-        (long) packingPlanExplicitResourcesConfig.resource.cpu);
+        (long) packingPlanExplicitResourcesConfig.getResource().cpu);
 
     Assert.assertEquals((4 * instanceRamDefault)
             + (long) ((DEFAULT_CONTAINER_PADDING / 100.0) * (4 * instanceRamDefault))
             + 3 * instanceRamDefault
             + (long) ((DEFAULT_CONTAINER_PADDING / 100.0) * (3 * instanceRamDefault))
             + instanceRamDefault,
-        packingPlanExplicitResourcesConfig.resource.ram);
+        packingPlanExplicitResourcesConfig.getResource().ram);
 
     Assert.assertEquals(4 * instanceDiskDefault
             + (long) ((DEFAULT_CONTAINER_PADDING / 100.0) * (4 * instanceDiskDefault))
             + 3 * instanceDiskDefault
             + (long) ((DEFAULT_CONTAINER_PADDING / 100.0) * (3 * instanceDiskDefault))
             + instanceDiskDefault,
-        packingPlanExplicitResourcesConfig.resource.disk);
+        packingPlanExplicitResourcesConfig.getResource().disk);
 
     // Ram for bolt/spout should be the value in component ram map
     for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitResourcesConfig.containers.values()) {
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.instances.values()) {
-        Assert.assertEquals(instanceRamDefault, instancePlan.resource.ram);
+        : packingPlanExplicitResourcesConfig.getContainers().values()) {
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+        Assert.assertEquals(instanceRamDefault, instancePlan.getResource().ram);
       }
     }
   }
@@ -365,15 +365,15 @@ public class ResourceCompliantRRPackingTest {
 
     // Ram for bolt should be the value in component ram map
     for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitRamMap.containers.values()) {
+        : packingPlanExplicitRamMap.getContainers().values()) {
       // The containerRam should be ignored, since we set the complete component ram map
-      Assert.assertNotEquals(containerRam, containerPlan.resource.ram);
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.instances.values()) {
-        if (instancePlan.componentName.equals(BOLT_NAME)) {
-          Assert.assertEquals(boltRam, instancePlan.resource.ram);
+      Assert.assertNotEquals(containerRam, containerPlan.getResource().ram);
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+        if (instancePlan.getComponentName().equals(BOLT_NAME)) {
+          Assert.assertEquals(boltRam, instancePlan.getResource().ram);
         }
-        if (instancePlan.componentName.equals(SPOUT_NAME)) {
-          Assert.assertEquals(instanceRamDefault, instancePlan.resource.ram);
+        if (instancePlan.getComponentName().equals(SPOUT_NAME)) {
+          Assert.assertEquals(instanceRamDefault, instancePlan.getResource().ram);
         }
       }
     }
@@ -410,14 +410,14 @@ public class ResourceCompliantRRPackingTest {
 
     // Ram for bolt should be the value in component ram map
     for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitRamMap.containers.values()) {
-      Assert.assertNotEquals(containerRam, containerPlan.resource.ram);
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.instances.values()) {
-        if (instancePlan.componentName.equals(BOLT_NAME)) {
-          Assert.assertEquals(boltRam, instancePlan.resource.ram);
+        : packingPlanExplicitRamMap.getContainers().values()) {
+      Assert.assertNotEquals(containerRam, containerPlan.getResource().ram);
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+        if (instancePlan.getComponentName().equals(BOLT_NAME)) {
+          Assert.assertEquals(boltRam, instancePlan.getResource().ram);
         }
-        if (instancePlan.componentName.equals(SPOUT_NAME)) {
-          Assert.assertEquals(spoutRam, instancePlan.resource.ram);
+        if (instancePlan.getComponentName().equals(SPOUT_NAME)) {
+          Assert.assertEquals(spoutRam, instancePlan.getResource().ram);
         }
       }
     }
@@ -445,7 +445,7 @@ public class ResourceCompliantRRPackingTest {
         getTopology(spoutParallelism, boltParallelism, topologyConfig);
     PackingPlan packingPlan =
         getResourceCompliantRRPackingPlan(topology);
-    Assert.assertEquals(packingPlan.containers.size(), 4);
+    Assert.assertEquals(packingPlan.getContainers().size(), 4);
 
     //The first 3 containers consist of 1 spout and 1 bolt (2 instances) and the fourth container
     //consists of 1 spout (1 instance)
@@ -458,7 +458,7 @@ public class ResourceCompliantRRPackingTest {
             + Math.round(HERON_INTERNAL_CONTAINERS * instanceCpuDefault
             + DEFAULT_CONTAINER_PADDING / 100.0 * (HERON_INTERNAL_CONTAINERS * instanceCpuDefault))
             + instanceCpuDefault),
-        (long) packingPlan.resource.cpu);
+        (long) packingPlan.getResource().cpu);
 
     Assert.assertEquals(2 * instanceRamDefault
             + (long) ((DEFAULT_CONTAINER_PADDING / 100.0) * (2 * instanceRamDefault))
@@ -470,7 +470,7 @@ public class ResourceCompliantRRPackingTest {
             + (long) ((DEFAULT_CONTAINER_PADDING / 100.0)
             * (HERON_INTERNAL_CONTAINERS * instanceRamDefault))
             + instanceRamDefault,
-        packingPlan.resource.ram);
+        packingPlan.getResource().ram);
 
     Assert.assertEquals(2 * instanceDiskDefault
             + (long) ((DEFAULT_CONTAINER_PADDING / 100.0) * (2 * instanceDiskDefault))
@@ -482,7 +482,7 @@ public class ResourceCompliantRRPackingTest {
             + (long) ((DEFAULT_CONTAINER_PADDING / 100.0)
             * (HERON_INTERNAL_CONTAINERS * instanceDiskDefault))
             + instanceDiskDefault,
-        packingPlan.resource.disk);
+        packingPlan.getResource().disk);
   }
 
   /**
@@ -513,7 +513,7 @@ public class ResourceCompliantRRPackingTest {
         getTopology(spoutParallelism, boltParallelism, topologyConfig);
     PackingPlan packingPlan =
         getResourceCompliantRRPackingPlan(topologyExplicitRamMap);
-    Assert.assertEquals(packingPlan.containers.size(), 7);
+    Assert.assertEquals(packingPlan.getContainers().size(), 7);
   }
 
   /**
@@ -535,14 +535,14 @@ public class ResourceCompliantRRPackingTest {
     // Two components
     Assert.assertEquals(2 * componentParallelism, numInstance);
     PackingPlan output = getResourceCompliantRRPackingPlan(topology);
-    Assert.assertEquals(numContainers, output.containers.size());
+    Assert.assertEquals(numContainers, output.getContainers().size());
 
-    for (PackingPlan.ContainerPlan container : output.containers.values()) {
-      Assert.assertEquals(numInstance / numContainers, container.instances.size());
+    for (PackingPlan.ContainerPlan container : output.getContainers().values()) {
+      Assert.assertEquals(numInstance / numContainers, container.getInstances().size());
       Assert.assertEquals(
-          2, countComponent("spout", container.instances));
+          2, countComponent("spout", container.getInstances()));
       Assert.assertEquals(
-          2, countComponent("bolt", container.instances));
+          2, countComponent("bolt", container.getInstances()));
     }
   }
 }

--- a/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/RoundRobinPackingTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/RoundRobinPackingTest.java
@@ -40,7 +40,7 @@ public class RoundRobinPackingTest {
   private int countCompoment(String component, Map<String, PackingPlan.InstancePlan> instances) {
     int count = 0;
     for (PackingPlan.InstancePlan pair : instances.values()) {
-      if (component.equals(RoundRobinPacking.getComponentName(pair.id))) {
+      if (component.equals(RoundRobinPacking.getComponentName(pair.getId()))) {
         count++;
       }
     }
@@ -125,20 +125,20 @@ public class RoundRobinPackingTest {
     Assert.assertEquals(
         (Math.max(spoutParallelism, boltParallelism)
             + RoundRobinPacking.DEFAULT_CPU_PADDING_PER_CONTAINER) * (numContainers + 1),
-        packingPlanNoExplicitResourcesConfig.resource.cpu, DELTA);
+        packingPlanNoExplicitResourcesConfig.getResource().cpu, DELTA);
 
     Assert.assertEquals(
         (spoutParallelism + boltParallelism) * Constants.GB
             + RoundRobinPacking.DEFAULT_RAM_PADDING_PER_CONTAINER * numContainers,
-        packingPlanNoExplicitResourcesConfig.resource.ram);
+        packingPlanNoExplicitResourcesConfig.getResource().ram);
 
     Assert.assertEquals(
         (Math.max(spoutParallelism, boltParallelism) * Constants.GB
             + RoundRobinPacking.DEFAULT_DISK_PADDING_PER_CONTAINER) * (numContainers + 1),
-        packingPlanNoExplicitResourcesConfig.resource.disk);
+        packingPlanNoExplicitResourcesConfig.getResource().disk);
 
     Assert.assertEquals(numContainers,
-        packingPlanNoExplicitResourcesConfig.containers.size());
+        packingPlanNoExplicitResourcesConfig.getContainers().size());
   }
 
   /**
@@ -167,39 +167,39 @@ public class RoundRobinPackingTest {
         getRoundRobinPackingPlan(topologyExplicitResourcesConfig);
 
     Assert.assertEquals(containerCpu * (numContainers + 1),
-        packingPlanExplicitResourcesConfig.resource.cpu, DELTA);
+        packingPlanExplicitResourcesConfig.getResource().cpu, DELTA);
 
     // The total recommended ram should be in the range of configured ram, account for rounding
     // errors
     Assert.assertEquals((double) containerRam * numContainers,
-        (double) packingPlanExplicitResourcesConfig.resource.ram,
+        (double) packingPlanExplicitResourcesConfig.getResource().ram,
         spoutParallelism + boltParallelism);
 
     Assert.assertEquals(containerDisk * (numContainers + 1),
-        packingPlanExplicitResourcesConfig.resource.disk);
+        packingPlanExplicitResourcesConfig.getResource().disk);
 
     Assert.assertEquals(numContainers,
-        packingPlanExplicitResourcesConfig.containers.size());
+        packingPlanExplicitResourcesConfig.getContainers().size());
 
     for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitResourcesConfig.containers.values()) {
-      Assert.assertEquals(containerCpu, containerPlan.resource.cpu, DELTA);
+        : packingPlanExplicitResourcesConfig.getContainers().values()) {
+      Assert.assertEquals(containerCpu, containerPlan.getResource().cpu, DELTA);
 
       Assert.assertEquals((double) containerRam,
-          (double) containerPlan.resource.ram,
-          containerPlan.instances.size());
+          (double) containerPlan.getResource().ram,
+          containerPlan.getInstances().size());
 
-      Assert.assertEquals(containerDisk, containerPlan.resource.disk);
+      Assert.assertEquals(containerDisk, containerPlan.getResource().disk);
 
       // All instances' resource requirement should be equal
       // So the size of set should be 1
       Set<Resource> resources = new HashSet<>();
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.instances.values()) {
-        resources.add(instancePlan.resource);
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+        resources.add(instancePlan.getResource());
       }
 
       Assert.assertEquals(1, resources.size());
-      int instancesCount = containerPlan.instances.values().size();
+      int instancesCount = containerPlan.getInstances().values().size();
       Assert.assertEquals(
           (containerRam - RoundRobinPacking.DEFAULT_RAM_PADDING_PER_CONTAINER) / instancesCount,
           resources.iterator().next().ram);
@@ -238,15 +238,15 @@ public class RoundRobinPackingTest {
 
     // Ram for bolt should be the value in component ram map
     for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitRamMap.containers.values()) {
+        : packingPlanExplicitRamMap.getContainers().values()) {
       // The containerRam should be ignored, since we set the complete component ram map
-      Assert.assertNotEquals(containerRam, containerPlan.resource.ram);
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.instances.values()) {
-        if (instancePlan.componentName.equals(BOLT_NAME)) {
-          Assert.assertEquals(boltRam, instancePlan.resource.ram);
+      Assert.assertNotEquals(containerRam, containerPlan.getResource().ram);
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+        if (instancePlan.getComponentName().equals(BOLT_NAME)) {
+          Assert.assertEquals(boltRam, instancePlan.getResource().ram);
         }
-        if (instancePlan.componentName.equals(SPOUT_NAME)) {
-          Assert.assertEquals(spoutRam, instancePlan.resource.ram);
+        if (instancePlan.getComponentName().equals(SPOUT_NAME)) {
+          Assert.assertEquals(spoutRam, instancePlan.getResource().ram);
         }
       }
     }
@@ -281,13 +281,13 @@ public class RoundRobinPackingTest {
 
     // Ram for bolt should be the value in component ram map
     for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitRamMap.containers.values()) {
-      Assert.assertEquals(containerRam, containerPlan.resource.ram);
+        : packingPlanExplicitRamMap.getContainers().values()) {
+      Assert.assertEquals(containerRam, containerPlan.getResource().ram);
       int boltCount = 0;
-      int instancesCount = containerPlan.instances.size();
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.instances.values()) {
-        if (instancePlan.componentName.equals(BOLT_NAME)) {
-          Assert.assertEquals(boltRam, instancePlan.resource.ram);
+      int instancesCount = containerPlan.getInstances().size();
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+        if (instancePlan.getComponentName().equals(BOLT_NAME)) {
+          Assert.assertEquals(boltRam, instancePlan.getResource().ram);
           boltCount++;
         }
       }
@@ -295,13 +295,13 @@ public class RoundRobinPackingTest {
       // Ram for spout should be:
       // (containerRam - all ram for bolt - ram for padding) / (# of spouts)
       int spoutCount = instancesCount - boltCount;
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.instances.values()) {
-        if (instancePlan.componentName.equals(SPOUT_NAME)) {
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+        if (instancePlan.getComponentName().equals(SPOUT_NAME)) {
           Assert.assertEquals(
               (containerRam
                   - boltCount * boltRam
                   - RoundRobinPacking.DEFAULT_RAM_PADDING_PER_CONTAINER) / spoutCount,
-              instancePlan.resource.ram);
+              instancePlan.getResource().ram);
         }
       }
     }
@@ -326,16 +326,16 @@ public class RoundRobinPackingTest {
     // Two components
     Assert.assertEquals(2 * componentParallelism, numInstance);
     PackingPlan output = getRoundRobinPackingPlan(topology);
-    Assert.assertEquals(numContainers, output.containers.size());
+    Assert.assertEquals(numContainers, output.getContainers().size());
 
-    for (PackingPlan.ContainerPlan container : output.containers.values()) {
-      Assert.assertEquals(numInstance / numContainers, container.instances.size());
+    for (PackingPlan.ContainerPlan container : output.getContainers().values()) {
+      Assert.assertEquals(numInstance / numContainers, container.getInstances().size());
 
       // Verify each container got 2 spout and 2 bolt and container 1 got
       Assert.assertEquals(
-          2, countCompoment("spout", container.instances));
+          2, countCompoment("spout", container.getInstances()));
       Assert.assertEquals(
-          2, countCompoment("bolt", container.instances));
+          2, countCompoment("bolt", container.getInstances()));
     }
   }
 }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
@@ -72,7 +72,7 @@ public class AuroraScheduler implements IScheduler {
 
   @Override
   public boolean onSchedule(PackingPlan packing) {
-    if (packing == null || packing.containers.isEmpty()) {
+    if (packing == null || packing.getContainers().isEmpty()) {
       LOG.severe("No container requested. Can't schedule");
       return false;
     }
@@ -133,7 +133,7 @@ public class AuroraScheduler implements IScheduler {
     // Align the cpu, ram, disk to the maximal one
     Resource containerResource = SchedulerUtils.getMaxRequiredResource(packing);
     // Update total topology resource requirement on Aurora clusters
-    packing.resource.ram = containerResource.ram * (packing.containers.size() + 1);
+    packing.getResource().ram = containerResource.ram * (packing.getContainers().size() + 1);
 
     auroraProperties.put("SANDBOX_EXECUTOR_BINARY", Context.executorSandboxBinary(config));
     auroraProperties.put("TOPOLOGY_NAME", topology.getName());

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/marathon/MarathonScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/marathon/MarathonScheduler.java
@@ -62,7 +62,7 @@ public class MarathonScheduler implements IScheduler {
 
   @Override
   public boolean onSchedule(PackingPlan packing) {
-    if (packing == null || packing.containers.isEmpty()) {
+    if (packing == null || packing.getContainers().isEmpty()) {
       LOG.severe("No container requested. Can't schedule");
       return false;
     }
@@ -101,7 +101,7 @@ public class MarathonScheduler implements IScheduler {
     // Align resources to maximal requested resource
     Resource containerResource = SchedulerUtils.getMaxRequiredResource(packing);
     // Add ram for tmaster container
-    packing.resource.ram = containerResource.ram * (packing.containers.size() + 1);
+    packing.getResource().ram = containerResource.ram * (packing.getContainers().size() + 1);
 
     // Create app conf list for each container
     ArrayNode instances = mapper.createArrayNode();

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/mesos/MesosScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/mesos/MesosScheduler.java
@@ -250,8 +250,8 @@ public class MesosScheduler implements IScheduler {
     double cpu = 0;
     double disk = 0;
     double mem = 0;
-    for (PackingPlan.ContainerPlan cp : packing.containers.values()) {
-      Resource containerResource = cp.resource;
+    for (PackingPlan.ContainerPlan cp : packing.getContainers().values()) {
+      Resource containerResource = cp.getResource();
       cpu = Math.max(cpu, containerResource.cpu);
       disk = Math.max(disk, containerResource.disk);
       mem = Math.max(mem, containerResource.ram);

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/slurm/SlurmScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/slurm/SlurmScheduler.java
@@ -75,7 +75,7 @@ public class SlurmScheduler implements IScheduler {
 
   @Override
   public boolean onSchedule(PackingPlan packing) {
-    if (packing == null || packing.containers.isEmpty()) {
+    if (packing == null || packing.getContainers().isEmpty()) {
       LOG.log(Level.SEVERE, "No container requested. Can't schedule");
       return false;
     }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/HeronMasterDriver.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/HeronMasterDriver.java
@@ -156,8 +156,8 @@ public class HeronMasterDriver {
    */
   void scheduleHeronWorkers(PackingPlan topologyPacking) {
     this.packing = topologyPacking;
-    for (Entry<String, ContainerPlan> entry : topologyPacking.containers.entrySet()) {
-      Resource reqResource = entry.getValue().resource;
+    for (Entry<String, ContainerPlan> entry : topologyPacking.getContainers().entrySet()) {
+      Resource reqResource = entry.getValue().getResource();
 
       int mem = getMemInMBForExecutor(reqResource);
       try {
@@ -397,13 +397,13 @@ public class HeronMasterDriver {
         if (executorId.equals(TMASTER_CONTAINER_ID)) {
           launchContainerForExecutor(TMASTER_CONTAINER_ID, 1, TM_MEM_SIZE_MB);
         } else {
-          if (packing.containers.get(executorId) == null) {
+          if (packing.getContainers().get(executorId) == null) {
             LOG.log(Level.SEVERE,
                 "Missing container {0} in packing, skipping container request",
                 executorId);
             return;
           }
-          Resource reqResource = packing.containers.get(executorId).resource;
+          Resource reqResource = packing.getContainers().get(executorId).getResource();
           launchContainerForExecutor(executorId,
               getCpuForExecutor(reqResource),
               getMemInMBForExecutor(reqResource));

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/YarnScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/YarnScheduler.java
@@ -39,7 +39,7 @@ public class YarnScheduler implements IScheduler {
 
   @Override
   public boolean onSchedule(PackingPlan packing) {
-    LOG.log(Level.INFO, "Launching topology master for packing: {0}", packing.id);
+    LOG.log(Level.INFO, "Launching topology master for packing: {0}", packing.getId());
     HeronMasterDriver driver = HeronMasterDriverProvider.getInstance();
     driver.scheduleTMasterContainer();
     driver.scheduleHeronWorkers(packing);

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraSchedulerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraSchedulerTest.java
@@ -83,7 +83,7 @@ public class AuroraSchedulerTest {
             PACKING_PLAN_ID,
             new HashMap<String, PackingPlan.ContainerPlan>(),
             Mockito.mock(Resource.class));
-    Assert.assertTrue(plan.containers.isEmpty());
+    Assert.assertTrue(plan.getContainers().isEmpty());
     // Fail to schedule due to PackingPlan is empty
     Assert.assertFalse(scheduler.onSchedule(plan));
 

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/marathon/MarathonSchedulerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/marathon/MarathonSchedulerTest.java
@@ -78,7 +78,7 @@ public class MarathonSchedulerTest {
             PACKING_PLAN_ID,
             new HashMap<String, PackingPlan.ContainerPlan>(),
             Mockito.mock(Resource.class));
-    Assert.assertTrue(pplan.containers.isEmpty());
+    Assert.assertTrue(pplan.getContainers().isEmpty());
     // Fail to schedule due to PackingPlan is empty
     Assert.assertFalse(scheduler.onSchedule(pplan));
 

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/slurm/SlurmSchedulerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/slurm/SlurmSchedulerTest.java
@@ -110,7 +110,7 @@ public class SlurmSchedulerTest {
             PACKING_PLAN_ID,
             new HashMap<String, PackingPlan.ContainerPlan>(),
             Mockito.mock(Resource.class));
-    Assert.assertTrue(plan.containers.isEmpty());
+    Assert.assertTrue(plan.getContainers().isEmpty());
     // Fail to schedule due to PackingPlan is empty
     Assert.assertFalse(scheduler.onSchedule(plan));
 

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/DriverOnLocalReefTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/DriverOnLocalReefTest.java
@@ -104,7 +104,7 @@ public class DriverOnLocalReefTest {
                               Map<String, PackingPlan.ContainerPlan> containers) {
       Resource resource = new Resource(cpu, mem * 1024 * 1024, 0L);
       PackingPlan.ContainerPlan container = new PackingPlan.ContainerPlan(id, null, resource);
-      containers.put(container.id, container);
+      containers.put(container.getId(), container);
     }
 
     class DriverStarter implements EventHandler<StartTime> {

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/HeronMasterDriverTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/HeronMasterDriverTest.java
@@ -100,7 +100,7 @@ public class HeronMasterDriverTest {
                             Map<String, PackingPlan.ContainerPlan> containers) {
     Resource resource = new Resource(cpu, mem * 1024 * 1024, 0L);
     PackingPlan.ContainerPlan container = new PackingPlan.ContainerPlan(id, null, resource);
-    containers.put(container.id, container);
+    containers.put(container.getId(), container);
   }
 
   @Test

--- a/heron/spi/src/java/com/twitter/heron/spi/packing/PackingPlanProtoSerializer.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/packing/PackingPlanProtoSerializer.java
@@ -34,10 +34,10 @@ public class PackingPlanProtoSerializer {
 
   private PackingPlans.ContainerPlan.Builder builder(PackingPlan.ContainerPlan containerPlan) {
     PackingPlans.ContainerPlan.Builder builder = PackingPlans.ContainerPlan.newBuilder()
-        .setId(containerPlan.id)
-        .setResource(builder(containerPlan.resource));
+        .setId(containerPlan.getId())
+        .setResource(builder(containerPlan.getResource()));
 
-    for (PackingPlan.InstancePlan instancePlan : containerPlan.instances.values()) {
+    for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
       builder.addInstancePlans(builder(instancePlan));
     }
 
@@ -46,9 +46,9 @@ public class PackingPlanProtoSerializer {
 
   private PackingPlans.InstancePlan.Builder builder(PackingPlan.InstancePlan instancePlan) {
     return PackingPlans.InstancePlan.newBuilder()
-        .setId(instancePlan.id)
-        .setComponentName(instancePlan.componentName)
-        .setResource(builder(instancePlan.resource));
+        .setId(instancePlan.getId())
+        .setComponentName(instancePlan.getComponentName())
+        .setResource(builder(instancePlan.getResource()));
   }
 
   private PackingPlans.Resource.Builder builder(Resource resource) {

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/SchedulerUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/SchedulerUtils.java
@@ -435,8 +435,8 @@ public final class SchedulerUtils {
   public static Resource getMaxRequiredResource(PackingPlan packingPlan) {
     Resource maxResource = new Resource(0, 0, 0);
 
-    for (PackingPlan.ContainerPlan entry : packingPlan.containers.values()) {
-      Resource resource = entry.resource;
+    for (PackingPlan.ContainerPlan entry : packingPlan.getContainers().values()) {
+      Resource resource = entry.getResource();
       maxResource.ram = Math.max(maxResource.ram, resource.ram);
       maxResource.cpu = Math.max(maxResource.cpu, resource.cpu);
       maxResource.disk = Math.max(maxResource.disk, resource.disk);


### PR DESCRIPTION
Addresses issues 1 in #1323: favor immutability.

Changes model objects in `heron/spi/src/java/com/twitter/heron/spi/packing/PackingPlan.java` to be immutable.