### PR TITLE
Use executor id as int type in the YARN scheduler

### DIFF
--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/HeronExecutorTask.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/HeronExecutorTask.java
@@ -75,7 +75,7 @@ public class HeronExecutorTask implements Task {
 
   @Inject
   public HeronExecutorTask(final REEFFileNames fileNames,
-                           @Parameter(HeronExecutorId.class) String heronExecutorId,
+                           @Parameter(HeronExecutorId.class) int heronExecutorId,
                            @Parameter(Cluster.class) String cluster,
                            @Parameter(Role.class) String role,
                            @Parameter(TopologyName.class) String topologyName,
@@ -86,7 +86,7 @@ public class HeronExecutorTask implements Task {
                            @Parameter(PackedPlan.class) String packedPlan,
                            @Parameter(ComponentRamMap.class) String componentRamMap,
                            @Parameter(VerboseLogMode.class) boolean verboseMode) {
-    this.heronExecutorId = Integer.valueOf(heronExecutorId);
+    this.heronExecutorId = heronExecutorId;
     this.cluster = cluster;
     this.role = role;
     this.topologyName = topologyName;

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/HeronExecutorTaskTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/yarn/HeronExecutorTaskTest.java
@@ -108,7 +108,7 @@ public class HeronExecutorTaskTest {
 
   private HeronExecutorTask getSpyOnHeronExecutorTask(REEFFileNames mockFiles) {
     HeronExecutorTask task = new HeronExecutorTask(mockFiles,
-        "5",
+        5,
         "cluster",
         "role",
         "testTopology",


### PR DESCRIPTION
These fixes the YARN scheduler and is related to container id type conversion, see #1295 and #1329.