### PR TITLE
Upgrade requests.

### DIFF
--- a/heron/shell/src/python/BUILD
+++ b/heron/shell/src/python/BUILD
@@ -9,7 +9,7 @@ pex_library(
         exclude = ["main.py"]
     ),
     reqs = [
-        "requests==2.3.0",
+        "requests==2.11.1",
         "tornado==4.0.2",
     ],
 )

--- a/heron/tools/ui/src/python/BUILD
+++ b/heron/tools/ui/src/python/BUILD
@@ -10,7 +10,7 @@ pex_library(
     ),
     reqs = [
         "pycrypto==2.6.1",
-        "requests==2.3.0",
+        "requests==2.11.1",
         "tornado==4.0.2",
     ],
     deps = [


### PR DESCRIPTION
Upgrade `requests` to version `2.11.1` since Twitter internal Python package repo removed `2.3.0` yesterday.