### PR TITLE
Add new python config loader class for state manager

### DIFF
--- a/heron/executor/src/python/BUILD
+++ b/heron/executor/src/python/BUILD
@@ -6,7 +6,7 @@ pex_library(
     name = "executor-py",
     srcs = ["heron_executor.py"],
     deps = [
-        "//heron/statemgrs/src/python:zk-statemgr-py",
+        "//heron/statemgrs/src/python:statemgr-py",
         "//heron/common/src/python:common-log-py",
     ],
     reqs = ["pyyaml==3.10"],

--- a/heron/statemgrs/src/python/BUILD
+++ b/heron/statemgrs/src/python/BUILD
@@ -3,7 +3,7 @@ package(default_visibility = ["//visibility:public"])
 load("/tools/rules/pex_rules", "pex_library")
 
 pex_library(
-  name = 'zk-statemgr-py',
+  name = 'statemgr-py',
   srcs = glob(['**/*.py']),
   deps = [
     '//heron/proto:proto-py',

--- a/heron/statemgrs/src/python/configloader.py
+++ b/heron/statemgrs/src/python/configloader.py
@@ -80,6 +80,7 @@ def __replace(config, wildcards, config_file):
   return config
 
 if __name__ == "__main__":
+  """ helper main method used to verify config files, intended for manual verification only """
   if len(sys.argv) > 1:
     locations = load_state_manager_locations('local', sys.argv[1])
   else:

--- a/heron/statemgrs/src/python/configloader.py
+++ b/heron/statemgrs/src/python/configloader.py
@@ -80,6 +80,7 @@ def __replace(config, wildcards, config_file):
   return config
 
 if __name__ == "__main__":
+  # pylint disable=pointless-string-statement
   """ helper main method used to verify config files, intended for manual verification only """
   if len(sys.argv) > 1:
     locations = load_state_manager_locations('local', sys.argv[1])

--- a/heron/statemgrs/src/python/configloader.py
+++ b/heron/statemgrs/src/python/configloader.py
@@ -70,8 +70,6 @@ def __replace(config, wildcards, config_file):
     original_value = config_value
     if isinstance(config_value, basestring):
       for token in wildcards:
-        print("config_value: %s, token: %s wildcard value: %s" %
-              (config_value, token, wildcards[token]))
         if wildcards[token]:
           config_value = config_value.replace(token, wildcards[token])
       found = re.findall(r'\${[A-Z_]+}', config_value)

--- a/heron/statemgrs/src/python/configloader.py
+++ b/heron/statemgrs/src/python/configloader.py
@@ -1,0 +1,89 @@
+# Copyright 2016 Twitter. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#!/usr/bin/env python2.7
+''' configloader.py '''
+
+import os
+import re
+import sys
+import yaml
+
+def load_state_manager_locations(cluster, state_manager_config_file='heron-conf/statemgr.yaml'):
+  """ Reads configs to determine which state manager to use and converts them to state manager
+  locations. Handles a subset of config wildcard substitution supported in the substitute method in
+  com.twitter.heron.spi.common.Misc.java"""
+  with open(state_manager_config_file, 'r') as stream:
+    config = yaml.load(stream)
+
+  home_dir = os.getenv('HOME')
+  wildcards = {
+      "~" : home_dir,
+      "${HOME}" : home_dir,
+      "${CLUSTER}" : cluster,
+  }
+  if os.getenv('JAVA_HOME'):
+    wildcards["${JAVA_HOME}"] = os.getenv('JAVA_HOME')
+
+  config = __replace(config, wildcards, state_manager_config_file)
+
+  # need to convert from the format in statemgr.yaml to the format that the python state managers
+  # takes. first, set reasonable defaults to local
+  state_manager_location = {
+      'type': 'file',
+      'name': 'local',
+      'tunnelhost': 'localhost',
+      'rootpath': '~/.herondata/repository/state/local',
+  }
+
+  # then map the statemgr.yaml config keys to the python state manager location
+  key_mappings = {
+      'heron.statemgr.connection.string': 'hostport',
+      'heron.statemgr.tunnel.host': 'tunnelhost',
+      'heron.statemgr.root.path': 'rootpath',
+  }
+  for config_key in key_mappings:
+    if config_key in config:
+      state_manager_location[key_mappings[config_key]] = config[config_key]
+
+  state_manager_class = config['heron.class.state.manager']
+  if state_manager_class == 'com.twitter.heron.statemgr.zookeeper.curator.CuratorStateManager':
+    state_manager_location['type'] = 'zookeeper'
+    state_manager_location['name'] = 'zk'
+
+  return [state_manager_location]
+
+def __replace(config, wildcards, config_file):
+  """For each kvp in config, do wildcard substitution on the values"""
+  for config_key in config:
+    config_value = config[config_key]
+    original_value = config_value
+    if isinstance(config_value, basestring):
+      for token in wildcards:
+        print("config_value: %s, token: %s wildcard value: %s" %
+              (config_value, token, wildcards[token]))
+        if wildcards[token]:
+          config_value = config_value.replace(token, wildcards[token])
+      found = re.findall(r'\${[A-Z_]+}', config_value)
+      if found:
+        raise ValueError("%s=%s in file %s contains unsupported or unset wildcard tokens: %s" %
+                         (config_key, original_value, config_file, ", ".join(found)))
+      config[config_key] = config_value
+  return config
+
+if __name__ == "__main__":
+  if len(sys.argv) > 1:
+    locations = load_state_manager_locations('local', sys.argv[1])
+  else:
+    locations = load_state_manager_locations('local')
+  print "locations: %s" % locations

--- a/heron/statemgrs/src/python/configloader.py
+++ b/heron/statemgrs/src/python/configloader.py
@@ -80,7 +80,7 @@ def __replace(config, wildcards, config_file):
   return config
 
 if __name__ == "__main__":
-  # pylint disable=pointless-string-statement
+  # pylint: disable=pointless-string-statement
   """ helper main method used to verify config files, intended for manual verification only """
   if len(sys.argv) > 1:
     locations = load_state_manager_locations('local', sys.argv[1])

--- a/heron/statemgrs/tests/python/BUILD
+++ b/heron/statemgrs/tests/python/BUILD
@@ -1,0 +1,15 @@
+load("/tools/rules/pex_rules", "pex_test")
+
+pex_test(
+    name = "statemanager_unittest",
+    srcs = ["configloader_unittest.py"],
+    deps = [
+        "//heron/statemgrs/src/python:statemgr-py",
+    ],
+    reqs = [
+        "py==1.4.27",
+        "pytest==2.6.4",
+        "unittest2==0.5.1",
+    ],
+    size = "small",
+)

--- a/heron/statemgrs/tests/python/configloader_unittest.py
+++ b/heron/statemgrs/tests/python/configloader_unittest.py
@@ -1,0 +1,96 @@
+# Copyright 2016 Twitter. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+'''heron executor unittest'''
+import os
+import unittest2 as unittest
+
+from heron.statemgrs.src.python import configloader
+
+class ConfigLoaderTest(unittest.TestCase):
+  """Unittest for ConfigLoader"""
+
+  def setUp(self):
+    os.environ['HOME'] = '/user/fake'
+
+    # Find the local working dir. For example, __file__ would be
+    # /tmp/_bazel_heron/randgen_dir/heron/heron/statemgrs/tests/python/configloader_unittest.py
+    self.heron_dir = '/'.join(__file__.split('/')[:-5])
+
+  def load_locations(self, cluster):
+    yaml_path = os.path.join(self.heron_dir,
+                             'heron/config/src/yaml/conf/%s/statemgr.yaml' % cluster)
+    return configloader.load_state_manager_locations(cluster, yaml_path)
+
+  def test_load_state_manager_locations_aurora(self):
+    self.assertEquals([{
+      'hostport': 'LOCALMODE',
+      'name': 'local',
+      'rootpath': '/vagrant/.herondata/repository/state/aurora',
+      'tunnelhost': 'localhost',
+      'type': 'file'
+    }], self.load_locations('aurora'))
+
+  def test_load_state_manager_locations_local(self):
+    self.assertEquals([{
+      'hostport': 'LOCALMODE',
+      'name': 'local',
+      'rootpath': '/user/fake/.herondata/repository/state/local',
+      'tunnelhost': 'localhost',
+      'type': 'file'
+    }], self.load_locations('local'))
+
+  def test_load_state_manager_locations_localzk(self):
+    self.assertEquals([{
+      'hostport': '127.0.0.1:2181',
+      'name': 'zk',
+      'rootpath': '/heron',
+      'tunnelhost': 'reachable.tunnel.host',
+      'type': 'zookeeper'
+    }], self.load_locations('localzk'))
+
+  def test_load_state_manager_locations_marathon(self):
+    self.assertEquals([{
+      'hostport': 'LOCALMODE',
+      'name': 'local',
+      'rootpath': '/user/fake/.herondata/repository/state/marathon',
+      'tunnelhost': 'localhost',
+      'type': 'file'
+    }], self.load_locations('marathon'))
+
+  def test_load_state_manager_locations_mesos(self):
+    self.assertEquals([{
+      'hostport': 'LOCALMODE',
+      'name': 'local',
+      'rootpath': '/user/fake/.herondata/repository/state/mesos',
+      'tunnelhost': 'localhost',
+      'type': 'file'
+    }], self.load_locations('mesos'))
+
+  def test_load_state_manager_locations_slurm(self):
+    self.assertEquals([{
+      'hostport': 'LOCALMODE',
+      'name': 'local',
+      'rootpath': '/user/fake/.herondata/repository/state/slurm',
+      'tunnelhost': 'localhost',
+      'type': 'file'
+    }], self.load_locations('slurm'))
+
+  def test_load_state_manager_locations_yarn(self):
+    self.assertEquals([{
+      'hostport': 'LOCALMODE',
+      'name': 'local',
+      'rootpath': '/user/fake/.herondata/repository/state/yarn',
+      'tunnelhost': 'localhost',
+      'type': 'file'
+    }], self.load_locations('yarn'))

--- a/heron/tools/explorer/src/python/BUILD
+++ b/heron/tools/explorer/src/python/BUILD
@@ -9,7 +9,7 @@ pex_library(
         "//heron/common/src/python:common-py",
         "//heron/tools/common/src/python:common-py",
         "//heron/tools/common/src/python:tracker-py",
-        "//heron/statemgrs/src/python:zk-statemgr-py",
+        "//heron/statemgrs/src/python:statemgr-py",
         "//heron/proto:proto-py",
     ],
     reqs = [

--- a/heron/tools/tracker/src/python/BUILD
+++ b/heron/tools/tracker/src/python/BUILD
@@ -11,7 +11,7 @@ pex_library(
     deps = [
         "//heron/common/src/python:common-py",
         "//heron/tools/common/src/python:common-py",
-        "//heron/statemgrs/src/python:zk-statemgr-py",
+        "//heron/statemgrs/src/python:statemgr-py",
         "//heron/proto:proto-py",
     ],
     reqs = [


### PR DESCRIPTION
Fixes #1343 by handling wildcard substitution in config values. Also creates a new configloader class to handle loading/transforming state manager configs. 

Also changes `//heron/statemgrs/src/python:zk-statemgr-py` to remove the `zk` part since this target also includes local state managers: `//heron/statemgrs/src/python:statemgr-py`.