### PR TITLE
refactor local test runner

### DIFF
--- a/integration-test/src/python/local_test_runner/BUILD
+++ b/integration-test/src/python/local_test_runner/BUILD
@@ -4,9 +4,7 @@ load("/tools/rules/pex_rules", "pex_binary")
 
 pex_binary(
     name = "local-test-runner",
-    srcs = [
-        "main.py"
-    ],
+    srcs = glob(["*.py"]),
     main = "main.py",
     resources = [
         "resources/test.conf",

--- a/integration-test/src/python/local_test_runner/main.py
+++ b/integration-test/src/python/local_test_runner/main.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #!/usr/bin/env python2.7
 
-''' main.py '''
+""" main.py """
 import getpass
 import json
 import logging
@@ -43,7 +43,7 @@ DEFAULT_TEST_CONF_FILE = "resources/test.conf"
 ProcessTuple = namedtuple('ProcessTuple', 'pid cmd')
 
 def run_all_tests(args):
-  ''' Run the test for each topology specified in the conf file '''
+  """ Run the test for each topology specified in the conf file """
   successes = []
   failures = []
   for testclass in TEST_CLASSES:
@@ -55,23 +55,23 @@ def run_all_tests(args):
       successes += [testname]
     else:
       failures += [testname]
-  return (successes, failures)
+  return successes, failures
 
 def main():
-  ''' main '''
+  """ main """
   root = logging.getLogger()
   root.setLevel(logging.DEBUG)
 
   # Read the configuration file from package
   conf_file = DEFAULT_TEST_CONF_FILE
-  confString = pkgutil.get_data(__name__, conf_file)
+  conf_string = pkgutil.get_data(__name__, conf_file)
   decoder = json.JSONDecoder(strict=False)
 
   # Convert the conf file to a json format
-  conf = decoder.decode(confString)
+  conf = decoder.decode(conf_string)
 
   # Get the directory of the heron root, which should be the directory that the script is run from
-  heronRepoDirectory = os.getcwd()
+  heron_repo_directory = os.getcwd()
 
   args = dict()
   home_directory = os.path.expanduser("~")
@@ -89,7 +89,7 @@ def main():
   args['cliPath'] = os.path.expanduser(conf['heronCliPath'])
   args['outputFile'] = os.path.join(args['workingDirectory'], conf['topology']['outputFile'])
   args['readFile'] = os.path.join(args['workingDirectory'], conf['topology']['readFile'])
-  args['testJarPath'] = os.path.join(heronRepoDirectory, conf['testJarPath'])
+  args['testJarPath'] = os.path.join(heron_repo_directory, conf['testJarPath'])
 
   start_time = time.time()
   (successes, failures) = run_all_tests(args)

--- a/integration-test/src/python/local_test_runner/main.py
+++ b/integration-test/src/python/local_test_runner/main.py
@@ -1,3 +1,18 @@
+# Copyright 2016 Twitter. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#!/usr/bin/env python2.7
+
 ''' main.py '''
 import getpass
 import json
@@ -5,308 +20,42 @@ import logging
 import os
 import pkgutil
 import time
-import signal
-import subprocess
 import sys
 from collections import namedtuple
 
+# import test_kill_bolt
+import test_kill_metricsmgr
+import test_kill_stmgr
+import test_kill_stmgr_metricsmgr
+import test_kill_tmaster
+
+TEST_CLASSES = [
+    test_kill_tmaster.TestKillTMaster,
+    test_kill_stmgr.TestKillStmgr,
+    test_kill_metricsmgr.TestKillMetricsMgr,
+    test_kill_stmgr_metricsmgr.TestKillStmgrMetricsMgr,
+    # test_kill_bolt.TestKillBolt,
+]
+
 # The location of default configure file
 DEFAULT_TEST_CONF_FILE = "resources/test.conf"
-# Test defaults
-# Test input. Please set each variable as it's own line, ended with \n, otherwise the value of lines
-# passed into the topology will be incorrect, and the test will fail.
-TEST_INPUT = ["1\n", "2\n", "3\n", "4\n", "5\n", "6\n", "7\n", "8\n",
-              "9\n", "10\n", "11\n", "12\n"]
-TEST_CASES = [
-    'KILL_TMASTER',
-    'KILL_STMGR',
-    'KILL_METRICSMGR',
-    'KILL_STMGR_METRICSMGR'
-]
-# Retry variables in case the output is different from the input
-RETRY_COUNT = 5
-RETRY_INTERVAL = 30
-# Topology shard definitions
-TMASTER_SHARD = 0
-NON_TMASTER_SHARD = 1
-# Topology process name definitions
-STMGR = 'stmgr'
-HERON_BIN = "bin"
-HERON_BOLT = 'local-write-bolt_2'
-HERON_CORE = "heron-core"
-HERON_EXECUTOR = 'heron-executor'
-HERON_METRICSMGR = 'metricsmgr'
-HERON_SANDBOX_HOME = "."
-HERON_SPOUT = 'paused-local-spout_1'
-HERON_STMGR = "heron-stmgr"
-HERON_STMGR_CMD = os.path.join(HERON_SANDBOX_HOME, HERON_CORE, HERON_BIN, HERON_STMGR)
-HERON_TMASTER = 'heron-tmaster'
 
 ProcessTuple = namedtuple('ProcessTuple', 'pid cmd')
 
-# pylint: disable=too-many-return-statements, too-many-branches,
-# pylint: disable=too-many-statements
-def runTest(test, topologyName, params):
-  ''' Runs the test for one topology '''
-  #submit topology
-  try:
-    submitTopology(
-        params['cliPath'],
-        params['cluster'],
-        params['testJarPath'],
-        params['topologyClassPath'],
-        params['topologyName'],
-        params['readFile'],
-        params['outputFile']
-    )
-  except Exception as e:
-    logging.error("Failed to submit %s topology: %s", topologyName, str(e))
-    return False
-
-  # block until ./heron-stmgr exists
-  processList = getProcesses()
-  while not processExists(processList, HERON_STMGR_CMD):
-    processList = getProcesses()
-
-  _safe_delete_file(params['readFile'])
-  _safe_delete_file(params['outputFile'])
-
-  # insert lines into temp file and then move to read file
-  try:
-    with open('temp.txt', 'w') as f:
-      for line in TEST_INPUT:
-        f.write(line)
-  except Exception as e:
-    logging.error("Failed to write to temp.txt file")
-    return False
-
-  # extra time to start up, write to .pid file, connect to tmaster, etc.
-  seconds = 30
-  logging.info("Sleeping for %s seconds to allow time for startup", seconds)
-  time.sleep(seconds)
-
-  # execute test case
-  if test == 'KILL_TMASTER':
-    restartShard(params['cliPath'], params['cluster'], params['topologyName'], TMASTER_SHARD)
-  elif test == 'KILL_STMGR':
-    logging.info("Executing kill stream manager")
-    stmgrPid = getPid('%s-%d' % (STMGR, NON_TMASTER_SHARD), params['workingDirectory'])
-    killProcess(stmgrPid)
-  elif test == 'KILL_METRICSMGR':
-    logging.info("Executing kill metrics manager")
-    metricsmgrPid = getPid('%s-%d' % (HERON_METRICSMGR, NON_TMASTER_SHARD),
-                           params['workingDirectory'])
-    killProcess(metricsmgrPid)
-  elif test == 'KILL_STMGR_METRICSMGR':
-    logging.info("Executing kill stream manager and metrics manager")
-    stmgrPid = getPid('%s-%d' % (STMGR, NON_TMASTER_SHARD), params['workingDirectory'])
-    killProcess(stmgrPid)
-
-    metricsmgrPid = getPid('%s-%d' % (HERON_METRICSMGR, NON_TMASTER_SHARD),
-                           params['workingDirectory'])
-    killProcess(metricsmgrPid)
-  elif test == 'KILL_BOLT':
-    logging.info("Executing kill bolt")
-    boltPid = getPid('container_%d_%s' % (NON_TMASTER_SHARD, HERON_BOLT),
-                     params['workingDirectory'])
-    killProcess(boltPid)
-
-  # block until ./heron-stmgr exists
-  processList = getProcesses()
-  while not processExists(processList, HERON_STMGR_CMD):
-    processList = getProcesses()
-
-  # move to read file. This guarantees contents will be put into the file the
-  # spout is reading from atomically
-  # which increases the determinism
-  os.rename('temp.txt', params['readFile'])
-
-  # sleep before attempting to get results
-  seconds = 30
-  logging.info("Sleeping for %s seconds before checking for results", seconds)
-  time.sleep(seconds)
-
-  def cleanup_test():
-    # kill topology
-    try:
-      killTopology(params['cliPath'], params['cluster'], params['topologyName'])
-    except Exception as e:
-      logging.error("Failed to kill %s topology: %s", topologyName, str(e))
-      return False
-
-    # delete test files
-    _safe_delete_file(params['readFile'])
-    _safe_delete_file(params['outputFile'])
-
-  # get actual and expected result
-  # retry if results are not equal a predesignated amount of times
-  expected_result = ""
-  actual_result = ""
-  retriesLeft = RETRY_COUNT
-  while retriesLeft > 0:
-    retriesLeft -= 1
-    try:
-      with open(params['readFile'], 'r') as f:
-        expected_result = f.read()
-      with open(params['outputFile'], 'r') as g:
-        actual_result = g.read()
-    except Exception as e:
-      logging.error("Failed to read expected or actual results from file for test %s: %s", test, e)
-      cleanup_test()
-      return False
-    # if we get expected result, no need to retry
-    if expected_result == actual_result:
-      break
-    if retriesLeft > 0:
-      expected_result = ""
-      actual_result = ""
-      logging.info("Failed to get expected results for test %s (attempt %s/%s), "\
-                   + "retrying after %s seconds",
-                   test, RETRY_COUNT - retriesLeft, RETRY_COUNT, RETRY_INTERVAL)
-      time.sleep(RETRY_INTERVAL)
-
-  cleanup_test()
-
-  # Compare the actual and expected result
-  if actual_result == expected_result:
-    logging.info("Actual result matched expected result for test %s", test)
-    logging.info("Actual result ---------- \n" + actual_result)
-    logging.info("Expected result ---------- \n" + expected_result)
-    return True
-  else:
-    logging.error("Actual result did not match expected result for test %s", test)
-    logging.info("Actual result ---------- \n" + actual_result)
-    logging.info("Expected result ---------- \n" + expected_result)
-    return False
-
-def submitTopology(heronCliPath, testCluster, testJarPath, topologyClassPath,
-                   topologyName, inputFile, outputFile):
-  ''' Submit topology using heron-cli '''
-  # unicode string messes up subprocess.call quotations, must change into string type
-  splitcmd = [
-      '%s' % (heronCliPath),
-      'submit',
-      '--verbose',
-      '--',
-      '%s' % (testCluster),
-      '%s' % (testJarPath),
-      '%s' % (topologyClassPath),
-      '%s' % (topologyName),
-      '%s' % (inputFile),
-      '%s' % (outputFile),
-      '%d' % (len(TEST_INPUT))
-  ]
-  logging.info("Submitting topology: %s", splitcmd)
-  p = subprocess.Popen(splitcmd)
-  p.wait()
-  logging.info("Submitted topology %s", topologyName)
-
-def killTopology(heronCliPath, testCluster, topologyName):
-  ''' Kill a topology using heron-cli '''
-  splitcmd = [
-      '%s' % (heronCliPath),
-      'kill',
-      '--verbose',
-      '%s' % (testCluster),
-      '%s' % (topologyName),
-  ]
-  logging.info("Killing topology: %s", splitcmd)
-  # this call can be blocking, no need for subprocess
-  if subprocess.call(splitcmd) != 0:
-    raise RuntimeError("Unable to kill the topology: %s" % topologyName)
-  logging.info("Successfully killed topology %s", topologyName)
-
-def runAllTests(args):
+def run_all_tests(args):
   ''' Run the test for each topology specified in the conf file '''
   successes = []
   failures = []
-  for test in TEST_CASES:
+  for testclass in TEST_CLASSES:
+    testname = testclass.__name__
     logging.info("==== Starting test %s of %s: %s ====",
-                 len(successes) + len(failures) + 1, len(TEST_CASES), test)
-    if runTest(test, test, args): # testcase passed
-      successes += [test]
+                 len(successes) + len(failures) + 1, len(TEST_CLASSES), testname)
+    template = testclass(testname, args)
+    if template.run_test(): # testcase passed
+      successes += [testname]
     else:
-      failures += [test]
+      failures += [testname]
   return (successes, failures)
-
-def restartShard(heronCliPath, testCluster, topologyName, shardNum):
-  ''' restart tmaster '''
-  splitcmd = [
-      '%s' % (heronCliPath),
-      'restart',
-      '--verbose',
-      '%s' % (testCluster),
-      '%s' % (topologyName),
-      '%d' % shardNum
-  ]
-  logging.info("Killing TMaster: %s", splitcmd)
-  if subprocess.call(splitcmd) != 0:
-    raise RuntimeError("Unable to kill TMaster")
-  logging.info("Killed TMaster")
-
-def getProcesses():
-  '''
-  returns a list of process tuples (pid, cmd)
-  This only applies only for local scheduler as it uses the ps command
-  and assumes the topology will be running on different processes on same machine
-  '''
-  processes = subprocess.check_output(['ps', '-o', 'pid,args'])
-  processes = processes.split('\n')
-  processes = processes[1:] # remove first line, which is name of columns
-  processList = []
-  for process in processes:
-    # remove empty lines
-    if process == '':
-      continue
-    pretuple = process.split(' ', 1)
-    processList.append(ProcessTuple(pretuple[0], pretuple[1]))
-  return processList
-
-def getPid(processName, heronWorkingDirectory):
-  '''
-  opens .pid file of process and reads the first and only line, which should be the process pid
-  if fail, return -1
-  '''
-  processPidFile = os.path.join(heronWorkingDirectory, processName + '.pid')
-  try:
-    with open(processPidFile, 'r') as f:
-      pid = f.readline()
-      return pid
-  except Exception:
-    print("Unable to open file %s", processPidFile)
-    logging.error("Unable to open file %s", processPidFile)
-    return -1
-
-def killProcess(processNumber):
-  ''' kills process by running unix command kill '''
-  logging.info("Killing process number %s", processNumber)
-
-  try:
-    os.kill(int(processNumber), signal.SIGTERM)
-  except OSError as ex:
-    if "No such process" in str(ex): # killing a non-existing process condsidered as success
-      logging.info(str(ex))
-    else:
-      raise RuntimeError("Unable to kill process %s" % processNumber)
-  except Exception:
-    raise RuntimeError("Unable to kill process %s" % processNumber)
-
-  logging.info("Killed process number %s", processNumber)
-
-def processExists(processList, processCmd):
-  ''' check if a process is running '''
-  for process in processList:
-    if processCmd in process.cmd:
-      return True
-  return False
-
-def _safe_delete_file(file_name):
-  if os.path.isfile(file_name) and os.path.exists(file_name):
-    try:
-      os.remove(file_name)
-    except Exception as e:
-      logging.error("Failed to delete file: %s: %s", file_name, e)
-      return False
 
 def main():
   ''' main '''
@@ -325,12 +74,12 @@ def main():
   heronRepoDirectory = os.getcwd()
 
   args = dict()
-  homeDirectory = os.path.expanduser("~")
+  home_directory = os.path.expanduser("~")
   args['cluster'] = conf['cluster']
   args['topologyName'] = conf['topology']['topologyName']
   args['topologyClassPath'] = conf['topology']['topologyClassPath']
   args['workingDirectory'] = os.path.join(
-      homeDirectory,
+      home_directory,
       ".herondata",
       "topologies",
       conf['cluster'],
@@ -343,7 +92,7 @@ def main():
   args['testJarPath'] = os.path.join(heronRepoDirectory, conf['testJarPath'])
 
   start_time = time.time()
-  (successes, failures) = runAllTests(args)
+  (successes, failures) = run_all_tests(args)
   elapsed_time = time.time() - start_time
   total = len(failures) + len(successes)
 

--- a/integration-test/src/python/local_test_runner/test_kill_bolt.py
+++ b/integration-test/src/python/local_test_runner/test_kill_bolt.py
@@ -1,0 +1,28 @@
+# Copyright 2016 Twitter. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''test_kill_bolt.py'''
+import logging
+import test_template
+
+NON_TMASTER_SHARD = 1
+HERON_BOLT = 'identity-bolt_3'
+
+class TestKillBolt(test_template.TestTemplate):
+
+  def execute_test_case(self):
+    logging.info("Executing kill bolt")
+    bolt_pid = self.get_pid(
+      'container_%d_%s' % (NON_TMASTER_SHARD, HERON_BOLT), self.params['workingDirectory'])
+    self.kill_process(bolt_pid)

--- a/integration-test/src/python/local_test_runner/test_kill_bolt.py
+++ b/integration-test/src/python/local_test_runner/test_kill_bolt.py
@@ -24,5 +24,5 @@ class TestKillBolt(test_template.TestTemplate):
   def execute_test_case(self):
     logging.info("Executing kill bolt")
     bolt_pid = self.get_pid(
-      'container_%d_%s' % (NON_TMASTER_SHARD, HERON_BOLT), self.params['workingDirectory'])
+        'container_%d_%s' % (NON_TMASTER_SHARD, HERON_BOLT), self.params['workingDirectory'])
     self.kill_process(bolt_pid)

--- a/integration-test/src/python/local_test_runner/test_kill_bolt.py
+++ b/integration-test/src/python/local_test_runner/test_kill_bolt.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-'''test_kill_bolt.py'''
+"""test_kill_bolt.py"""
 import logging
 import test_template
 

--- a/integration-test/src/python/local_test_runner/test_kill_metricsmgr.py
+++ b/integration-test/src/python/local_test_runner/test_kill_metricsmgr.py
@@ -1,0 +1,21 @@
+# Copyright 2016 Twitter. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''test_kill_metricsmgr.py'''
+import test_template
+
+class TestKillMetricsMgr(test_template.TestTemplate):
+
+  def execute_test_case(self):
+    self.kill_metricsmgr()

--- a/integration-test/src/python/local_test_runner/test_kill_metricsmgr.py
+++ b/integration-test/src/python/local_test_runner/test_kill_metricsmgr.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-'''test_kill_metricsmgr.py'''
+"""test_kill_metricsmgr.py"""
 import test_template
 
 class TestKillMetricsMgr(test_template.TestTemplate):

--- a/integration-test/src/python/local_test_runner/test_kill_stmgr.py
+++ b/integration-test/src/python/local_test_runner/test_kill_stmgr.py
@@ -1,0 +1,21 @@
+# Copyright 2016 Twitter. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''test_kill_stmgr.py'''
+import test_template
+
+class TestKillStmgr(test_template.TestTemplate):
+
+  def execute_test_case(self):
+    self.kill_strmgr()

--- a/integration-test/src/python/local_test_runner/test_kill_stmgr.py
+++ b/integration-test/src/python/local_test_runner/test_kill_stmgr.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-'''test_kill_stmgr.py'''
+"""test_kill_stmgr.py"""
 import test_template
 
 class TestKillStmgr(test_template.TestTemplate):

--- a/integration-test/src/python/local_test_runner/test_kill_stmgr_metricsmgr.py
+++ b/integration-test/src/python/local_test_runner/test_kill_stmgr_metricsmgr.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-'''test_kill_stmgr_metricsmgr.py'''
+"""test_kill_stmgr_metricsmgr.py"""
 import test_template
 
 class TestKillStmgrMetricsMgr(test_template.TestTemplate):

--- a/integration-test/src/python/local_test_runner/test_kill_stmgr_metricsmgr.py
+++ b/integration-test/src/python/local_test_runner/test_kill_stmgr_metricsmgr.py
@@ -1,0 +1,22 @@
+# Copyright 2016 Twitter. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''test_kill_stmgr_metricsmgr.py'''
+import test_template
+
+class TestKillStmgrMetricsMgr(test_template.TestTemplate):
+
+  def execute_test_case(self):
+    self.kill_strmgr()
+    self.kill_metricsmgr()

--- a/integration-test/src/python/local_test_runner/test_kill_tmaster.py
+++ b/integration-test/src/python/local_test_runner/test_kill_tmaster.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-'''test_kill_tmaster.py'''
+"""test_kill_tmaster.py"""
 import logging
 import subprocess
 import test_template
@@ -25,9 +25,9 @@ class TestKillTMaster(test_template.TestTemplate):
     restart_shard(self.params['cliPath'], self.params['cluster'],
                   self.params['topologyName'], TMASTER_SHARD)
 
-def restart_shard(heronCliPath, testCluster, topology_name, shardNum):
-  ''' restart tmaster '''
-  splitcmd = [heronCliPath, 'restart', '--verbose', testCluster, topology_name, str(shardNum)]
+def restart_shard(heron_cli_path, test_cluster, topology_name, shard_num):
+  """ restart tmaster """
+  splitcmd = [heron_cli_path, 'restart', '--verbose', test_cluster, topology_name, str(shard_num)]
 
   logging.info("Killing TMaster: %s", splitcmd)
   if subprocess.call(splitcmd) != 0:

--- a/integration-test/src/python/local_test_runner/test_kill_tmaster.py
+++ b/integration-test/src/python/local_test_runner/test_kill_tmaster.py
@@ -1,0 +1,35 @@
+# Copyright 2016 Twitter. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''test_kill_tmaster.py'''
+import logging
+import subprocess
+import test_template
+
+TMASTER_SHARD = 0
+
+class TestKillTMaster(test_template.TestTemplate):
+
+  def execute_test_case(self):
+    restart_shard(self.params['cliPath'], self.params['cluster'],
+                  self.params['topologyName'], TMASTER_SHARD)
+
+def restart_shard(heronCliPath, testCluster, topology_name, shardNum):
+  ''' restart tmaster '''
+  splitcmd = [heronCliPath, 'restart', '--verbose', testCluster, topology_name, str(shardNum)]
+
+  logging.info("Killing TMaster: %s", splitcmd)
+  if subprocess.call(splitcmd) != 0:
+    raise RuntimeError("Unable to kill TMaster")
+  logging.info("Killed TMaster")

--- a/integration-test/src/python/local_test_runner/test_template.py
+++ b/integration-test/src/python/local_test_runner/test_template.py
@@ -1,0 +1,300 @@
+# Copyright 2016 Twitter. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+''' test_template.py '''
+import logging
+import os
+import time
+import signal
+import subprocess
+from collections import namedtuple
+
+# Test input. Please set each variable as it's own line, ended with \n, otherwise the value of lines
+# passed into the topology will be incorrect, and the test will fail.
+TEST_INPUT = ["1\n", "2\n", "3\n", "4\n", "5\n", "6\n", "7\n", "8\n",
+              "9\n", "10\n", "11\n", "12\n"]
+
+# Retry variables in case the output is different from the input
+RETRY_COUNT = 5
+RETRY_INTERVAL = 30
+# Topology shard definitions
+NON_TMASTER_SHARD = 1
+# Topology process name definitions
+STMGR = 'stmgr'
+HERON_BIN = "bin"
+HERON_CORE = "heron-core"
+HERON_METRICSMGR = 'metricsmgr'
+HERON_SANDBOX_HOME = "."
+HERON_STMGR = "heron-stmgr"
+HERON_STMGR_CMD = os.path.join(HERON_SANDBOX_HOME, HERON_CORE, HERON_BIN, HERON_STMGR)
+ProcessTuple = namedtuple('ProcessTuple', 'pid cmd')
+
+class TestTemplate(object):
+  """ Class that encapsulates the template used for integration tests. Intended to be abstract and
+  subclassed for specific tests. """
+
+  def __init__(self, testname, params):
+    self.testname = testname
+    self.params = params
+
+  # pylint: disable=too-many-return-statements, too-many-branches,
+  # pylint: disable=too-many-statements
+  def run_test(self):
+    """ Runs the test template """
+
+    try:
+      self.submit_topology()
+      _block_until_topology_running()
+
+      self._prepare_test_data()
+
+      _sleep("to allow time for startup", 30)
+      self.execute_test_case()
+      _block_until_topology_running()
+
+      self._inject_test_data()
+      _sleep("before checking for results", 30)
+
+      self.pre_check_results()
+    except Exception as e:
+      logging.error("Test failed, attempting to clean up: %s", e)
+      self.cleanup_test()
+      return False
+
+    return self._check_results()
+
+  def submit_topology(self):
+    #submit topology
+    try:
+      _submit_topology(
+          self.params['cliPath'],
+          self.params['cluster'],
+          self.params['testJarPath'],
+          self.params['topologyClassPath'],
+          self.params['topologyName'],
+          self.params['readFile'],
+          self.params['outputFile']
+      )
+    except Exception as e:
+      logging.error("Failed to submit %s topology: %s", self.params['topologyName'], str(e))
+      return False
+
+  def execute_test_case(self):
+    pass
+
+  def pre_check_results(self):
+    pass
+
+  def cleanup_test(self):
+    try:
+      _kill_topology(self.params['cliPath'], self.params['cluster'], self.params['topologyName'])
+    except Exception as e:
+      logging.error("Failed to kill %s topology: %s", self.params['topologyName'], str(e))
+      return False
+    finally:
+      self._delete_test_data_files()
+
+  def _delete_test_data_files(self):
+    _safe_delete_file(self.params['readFile'])
+    _safe_delete_file(self.params['outputFile'])
+
+  def _prepare_test_data(self):
+    self._delete_test_data_files()
+
+    # insert lines into temp file and then move to read file
+    try:
+      with open('temp.txt', 'w') as f:
+        for line in TEST_INPUT:
+          f.write(line)
+    except Exception as e:
+      logging.error("Failed to write to temp.txt file: %s", str(e))
+      return False
+
+  def _inject_test_data(self):
+    # move to read file. This guarantees contents will be put into the file the
+    # spout is reading from atomically
+    # which increases the determinism
+    os.rename('temp.txt', self.params['readFile'])
+
+  def _check_results(self):
+    """ get actual and expected result.
+    retry if results are not equal a predesignated amount of times
+    """
+    expected_result = ""
+    actual_result = ""
+    retriesLeft = RETRY_COUNT
+    while retriesLeft > 0:
+      retriesLeft -= 1
+      try:
+        with open(self.params['readFile'], 'r') as f:
+          expected_result = f.read()
+        with open(self.params['outputFile'], 'r') as g:
+          actual_result = g.read()
+      except Exception as e:
+        logging.error(
+            "Failed to read expected or actual results from file for test %s: %s", self.testname, e)
+        self.cleanup_test()
+        return False
+      # if we get expected result, no need to retry
+      if expected_result == actual_result:
+        break
+      if retriesLeft > 0:
+        expected_result = ""
+        actual_result = ""
+        logging.info("Failed to get expected results for test %s (attempt %s/%s), "\
+                     + "retrying after %s seconds",
+                     self.testname, RETRY_COUNT - retriesLeft, RETRY_COUNT, RETRY_INTERVAL)
+        time.sleep(RETRY_INTERVAL)
+
+    self.cleanup_test()
+
+    # Compare the actual and expected result
+    if actual_result == expected_result:
+      logging.info("Actual result matched expected result for test %s", self.testname)
+      logging.info("Actual result ---------- \n" + actual_result)
+      logging.info("Expected result ---------- \n" + expected_result)
+      return True
+    else:
+      logging.error("Actual result did not match expected result for test %s", self.testname)
+      logging.info("Actual result ---------- \n" + actual_result)
+      logging.info("Expected result ---------- \n" + expected_result)
+      return False
+
+  # pylint: disable=no-self-use
+  def get_pid(self, processName, heronWorkingDirectory):
+    '''
+    opens .pid file of process and reads the first and only line, which should be the process pid
+    if fail, return -1
+    '''
+    process_pid_file = os.path.join(heronWorkingDirectory, processName + '.pid')
+    try:
+      with open(process_pid_file, 'r') as f:
+        pid = f.readline()
+        return pid
+    except Exception:
+      logging.error("Unable to open file %s", process_pid_file)
+      return -1
+
+  # pylint: disable=no-self-use
+  def kill_process(self, process_number):
+    ''' kills process by running unix command kill '''
+    if process_number < 1:
+      raise RuntimeError(
+        "Not attempting to kill process id < 1 passed to kill_process: %d" % process_number)
+
+    logging.info("Killing process number %s", process_number)
+
+    try:
+      os.kill(int(process_number), signal.SIGTERM)
+    except OSError as ex:
+      if "No such process" in str(ex): # killing a non-existing process condsidered as success
+        logging.info(str(ex))
+      else:
+        raise RuntimeError("Unable to kill process %s" % process_number)
+    except Exception:
+      raise RuntimeError("Unable to kill process %s" % process_number)
+
+    logging.info("Killed process number %s", process_number)
+
+  def kill_strmgr(self):
+    logging.info("Executing kill stream manager")
+    stmgr_pid = self.get_pid('%s-%d' % (STMGR, NON_TMASTER_SHARD), self.params['workingDirectory'])
+    self.kill_process(stmgr_pid)
+
+  def kill_metricsmgr(self):
+    logging.info("Executing kill metrics manager")
+    metricsmgr_pid = self.get_pid(
+      '%s-%d' % (HERON_METRICSMGR, NON_TMASTER_SHARD), self.params['workingDirectory'])
+    self.kill_process(metricsmgr_pid)
+
+def _block_until_topology_running():
+  # block until ./heron-stmgr exists
+  processList = _get_processes()
+  while not _process_exists(processList, HERON_STMGR_CMD):
+    processList = _get_processes()
+
+def _submit_topology(heronCliPath, testCluster, testJarPath, topologyClassPath,
+                     topology_name, inputFile, outputFile):
+  ''' Submit topology using heron-cli '''
+  # unicode string messes up subprocess.call quotations, must change into string type
+  splitcmd = [
+      '%s' % (heronCliPath),
+      'submit',
+      '--verbose',
+      '--',
+      '%s' % (testCluster),
+      '%s' % (testJarPath),
+      '%s' % (topologyClassPath),
+      '%s' % (topology_name),
+      '%s' % (inputFile),
+      '%s' % (outputFile),
+      '%d' % (len(TEST_INPUT))
+  ]
+  logging.info("Submitting topology: %s", splitcmd)
+  p = subprocess.Popen(splitcmd)
+  p.wait()
+  logging.info("Submitted topology %s", topology_name)
+
+def _kill_topology(heronCliPath, testCluster, topology_name):
+  ''' Kill a topology using heron-cli '''
+  splitcmd = [
+      '%s' % (heronCliPath),
+      'kill',
+      '--verbose',
+      '%s' % (testCluster),
+      '%s' % (topology_name),
+  ]
+  logging.info("Killing topology: %s", splitcmd)
+  # this call can be blocking, no need for subprocess
+  if subprocess.call(splitcmd) != 0:
+    raise RuntimeError("Unable to kill the topology: %s" % topology_name)
+  logging.info("Successfully killed topology %s", topology_name)
+
+def _get_processes():
+  '''
+  returns a list of process tuples (pid, cmd)
+  This only applies only for local scheduler as it uses the ps command
+  and assumes the topology will be running on different processes on same machine
+  '''
+  # pylint: disable=fixme
+  # TODO: if the submit fails before we get here (e.g., Topology already exists), this hangs
+  processes = subprocess.check_output(['ps', '-o', 'pid,args'])
+  processes = processes.split('\n')
+  processes = processes[1:] # remove first line, which is name of columns
+  processList = []
+  for process in processes:
+    # remove empty lines
+    if process == '':
+      continue
+    pretuple = process.split(' ', 1)
+    processList.append(ProcessTuple(pretuple[0], pretuple[1]))
+  return processList
+
+def _sleep(message, seconds):
+  logging.info("Sleeping for %d seconds %s", seconds, message)
+  time.sleep(seconds)
+
+def _process_exists(processList, processCmd):
+  ''' check if a process is running '''
+  for process in processList:
+    if processCmd in process.cmd:
+      return True
+  return False
+
+def _safe_delete_file(file_name):
+  if os.path.isfile(file_name) and os.path.exists(file_name):
+    try:
+      os.remove(file_name)
+    except Exception as e:
+      logging.error("Failed to delete file: %s: %s", file_name, e)
+      return False

--- a/integration-test/src/python/local_test_runner/test_template.py
+++ b/integration-test/src/python/local_test_runner/test_template.py
@@ -174,12 +174,12 @@ class TestTemplate(object):
       return False
 
   # pylint: disable=no-self-use
-  def get_pid(self, processName, heronWorkingDirectory):
+  def get_pid(self, process_name, heron_working_directory):
     """
     opens .pid file of process and reads the first and only line, which should be the process pid
     if fail, return -1
     """
-    process_pid_file = os.path.join(heronWorkingDirectory, processName + '.pid')
+    process_pid_file = os.path.join(heron_working_directory, process_name + '.pid')
     try:
       with open(process_pid_file, 'r') as f:
         pid = f.readline()

--- a/integration-test/src/python/local_test_runner/test_template.py
+++ b/integration-test/src/python/local_test_runner/test_template.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-''' test_template.py '''
+""" test_template.py """
 import logging
 import os
 import time
@@ -132,9 +132,9 @@ class TestTemplate(object):
     """
     expected_result = ""
     actual_result = ""
-    retriesLeft = RETRY_COUNT
-    while retriesLeft > 0:
-      retriesLeft -= 1
+    retries_left = RETRY_COUNT
+    while retries_left > 0:
+      retries_left -= 1
       try:
         with open(self.params['readFile'], 'r') as f:
           expected_result = f.read()
@@ -148,12 +148,12 @@ class TestTemplate(object):
       # if we get expected result, no need to retry
       if expected_result == actual_result:
         break
-      if retriesLeft > 0:
+      if retries_left > 0:
         expected_result = ""
         actual_result = ""
         logging.info("Failed to get expected results for test %s (attempt %s/%s), "\
                      + "retrying after %s seconds",
-                     self.testname, RETRY_COUNT - retriesLeft, RETRY_COUNT, RETRY_INTERVAL)
+                     self.testname, RETRY_COUNT - retries_left, RETRY_COUNT, RETRY_INTERVAL)
         time.sleep(RETRY_INTERVAL)
 
     self.cleanup_test()
@@ -172,10 +172,10 @@ class TestTemplate(object):
 
   # pylint: disable=no-self-use
   def get_pid(self, processName, heronWorkingDirectory):
-    '''
+    """
     opens .pid file of process and reads the first and only line, which should be the process pid
     if fail, return -1
-    '''
+    """
     process_pid_file = os.path.join(heronWorkingDirectory, processName + '.pid')
     try:
       with open(process_pid_file, 'r') as f:
@@ -187,7 +187,7 @@ class TestTemplate(object):
 
   # pylint: disable=no-self-use
   def kill_process(self, process_number):
-    ''' kills process by running unix command kill '''
+    """ kills process by running unix command kill """
     if process_number < 1:
       raise RuntimeError(
         "Not attempting to kill process id < 1 passed to kill_process: %d" % process_number)
@@ -219,41 +219,26 @@ class TestTemplate(object):
 
 def _block_until_topology_running():
   # block until ./heron-stmgr exists
-  processList = _get_processes()
-  while not _process_exists(processList, HERON_STMGR_CMD):
-    processList = _get_processes()
+  process_list = _get_processes()
+  while not _process_exists(process_list, HERON_STMGR_CMD):
+    process_list = _get_processes()
 
-def _submit_topology(heronCliPath, testCluster, testJarPath, topologyClassPath,
-                     topology_name, inputFile, outputFile):
-  ''' Submit topology using heron-cli '''
+def _submit_topology(heron_cli_path, test_cluster, test_jar_path, topology_class_path,
+                     topology_name, input_file, output_file):
+  """ Submit topology using heron-cli """
   # unicode string messes up subprocess.call quotations, must change into string type
   splitcmd = [
-      '%s' % (heronCliPath),
-      'submit',
-      '--verbose',
-      '--',
-      '%s' % (testCluster),
-      '%s' % (testJarPath),
-      '%s' % (topologyClassPath),
-      '%s' % (topology_name),
-      '%s' % (inputFile),
-      '%s' % (outputFile),
-      '%d' % (len(TEST_INPUT))
+      heron_cli_path, 'submit', '--verbose', '--', test_cluster, test_jar_path,
+      topology_class_path, topology_name, input_file, output_file, str(len(TEST_INPUT))
   ]
   logging.info("Submitting topology: %s", splitcmd)
   p = subprocess.Popen(splitcmd)
   p.wait()
   logging.info("Submitted topology %s", topology_name)
 
-def _kill_topology(heronCliPath, testCluster, topology_name):
-  ''' Kill a topology using heron-cli '''
-  splitcmd = [
-      '%s' % (heronCliPath),
-      'kill',
-      '--verbose',
-      '%s' % (testCluster),
-      '%s' % (topology_name),
-  ]
+def _kill_topology(heron_cli_path, test_cluster, topology_name):
+  """ Kill a topology using heron-cli """
+  splitcmd = [heron_cli_path, 'kill', '--verbose', test_cluster, topology_name]
   logging.info("Killing topology: %s", splitcmd)
   # this call can be blocking, no need for subprocess
   if subprocess.call(splitcmd) != 0:
@@ -261,33 +246,33 @@ def _kill_topology(heronCliPath, testCluster, topology_name):
   logging.info("Successfully killed topology %s", topology_name)
 
 def _get_processes():
-  '''
+  """
   returns a list of process tuples (pid, cmd)
   This only applies only for local scheduler as it uses the ps command
   and assumes the topology will be running on different processes on same machine
-  '''
+  """
   # pylint: disable=fixme
   # TODO: if the submit fails before we get here (e.g., Topology already exists), this hangs
   processes = subprocess.check_output(['ps', '-o', 'pid,args'])
   processes = processes.split('\n')
   processes = processes[1:] # remove first line, which is name of columns
-  processList = []
+  process_list = []
   for process in processes:
     # remove empty lines
     if process == '':
       continue
     pretuple = process.split(' ', 1)
-    processList.append(ProcessTuple(pretuple[0], pretuple[1]))
-  return processList
+    process_list.append(ProcessTuple(pretuple[0], pretuple[1]))
+  return process_list
 
 def _sleep(message, seconds):
   logging.info("Sleeping for %d seconds %s", seconds, message)
   time.sleep(seconds)
 
-def _process_exists(processList, processCmd):
-  ''' check if a process is running '''
-  for process in processList:
-    if processCmd in process.cmd:
+def _process_exists(process_list, process_cmd):
+  """ check if a process is running """
+  for process in process_list:
+    if process_cmd in process.cmd:
       return True
   return False
 

--- a/integration-test/src/python/local_test_runner/test_template.py
+++ b/integration-test/src/python/local_test_runner/test_template.py
@@ -65,7 +65,9 @@ class TestTemplate(object):
       self._inject_test_data()
       _sleep("before checking for results", 30)
 
-      self.pre_check_results()
+      if not self.pre_check_results():
+        self.cleanup_test()
+        return False
     except Exception as e:
       logging.error("Test failed, attempting to clean up: %s", e)
       self.cleanup_test()
@@ -92,8 +94,9 @@ class TestTemplate(object):
   def execute_test_case(self):
     pass
 
+  # pylint: disable=no-self-use
   def pre_check_results(self):
-    pass
+    return True
 
   def cleanup_test(self):
     try:

--- a/integration-test/src/python/local_test_runner/test_template.py
+++ b/integration-test/src/python/local_test_runner/test_template.py
@@ -193,7 +193,7 @@ class TestTemplate(object):
     """ kills process by running unix command kill """
     if process_number < 1:
       raise RuntimeError(
-        "Not attempting to kill process id < 1 passed to kill_process: %d" % process_number)
+          "Not attempting to kill process id < 1 passed to kill_process: %d" % process_number)
 
     logging.info("Killing process number %s", process_number)
 
@@ -217,7 +217,7 @@ class TestTemplate(object):
   def kill_metricsmgr(self):
     logging.info("Executing kill metrics manager")
     metricsmgr_pid = self.get_pid(
-      '%s-%d' % (HERON_METRICSMGR, NON_TMASTER_SHARD), self.params['workingDirectory'])
+        '%s-%d' % (HERON_METRICSMGR, NON_TMASTER_SHARD), self.params['workingDirectory'])
     self.kill_process(metricsmgr_pid)
 
 def _block_until_topology_running():


### PR DESCRIPTION
Refactors local_test_runner integration test to prepare for adding a scaling test

- Change to object-oriented from proceedural
- Use the template pattern to allow for test subclassing (see `TestTemplate.run_test()`)
- Change method and variable names to be snake_case instead of camelCase (idiomatic python)

Required for #1292.
