### PR TITLE
Change PackingPlan models to use Sets instead of Maps

### DIFF
--- a/heron/common/src/java/com/twitter/heron/common/utils/logging/ErrorReportLoggingHandler.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/logging/ErrorReportLoggingHandler.java
@@ -85,7 +85,7 @@ public class ErrorReportLoggingHandler extends Handler {
         exceptionDataBuilder.setCount(exceptionDataBuilder.getCount() + 1);
         exceptionDataBuilder.setLasttime(new Date().toString());
         exceptionDataBuilder.setStacktrace(trace);
-        exceptionDataBuilder.setLogging("" + record.getMessage());
+        exceptionDataBuilder.setLogging(record.getMessage());
       }
     }
   }

--- a/heron/packing/src/java/com/twitter/heron/packing/NullPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/NullPacking.java
@@ -14,7 +14,7 @@
 
 package com.twitter.heron.packing;
 
-import java.util.HashMap;
+import java.util.HashSet;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.spi.common.Config;
@@ -32,7 +32,7 @@ public class NullPacking implements IPacking {
   public PackingPlan pack() {
     return new PackingPlan(
         "",
-        new HashMap<String, PackingPlan.ContainerPlan>(),
+        new HashSet<PackingPlan.ContainerPlan>(),
         new Resource(0.0, 0L, 0L));
   }
 

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
@@ -105,7 +105,7 @@ public class ResourceCompliantRRPacking implements IPacking {
   protected int numAdjustments;
 
   public static String getContainerId(int index) {
-    return "" + index;
+    return Integer.toString(index);
   }
 
   public static String getInstanceId(

--- a/heron/packing/tests/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPackingTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPackingTest.java
@@ -239,7 +239,7 @@ public class FirstFitDecreasingPackingTest {
         packingPlanExplicitResourcesConfig.getResource().disk);
 
     for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitResourcesConfig.getContainers().values()) {
+        : packingPlanExplicitResourcesConfig.getContainers()) {
       Assert.assertEquals(Math.round(totalInstances * instanceCpuDefault
               + (DEFAULT_CONTAINER_PADDING / 100.0 * totalInstances * instanceCpuDefault)),
           (long) containerPlan.getResource().cpu);
@@ -255,7 +255,7 @@ public class FirstFitDecreasingPackingTest {
       // All instances' resource requirement should be equal
       // So the size of set should be 1
       Set<Resource> resources = new HashSet<>();
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
         resources.add(instancePlan.getResource());
       }
 
@@ -317,9 +317,9 @@ public class FirstFitDecreasingPackingTest {
 
     // Ram for bolt should be the value in component ram map
     for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitRamMap.getContainers().values()) {
+        : packingPlanExplicitRamMap.getContainers()) {
       Assert.assertNotEquals(maxContainerRam, containerPlan.getResource().ram);
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
         if (instancePlan.getComponentName().equals(BOLT_NAME)) {
           Assert.assertEquals(boltRam, instancePlan.getResource().ram);
         }
@@ -381,8 +381,8 @@ public class FirstFitDecreasingPackingTest {
 
     // Ram for bolt/spout should be the value in component ram map
     for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitRamMap.getContainers().values()) {
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+        : packingPlanExplicitRamMap.getContainers()) {
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
         if (instancePlan.getComponentName().equals(BOLT_NAME)) {
           Assert.assertEquals(boltRam, instancePlan.getResource().ram);
         }
@@ -442,8 +442,8 @@ public class FirstFitDecreasingPackingTest {
         packingPlanExplicitRamMap.getResource().disk);
 
     for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitRamMap.getContainers().values()) {
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+        : packingPlanExplicitRamMap.getContainers()) {
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
         // Ram for bolt should be the value in component ram map
         if (instancePlan.getComponentName().equals(BOLT_NAME)) {
           Assert.assertEquals(boltRam, instancePlan.getResource().ram);
@@ -505,8 +505,8 @@ public class FirstFitDecreasingPackingTest {
         packingPlanExplicitRamMap.getResource().disk);
 
     for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitRamMap.getContainers().values()) {
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+        : packingPlanExplicitRamMap.getContainers()) {
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
         // Ram for bolt should be the value in component ram map
         if (instancePlan.getComponentName().equals(BOLT_NAME)) {
           Assert.assertEquals(boltRam, instancePlan.getResource().ram);

--- a/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPackingTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPackingTest.java
@@ -44,9 +44,9 @@ public class ResourceCompliantRRPackingTest {
   private double instanceCpuDefault;
   private long instanceDiskDefault;
 
-  private int countComponent(String component, Map<String, PackingPlan.InstancePlan> instances) {
+  private int countComponent(String component, Set<PackingPlan.InstancePlan> instances) {
     int count = 0;
-    for (PackingPlan.InstancePlan pair : instances.values()) {
+    for (PackingPlan.InstancePlan pair : instances) {
       if (component.equals(RoundRobinPacking.getComponentName(pair.getId()))) {
         count++;
       }
@@ -251,7 +251,7 @@ public class ResourceCompliantRRPackingTest {
         packingPlanExplicitResourcesConfig.getResource().disk);
 
     for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitResourcesConfig.getContainers().values()) {
+        : packingPlanExplicitResourcesConfig.getContainers()) {
       Assert.assertEquals(Math.round(totalInstances * instanceCpuDefault
               + (DEFAULT_CONTAINER_PADDING / 100.0) * totalInstances * instanceCpuDefault),
           (long) containerPlan.getResource().cpu);
@@ -267,7 +267,7 @@ public class ResourceCompliantRRPackingTest {
       // All instances' resource requirement should be equal
       // So the size of set should be 1
       Set<Resource> resources = new HashSet<>();
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
         resources.add(instancePlan.getResource());
       }
 
@@ -328,8 +328,8 @@ public class ResourceCompliantRRPackingTest {
 
     // Ram for bolt/spout should be the value in component ram map
     for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitResourcesConfig.getContainers().values()) {
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+        : packingPlanExplicitResourcesConfig.getContainers()) {
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
         Assert.assertEquals(instanceRamDefault, instancePlan.getResource().ram);
       }
     }
@@ -365,10 +365,10 @@ public class ResourceCompliantRRPackingTest {
 
     // Ram for bolt should be the value in component ram map
     for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitRamMap.getContainers().values()) {
+        : packingPlanExplicitRamMap.getContainers()) {
       // The containerRam should be ignored, since we set the complete component ram map
       Assert.assertNotEquals(containerRam, containerPlan.getResource().ram);
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
         if (instancePlan.getComponentName().equals(BOLT_NAME)) {
           Assert.assertEquals(boltRam, instancePlan.getResource().ram);
         }
@@ -410,9 +410,9 @@ public class ResourceCompliantRRPackingTest {
 
     // Ram for bolt should be the value in component ram map
     for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitRamMap.getContainers().values()) {
+        : packingPlanExplicitRamMap.getContainers()) {
       Assert.assertNotEquals(containerRam, containerPlan.getResource().ram);
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
         if (instancePlan.getComponentName().equals(BOLT_NAME)) {
           Assert.assertEquals(boltRam, instancePlan.getResource().ram);
         }
@@ -537,7 +537,7 @@ public class ResourceCompliantRRPackingTest {
     PackingPlan output = getResourceCompliantRRPackingPlan(topology);
     Assert.assertEquals(numContainers, output.getContainers().size());
 
-    for (PackingPlan.ContainerPlan container : output.getContainers().values()) {
+    for (PackingPlan.ContainerPlan container : output.getContainers()) {
       Assert.assertEquals(numInstance / numContainers, container.getInstances().size());
       Assert.assertEquals(
           2, countComponent("spout", container.getInstances()));

--- a/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/RoundRobinPackingTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/RoundRobinPackingTest.java
@@ -37,9 +37,9 @@ public class RoundRobinPackingTest {
   private static final String SPOUT_NAME = "spout";
   private static final double DELTA = 0.1;
 
-  private int countCompoment(String component, Map<String, PackingPlan.InstancePlan> instances) {
+  private int countCompoment(String component, Set<PackingPlan.InstancePlan> instances) {
     int count = 0;
-    for (PackingPlan.InstancePlan pair : instances.values()) {
+    for (PackingPlan.InstancePlan pair : instances) {
       if (component.equals(RoundRobinPacking.getComponentName(pair.getId()))) {
         count++;
       }
@@ -182,7 +182,7 @@ public class RoundRobinPackingTest {
         packingPlanExplicitResourcesConfig.getContainers().size());
 
     for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitResourcesConfig.getContainers().values()) {
+        : packingPlanExplicitResourcesConfig.getContainers()) {
       Assert.assertEquals(containerCpu, containerPlan.getResource().cpu, DELTA);
 
       Assert.assertEquals((double) containerRam,
@@ -194,12 +194,12 @@ public class RoundRobinPackingTest {
       // All instances' resource requirement should be equal
       // So the size of set should be 1
       Set<Resource> resources = new HashSet<>();
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
         resources.add(instancePlan.getResource());
       }
 
       Assert.assertEquals(1, resources.size());
-      int instancesCount = containerPlan.getInstances().values().size();
+      int instancesCount = containerPlan.getInstances().size();
       Assert.assertEquals(
           (containerRam - RoundRobinPacking.DEFAULT_RAM_PADDING_PER_CONTAINER) / instancesCount,
           resources.iterator().next().ram);
@@ -238,10 +238,10 @@ public class RoundRobinPackingTest {
 
     // Ram for bolt should be the value in component ram map
     for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitRamMap.getContainers().values()) {
+        : packingPlanExplicitRamMap.getContainers()) {
       // The containerRam should be ignored, since we set the complete component ram map
       Assert.assertNotEquals(containerRam, containerPlan.getResource().ram);
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
         if (instancePlan.getComponentName().equals(BOLT_NAME)) {
           Assert.assertEquals(boltRam, instancePlan.getResource().ram);
         }
@@ -281,11 +281,11 @@ public class RoundRobinPackingTest {
 
     // Ram for bolt should be the value in component ram map
     for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitRamMap.getContainers().values()) {
+        : packingPlanExplicitRamMap.getContainers()) {
       Assert.assertEquals(containerRam, containerPlan.getResource().ram);
       int boltCount = 0;
       int instancesCount = containerPlan.getInstances().size();
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
         if (instancePlan.getComponentName().equals(BOLT_NAME)) {
           Assert.assertEquals(boltRam, instancePlan.getResource().ram);
           boltCount++;
@@ -295,7 +295,7 @@ public class RoundRobinPackingTest {
       // Ram for spout should be:
       // (containerRam - all ram for bolt - ram for padding) / (# of spouts)
       int spoutCount = instancesCount - boltCount;
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
         if (instancePlan.getComponentName().equals(SPOUT_NAME)) {
           Assert.assertEquals(
               (containerRam
@@ -328,7 +328,7 @@ public class RoundRobinPackingTest {
     PackingPlan output = getRoundRobinPackingPlan(topology);
     Assert.assertEquals(numContainers, output.getContainers().size());
 
-    for (PackingPlan.ContainerPlan container : output.getContainers().values()) {
+    for (PackingPlan.ContainerPlan container : output.getContainers()) {
       Assert.assertEquals(numInstance / numContainers, container.getInstances().size());
 
       // Verify each container got 2 spout and 2 bolt and container 1 got

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/LaunchRunnerTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/LaunchRunnerTest.java
@@ -14,7 +14,7 @@
 
 package com.twitter.heron.scheduler;
 
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -126,7 +126,7 @@ public class LaunchRunnerTest {
 
     PackingPlan packingPlan = Mockito.mock(PackingPlan.class);
     Mockito.when(packingPlan.getContainers()).thenReturn(
-        new HashMap<String, PackingPlan.ContainerPlan>());
+        new HashSet<PackingPlan.ContainerPlan>());
     Mockito.when(packingPlan.getComponentRamDistribution()).thenReturn("ramdist");
     Mockito.when(packingPlan.getId()).thenReturn("packing_plan_id");
     Mockito.when(packingPlan.getResource()).thenReturn(new Resource(0, 0, 0));

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/SchedulerMainTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/SchedulerMainTest.java
@@ -15,8 +15,9 @@
 package com.twitter.heron.scheduler;
 
 import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
 import java.util.Properties;
+import java.util.Set;
 
 import com.google.common.util.concurrent.SettableFuture;
 
@@ -120,11 +121,10 @@ public class SchedulerMainTest {
 
   // TODO reuse PackingTestUtils.createTestProtoPackingPlan once PR#1321 is merged
   private SettableFuture<PackingPlans.PackingPlan> getTestPacking() {
-    Map<String, PackingPlan.InstancePlan> instances = new HashMap<>();
-    instances.put("1:1:1:1",
-        new PackingPlan.InstancePlan("1:1:1:1", "dummy", new Resource(1, 1, 1)));
-    Map<String, PackingPlan.ContainerPlan> containers = new HashMap<>();
-    containers.put("1", new PackingPlan.ContainerPlan("1", instances, new Resource(1, 1, 1)));
+    Set<PackingPlan.InstancePlan> instances = new HashSet<>();
+    instances.add(new PackingPlan.InstancePlan("1:1:1:1", "dummy", new Resource(1, 1, 1)));
+    Set<PackingPlan.ContainerPlan> containers = new HashSet<>();
+    containers.add(new PackingPlan.ContainerPlan("1", instances, new Resource(1, 1, 1)));
     PackingPlan packingPlan = new PackingPlan("packing-id", containers, new Resource(1, 1, 1));
     final SettableFuture<PackingPlans.PackingPlan> future = SettableFuture.create();
     future.set(new PackingPlanProtoSerializer().toProto(packingPlan));

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraController.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraController.java
@@ -84,7 +84,7 @@ public class AuroraController {
     List<String> auroraCmd = new ArrayList<>(Arrays.asList("aurora", "job", "restart"));
     String jobSpec = String.format("%s/%s/%s/%s", cluster, role, env, jobName);
     if (containerId != -1) {
-      jobSpec = String.format("%s/%s", jobSpec, "" + containerId);
+      jobSpec = String.format("%s/%s", jobSpec, Integer.toString(containerId));
     }
     auroraCmd.add(jobSpec);
 
@@ -111,6 +111,6 @@ public class AuroraController {
     // Note that we can not use "--no-batching" since "restart" command does not accept it.
     // So we play a small trick here by setting batch size Integer.MAX_VALUE.
     auroraCmd.add("--batch-size");
-    auroraCmd.add("" + Integer.MAX_VALUE);
+    auroraCmd.add(Integer.toString(Integer.MAX_VALUE));
   }
 }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/mesos/MesosScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/mesos/MesosScheduler.java
@@ -250,7 +250,7 @@ public class MesosScheduler implements IScheduler {
     double cpu = 0;
     double disk = 0;
     double mem = 0;
-    for (PackingPlan.ContainerPlan cp : packing.getContainers().values()) {
+    for (PackingPlan.ContainerPlan cp : packing.getContainers()) {
       Resource containerResource = cp.getResource();
       cpu = Math.max(cpu, containerResource.cpu);
       disk = Math.max(disk, containerResource.disk);

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraControllerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraControllerTest.java
@@ -83,7 +83,7 @@ public class AuroraControllerTest {
     List<String> expectedCommand =
         new ArrayList<>(Arrays.asList("aurora", "job", "killall",
             String.format("%s/%s/%s/%s", CLUSTER, ROLE, ENV, JOB_NAME),
-            VERBOSE_CONFIG, BATCH_CONFIG, "" + Integer.MAX_VALUE));
+            VERBOSE_CONFIG, BATCH_CONFIG, Integer.toString(Integer.MAX_VALUE)));
 
     // Failed
     Mockito.doReturn(false).when(controller).runProcess(Matchers.anyListOf(String.class));
@@ -102,7 +102,7 @@ public class AuroraControllerTest {
     List<String> expectedCommand =
         new ArrayList<>(Arrays.asList("aurora", "job", "restart",
             String.format("%s/%s/%s/%s/%d", CLUSTER, ROLE, ENV, JOB_NAME, containerId),
-            VERBOSE_CONFIG, BATCH_CONFIG, "" + Integer.MAX_VALUE));
+            VERBOSE_CONFIG, BATCH_CONFIG, Integer.toString(Integer.MAX_VALUE)));
 
     // Failed
     Mockito.doReturn(false).when(controller).runProcess(Matchers.anyListOf(String.class));

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraSchedulerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraSchedulerTest.java
@@ -15,8 +15,9 @@
 package com.twitter.heron.scheduler.aurora;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -81,15 +82,15 @@ public class AuroraSchedulerTest {
     PackingPlan plan =
         new PackingPlan(
             PACKING_PLAN_ID,
-            new HashMap<String, PackingPlan.ContainerPlan>(),
+            new HashSet<PackingPlan.ContainerPlan>(),
             Mockito.mock(Resource.class));
     Assert.assertTrue(plan.getContainers().isEmpty());
     // Fail to schedule due to PackingPlan is empty
     Assert.assertFalse(scheduler.onSchedule(plan));
 
     // Construct valid PackingPlan
-    Map<String, PackingPlan.ContainerPlan> containers = new HashMap<>();
-    containers.put(CONTAINER_ID, Mockito.mock(PackingPlan.ContainerPlan.class));
+    Set<PackingPlan.ContainerPlan> containers = new HashSet<>();
+    containers.add(Mockito.mock(PackingPlan.ContainerPlan.class));
     PackingPlan validPlan =
         new PackingPlan(PACKING_PLAN_ID, containers, Mockito.mock(Resource.class));
 

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/marathon/MarathonSchedulerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/marathon/MarathonSchedulerTest.java
@@ -14,9 +14,9 @@
 
 package com.twitter.heron.scheduler.marathon;
 
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -76,14 +76,14 @@ public class MarathonSchedulerTest {
     PackingPlan pplan  =
         new PackingPlan(
             PACKING_PLAN_ID,
-            new HashMap<String, PackingPlan.ContainerPlan>(),
+            new HashSet<PackingPlan.ContainerPlan>(),
             Mockito.mock(Resource.class));
     Assert.assertTrue(pplan.getContainers().isEmpty());
     // Fail to schedule due to PackingPlan is empty
     Assert.assertFalse(scheduler.onSchedule(pplan));
 
-    Map<String, PackingPlan.ContainerPlan> containers = new HashMap<>();
-    containers.put(CONTAINER_ID, Mockito.mock(PackingPlan.ContainerPlan.class));
+    Set<PackingPlan.ContainerPlan> containers = new HashSet<>();
+    containers.add(Mockito.mock(PackingPlan.ContainerPlan.class));
     PackingPlan validPlan =
         new PackingPlan(PACKING_PLAN_ID, containers, Mockito.mock(Resource.class));
 

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/mesos/MesosSchedulerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/mesos/MesosSchedulerTest.java
@@ -15,8 +15,10 @@
 package com.twitter.heron.scheduler.mesos;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import org.apache.mesos.SchedulerDriver;
 import org.junit.After;
@@ -126,11 +128,11 @@ public class MesosSchedulerTest {
     Resource containerResources = new Resource(CPU, MEM, DISK);
     PackingPlan.ContainerPlan containerPlan =
         new PackingPlan.ContainerPlan(
-            "id", new HashMap<String, PackingPlan.InstancePlan>(), containerResources);
+            "id", new HashSet<PackingPlan.InstancePlan>(), containerResources);
 
-    Map<String, PackingPlan.ContainerPlan> map = new HashMap<>();
-    map.put("id", containerPlan);
-    PackingPlan packingPlan = new PackingPlan(TOPOLOGY_NAME, map, containerResources);
+    Set<PackingPlan.ContainerPlan> containerPlans = new HashSet<>();
+    containerPlans.add(containerPlan);
+    PackingPlan packingPlan = new PackingPlan(TOPOLOGY_NAME, containerPlans, containerResources);
 
 
     BaseContainer container = scheduler.getBaseContainer(0, packingPlan);

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/slurm/SlurmLauncherTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/slurm/SlurmLauncherTest.java
@@ -15,7 +15,7 @@
 package com.twitter.heron.scheduler.slurm;
 
 
-import java.util.HashMap;
+import java.util.HashSet;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -62,7 +62,7 @@ public class SlurmLauncherTest {
     PackingPlan plan =
         new PackingPlan(
             "plan.id",
-            new HashMap<String, PackingPlan.ContainerPlan>(),
+            new HashSet<PackingPlan.ContainerPlan>(),
             Mockito.mock(Resource.class));
 
     PowerMockito.spy(SlurmContext.class);

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/slurm/SlurmSchedulerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/slurm/SlurmSchedulerTest.java
@@ -14,8 +14,8 @@
 
 package com.twitter.heron.scheduler.slurm;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -108,15 +108,15 @@ public class SlurmSchedulerTest {
     PackingPlan plan =
         new PackingPlan(
             PACKING_PLAN_ID,
-            new HashMap<String, PackingPlan.ContainerPlan>(),
+            new HashSet<PackingPlan.ContainerPlan>(),
             Mockito.mock(Resource.class));
     Assert.assertTrue(plan.getContainers().isEmpty());
     // Fail to schedule due to PackingPlan is empty
     Assert.assertFalse(scheduler.onSchedule(plan));
 
     // Construct valid PackingPlan
-    Map<String, PackingPlan.ContainerPlan> containers = new HashMap<>();
-    containers.put(CONTAINER_ID, Mockito.mock(PackingPlan.ContainerPlan.class));
+    Set<PackingPlan.ContainerPlan> containers = new HashSet<>();
+    containers.add(Mockito.mock(PackingPlan.ContainerPlan.class));
     PackingPlan validPlan =
         new PackingPlan(PACKING_PLAN_ID, containers, Mockito.mock(Resource.class));
 

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/DriverOnLocalReefTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/DriverOnLocalReefTest.java
@@ -15,8 +15,8 @@
 package com.twitter.heron.scheduler.yarn;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -101,10 +101,10 @@ public class DriverOnLocalReefTest {
     private void addContainer(String id,
                               double cpu,
                               long mem,
-                              Map<String, PackingPlan.ContainerPlan> containers) {
+                              Set<PackingPlan.ContainerPlan> containers) {
       Resource resource = new Resource(cpu, mem * 1024 * 1024, 0L);
       PackingPlan.ContainerPlan container = new PackingPlan.ContainerPlan(id, null, resource);
-      containers.put(container.getId(), container);
+      containers.add(container);
     }
 
     class DriverStarter implements EventHandler<StartTime> {
@@ -112,7 +112,7 @@ public class DriverOnLocalReefTest {
       public void onNext(StartTime startTime) {
         counter = new CountDownLatch(2);
         driver.scheduleTMasterContainer();
-        Map<String, PackingPlan.ContainerPlan> containers = new HashMap<>();
+        Set<PackingPlan.ContainerPlan> containers = new HashSet<>();
         addContainer("1", 1.0, 512L, containers);
         PackingPlan packing = new PackingPlan("packingId", containers, null);
         driver.scheduleHeronWorkers(packing);

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/HeronMasterDriverTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/HeronMasterDriverTest.java
@@ -15,8 +15,8 @@
 package com.twitter.heron.scheduler.yarn;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
@@ -84,7 +84,7 @@ public class HeronMasterDriverTest {
     Mockito.doReturn(mockConfig).when(spyDriver).createContextConfig("1");
     Mockito.doReturn(mockConfig).when(spyDriver).createContextConfig("2");
 
-    Map<String, PackingPlan.ContainerPlan> containers = new HashMap<>();
+    Set<PackingPlan.ContainerPlan> containers = new HashSet<>();
     addContainer("1", 2.0, 2048L, containers);
     addContainer("2", 4.0, 2050L, containers);
 
@@ -97,10 +97,11 @@ public class HeronMasterDriverTest {
   private void addContainer(String id,
                             double cpu,
                             long mem,
-                            Map<String, PackingPlan.ContainerPlan> containers) {
+                            Set<PackingPlan.ContainerPlan> containers) {
     Resource resource = new Resource(cpu, mem * 1024 * 1024, 0L);
-    PackingPlan.ContainerPlan container = new PackingPlan.ContainerPlan(id, null, resource);
-    containers.put(container.getId(), container);
+    PackingPlan.ContainerPlan container
+        = new PackingPlan.ContainerPlan(id, new HashSet<PackingPlan.InstancePlan>(), resource);
+    containers.add(container);
   }
 
   @Test
@@ -206,9 +207,9 @@ public class HeronMasterDriverTest {
     Mockito.when(mockWorkerEvaluator.getId()).thenReturn("worker");
     Mockito.doReturn(mockWorkerEvaluator).when(spyDriver).allocateContainer("1", 1, 1024);
 
-    Map<String, PackingPlan.ContainerPlan> containers = new HashMap<>();
+    Set<PackingPlan.ContainerPlan> containers = new HashSet<>();
     addContainer("1", 1.0, 1024L, containers);
-    PackingPlan packing = new PackingPlan("packingId", containers, null);
+    PackingPlan packing = new PackingPlan("packingId", containers, new Resource(1.5, 2, 3));
     spyDriver.scheduleHeronWorkers(packing);
     Mockito.verify(mockWorkerEvaluator, Mockito.timeout(1000).times(1))
         .submitContext(Mockito.any(Configuration.class));

--- a/heron/spi/src/java/BUILD
+++ b/heron/spi/src/java/BUILD
@@ -74,7 +74,8 @@ packing_deps_files = [
     "//heron/api/src/java:classification",
     "//heron/common/src/java:config-java",
     "//heron/proto:proto_packing_plan_java",
-    "//heron/proto:proto_topology_java"
+    "//heron/proto:proto_topology_java",
+    "@com_google_guava_guava//jar",
 ]
 
 uploader_deps_files = [

--- a/heron/spi/src/java/com/twitter/heron/spi/packing/PackingPlan.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/packing/PackingPlan.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
 
 public class PackingPlan {
   private final String id;
@@ -28,7 +29,7 @@ public class PackingPlan {
 
   public PackingPlan(String id, Set<ContainerPlan> containers, Resource resource) {
     this.id = id;
-    this.containers = containers;
+    this.containers = ImmutableSet.copyOf(containers);
     this.resource = resource;
     containersMap = new HashMap<>();
     for (ContainerPlan containerPlan : containers) {
@@ -223,7 +224,7 @@ public class PackingPlan {
 
     public ContainerPlan(String id, Set<InstancePlan> instances, Resource resource) {
       this.id = id;
-      this.instances = instances;
+      this.instances = ImmutableSet.copyOf(instances);
       this.resource = resource;
     }
 

--- a/heron/spi/src/java/com/twitter/heron/spi/packing/PackingPlanProtoDeserializer.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/packing/PackingPlanProtoDeserializer.java
@@ -13,8 +13,8 @@
 // limitations under the License.
 package com.twitter.heron.spi.packing;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 
 import com.twitter.heron.proto.system.PackingPlans;
 
@@ -24,9 +24,9 @@ import com.twitter.heron.proto.system.PackingPlans;
 public class PackingPlanProtoDeserializer {
 
   public PackingPlan fromProto(PackingPlans.PackingPlan packingPlan) {
-    Map<String, PackingPlan.ContainerPlan> containers = new HashMap<>();
+    Set<PackingPlan.ContainerPlan> containers = new HashSet<>();
     for (PackingPlans.ContainerPlan containerPlan : packingPlan.getContainerPlansList()) {
-      containers.put(containerPlan.getId(), convert(containerPlan));
+      containers.add(convert(containerPlan));
     }
 
     return new PackingPlan(
@@ -36,9 +36,9 @@ public class PackingPlanProtoDeserializer {
   }
 
   private PackingPlan.ContainerPlan convert(PackingPlans.ContainerPlan containerPlan) {
-    Map<String, PackingPlan.InstancePlan> instances = new HashMap<>();
+    Set<PackingPlan.InstancePlan> instances = new HashSet<>();
     for (PackingPlans.InstancePlan instancePlan : containerPlan.getInstancePlansList()) {
-      instances.put(instancePlan.getId(), convert(instancePlan));
+      instances.add(convert(instancePlan));
     }
 
     return new PackingPlan.ContainerPlan(

--- a/heron/spi/src/java/com/twitter/heron/spi/packing/PackingPlanProtoSerializer.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/packing/PackingPlanProtoSerializer.java
@@ -25,7 +25,7 @@ public class PackingPlanProtoSerializer {
         .setId(packingPlan.getId())
         .setResource(builder(packingPlan.getResource()));
 
-    for (PackingPlan.ContainerPlan containerPlan : packingPlan.getContainers().values()) {
+    for (PackingPlan.ContainerPlan containerPlan : packingPlan.getContainers()) {
       builder.addContainerPlans(builder(containerPlan));
     }
 
@@ -37,7 +37,7 @@ public class PackingPlanProtoSerializer {
         .setId(containerPlan.getId())
         .setResource(builder(containerPlan.getResource()));
 
-    for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances().values()) {
+    for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
       builder.addInstancePlans(builder(instancePlan));
     }
 

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/SchedulerUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/SchedulerUtils.java
@@ -435,8 +435,8 @@ public final class SchedulerUtils {
   public static Resource getMaxRequiredResource(PackingPlan packingPlan) {
     Resource maxResource = new Resource(0, 0, 0);
 
-    for (PackingPlan.ContainerPlan entry : packingPlan.getContainers().values()) {
-      Resource resource = entry.getResource();
+    for (PackingPlan.ContainerPlan containerPlan : packingPlan.getContainers()) {
+      Resource resource = containerPlan.getResource();
       maxResource.ram = Math.max(maxResource.ram, resource.ram);
       maxResource.cpu = Math.max(maxResource.cpu, resource.cpu);
       maxResource.disk = Math.max(maxResource.disk, resource.disk);

--- a/heron/spi/tests/java/com/twitter/heron/spi/packing/PackingPlanTest.java
+++ b/heron/spi/tests/java/com/twitter/heron/spi/packing/PackingPlanTest.java
@@ -16,8 +16,10 @@ package com.twitter.heron.spi.packing;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -29,13 +31,13 @@ public class PackingPlanTest {
     Resource resource =
         new Resource(1.0, 1 * Constants.GB, 10 * Constants.GB);
 
-    Map<String, PackingPlan.ContainerPlan> containerPlanMap = new HashMap<>();
+    Set<PackingPlan.ContainerPlan> containerPlans = new HashSet<>();
 
     for (Map.Entry<String, List<String>> entry : basePacking.entrySet()) {
       String containerId = entry.getKey();
       List<String> instanceList = entry.getValue();
 
-      Map<String, PackingPlan.InstancePlan> instancePlanMap = new HashMap<>();
+      Set<PackingPlan.InstancePlan> instancePlans = new HashSet<>();
 
       for (String instanceId : instanceList) {
         String componentName = instanceId.split(":")[1];
@@ -47,16 +49,16 @@ public class PackingPlanTest {
         }
         PackingPlan.InstancePlan instancePlan =
             new PackingPlan.InstancePlan(instanceId, componentName, instanceResource);
-        instancePlanMap.put(instanceId, instancePlan);
+        instancePlans.add(instancePlan);
       }
 
       PackingPlan.ContainerPlan containerPlan =
-          new PackingPlan.ContainerPlan(containerId, instancePlanMap, resource);
+          new PackingPlan.ContainerPlan(containerId, instancePlans, resource);
 
-      containerPlanMap.put(containerId, containerPlan);
+      containerPlans.add(containerPlan);
     }
 
-    return new PackingPlan("", containerPlanMap, resource);
+    return new PackingPlan("", containerPlans, resource);
   }
 
   @Test

--- a/heron/spi/tests/java/com/twitter/heron/spi/utils/LauncherUtilsTest.java
+++ b/heron/spi/tests/java/com/twitter/heron/spi/utils/LauncherUtilsTest.java
@@ -14,8 +14,8 @@
 
 package com.twitter.heron.spi.utils;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -67,14 +67,14 @@ public class LauncherUtilsTest {
     Assert.assertNull(Runtime.instanceDistribution(runtime));
     Assert.assertNull(Runtime.componentRamMap(runtime));
 
-    Map<String, PackingPlan.ContainerPlan> containerMap = new HashMap<>();
-    containerMap.put("1", null);
-    containerMap.put("2", null);
+    Set<PackingPlan.ContainerPlan> containers = new HashSet<>();
+    containers.add(Mockito.mock(PackingPlan.ContainerPlan.class));
+    containers.add(Mockito.mock(PackingPlan.ContainerPlan.class));
 
     PackingPlan mockPacking = Mockito.mock(PackingPlan.class);
     Mockito.when(mockPacking.getInstanceDistribution()).thenReturn("instances");
     Mockito.when(mockPacking.getComponentRamDistribution()).thenReturn("ramMap");
-    Mockito.when(mockPacking.getContainers()).thenReturn(containerMap);
+    Mockito.when(mockPacking.getContainers()).thenReturn(containers);
 
     Config newRuntime = LauncherUtils.getInstance()
         .createConfigWithPackingDetails(runtime, mockPacking);

--- a/heron/spi/tests/java/com/twitter/heron/spi/utils/NetworkUtilsTest.java
+++ b/heron/spi/tests/java/com/twitter/heron/spi/utils/NetworkUtilsTest.java
@@ -92,7 +92,7 @@ public class NetworkUtilsTest {
 
     HttpExchange exchange = Mockito.mock(HttpExchange.class);
     Headers headers = Mockito.mock(Headers.class);
-    Mockito.doReturn("" + expectedBytes.length).
+    Mockito.doReturn(Integer.toString(expectedBytes.length)).
         when(headers).getFirst(Matchers.anyString());
 
     Mockito.doReturn(headers).when(exchange).getRequestHeaders();


### PR DESCRIPTION
Using Maps in this API adds unnecessary friction without benefit. This clean-up is the second half of #1323.

See `heron/spi/src/java/com/twitter/heron/spi/packing/PackingPlan.java` for the key changes. The rest of the classes are just updated to reflect the `PackingPlan` API change.