### PR TITLE
Add ubuntu16.04-based docker containers

### DIFF
--- a/docker/Dockerfile.dist.ubuntu16.04
+++ b/docker/Dockerfile.dist.ubuntu16.04
@@ -27,7 +27,6 @@ ADD artifacts /heron
 WORKDIR /heron
 
 #run heron installers
-RUN /heron/heron-tools-install-*-ubuntu16.04.sh && \
-    /heron/heron-client-install-*-ubuntu16.04.sh && \
+RUN /heron/heron-client-install-*-ubuntu16.04.sh && \
     /heron/heron-tools-install-*-ubuntu16.04.sh
 

--- a/docker/Dockerfile.dist.ubuntu16.04
+++ b/docker/Dockerfile.dist.ubuntu16.04
@@ -1,0 +1,33 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get -y install \
+      curl \
+      git \
+      libssl-dev \
+      libtool \
+      libunwind8 \
+      libunwind-setjmp0-dev \
+      python \
+      software-properties-common \
+      unzip \
+      wget \
+      zip
+
+RUN \
+  echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
+  add-apt-repository -y ppa:webupd8team/java && \
+  apt-get update && \
+  apt-get install -y oracle-java8-installer && \
+  rm -rf /var/lib/apt/lists/* && \
+  rm -rf /var/cache/oracle-jdk8-installer
+ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+
+ADD artifacts /heron
+
+WORKDIR /heron
+
+#run heron installers
+RUN /heron/heron-tools-install-*-ubuntu16.04.sh && \
+    /heron/heron-client-install-*-ubuntu16.04.sh && \
+    /heron/heron-tools-install-*-ubuntu16.04.sh
+

--- a/docker/Dockerfile.ubuntu16.04
+++ b/docker/Dockerfile.ubuntu16.04
@@ -1,0 +1,41 @@
+FROM ubuntu:16.04
+
+# This is passed to the heron build command via the --config flag
+ENV TARGET_PLATFORM ubuntu
+ENV bazelVersion 0.2.3
+
+RUN apt-get update && apt-get -y install \
+      automake \
+      build-essential \
+      cmake \
+      curl \
+      libssl-dev \
+      git \
+      libtool \
+      libunwind8 \
+      libunwind-setjmp0-dev \
+      python \
+      python2.7-dev \
+      python-software-properties \
+      software-properties-common \
+      python-setuptools \
+      zip \
+      unzip \
+      wget
+
+RUN \
+  echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
+  add-apt-repository -y ppa:webupd8team/java && \
+  apt-get update && \
+  apt-get install -y oracle-java8-installer && \
+  rm -rf /var/lib/apt/lists/* && \
+  rm -rf /var/cache/oracle-jdk8-installer
+ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+
+RUN wget -O /tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/$bazelVersion/bazel-$bazelVersion-installer-linux-x86_64.sh \
+      && chmod +x /tmp/bazel.sh \
+      && /tmp/bazel.sh
+
+ADD bazelrc /root/.bazelrc
+ADD compile-platform.sh /compile-platform.sh
+

--- a/docker/build-artifacts.sh
+++ b/docker/build-artifacts.sh
@@ -148,7 +148,7 @@ case $# in
   *)
     echo "Usage: $0 <platform> <version_string> [source-tarball] <output-directory> "
     echo "  "
-    echo "Platforms Supported: darwin, ubuntu14.04, ubuntu15.10, centos7"
+    echo "Platforms Supported: darwin, ubuntu14.04, ubuntu15.10, ubuntu16.04 centos7"
     echo "  "
     echo "Example:"
     echo "  ./build-artifacts.sh ubuntu14.04 0.12.0 ."


### PR DESCRIPTION
Add ubuntu16.04 based docker containers for heron-compile and heron itself

To compile source using a docker container:

```
./docker/build-artifacts.sh <platform> <version_string> [source-tarball] <output-directory>
# e.g.  ./docker/build-artifacts.sh ubuntu16.04 testbuild ~/heron-release
```

To build docker containers for running heron daemons:

```
./docker/build-docker.sh <platform> <version_string> <output-directory>
# e.g. ./docker/build-docker.sh ubuntu16.04 testbuild ~/heron-release
```

To run docker containers for local dev work:

```
./docker/start-docker.sh heron:<version_string>-<platform>
# e.g. ./docker/start-docker.sh heron:testbuild-ubuntu16.04
```