### PR TITLE
DO NOT MERGE Convert container id type to int from String

### DIFF
--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -421,7 +421,7 @@ class HeronExecutor(object):
     """
     this_container_plan = None
     for container_plan in packing_plan.container_plans:
-      if container_plan.id == str(container_id):
+      if container_plan.id == container_id:
         this_container_plan = container_plan
 
     # make sure that our shard id is a valid one

--- a/heron/executor/tests/python/heron_executor_unittest.py
+++ b/heron/executor/tests/python/heron_executor_unittest.py
@@ -72,7 +72,7 @@ class HeronExecutorTest(unittest.TestCase):
     packing_plan = PackingPlan()
     for container_id in instance_distribution.keys():
       container_plan = packing_plan.container_plans.add()
-      container_plan.id = str(container_id)
+      container_plan.id = int(container_id)
       for (component_name, global_task_id, component_index) in instance_distribution[container_id]:
         instance_plan = container_plan.instance_plans.add()
         instance_plan.id = "%s:%s:%s:%s" %\

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
@@ -104,10 +104,6 @@ public class ResourceCompliantRRPacking implements IPacking {
   protected int numContainers;
   protected int numAdjustments;
 
-  public static String getContainerId(int index) {
-    return Integer.toString(index);
-  }
-
   public static String getInstanceId(
       int containerIdx, String componentName, int instanceIdx, int componentIdx) {
     return String.format("%d:%s:%d:%d", containerIdx, componentName, instanceIdx, componentIdx);
@@ -149,8 +145,7 @@ public class ResourceCompliantRRPacking implements IPacking {
   public PackingPlan pack() {
     int adjustments = this.numAdjustments;
     // Get the instances using a resource compliant round robin allocation
-    Map<String, List<String>> resourceCompliantRRAllocation
-        = getResourceCompliantRRAllocation();
+    Map<Integer, List<String>> resourceCompliantRRAllocation = getResourceCompliantRRAllocation();
 
     while (resourceCompliantRRAllocation == null) {
       if (this.numAdjustments > adjustments) {
@@ -173,9 +168,9 @@ public class ResourceCompliantRRPacking implements IPacking {
     long topologyDisk = 0;
     double topologyCpu = 0.0;
 
-    for (Map.Entry<String, List<String>> entry : resourceCompliantRRAllocation.entrySet()) {
+    for (Map.Entry<Integer, List<String>> entry : resourceCompliantRRAllocation.entrySet()) {
 
-      String containerId = entry.getKey();
+      int containerId = entry.getKey();
       List<String> instanceList = entry.getValue();
 
       long containerRam = 0;
@@ -283,9 +278,9 @@ public class ResourceCompliantRRPacking implements IPacking {
    *
    * @return Map &lt; containerId, list of InstanceId belonging to this container &gt;
    */
-  protected Map<String, List<String>> getResourceCompliantRRAllocation() {
+  protected Map<Integer, List<String>> getResourceCompliantRRAllocation() {
 
-    Map<String, List<String>> allocation = new HashMap<>();
+    Map<Integer, List<String>> allocation = new HashMap<>();
     ArrayList<Container> containers = new ArrayList<>();
     ArrayList<RamRequirement> ramRequirements = getRAMInstances();
 
@@ -297,7 +292,7 @@ public class ResourceCompliantRRPacking implements IPacking {
     }
 
     for (int i = 1; i <= numContainers; ++i) {
-      allocation.put(getContainerId(i), new ArrayList<String>());
+      allocation.put(i, new ArrayList<String>());
     }
     for (int i = 0; i <= numContainers - 1; i++) {
       allocateNewContainer(containers);
@@ -313,7 +308,7 @@ public class ResourceCompliantRRPacking implements IPacking {
       for (int i = 0; i < numInstance; ++i) {
         if (placeResourceCompliantRRInstance(containers, containerId,
             ramRequirement, instanceCpuDefault, instanceDiskDefault)) {
-          allocation.get(getContainerId(containerId))
+          allocation.get(containerId)
               .add(getInstanceId(containerId, component, globalTaskIndex, i));
         } else {
           List<TopologyAPI.Config.KeyValue> topologyConfig

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
@@ -100,10 +100,10 @@ public class RoundRobinPacking implements IPacking {
   @Override
   public PackingPlan pack() {
     // Get the instances' round-robin allocation
-    Map<String, List<String>> roundRobinAllocation = getRoundRobinAllocation();
+    Map<Integer, List<String>> roundRobinAllocation = getRoundRobinAllocation();
 
     // Get the ram map for every instance
-    Map<String, Map<String, Long>> instancesRamMap =
+    Map<Integer, Map<String, Long>> instancesRamMap =
         getInstancesRamMapInContainer(roundRobinAllocation);
 
     long containerDiskInBytes = getContainerDiskHint(roundRobinAllocation);
@@ -112,8 +112,8 @@ public class RoundRobinPacking implements IPacking {
     // Construct the PackingPlan
     Set<PackingPlan.ContainerPlan> containerPlans = new HashSet<>();
     long topologyRam = 0;
-    for (Map.Entry<String, List<String>> entry : roundRobinAllocation.entrySet()) {
-      String containerId = entry.getKey();
+    for (Map.Entry<Integer, List<String>> entry : roundRobinAllocation.entrySet()) {
+      int containerId = entry.getKey();
       List<String> instanceList = entry.getValue();
 
       // Calculate the resource required for single instance
@@ -177,15 +177,14 @@ public class RoundRobinPacking implements IPacking {
    * @param allocation the allocation of instances in different container
    * @return A map: (containerId -&gt; (instanceId -&gt; instanceRequiredRam))
    */
-  protected Map<String, Map<String, Long>> getInstancesRamMapInContainer(
-      Map<String, List<String>> allocation) {
-    Map<String, Long> ramMap =
-        TopologyUtils.getComponentRamMapConfig(topology);
+  protected Map<Integer, Map<String, Long>> getInstancesRamMapInContainer(
+      Map<Integer, List<String>> allocation) {
+    Map<String, Long> ramMap = TopologyUtils.getComponentRamMapConfig(topology);
 
-    Map<String, Map<String, Long>> instancesRamMapInContainer = new HashMap<>();
+    Map<Integer, Map<String, Long>> instancesRamMapInContainer = new HashMap<>();
 
-    for (Map.Entry<String, List<String>> entry : allocation.entrySet()) {
-      String containerId = entry.getKey();
+    for (Map.Entry<Integer, List<String>> entry : allocation.entrySet()) {
+      int containerId = entry.getKey();
       Map<String, Long> ramInsideContainer = new HashMap<>();
       instancesRamMapInContainer.put(containerId, ramInsideContainer);
       List<String> instancesToBeAccounted = new ArrayList<>();
@@ -239,8 +238,8 @@ public class RoundRobinPacking implements IPacking {
    *
    * @return containerId -&gt; list of InstanceId belonging to this container
    */
-  protected Map<String, List<String>> getRoundRobinAllocation() {
-    Map<String, List<String>> allocation = new HashMap<>();
+  protected Map<Integer, List<String>> getRoundRobinAllocation() {
+    Map<Integer, List<String>> allocation = new HashMap<>();
     int numContainer = TopologyUtils.getNumContainers(topology);
     int totalInstance = TopologyUtils.getTotalInstance(topology);
     if (numContainer > totalInstance) {
@@ -248,7 +247,7 @@ public class RoundRobinPacking implements IPacking {
     }
 
     for (int i = 1; i <= numContainer; ++i) {
-      allocation.put(getContainerId(i), new ArrayList<String>());
+      allocation.put(i, new ArrayList<String>());
     }
 
     int index = 1;
@@ -257,10 +256,7 @@ public class RoundRobinPacking implements IPacking {
     for (String component : parallelismMap.keySet()) {
       int numInstance = parallelismMap.get(component);
       for (int i = 0; i < numInstance; ++i) {
-        allocation.
-            get(getContainerId(index)).
-            add(getInstanceId(index, component, globalTaskIndex, i));
-
+        allocation.get(index).add(getInstanceId(index, component, globalTaskIndex, i));
         index = (index == numContainer) ? 1 : index + 1;
         globalTaskIndex++;
       }
@@ -274,7 +270,7 @@ public class RoundRobinPacking implements IPacking {
    * @param allocation the instances' allocation
    * @return # of instances in the largest container
    */
-  protected int getLargestContainerSize(Map<String, List<String>> allocation) {
+  protected int getLargestContainerSize(Map<Integer, List<String>> allocation) {
     int max = 0;
     for (List<String> instances : allocation.values()) {
       if (instances.size() > max) {
@@ -290,7 +286,7 @@ public class RoundRobinPacking implements IPacking {
    * @param allocation packing output.
    * @return cpu per container.
    */
-  protected double getContainerCpuHint(Map<String, List<String>> allocation) {
+  protected double getContainerCpuHint(Map<Integer, List<String>> allocation) {
     List<TopologyAPI.Config.KeyValue> topologyConfig = topology.getTopologyConfig().getKvsList();
     double defaultContainerCpu =
         DEFAULT_CPU_PADDING_PER_CONTAINER + getLargestContainerSize(allocation);
@@ -308,7 +304,7 @@ public class RoundRobinPacking implements IPacking {
    * @param allocation packing output.
    * @return disk per container.
    */
-  protected long getContainerDiskHint(Map<String, List<String>> allocation) {
+  protected long getContainerDiskHint(Map<Integer, List<String>> allocation) {
     long defaultContainerDisk =
         instanceDiskDefault * getLargestContainerSize(allocation)
             + DEFAULT_DISK_PADDING_PER_CONTAINER;
@@ -328,7 +324,7 @@ public class RoundRobinPacking implements IPacking {
    * @param allocation packing
    * @return Container ram requirement
    */
-  public long getContainerRamHint(Map<String, List<String>> allocation) {
+  public long getContainerRamHint(Map<Integer, List<String>> allocation) {
     List<TopologyAPI.Config.KeyValue> topologyConfig = topology.getTopologyConfig().getKvsList();
 
     String ramHint = TopologyUtils.getConfigWithDefault(
@@ -360,11 +356,6 @@ public class RoundRobinPacking implements IPacking {
     }
 
     return true;
-  }
-
-
-  public static String getContainerId(int index) {
-    return Integer.toString(index);
   }
 
   public static String getInstanceId(

--- a/heron/proto/packing_plan.proto
+++ b/heron/proto/packing_plan.proto
@@ -19,7 +19,7 @@ message InstancePlan {
 }
 
 message ContainerPlan {
-  required string id = 1;
+  required int32 id = 1;
   repeated InstancePlan instance_plans = 2;
   required Resource resource = 3;
 }

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/SchedulerMainTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/SchedulerMainTest.java
@@ -124,7 +124,7 @@ public class SchedulerMainTest {
     Set<PackingPlan.InstancePlan> instances = new HashSet<>();
     instances.add(new PackingPlan.InstancePlan("1:1:1:1", "dummy", new Resource(1, 1, 1)));
     Set<PackingPlan.ContainerPlan> containers = new HashSet<>();
-    containers.add(new PackingPlan.ContainerPlan("1", instances, new Resource(1, 1, 1)));
+    containers.add(new PackingPlan.ContainerPlan(1, instances, new Resource(1, 1, 1)));
     PackingPlan packingPlan = new PackingPlan("packing-id", containers, new Resource(1, 1, 1));
     final SettableFuture<PackingPlans.PackingPlan> future = SettableFuture.create();
     future.set(new PackingPlanProtoSerializer().toProto(packingPlan));

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/HeronConfigurationOptions.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/HeronConfigurationOptions.java
@@ -59,7 +59,7 @@ public class HeronConfigurationOptions {
   }
 
   @NamedParameter(doc = "Heron Executors Id, 0 = TM, 1 <= worker", default_value = "0")
-  public class HeronExecutorId implements Name<String> {
+  public class HeronExecutorId implements Name<Integer> {
   }
 
   @NamedParameter(doc = "verbose logs", default_value = "false")

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/HeronTaskConfiguration.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/HeronTaskConfiguration.java
@@ -42,7 +42,7 @@ public class HeronTaskConfiguration extends ConfigurationModuleBuilder {
   public static final RequiredParameter<String> ENV = new RequiredParameter<>();
   public static final RequiredParameter<String> PACKED_PLAN = new RequiredParameter<>();
   public static final RequiredParameter<String> COMPONENT_RAM_MAP = new RequiredParameter<>();
-  public static final RequiredParameter<String> CONTAINER_ID = new RequiredParameter<>();
+  public static final RequiredParameter<Integer> CONTAINER_ID = new RequiredParameter<>();
   public static final OptionalParameter<Boolean> VERBOSE = new OptionalParameter<>();
 
   public static final ConfigurationModule CONF = new HeronTaskConfiguration()

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/YarnScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/YarnScheduler.java
@@ -73,7 +73,7 @@ public class YarnScheduler implements IScheduler {
       if (containerId == -1) {
         HeronMasterDriverProvider.getInstance().restartTopology();
       } else {
-        HeronMasterDriverProvider.getInstance().restartWorker(String.valueOf(containerId));
+        HeronMasterDriverProvider.getInstance().restartWorker(containerId);
       }
       return true;
     } catch (HeronMasterDriver.ContainerAllocationException e) {

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/mesos/MesosSchedulerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/mesos/MesosSchedulerTest.java
@@ -128,7 +128,7 @@ public class MesosSchedulerTest {
     Resource containerResources = new Resource(CPU, MEM, DISK);
     PackingPlan.ContainerPlan containerPlan =
         new PackingPlan.ContainerPlan(
-            "id", new HashSet<PackingPlan.InstancePlan>(), containerResources);
+            0, new HashSet<PackingPlan.InstancePlan>(), containerResources);
 
     Set<PackingPlan.ContainerPlan> containerPlans = new HashSet<>();
     containerPlans.add(containerPlan);

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/DriverOnLocalReefTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/DriverOnLocalReefTest.java
@@ -98,7 +98,7 @@ public class DriverOnLocalReefTest {
       driver = new HeronMasterDriver(requestor, null, "", "", "", "", null, null, null, 0, false);
     }
 
-    private void addContainer(String id,
+    private void addContainer(int id,
                               double cpu,
                               long mem,
                               Set<PackingPlan.ContainerPlan> containers) {
@@ -114,7 +114,7 @@ public class DriverOnLocalReefTest {
           counter = new CountDownLatch(2);
           driver.scheduleTMasterContainer();
           Set<PackingPlan.ContainerPlan> containers = new HashSet<>();
-          addContainer("1", 1.0, 512L, containers);
+          addContainer(1, 1.0, 512L, containers);
           PackingPlan packing = new PackingPlan("packingId", containers, null);
           driver.scheduleHeronWorkers(packing);
           counter.await(1, TimeUnit.SECONDS);

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/HeronMasterDriverTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/HeronMasterDriverTest.java
@@ -62,10 +62,10 @@ public class HeronMasterDriverTest {
   public void requestsEvaluatorForTMaster() throws Exception {
     AllocatedEvaluator mockEvaluator = Mockito.mock(AllocatedEvaluator.class);
     Mockito.when(mockEvaluator.getId()).thenReturn("testEvaluatorId");
-    Mockito.doReturn(mockEvaluator).when(spyDriver).allocateContainer("0", 1, 1024);
+    Mockito.doReturn(mockEvaluator).when(spyDriver).allocateContainer(0, 1, 1024);
 
     Configuration mockConfig = Mockito.mock(Configuration.class);
-    Mockito.doReturn(mockConfig).when(spyDriver).createContextConfig("0");
+    Mockito.doReturn(mockConfig).when(spyDriver).createContextConfig(0);
 
     spyDriver.scheduleTMasterContainer();
     Mockito.verify(mockEvaluator, Mockito.timeout(1000).times(1)).submitContext(mockConfig);
@@ -75,19 +75,19 @@ public class HeronMasterDriverTest {
   public void requestsEvaluatorsForWorkers() throws Exception {
     AllocatedEvaluator mockEvaluator1 = Mockito.mock(AllocatedEvaluator.class);
     Mockito.when(mockEvaluator1.getId()).thenReturn("testEvaluatorId1");
-    Mockito.doReturn(mockEvaluator1).when(spyDriver).allocateContainer("1", 2, 2048);
+    Mockito.doReturn(mockEvaluator1).when(spyDriver).allocateContainer(1, 2, 2048);
 
     AllocatedEvaluator mockEvaluator2 = Mockito.mock(AllocatedEvaluator.class);
     Mockito.when(mockEvaluator2.getId()).thenReturn("testEvaluatorId2");
-    Mockito.doReturn(mockEvaluator2).when(spyDriver).allocateContainer("2", 4, 2050);
+    Mockito.doReturn(mockEvaluator2).when(spyDriver).allocateContainer(2, 4, 2050);
 
     Configuration mockConfig = Mockito.mock(Configuration.class);
-    Mockito.doReturn(mockConfig).when(spyDriver).createContextConfig("1");
-    Mockito.doReturn(mockConfig).when(spyDriver).createContextConfig("2");
+    Mockito.doReturn(mockConfig).when(spyDriver).createContextConfig(1);
+    Mockito.doReturn(mockConfig).when(spyDriver).createContextConfig(2);
 
     Set<PackingPlan.ContainerPlan> containers = new HashSet<>();
-    addContainer("1", 2.0, 2048L, containers);
-    addContainer("2", 4.0, 2050L, containers);
+    addContainer(1, 2.0, 2048L, containers);
+    addContainer(2, 4.0, 2050L, containers);
 
     PackingPlan packing = new PackingPlan("packingId", containers, null);
     spyDriver.scheduleHeronWorkers(packing);
@@ -95,7 +95,7 @@ public class HeronMasterDriverTest {
     Mockito.verify(mockEvaluator2, Mockito.timeout(1000).times(1)).submitContext(mockConfig);
   }
 
-  private void addContainer(String id,
+  private void addContainer(int id,
                             double cpu,
                             long mem,
                             Set<PackingPlan.ContainerPlan> containers) {
@@ -132,8 +132,8 @@ public class HeronMasterDriverTest {
     for (int id = 0; id < numContainers; id++) {
       AllocatedEvaluator mockEvaluator = Mockito.mock(AllocatedEvaluator.class);
       Mockito.when(mockEvaluator.getId()).thenReturn("container-" + id);
-      Mockito.doReturn(mockEvaluator).when(spyDriver).allocateContainer("" + id, id + 1, id + 1);
-      spyDriver.launchContainerForExecutor("" + id, id + 1, id + 1);
+      Mockito.doReturn(mockEvaluator).when(spyDriver).allocateContainer(id, id + 1, id + 1);
+      spyDriver.launchContainerForExecutor(id, id + 1, id + 1);
       Mockito.verify(mockEvaluator, Mockito.timeout(1000).times(1))
           .submitContext(Mockito.any(Configuration.class));
       mockEvaluators[id] = mockEvaluator;
@@ -158,14 +158,14 @@ public class HeronMasterDriverTest {
     for (int id = 0; id < numContainers; id++) {
       AllocatedEvaluator mockEvaluator = Mockito.mock(AllocatedEvaluator.class);
       Mockito.when(mockEvaluator.getId()).thenReturn("container-" + id);
-      Mockito.doReturn(mockEvaluator).when(spyDriver).allocateContainer("" + id, id + 1, id + 1);
-      spyDriver.launchContainerForExecutor("" + id, id + 1, id + 1);
+      Mockito.doReturn(mockEvaluator).when(spyDriver).allocateContainer(id, id + 1, id + 1);
+      spyDriver.launchContainerForExecutor(id, id + 1, id + 1);
       Mockito.verify(mockEvaluator, Mockito.timeout(1000).times(1))
           .submitContext(Mockito.any(Configuration.class));
       mockEvaluators[id] = mockEvaluator;
     }
 
-    spyDriver.restartWorker("1");
+    spyDriver.restartWorker(1);
 
     Mockito.verify(mockEvaluators[1]).close();
     Mockito.verify(mockEvaluators[1], Mockito.timeout(1000).times(2))
@@ -178,7 +178,7 @@ public class HeronMasterDriverTest {
   public void handlesFailedTMasterContainer() throws Exception {
     AllocatedEvaluator mockTMasterEvaluator = Mockito.mock(AllocatedEvaluator.class);
     Mockito.when(mockTMasterEvaluator.getId()).thenReturn("tMaster");
-    Mockito.doReturn(mockTMasterEvaluator).when(spyDriver).allocateContainer("0", 1, 1024);
+    Mockito.doReturn(mockTMasterEvaluator).when(spyDriver).allocateContainer(0, 1, 1024);
 
     spyDriver.scheduleTMasterContainer();
     Mockito.verify(mockTMasterEvaluator, Mockito.timeout(1000).times(1))
@@ -188,17 +188,17 @@ public class HeronMasterDriverTest {
     Mockito.when(mockFailedContainer.getId()).thenReturn("tMaster");
     spyDriver.new FailedContainerHandler().onNext(mockFailedContainer);
 
-    Mockito.verify(spyDriver, Mockito.timeout(1000).times(2)).allocateContainer("0", 1, 1024);
+    Mockito.verify(spyDriver, Mockito.timeout(1000).times(2)).allocateContainer(0, 1, 1024);
   }
 
   @Test
   public void handlesFailedWorkerContainer() throws Exception {
     AllocatedEvaluator mockWorkerEvaluator = Mockito.mock(AllocatedEvaluator.class);
     Mockito.when(mockWorkerEvaluator.getId()).thenReturn("worker");
-    Mockito.doReturn(mockWorkerEvaluator).when(spyDriver).allocateContainer("1", 1, 1024);
+    Mockito.doReturn(mockWorkerEvaluator).when(spyDriver).allocateContainer(1, 1, 1024);
 
     Set<PackingPlan.ContainerPlan> containers = new HashSet<>();
-    addContainer("1", 1.0, 1024L, containers);
+    addContainer(1, 1.0, 1024L, containers);
     PackingPlan packing = new PackingPlan("packingId", containers, new Resource(1.5, 2, 3));
     spyDriver.scheduleHeronWorkers(packing);
     Mockito.verify(mockWorkerEvaluator, Mockito.timeout(1000).times(1))
@@ -208,12 +208,12 @@ public class HeronMasterDriverTest {
     Mockito.when(mockFailedContainer.getId()).thenReturn("worker");
     spyDriver.new FailedContainerHandler().onNext(mockFailedContainer);
 
-    Mockito.verify(spyDriver, Mockito.timeout(1000).times(2)).allocateContainer("1", 1, 1024);
+    Mockito.verify(spyDriver, Mockito.timeout(1000).times(2)).allocateContainer(1, 1, 1024);
   }
 
   @Test
   public void createsContextConfigForExecutorId() {
-    Configuration config = driver.createContextConfig("4");
+    Configuration config = driver.createContextConfig(4);
     boolean found = false;
     for (NamedParameterNode<?> namedParameterNode : config.getNamedParameters()) {
       if (namedParameterNode.getName().equals(ContextIdentifier.class.getSimpleName())) {
@@ -233,7 +233,7 @@ public class HeronMasterDriverTest {
     Mockito.when(mockEvaluator.getId()).thenReturn("testEvaluatorId");
     spyDriver.new ContainerAllocationHandler().onNext(mockEvaluator);
 
-    AllocatedEvaluator evaluator = spyDriver.allocateContainer("5", 7, 234);
+    AllocatedEvaluator evaluator = spyDriver.allocateContainer(5, 7, 234);
     Mockito.verify(mockRequestor).submit(evaluatorRequest);
     Assert.assertEquals(evaluator, mockEvaluator);
   }

--- a/heron/spi/src/java/com/twitter/heron/spi/packing/PackingPlan.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/packing/PackingPlan.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableSet;
 
 public class PackingPlan {
   private final String id;
-  private final Map<String, ContainerPlan> containersMap;
+  private final Map<Integer, ContainerPlan> containersMap;
   private final Set<ContainerPlan> containers;
   private final Resource resource;
 
@@ -49,7 +49,7 @@ public class PackingPlan {
     return containers;
   }
 
-  public Optional<ContainerPlan> getContainer(String containerId) {
+  public Optional<ContainerPlan> getContainer(int containerId) {
     return Optional.fromNullable(this.containersMap.get(containerId));
   }
 
@@ -86,7 +86,7 @@ public class PackingPlan {
   public String getInstanceDistribution() {
     StringBuilder[] containerBuilder = new StringBuilder[this.getContainers().size()];
     for (PackingPlan.ContainerPlan container : this.getContainers()) {
-      int index = Integer.parseInt(container.id);
+      int index = container.id;
       containerBuilder[index - 1] = new StringBuilder();
 
       for (PackingPlan.InstancePlan instance : container.getInstances()) {
@@ -218,17 +218,17 @@ public class PackingPlan {
   }
 
   public static class ContainerPlan {
-    private final String id;
+    private final int id;
     private final Set<InstancePlan> instances;
     private final Resource resource;
 
-    public ContainerPlan(String id, Set<InstancePlan> instances, Resource resource) {
+    public ContainerPlan(int id, Set<InstancePlan> instances, Resource resource) {
       this.id = id;
       this.instances = ImmutableSet.copyOf(instances);
       this.resource = resource;
     }
 
-    public String getId() {
+    public int getId() {
       return id;
     }
 
@@ -251,14 +251,14 @@ public class PackingPlan {
 
       ContainerPlan that = (ContainerPlan) o;
 
-      return id.equals(that.id)
+      return id == that.id
           && getInstances().equals(that.getInstances())
           && getResource().equals(that.getResource());
     }
 
     @Override
     public int hashCode() {
-      int result = id.hashCode();
+      int result = id;
       result = 31 * result + getInstances().hashCode();
       result = 31 * result + getResource().hashCode();
       return result;

--- a/heron/spi/tests/java/com/twitter/heron/spi/packing/PackingPlanTest.java
+++ b/heron/spi/tests/java/com/twitter/heron/spi/packing/PackingPlanTest.java
@@ -27,14 +27,14 @@ import org.junit.Test;
 import com.twitter.heron.spi.common.Constants;
 
 public class PackingPlanTest {
-  private static PackingPlan generatePacking(Map<String, List<String>> basePacking) {
+  private static PackingPlan generatePacking(Map<Integer, List<String>> basePacking) {
     Resource resource =
         new Resource(1.0, 1 * Constants.GB, 10 * Constants.GB);
 
     Set<PackingPlan.ContainerPlan> containerPlans = new HashSet<>();
 
-    for (Map.Entry<String, List<String>> entry : basePacking.entrySet()) {
-      String containerId = entry.getKey();
+    for (Map.Entry<Integer, List<String>> entry : basePacking.entrySet()) {
+      int containerId = entry.getKey();
       List<String> instanceList = entry.getValue();
 
       Set<PackingPlan.InstancePlan> instancePlans = new HashSet<>();
@@ -63,8 +63,8 @@ public class PackingPlanTest {
 
   @Test
   public void testPackingToString() {
-    Map<String, List<String>> packing = new HashMap<>();
-    packing.put("1", Arrays.asList("1:spout:1:0", "1:bolt:3:0"));
+    Map<Integer, List<String>> packing = new HashMap<>();
+    packing.put(1, Arrays.asList("1:spout:1:0", "1:bolt:3:0"));
     String expectedStr0 = "1:spout:1:0:bolt:3:0";
     String expectedStr1 = "1:bolt:3:0:spout:1:0";
 
@@ -73,7 +73,7 @@ public class PackingPlanTest {
 
     Assert.assertTrue(packingStr.equals(expectedStr0) || packingStr.equals(expectedStr1));
 
-    packing.put("2", Arrays.asList("2:spout:2:1"));
+    packing.put(2, Arrays.asList("2:spout:2:1"));
     packingPlan = generatePacking(packing);
     packingStr = packingPlan.getInstanceDistribution();
 
@@ -97,9 +97,9 @@ public class PackingPlanTest {
 
   @Test
   public void testPackingPlanSerde() {
-    Map<String, List<String>> packing = new HashMap<>();
-    packing.put("1", Arrays.asList("1:spout:1:0", "1:bolt:3:0"));
-    packing.put("2", Arrays.asList("2:spout:2:1"));
+    Map<Integer, List<String>> packing = new HashMap<>();
+    packing.put(1, Arrays.asList("1:spout:1:0", "1:bolt:3:0"));
+    packing.put(2, Arrays.asList("2:spout:2:1"));
     PackingPlan packingPlan = generatePacking(packing);
 
     PackingPlanProtoSerializer serializer = new PackingPlanProtoSerializer();


### PR DESCRIPTION
Fixes #1295 
Container Id is declared as of type String. The value of id is always an int.
The users always assume id to be an int and the code is sprinkled with
int-to-string-to-int conversion. This update fixes it.