### PR TITLE
Visual Studio Code files ignored.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ website/node_modules/
 website/public/
 website/static/
 /bin/
+
+# Visual Studio Code
+.vscode


### PR DESCRIPTION
Visual Studio Code is one of the last editors. Like many of them, it creates some folders to keep configuration stuff that should be ignored in the origin repo.

This commit adds the .vscode folder to the .gitignore file