### PR TITLE
Reduce duplicate packing code

### DIFF
--- a/heron/packing/src/java/com/twitter/heron/packing/Container.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/Container.java
@@ -15,6 +15,8 @@
 
 package com.twitter.heron.packing;
 
+import com.twitter.heron.spi.packing.Resource;
+
 /**
  * Class that describes a container used to place Heron Instances with specific memory, CpuCores and disk
  * requirements. Each container has limited ram, CpuCores and disk resources.
@@ -31,13 +33,13 @@ public class Container {
   private double maxCpuCores;
   private long maxDisk;
 
-  public Container(long maxRam, double maxCpuCores, long maxDisk) {
+  public Container(Resource resource) {
     this.usedRam = 0;
     this.usedCpuCores = 0;
     this.usedDisk = 0;
-    this.maxRam = maxRam;
-    this.maxCpuCores = maxCpuCores;
-    this.maxDisk = maxDisk;
+    this.maxRam = resource.getRam();
+    this.maxCpuCores = resource.getCpu();
+    this.maxDisk = resource.getDisk();
   }
 
   /**
@@ -45,14 +47,10 @@ public class Container {
    *
    * @return true if the container has space otherwise return false
    */
-  public boolean hasSpace(long ram, double cpuCores, long disk) {
-    if (usedRam + ram <= maxRam
+  private boolean hasSpace(long ram, double cpuCores, long disk) {
+    return usedRam + ram <= maxRam
         && usedCpuCores + cpuCores <= maxCpuCores
-        && usedDisk + disk <= maxDisk) {
-
-      return true;
-    }
-    return false;
+        && usedDisk + disk <= maxDisk;
   }
 
   /**
@@ -61,16 +59,14 @@ public class Container {
    *
    * @return true if the instance can be added to the container, false otherwise
    */
-  public boolean add(long ram, double cpuCores, long disk) {
-    if (this.hasSpace(ram, cpuCores, disk)) {
-      usedRam += ram;
-      usedCpuCores += cpuCores;
-      usedDisk += disk;
+  public boolean add(Resource resource) {
+    if (this.hasSpace(resource.getRam(), resource.getCpu(), resource.getDisk())) {
+      usedRam += resource.getRam();
+      usedCpuCores += resource.getCpu();
+      usedDisk += resource.getDisk();
       return true;
     } else {
       return false;
     }
   }
-
-
 }

--- a/heron/packing/src/java/com/twitter/heron/packing/PackingUtils.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/PackingUtils.java
@@ -1,0 +1,153 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.twitter.heron.packing;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import com.twitter.heron.spi.common.Constants;
+import com.twitter.heron.spi.packing.PackingPlan;
+import com.twitter.heron.spi.packing.Resource;
+
+/**
+ * Shared utilities for packing algorithms
+ */
+public final class PackingUtils {
+  private static final Logger LOG = Logger.getLogger(PackingUtils.class.getName());
+
+  private PackingUtils() {
+  }
+
+  /**
+   * Check whether the Instance has enough RAM and whether it can fit within the container limits.
+   *
+   * @param instanceResources The resources allocated to the instance
+   * @return true if the instance is valid, false otherwise
+   */
+  public static boolean isValidInstance(Resource instanceResources,
+                                        long minInstanceRam,
+                                        Resource maxContainerResources) {
+
+    if (instanceResources.getRam() < minInstanceRam) {
+      LOG.severe(String.format(
+          "Instance requires %d MB ram which is less than the minimum %d MB ram per instance",
+          instanceResources.getRam(), minInstanceRam / Constants.MB));
+      return false;
+    }
+
+    if (instanceResources.getRam() > maxContainerResources.getRam()) {
+      LOG.severe(String.format(
+          "This instance requires containers of at least %d MB ram. The current max container"
+              + "size is %d MB",
+          instanceResources.getRam(), maxContainerResources.getRam()));
+      return false;
+    }
+
+    if (instanceResources.getCpu() > maxContainerResources.getCpu()) {
+      LOG.severe(String.format(
+          "This instance requires containers with at least %s cpu cores. The current max container"
+              + "size is %s cores",
+          instanceResources.getCpu(), maxContainerResources.getCpu()));
+      return false;
+    }
+
+    if (instanceResources.getDisk() > maxContainerResources.getDisk()) {
+      LOG.severe(String.format(
+          "This instance requires containers of at least %d MB disk. The current max container"
+              + "size is %d MB",
+          instanceResources.getDisk(), maxContainerResources.getDisk()));
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Estimate the per instance and topology resources for the packing plan based on the ramMap,
+   * instance defaults and paddingPercentage.
+   *
+   * @return Set<PackingPlan.ContainerPlan> container plans
+   */
+  public static Set<PackingPlan.ContainerPlan> buildContainerPlans(
+      Map<Integer, List<String>> containerInstances,
+      Map<String, Long> ramMap,
+      Resource instanceDefaults,
+      double paddingPercentage) {
+    Set<PackingPlan.ContainerPlan> containerPlans = new HashSet<>();
+
+    for (Integer containerId : containerInstances.keySet()) {
+      List<String> instanceList = containerInstances.get(containerId);
+
+      long containerRam = 0;
+      long containerDiskInBytes = 0;
+      double containerCpu = 0;
+
+      // Calculate the resource required for single instance
+      Set<PackingPlan.InstancePlan> instancePlans = new HashSet<>();
+
+      for (String instanceId : instanceList) {
+        long instanceRam = 0;
+        if (ramMap.containsKey(getComponentName(instanceId))) {
+          instanceRam = ramMap.get(getComponentName(instanceId));
+        } else {
+          instanceRam = instanceDefaults.getRam();
+        }
+        containerRam += instanceRam;
+
+        // Currently not yet support disk or cpu config for different components,
+        // so just use the default value.
+        long instanceDisk = instanceDefaults.getDisk();
+        containerDiskInBytes += instanceDisk;
+
+        double instanceCpu = instanceDefaults.getCpu();
+        containerCpu += instanceCpu;
+
+        Resource resource =
+            new Resource(instanceCpu, instanceRam, instanceDisk);
+        PackingPlan.InstancePlan instancePlan =
+            new PackingPlan.InstancePlan(
+                instanceId,
+                getComponentName(instanceId),
+                resource);
+        // Insert it into the map
+        instancePlans.add(instancePlan);
+      }
+
+      containerCpu += (paddingPercentage * containerCpu) / 100;
+      containerRam += (paddingPercentage * containerRam) / 100;
+      containerDiskInBytes += (paddingPercentage * containerDiskInBytes) / 100;
+
+      Resource resource =
+          new Resource(Math.round(containerCpu), containerRam, containerDiskInBytes);
+
+      PackingPlan.ContainerPlan containerPlan =
+          new PackingPlan.ContainerPlan(containerId, instancePlans, resource);
+
+      containerPlans.add(containerPlan);
+    }
+
+    return containerPlans;
+  }
+
+  public static String getInstanceId(
+      int containerIdx, String componentName, int instanceIdx, int componentIdx) {
+    return String.format("%d:%s:%d:%d", containerIdx, componentName, instanceIdx, componentIdx);
+  }
+
+  public static String getComponentName(String instanceId) {
+    return instanceId.split(":")[1];
+  }
+}

--- a/heron/packing/src/java/com/twitter/heron/packing/PackingUtils.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/PackingUtils.java
@@ -79,7 +79,7 @@ public final class PackingUtils {
    * Estimate the per instance and topology resources for the packing plan based on the ramMap,
    * instance defaults and paddingPercentage.
    *
-   * @return Set<PackingPlan.ContainerPlan> container plans
+   * @return container plans
    */
   public static Set<PackingPlan.ContainerPlan> buildContainerPlans(
       Map<Integer, List<String>> containerInstances,

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
@@ -14,10 +14,8 @@
 
 package com.twitter.heron.packing.roundrobin;
 
-
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -25,6 +23,7 @@ import java.util.logging.Logger;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.packing.Container;
+import com.twitter.heron.packing.PackingUtils;
 import com.twitter.heron.packing.RamRequirement;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Constants;
@@ -33,6 +32,10 @@ import com.twitter.heron.spi.packing.IPacking;
 import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.packing.Resource;
 import com.twitter.heron.spi.utils.TopologyUtils;
+
+import static com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_CPU_REQUESTED;
+import static com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_DISK_REQUESTED;
+import static com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED;
 
 /**
  * ResourceCompliantRoundRobin packing algorithm
@@ -88,32 +91,19 @@ import com.twitter.heron.spi.utils.TopologyUtils;
  */
 public class ResourceCompliantRRPacking implements IPacking {
 
-  public static final long MIN_RAM_PER_INSTANCE = 192L * Constants.MB;
-  public static final int DEFAULT_CONTAINER_PADDING_PERCENTAGE = 10;
-  public static final int DEFAULT_NUMBER_INSTANCES_PER_CONTAINER = 4;
+  private static final long MIN_RAM_PER_INSTANCE = 192L * Constants.MB;
+  private static final int DEFAULT_CONTAINER_PADDING_PERCENTAGE = 10;
+  private static final int DEFAULT_NUMBER_INSTANCES_PER_CONTAINER = 4;
 
   private static final Logger LOG = Logger.getLogger(ResourceCompliantRRPacking.class.getName());
-  protected TopologyAPI.Topology topology;
+  private TopologyAPI.Topology topology;
 
-  protected long instanceRamDefault;
-  protected double instanceCpuDefault;
-  protected long instanceDiskDefault;
-  protected long maxContainerRam;
-  protected double maxContainerCpu;
-  protected long maxContainerDisk;
-  protected int numContainers;
-  protected int numAdjustments;
+  private Resource defaultInstanceResources;
+  private Resource maxContainerResources;
+  private int numContainers;
+  private int numAdjustments;
 
-  public static String getInstanceId(
-      int containerIdx, String componentName, int instanceIdx, int componentIdx) {
-    return String.format("%d:%s:%d:%d", containerIdx, componentName, instanceIdx, componentIdx);
-  }
-
-  public static String getComponentName(String instanceId) {
-    return instanceId.split(":")[1];
-  }
-
-  public void increasenumContainers() {
+  private void increaseNumContainers() {
     this.numContainers++;
     this.numAdjustments++;
   }
@@ -122,41 +112,37 @@ public class ResourceCompliantRRPacking implements IPacking {
   public void initialize(Config config, TopologyAPI.Topology inputTopology) {
     this.topology = inputTopology;
     this.numContainers = TopologyUtils.getNumContainers(topology);
-    this.instanceRamDefault = Context.instanceRam(config);
-    this.instanceCpuDefault = Context.instanceCpu(config).doubleValue();
-    this.instanceDiskDefault = Context.instanceDisk(config);
+    this.defaultInstanceResources = new Resource(
+        Context.instanceCpu(config),
+        Context.instanceRam(config),
+        Context.instanceDisk(config));
     this.numAdjustments = 0;
 
     List<TopologyAPI.Config.KeyValue> topologyConfig = topology.getTopologyConfig().getKvsList();
-    this.maxContainerRam = Long.parseLong(TopologyUtils.getConfigWithDefault(
-        topologyConfig, com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED,
-        Long.toString(instanceRamDefault * DEFAULT_NUMBER_INSTANCES_PER_CONTAINER)));
-
-    this.maxContainerCpu = Double.parseDouble(TopologyUtils.getConfigWithDefault(
-        topologyConfig, com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_CPU_REQUESTED,
-        Double.toString(instanceCpuDefault * DEFAULT_NUMBER_INSTANCES_PER_CONTAINER)));
-
-    this.maxContainerDisk = Long.parseLong(TopologyUtils.getConfigWithDefault(
-        topologyConfig, com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_DISK_REQUESTED,
-        Long.toString(instanceDiskDefault * DEFAULT_NUMBER_INSTANCES_PER_CONTAINER)));
+    this.maxContainerResources = new Resource(
+        TopologyUtils.getConfigWithDefault(topologyConfig, TOPOLOGY_CONTAINER_CPU_REQUESTED,
+            this.defaultInstanceResources.getCpu() * DEFAULT_NUMBER_INSTANCES_PER_CONTAINER),
+        TopologyUtils.getConfigWithDefault(topologyConfig, TOPOLOGY_CONTAINER_RAM_REQUESTED,
+            this.defaultInstanceResources.getRam() * DEFAULT_NUMBER_INSTANCES_PER_CONTAINER),
+        TopologyUtils.getConfigWithDefault(topologyConfig, TOPOLOGY_CONTAINER_DISK_REQUESTED,
+            this.defaultInstanceResources.getDisk() * DEFAULT_NUMBER_INSTANCES_PER_CONTAINER));
   }
 
   @Override
   public PackingPlan pack() {
     int adjustments = this.numAdjustments;
     // Get the instances using a resource compliant round robin allocation
-    Map<Integer, List<String>> resourceCompliantRRAllocation = getResourceCompliantRRAllocation();
+    Map<Integer, List<String>> containerInstances = getResourceCompliantRRAllocation();
 
-    while (resourceCompliantRRAllocation == null) {
+    while (containerInstances == null) {
       if (this.numAdjustments > adjustments) {
         adjustments++;
-        resourceCompliantRRAllocation = getResourceCompliantRRAllocation();
+        containerInstances = getResourceCompliantRRAllocation();
       } else {
         return null;
       }
     }
     // Construct the PackingPlan
-    Set<PackingPlan.ContainerPlan> containerPlans = new HashSet<>();
     Map<String, Long> ramMap = TopologyUtils.getComponentRamMapConfig(topology);
 
     List<TopologyAPI.Config.KeyValue> topologyConfig = topology.getTopologyConfig().getKvsList();
@@ -164,58 +150,8 @@ public class ResourceCompliantRRPacking implements IPacking {
         topologyConfig, com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_PADDING_PERCENTAGE,
         Integer.toString(DEFAULT_CONTAINER_PADDING_PERCENTAGE)));
 
-    for (Map.Entry<Integer, List<String>> entry : resourceCompliantRRAllocation.entrySet()) {
-
-      int containerId = entry.getKey();
-      List<String> instanceList = entry.getValue();
-
-      long containerRam = 0;
-      long containerDiskInBytes = 0;
-      double containerCpu = 0;
-
-      // Calculate the resource required for single instance
-      Set<PackingPlan.InstancePlan> instancePlans = new HashSet<>();
-
-      for (String instanceId : instanceList) {
-        long instanceRam = 0;
-        if (ramMap.containsKey(getComponentName(instanceId))) {
-          instanceRam = ramMap.get(getComponentName(instanceId));
-        } else {
-          instanceRam = instanceRamDefault;
-        }
-        containerRam += instanceRam;
-
-        // Currently not yet support disk or cpu config for different components,
-        // so just use the default value.
-        long instanceDisk = instanceDiskDefault;
-        containerDiskInBytes += instanceDisk;
-
-        double instanceCpu = instanceCpuDefault;
-        containerCpu += instanceCpu;
-
-        Resource resource =
-            new Resource(instanceCpu, instanceRam, instanceDisk);
-        PackingPlan.InstancePlan instancePlan =
-            new PackingPlan.InstancePlan(
-                instanceId,
-                getComponentName(instanceId),
-                resource);
-        // Insert it into the map
-        instancePlans.add(instancePlan);
-      }
-
-      containerCpu += (paddingPercentage * containerCpu) / 100;
-      containerRam += (paddingPercentage * containerRam) / 100;
-      containerDiskInBytes += (paddingPercentage * containerDiskInBytes) / 100;
-
-      Resource resource =
-          new Resource(Math.round(containerCpu), containerRam, containerDiskInBytes);
-
-      PackingPlan.ContainerPlan containerPlan =
-          new PackingPlan.ContainerPlan(containerId, instancePlans, resource);
-
-      containerPlans.add(containerPlan);
-    }
+    Set<PackingPlan.ContainerPlan> containerPlans = PackingUtils.buildContainerPlans(
+        containerInstances, ramMap, this.defaultInstanceResources, paddingPercentage);
 
     return new PackingPlan(topology.getId(), containerPlans);
   }
@@ -236,8 +172,9 @@ public class ResourceCompliantRRPacking implements IPacking {
     Map<String, Long> ramMap = TopologyUtils.getComponentRamMapConfig(topology);
     for (String component : parallelismMap.keySet()) {
       if (ramMap.containsKey(component)) {
-        if (!isValidInstance(new Resource(instanceCpuDefault,
-            ramMap.get(component), instanceDiskDefault))) {
+        if (!PackingUtils.isValidInstance(
+            this.defaultInstanceResources.cloneWithRam(ramMap.get(component)),
+            MIN_RAM_PER_INSTANCE, this.maxContainerResources)) {
           throw new RuntimeException("The topology configuration does not have "
               + "valid resource requirements. Please make sure that the instance resource "
               + "requirements do not exceed the maximum per-container resources.");
@@ -245,13 +182,14 @@ public class ResourceCompliantRRPacking implements IPacking {
           ramRequirements.add(new RamRequirement(component, ramMap.get(component)));
         }
       } else {
-        if (!isValidInstance(new Resource(instanceCpuDefault,
-            instanceRamDefault, instanceDiskDefault))) {
+        if (!PackingUtils.isValidInstance(this.defaultInstanceResources,
+            MIN_RAM_PER_INSTANCE, this.maxContainerResources)) {
           throw new RuntimeException("The topology configuration does not have "
               + "valid resource requirements. Please make sure that the instance resource "
               + "requirements do not exceed the maximum per-container resources.");
         } else {
-          ramRequirements.add(new RamRequirement(component, instanceRamDefault));
+          ramRequirements.add(
+              new RamRequirement(component, this.defaultInstanceResources.getRam()));
         }
       }
     }
@@ -263,7 +201,7 @@ public class ResourceCompliantRRPacking implements IPacking {
    *
    * @return Map &lt; containerId, list of InstanceId belonging to this container &gt;
    */
-  protected Map<Integer, List<String>> getResourceCompliantRRAllocation() {
+  private Map<Integer, List<String>> getResourceCompliantRRAllocation() {
 
     Map<Integer, List<String>> allocation = new HashMap<>();
     ArrayList<Container> containers = new ArrayList<>();
@@ -291,15 +229,15 @@ public class ResourceCompliantRRPacking implements IPacking {
       long ramRequirement = ramRequirements.get(componentIndex).getRamRequirement();
       int numInstance = parallelismMap.get(component);
       for (int i = 0; i < numInstance; ++i) {
-        if (placeResourceCompliantRRInstance(containers, containerId,
-            ramRequirement, instanceCpuDefault, instanceDiskDefault)) {
-          allocation.get(containerId)
-              .add(getInstanceId(containerId, component, globalTaskIndex, i));
+        Resource instanceResource = this.defaultInstanceResources.cloneWithRam(ramRequirement);
+        if (placeResourceCompliantRRInstance(containers, containerId, instanceResource)) {
+          allocation.get(containerId).add(PackingUtils.getInstanceId(
+              containerId, component, globalTaskIndex, i));
         } else {
           List<TopologyAPI.Config.KeyValue> topologyConfig
               = topology.getTopologyConfig().getKvsList();
           //Automatically adjust the number of containers
-          increasenumContainers();
+          increaseNumContainers();
           LOG.info(String.format("Increasing the number of containers to "
               + this.numContainers + " and attempting packing again."));
           return null;
@@ -317,13 +255,9 @@ public class ResourceCompliantRRPacking implements IPacking {
    *
    * @return true if the container incorporated the instance, otherwise return false
    */
-  public boolean placeResourceCompliantRRInstance(ArrayList<Container> containers, int containerId,
-                                                  long ramRequirement, double cpuRequirement,
-                                                  long diskRequirement) {
-    if (containers.get(containerId - 1).add(ramRequirement, cpuRequirement, diskRequirement)) {
-      return true;
-    }
-    return false;
+  private boolean placeResourceCompliantRRInstance(ArrayList<Container> containers, int containerId,
+                                                   Resource resource) {
+    return containers.get(containerId - 1).add(resource);
   }
 
   /**
@@ -333,50 +267,10 @@ public class ResourceCompliantRRPacking implements IPacking {
    * @return the number of containers
    */
   private int allocateNewContainer(ArrayList<Container> containers) {
-    containers.add(new Container(maxContainerRam, maxContainerCpu, maxContainerDisk));
+    containers.add(new Container(this.maxContainerResources));
     return containers.size();
   }
 
-  /**
-   * Check whether the Instance has enough RAM and whether it can fit within the container limits.
-   *
-   * @param instanceResources The resources allocated to the instance
-   * @return true if the instance is valid, false otherwise
-   */
-  protected boolean isValidInstance(Resource instanceResources) {
-
-    if (instanceResources.getRam() < MIN_RAM_PER_INSTANCE) {
-      LOG.severe(String.format(
-          "Require at least %d MB ram per instance",
-          MIN_RAM_PER_INSTANCE / Constants.MB));
-      return false;
-    }
-
-    if (instanceResources.getRam() > maxContainerRam) {
-      LOG.severe(String.format(
-          "This instance requires containers of at least %d MB ram. The current max container"
-              + "size is %d MB",
-          instanceResources.getRam(), maxContainerRam));
-      return false;
-    }
-
-    if (instanceResources.getCpu() > maxContainerCpu) {
-      LOG.severe(String.format(
-          "This instance requires containers with at least %d cpu cores. The current max container"
-              + "size is %d cores",
-          instanceResources.getCpu(), maxContainerCpu));
-      return false;
-    }
-
-    if (instanceResources.getDisk() > maxContainerDisk) {
-      LOG.severe(String.format(
-          "This instance requires containers of at least %d MB disk. The current max container"
-              + "size is %d MB",
-          instanceResources.getDisk(), maxContainerDisk));
-      return false;
-    }
-    return true;
-  }
 }
 
 

--- a/heron/packing/tests/java/BUILD
+++ b/heron/packing/tests/java/BUILD
@@ -2,6 +2,7 @@
 load("/tools/rules/heron_deps", "heron_java_proto_files")
 
 packing_deps_files = [
+    ":packing-utils",
     "//heron/spi/src/java:common-spi-java",
     "//heron/spi/src/java:packing-spi-java",
     "//heron/packing/src/java:roundrobin-packing",
@@ -28,6 +29,17 @@ binpacking_deps_files = \
         "//heron/api/src/java:api-java",
         "//heron/spi/src/java:utils-spi-java",
     ]
+
+java_library(
+    name = "packing-utils",
+    srcs = glob(
+        ["com/twitter/heron/packing/*.java"]
+    ),
+    deps = [
+        "//heron/spi/src/java:packing-spi-java",
+        "//third_party/java:junit4",
+    ],
+)
 
 java_test(
     name = "RoundRobinPackingTest",

--- a/heron/packing/tests/java/com/twitter/heron/packing/AssertPacking.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/AssertPacking.java
@@ -1,0 +1,61 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.twitter.heron.packing;
+
+import java.util.Set;
+
+import org.junit.Assert;
+
+import com.twitter.heron.spi.packing.PackingPlan;
+
+/**
+ * Utility methods for common test assertions related to packing
+ */
+public final class AssertPacking {
+
+  private AssertPacking() {
+  }
+
+  /**
+   * Verifies that the containerPlan has at least one bolt named boltName with ram equal to
+   * expectedBoltRam and likewise for spouts. If notExpectedContainerRam is not null, verifies that
+   * the container ram is not that.
+   */
+  public static void assertContainers(Set<PackingPlan.ContainerPlan> containerPlans,
+                                      String boltName, String spoutName,
+                                      long expectedBoltRam, long expectedSpoutRam,
+                                      Long notExpectedContainerRam) {
+    boolean boltFound = false;
+    boolean spoutFound = false;
+    // Ram for bolt should be the value in component ram map
+    for (PackingPlan.ContainerPlan containerPlan : containerPlans) {
+      if (notExpectedContainerRam != null) {
+        Assert.assertNotEquals(
+            notExpectedContainerRam, (Long) containerPlan.getResource().getRam());
+      }
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
+        if (instancePlan.getComponentName().equals(boltName)) {
+          Assert.assertEquals(expectedBoltRam, instancePlan.getResource().getRam());
+          boltFound = true;
+        }
+        if (instancePlan.getComponentName().equals(spoutName)) {
+          Assert.assertEquals(expectedSpoutRam, instancePlan.getResource().getRam());
+          spoutFound = true;
+        }
+      }
+    }
+    Assert.assertTrue("Bolt not found in any of the container plans: " + boltName, boltFound);
+    Assert.assertTrue("Spout not found in any of the container plans: " + spoutName, spoutFound);
+  }
+}

--- a/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/RoundRobinPackingTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/RoundRobinPackingTest.java
@@ -21,6 +21,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.twitter.heron.api.generated.TopologyAPI;
+import com.twitter.heron.packing.AssertPacking;
 import com.twitter.heron.packing.PackingUtils;
 import com.twitter.heron.spi.common.ClusterDefaults;
 import com.twitter.heron.spi.common.Config;
@@ -36,16 +37,6 @@ public class RoundRobinPackingTest {
   private static final String SPOUT_NAME = "spout";
   private static final double DELTA = 0.1;
 
-  private int countCompoment(String component, Set<PackingPlan.InstancePlan> instances) {
-    int count = 0;
-    for (PackingPlan.InstancePlan pair : instances) {
-      if (component.equals(PackingUtils.getComponentName(pair.getId()))) {
-        count++;
-      }
-    }
-    return count;
-  }
-
   private TopologyAPI.Topology getTopology(
       int spoutParallelism, int boltParallelism,
       com.twitter.heron.api.Config topologyConfig) {
@@ -53,7 +44,7 @@ public class RoundRobinPackingTest {
         spoutParallelism, boltParallelism);
   }
 
-  protected PackingPlan getRoundRobinPackingPlan(TopologyAPI.Topology topology) {
+  private PackingPlan getRoundRobinPackingPlan(TopologyAPI.Topology topology) {
     Config config = Config.newBuilder()
         .put(Keys.topologyId(), topology.getId())
         .put(Keys.topologyName(), topology.getName())
@@ -91,6 +82,7 @@ public class RoundRobinPackingTest {
     int numContainers = 2;
     int spoutParallelism = 4;
     int boltParallelism = 3;
+    Integer totalInstances = spoutParallelism + boltParallelism;
 
     // Set up the topology and its config
     com.twitter.heron.api.Config topologyConfig = new com.twitter.heron.api.Config();
@@ -104,6 +96,7 @@ public class RoundRobinPackingTest {
 
     Assert.assertEquals(numContainers,
         packingPlanNoExplicitResourcesConfig.getContainers().size());
+    Assert.assertEquals(totalInstances, packingPlanNoExplicitResourcesConfig.getInstanceCount());
   }
 
   /**
@@ -114,6 +107,7 @@ public class RoundRobinPackingTest {
     int numContainers = 2;
     int spoutParallelism = 4;
     int boltParallelism = 3;
+    Integer totalInstances = spoutParallelism + boltParallelism;
 
     // Set up the topology and its config
     com.twitter.heron.api.Config topologyConfig = new com.twitter.heron.api.Config();
@@ -133,6 +127,7 @@ public class RoundRobinPackingTest {
 
     Assert.assertEquals(numContainers,
         packingPlanExplicitResourcesConfig.getContainers().size());
+    Assert.assertEquals(totalInstances, packingPlanExplicitResourcesConfig.getInstanceCount());
 
     for (PackingPlan.ContainerPlan containerPlan
         : packingPlanExplicitResourcesConfig.getContainers()) {
@@ -167,6 +162,7 @@ public class RoundRobinPackingTest {
     int numContainers = 2;
     int spoutParallelism = 4;
     int boltParallelism = 3;
+    Integer totalInstances = spoutParallelism + boltParallelism;
 
     // Set up the topology and its config
     com.twitter.heron.api.Config topologyConfig = new com.twitter.heron.api.Config();
@@ -189,20 +185,9 @@ public class RoundRobinPackingTest {
     PackingPlan packingPlanExplicitRamMap =
         getRoundRobinPackingPlan(topologyExplicitRamMap);
 
-    // Ram for bolt should be the value in component ram map
-    for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitRamMap.getContainers()) {
-      // The containerRam should be ignored, since we set the complete component ram map
-      Assert.assertNotEquals(containerRam, containerPlan.getResource().getRam());
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
-        if (instancePlan.getComponentName().equals(BOLT_NAME)) {
-          Assert.assertEquals(boltRam, instancePlan.getResource().getRam());
-        }
-        if (instancePlan.getComponentName().equals(SPOUT_NAME)) {
-          Assert.assertEquals(spoutRam, instancePlan.getResource().getRam());
-        }
-      }
-    }
+    AssertPacking.assertContainers(packingPlanExplicitRamMap.getContainers(),
+        BOLT_NAME, SPOUT_NAME, boltRam, spoutRam, containerRam);
+    Assert.assertEquals(totalInstances, packingPlanExplicitRamMap.getInstanceCount());
   }
 
   /**
@@ -213,6 +198,7 @@ public class RoundRobinPackingTest {
     int numContainers = 2;
     int spoutParallelism = 4;
     int boltParallelism = 3;
+    Integer totalInstances = spoutParallelism + boltParallelism;
 
     // Set up the topology and its config
     com.twitter.heron.api.Config topologyConfig = new com.twitter.heron.api.Config();
@@ -231,6 +217,7 @@ public class RoundRobinPackingTest {
         getTopology(spoutParallelism, boltParallelism, topologyConfig);
     PackingPlan packingPlanExplicitRamMap =
         getRoundRobinPackingPlan(topologyExplicitRamMap);
+    Assert.assertEquals(totalInstances, packingPlanExplicitRamMap.getInstanceCount());
 
     // Ram for bolt should be the value in component ram map
     for (PackingPlan.ContainerPlan containerPlan
@@ -280,15 +267,26 @@ public class RoundRobinPackingTest {
     Assert.assertEquals(2 * componentParallelism, numInstance);
     PackingPlan output = getRoundRobinPackingPlan(topology);
     Assert.assertEquals(numContainers, output.getContainers().size());
+    Assert.assertEquals((Integer) numInstance, output.getInstanceCount());
 
     for (PackingPlan.ContainerPlan container : output.getContainers()) {
       Assert.assertEquals(numInstance / numContainers, container.getInstances().size());
 
       // Verify each container got 2 spout and 2 bolt and container 1 got
-      Assert.assertEquals(
-          2, countCompoment("spout", container.getInstances()));
-      Assert.assertEquals(
-          2, countCompoment("bolt", container.getInstances()));
+      assertComponentCount(container, "spout", 2);
+      assertComponentCount(container, "bolt", 2);
     }
   }
+
+  private static void assertComponentCount(
+      PackingPlan.ContainerPlan containerPlan, String componentName, int expectedCount) {
+    int count = 0;
+    for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
+      if (componentName.equals(PackingUtils.getComponentName(instancePlan.getId()))) {
+        count++;
+      }
+    }
+    Assert.assertEquals(expectedCount, count);
+  }
+
 }

--- a/heron/spi/src/java/com/twitter/heron/spi/packing/Resource.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/packing/Resource.java
@@ -52,6 +52,10 @@ public class Resource {
     return disk;
   }
 
+  public Resource cloneWithRam(long newRam) {
+    return new Resource(this.getCpu(), newRam, this.getDisk());
+  }
+
   @Override
   public int hashCode() {
     return (Long.hashCode(getRam()) << 2)

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/TopologyTests.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/TopologyTests.java
@@ -105,4 +105,18 @@ public final class TopologyTests {
     return createTopologyWithConnection(
         topologyName, heronConfig, spouts, bolts, new HashMap<String, String>());
   }
+
+  public static TopologyAPI.Topology createTopology(String topologyName, Config topologyConfig,
+                                                    String spoutName, String boltName,
+                                                    int spoutParallelism, int boltParallelism) {
+    // Setup the spout parallelism
+    Map<String, Integer> spouts = new HashMap<>();
+    spouts.put(spoutName, spoutParallelism);
+
+    // Setup the bolt parallelism
+    Map<String, Integer> bolts = new HashMap<>();
+    bolts.put(boltName, boltParallelism);
+
+    return TopologyTests.createTopology(topologyName, topologyConfig, spouts, bolts);
+  }
 }

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/TopologyUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/TopologyUtils.java
@@ -63,6 +63,21 @@ public final class TopologyUtils {
     return defaultValue;
   }
 
+  public static Long getConfigWithDefault(
+      List<TopologyAPI.Config.KeyValue> config, String key, Long defaultValue) {
+    return Long.parseLong(getConfigWithDefault(config, key, Long.toString(defaultValue)));
+  }
+
+  public static Integer getConfigWithDefault(
+      List<TopologyAPI.Config.KeyValue> config, String key, Integer defaultValue) {
+    return Integer.parseInt(getConfigWithDefault(config, key, Integer.toString(defaultValue)));
+  }
+
+  public static Double getConfigWithDefault(
+      List<TopologyAPI.Config.KeyValue> config, String key, Double defaultValue) {
+    return Double.parseDouble(getConfigWithDefault(config, key, Double.toString(defaultValue)));
+  }
+
   public static String getConfigWithException(
       List<TopologyAPI.Config.KeyValue> config, String key) {
     for (TopologyAPI.Config.KeyValue kv : config) {
@@ -177,7 +192,8 @@ public final class TopologyUtils {
     Set<String> componentNames = getComponentParallelism(topology).keySet();
 
     // Parse the config value
-    String ramMapStr = getConfigWithDefault(topologyConfig, Config.TOPOLOGY_COMPONENT_RAMMAP, null);
+    String ramMapStr = getConfigWithDefault(
+        topologyConfig, Config.TOPOLOGY_COMPONENT_RAMMAP, (String) null);
     if (ramMapStr != null) {
       String[] ramMapTokens = ramMapStr.split(",");
       for (String token : ramMapTokens) {


### PR DESCRIPTION
Refactors packing impls to do some housekeeping and reduce lines of code:

- Reduces duplicate logic found in the packing algos and their tests
- Adds convenience methods for common logic
- Makes methods that can be private private.
- Reduces verbosity by utilizing `Resource` objects instead of tuples of cpu, ram, disk.