### PR TITLE
Improve TMaster return message when metrics is not available

### DIFF
--- a/heron/tmaster/src/cpp/manager/stats-interface.h
+++ b/heron/tmaster/src/cpp/manager/stats-interface.h
@@ -21,15 +21,17 @@
 #include "proto/tmaster.pb.h"
 #include "basics/basics.h"
 
+
 namespace heron {
 namespace tmaster {
 
 class TMetricsCollector;
+class TMaster;
 
 class StatsInterface {
  public:
   StatsInterface(EventLoop* eventLoop, const NetworkOptions& options,
-                 TMetricsCollector* _collector);
+                 TMetricsCollector* _collector, TMaster* tmaster);
   virtual ~StatsInterface();
 
  private:
@@ -40,6 +42,7 @@ class StatsInterface {
 
   HTTPServer* http_server_;  // Our http server
   TMetricsCollector* metrics_collector_;
+  TMaster* tmaster_;
 };
 }  // namespace tmaster
 }  // namespace heron

--- a/heron/tmaster/src/cpp/manager/stats-interface.h
+++ b/heron/tmaster/src/cpp/manager/stats-interface.h
@@ -21,7 +21,6 @@
 #include "proto/tmaster.pb.h"
 #include "basics/basics.h"
 
-
 namespace heron {
 namespace tmaster {
 

--- a/heron/tmaster/src/cpp/manager/tmaster.cpp
+++ b/heron/tmaster/src/cpp/manager/tmaster.cpp
@@ -315,7 +315,7 @@ void TMaster::GetPhysicalPlanDone(proto::system::PhysicalPlan* _pplan,
                                         ->GetHeronTmasterNetworkStatsOptionsMaximumPacketMb() *
                                     1024 * 1024);
   stats_options.set_socket_family(PF_INET);
-  stats_ = new StatsInterface(eventLoop_, stats_options, metrics_collector_);
+  stats_ = new StatsInterface(eventLoop_, stats_options, metrics_collector_, this);
 }
 
 void TMaster::ActivateTopology(VCallback<proto::system::StatusCode> cb) {

--- a/heron/tmaster/src/cpp/manager/tmaster.h
+++ b/heron/tmaster/src/cpp/manager/tmaster.h
@@ -67,6 +67,7 @@ class TMaster {
   // TODO(mfu): Should we provide this?
   // topology_ should only be used to construct physical plan when TMaster first starts
   // Providing an accessor is bug prone.
+  // Now used in GetMetrics function in tmetrics-collector
   const proto::api::Topology* getInitialTopology() const { return topology_; }
 
  private:

--- a/heron/tmaster/src/cpp/manager/tmetrics-collector.cpp
+++ b/heron/tmaster/src/cpp/manager/tmetrics-collector.cpp
@@ -122,10 +122,11 @@ MetricResponse* TMetricsCollector::GetMetrics(const MetricRequest& _request,
       }
     }
     if (component_exists) {
-      LOG(WARNING) << "Metrics for " << _request.component_name() << " are not available";
+      LOG(WARNING) << "Metrics for component `" << _request.component_name()
+                                                << "` are not available";
       response->mutable_status()->set_status(proto::system::NOTOK);
-      response->mutable_status()->set_message("Metrics not available for component: " + \
-                                              _request.component_name());
+      response->mutable_status()->set_message("Metrics not available for component `" + \
+                                              _request.component_name() + "`");
     } else {
       LOG(ERROR) << "GetMetrics request received for unknown component "
                  << _request.component_name();
@@ -134,7 +135,7 @@ MetricResponse* TMetricsCollector::GetMetrics(const MetricRequest& _request,
     }
 
   } else if (!_request.has_interval() && !_request.has_explicit_interval()) {
-    LOG(ERROR) << "GetMetrics request does not have either interval "
+    LOG(ERROR) << "GetMetrics request does not have either interval"
                << " nor explicit interval";
     response->mutable_status()->set_status(proto::system::NOTOK);
     response->mutable_status()->set_message("No interval or explicit interval set");

--- a/heron/tmaster/src/cpp/manager/tmetrics-collector.cpp
+++ b/heron/tmaster/src/cpp/manager/tmetrics-collector.cpp
@@ -122,7 +122,7 @@ MetricResponse* TMetricsCollector::GetMetrics(const MetricRequest& _request,
       }
     }
     if (component_exists) {
-      LOG(WARNING) << "Metrics for " << _request.component_name() << " is not available";
+      LOG(WARNING) << "Metrics for " << _request.component_name() << " are not available";
       response->mutable_status()->set_status(proto::system::NOTOK);
       response->mutable_status()->set_message("Metrics not available for component: " + \
                                               _request.component_name());

--- a/heron/tmaster/src/cpp/manager/tmetrics-collector.cpp
+++ b/heron/tmaster/src/cpp/manager/tmetrics-collector.cpp
@@ -97,7 +97,6 @@ void TMetricsCollector::AddExceptionsForComponent(const sp_string& component_nam
 void TMetricsCollector::AddMetric(const PublishMetrics& _metrics) {
   for (sp_int32 i = 0; i < _metrics.metrics_size(); ++i) {
     const sp_string& component_name = _metrics.metrics(i).component_name();
-    LOG(INFO) << "Add metrics for component " << component_name << std::endl;
     AddMetricsForComponent(component_name, _metrics.metrics(i));
   }
   for (int i = 0; i < _metrics.exceptions_size(); i++) {

--- a/heron/tmaster/src/cpp/manager/tmetrics-collector.cpp
+++ b/heron/tmaster/src/cpp/manager/tmetrics-collector.cpp
@@ -114,11 +114,15 @@ MetricResponse* TMetricsCollector::GetMetrics(const MetricRequest& _request,
     for (int i = 0; i < _topology->spouts_size(); i++) {
       if ((_topology->spouts(i)).comp().name() == _request.component_name()) {
         component_exists = true;
+        break;
       }
     }
-    for (int i = 0; i < _topology->bolts_size(); i++) {
-      if ((_topology->bolts(i)).comp().name() == _request.component_name()) {
-        component_exists = true;
+    if (!component_exists) {
+      for (int i = 0; i < _topology->bolts_size(); i++) {
+        if ((_topology->bolts(i)).comp().name() == _request.component_name()) {
+          component_exists = true;
+          break;
+        }
       }
     }
     if (component_exists) {

--- a/heron/tmaster/src/cpp/manager/tmetrics-collector.h
+++ b/heron/tmaster/src/cpp/manager/tmetrics-collector.h
@@ -24,6 +24,7 @@
 #include "basics/sptypes.h"
 #include "network/event_loop.h"
 #include "proto/tmaster.pb.h"
+#include "proto/topology.pb.h"
 #include "metrics/tmaster-metrics.h"
 
 namespace heron {
@@ -46,7 +47,8 @@ class TMetricsCollector {
 
   // Returns a new response to fetch metrics. The request gets propagated to Component's and
   // Instance's get metrics. Doesn't own Response.
-  proto::tmaster::MetricResponse* GetMetrics(const proto::tmaster::MetricRequest& _request);
+  proto::tmaster::MetricResponse* GetMetrics(const proto::tmaster::MetricRequest& _request,
+                                             const proto::api::Topology* _topology);
 
   // Returns response for fetching exceptions. Doesn't own response.
   proto::tmaster::ExceptionLogResponse* GetExceptions(

--- a/heron/tools/tracker/src/python/handlers/metricshandler.py
+++ b/heron/tools/tracker/src/python/handlers/metricshandler.py
@@ -145,7 +145,7 @@ class MetricsHandler(BaseHandler):
 
     if metricResponse.status.status == common_pb2.NOTOK:
       if metricResponse.status.HasField("message"):
-        Log.warn(metricResponse.status.message)
+        Log.warn("Received response from Tmaster: %s", metricResponse.status.message)
 
     # Form the response.
     ret = {}

--- a/heron/tools/tracker/src/python/handlers/metricshandler.py
+++ b/heron/tools/tracker/src/python/handlers/metricshandler.py
@@ -145,7 +145,7 @@ class MetricsHandler(BaseHandler):
 
     if metricResponse.status.status == common_pb2.NOTOK:
       if metricResponse.status.HasField("message"):
-        Log.error(metricResponse.status.message)
+        Log.warn(metricResponse.status.message)
 
     # Form the response.
     ret = {}

--- a/heron/tools/tracker/src/python/metricstimeline.py
+++ b/heron/tools/tracker/src/python/metricstimeline.py
@@ -110,7 +110,7 @@ def getMetricsTimeline(tmaster,
 
   if metricResponse.status.status == common_pb2.NOTOK:
     if metricResponse.status.HasField("message"):
-      Log.warn(metricResponse.status.message)
+      Log.warn("Received response from Tmaster: %s", metricResponse.status.message)
 
   # Form the response.
   ret = {}

--- a/heron/tools/tracker/src/python/metricstimeline.py
+++ b/heron/tools/tracker/src/python/metricstimeline.py
@@ -110,7 +110,7 @@ def getMetricsTimeline(tmaster,
 
   if metricResponse.status.status == common_pb2.NOTOK:
     if metricResponse.status.HasField("message"):
-      Log.error(metricResponse.status.message)
+      Log.warn(metricResponse.status.message)
 
   # Form the response.
   ret = {}


### PR DESCRIPTION
In `GetMetrics` function, if there is no metrics associated with a component, we will now check if the component actually exists in the topology. If it exists in the topology, we know that the metrics is not yet available. We can then return a more proper error message.

resolves #1322 

cc @kramasamy @cckellogg @billonahill 