### PR TITLE
Change hashCode() call on numbers to be java 1.7 compliant

### DIFF
--- a/heron/spi/src/java/com/twitter/heron/spi/packing/Resource.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/packing/Resource.java
@@ -54,9 +54,9 @@ public class Resource {
 
   @Override
   public int hashCode() {
-    return (Long.hashCode(getRam()) << 2)
-         & (Long.hashCode(getDisk()) << 1)
-         & (Double.hashCode(getCpu()));
+    return (Long.valueOf(getRam()).hashCode() << 2)
+         & (Long.valueOf(getDisk()).hashCode() << 1)
+         & (Double.valueOf(getCpu()).hashCode());
   }
 
   @Override


### PR DESCRIPTION
Fixes #1351 by using the instance `hashCode()` method (>=1.7) instead of the static helper (>=1.8). See https://docs.oracle.com/javase/8/docs/api/java/lang/Long.html#hashCode