### PR TITLE
Failed to submit topo using extra_launch_classpath arg  #1372

### DIFF
--- a/heron/tools/common/src/python/utils/classpath.py
+++ b/heron/tools/common/src/python/utils/classpath.py
@@ -23,8 +23,8 @@ def valid_path(path):
   '''
   # check if the suffic of classpath suffix exists as directory
   if path.endswith('*'):
-    Log.debug('Checking classpath entry suffix as directory: %s', path[-1])
-    if os.path.isdir(path[-1]):
+    Log.debug('Checking classpath entry suffix as directory: %s', path[:-1])
+    if os.path.isdir(path[:-1]):
       return True
     return False
 


### PR DESCRIPTION
It seems something wrong submitting topo using `extra_launch_classpath` arg if directory ends with '*' .

this PR try to fix it