### PR TITLE
Repacking to use globally unique task ids

### DIFF
--- a/heron/packing/src/java/com/twitter/heron/packing/PackingUtils.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/PackingUtils.java
@@ -115,13 +115,11 @@ public final class PackingUtils {
         double instanceCpu = instanceDefaults.getCpu();
         containerCpu += instanceCpu;
 
-        Resource resource =
-            new Resource(instanceCpu, instanceRam, instanceDisk);
         PackingPlan.InstancePlan instancePlan =
             new PackingPlan.InstancePlan(
                 instanceId,
                 getComponentName(instanceId),
-                resource);
+                new Resource(instanceCpu, instanceRam, instanceDisk));
         // Insert it into the map
         instancePlans.add(instancePlan);
       }
@@ -142,6 +140,11 @@ public final class PackingUtils {
     return containerPlans;
   }
 
+  // TODO: The instanceId string is actually assumed to be the specific format shown below, which
+  // should not be the case. For example, if instanceIds are generated with reused instanceIdx
+  // values, tuples can be mis-routed. Instead of loading the instance id with delimited tokens
+  // with hidden meaning and consequences, we should promote these concepts into the InstancePlan
+  // object as first-class concepts that are properly typed.
   public static String getInstanceId(
       int containerIdx, String componentName, int instanceIdx, int componentIdx) {
     return String.format("%d:%s:%d:%d", containerIdx, componentName, instanceIdx, componentIdx);
@@ -149,5 +152,9 @@ public final class PackingUtils {
 
   public static String getComponentName(String instanceId) {
     return instanceId.split(":")[1];
+  }
+
+  public static Integer getGlobalInstanceIndex(String instanceId) {
+    return Integer.parseInt(instanceId.split(":")[2]);
   }
 }

--- a/heron/packing/src/java/com/twitter/heron/packing/PackingUtils.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/PackingUtils.java
@@ -145,6 +145,7 @@ public final class PackingUtils {
   // values, tuples can be mis-routed. Instead of loading the instance id with delimited tokens
   // with hidden meaning and consequences, we should promote these concepts into the InstancePlan
   // object as first-class concepts that are properly typed.
+  // See https://github.com/twitter/heron/issues/1376
   public static String getInstanceId(
       int containerIdx, String componentName, int instanceIdx, int componentIdx) {
     return String.format("%d:%s:%d:%d", containerIdx, componentName, instanceIdx, componentIdx);

--- a/heron/packing/src/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPacking.java
@@ -230,7 +230,7 @@ public class FirstFitDecreasingPacking implements IPacking, IRepacking {
    */
   private Map<Integer, List<String>> getFFDAllocation() {
     Map<String, Integer> parallelismMap = TopologyUtils.getComponentParallelism(topology);
-    return assignInstancestoContainers(parallelismMap, 0);
+    return assignInstancesToContainers(parallelismMap, 1, 1);
   }
 
   /**
@@ -241,39 +241,42 @@ public class FirstFitDecreasingPacking implements IPacking, IRepacking {
   private Map<Integer, List<String>> getFFDAllocation(PackingPlan currentPackingPlan,
                                                       Map<String, Integer> componentChanges) {
     int numContainers = currentPackingPlan.getContainers().size();
-    return assignInstancestoContainers(componentChanges, numContainers);
+    int maxInstanceIndex = 0;
+    for (PackingPlan.ContainerPlan containerPlan : currentPackingPlan.getContainers()) {
+      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
+        maxInstanceIndex = Math.max(
+            maxInstanceIndex, PackingUtils.getGlobalInstanceIndex(instancePlan.getId()));
+      }
+    }
+    return assignInstancesToContainers(componentChanges, numContainers + 1, maxInstanceIndex + 1);
   }
 
   /**
-   * Place a set of instances into the containers using the FFD heuristic.
-   * The method starts with an existing number of containers and
-   * may add extra containers if needed.
+   * Place a set of instances into container using the FFD heuristic. Adds new containers and
+   * instances starting at {@code firstContainerIndex) and {@code firstTaskIndex}, respectively.
    *
    * @return true if a placement was found, false otherwise
    */
-  private Map<Integer, List<String>> assignInstancestoContainers(
-      Map<String, Integer> parallelismMap,
-      int startNumContainers) {
+  private Map<Integer, List<String>> assignInstancesToContainers(
+      Map<String, Integer> parallelismMap, int firstContainerIndex, int firstTaskIndex) {
     Map<Integer, List<String>> allocation = new HashMap<>();
     ArrayList<Container> containers = new ArrayList<>();
     ArrayList<RamRequirement> ramRequirements = getSortedRAMInstances(parallelismMap);
-    int globalTaskIndex = 1;
+    int globalTaskIndex = firstTaskIndex;
     for (RamRequirement ramRequirement : ramRequirements) {
       String component = ramRequirement.getComponentName();
       int numInstance = parallelismMap.get(component);
       for (int j = 0; j < numInstance; j++) {
         Resource instanceResource =
             this.defaultInstanceResources.cloneWithRam(ramRequirement.getRamRequirement());
-        int containerId = placeFFDInstance(containers, instanceResource);
-        if (allocation.containsKey(containerId + startNumContainers)) {
-          allocation.get(containerId + startNumContainers).add(PackingUtils.getInstanceId(
-              containerId + startNumContainers, component, globalTaskIndex, j));
-        } else {
-          ArrayList<String> instance = new ArrayList<>();
-          instance.add(PackingUtils.getInstanceId(
-              containerId + startNumContainers, component, globalTaskIndex, j));
-          allocation.put(containerId + startNumContainers, instance);
+        // placeFFDInstance returns containerIds that are 1-based so we have to offset by 1
+        int containerId = placeFFDInstance(containers, instanceResource) + firstContainerIndex - 1;
+        List<String> instances = allocation.get(containerId);
+        if (instances == null) {
+          instances = new ArrayList<>();
         }
+        instances.add(PackingUtils.getInstanceId(containerId, component, globalTaskIndex, j));
+        allocation.put(containerId, instances);
         globalTaskIndex++;
       }
     }

--- a/heron/packing/src/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPacking.java
@@ -275,9 +275,8 @@ public class FirstFitDecreasingPacking implements IPacking, IRepacking {
         if (instances == null) {
           instances = new ArrayList<>();
         }
-        instances.add(PackingUtils.getInstanceId(containerId, component, globalTaskIndex, j));
+        instances.add(PackingUtils.getInstanceId(containerId, component, globalTaskIndex++, j));
         allocation.put(containerId, instances);
-        globalTaskIndex++;
       }
     }
     return allocation;

--- a/heron/packing/tests/java/BUILD
+++ b/heron/packing/tests/java/BUILD
@@ -36,6 +36,7 @@ java_library(
         ["com/twitter/heron/packing/*.java"]
     ),
     deps = [
+        "//heron/packing/src/java:roundrobin-packing",
         "//heron/spi/src/java:packing-spi-java",
         "//third_party/java:junit4",
     ],

--- a/heron/packing/tests/java/com/twitter/heron/packing/AssertPacking.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/AssertPacking.java
@@ -13,6 +13,9 @@
 // limitations under the License.
 package com.twitter.heron.packing;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.Assert;
@@ -38,6 +41,9 @@ public final class AssertPacking {
                                       Long notExpectedContainerRam) {
     boolean boltFound = false;
     boolean spoutFound = false;
+    List<Integer> expectedInstanceIndecies = new ArrayList<>();
+    List<Integer> foundInstanceIndecies = new ArrayList<>();
+    int expectedInstanceIndex = 1;
     // Ram for bolt should be the value in component ram map
     for (PackingPlan.ContainerPlan containerPlan : containerPlans) {
       if (notExpectedContainerRam != null) {
@@ -45,6 +51,8 @@ public final class AssertPacking {
             notExpectedContainerRam, (Long) containerPlan.getResource().getRam());
       }
       for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
+        expectedInstanceIndecies.add(expectedInstanceIndex++);
+        foundInstanceIndecies.add(PackingUtils.getGlobalInstanceIndex(instancePlan.getId()));
         if (instancePlan.getComponentName().equals(boltName)) {
           Assert.assertEquals(expectedBoltRam, instancePlan.getResource().getRam());
           boltFound = true;
@@ -57,6 +65,10 @@ public final class AssertPacking {
     }
     Assert.assertTrue("Bolt not found in any of the container plans: " + boltName, boltFound);
     Assert.assertTrue("Spout not found in any of the container plans: " + spoutName, spoutFound);
+
+    Collections.sort(foundInstanceIndecies);
+    Assert.assertEquals("Unexpected instance global id set found.",
+        expectedInstanceIndecies, foundInstanceIndecies);
   }
 
   public static void assertContainerRam(Set<PackingPlan.ContainerPlan> containerPlans,

--- a/heron/packing/tests/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPackingTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPackingTest.java
@@ -359,8 +359,8 @@ public class FirstFitDecreasingPackingTest {
     int numScalingInstances = 3;
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put(BOLT_NAME, numScalingInstances);
-    PackingPlan newPackingPlan = getFirstFitDecreasingPackingPlanRepack(topology, packingPlan,
-        componentChanges);
+    PackingPlan newPackingPlan =
+        getFirstFitDecreasingPackingPlanRepack(topology, packingPlan, componentChanges);
 
     Assert.assertEquals(3, newPackingPlan.getContainers().size());
     Assert.assertEquals((Integer) (totalInstances + numScalingInstances),
@@ -370,7 +370,6 @@ public class FirstFitDecreasingPackingTest {
         instanceDefaultResources.getRam(), null);
     AssertPacking.assertContainerRam(newPackingPlan.getContainers(),
         defaultNumInstancesperContainer * instanceDefaultResources.getRam());
-
   }
 
   /**
@@ -401,9 +400,8 @@ public class FirstFitDecreasingPackingTest {
     int numScalingInstances = 3;
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put(BOLT_NAME, numScalingInstances);
-    PackingPlan newPackingPlan = getFirstFitDecreasingPackingPlanRepack(topologyExplicitRamMap,
-        packingPlanExplicitRamMap,
-        componentChanges);
+    PackingPlan newPackingPlan = getFirstFitDecreasingPackingPlanRepack(
+        topologyExplicitRamMap, packingPlanExplicitRamMap, componentChanges);
 
     Assert.assertEquals(4, newPackingPlan.getContainers().size());
     Assert.assertEquals((Integer) (totalInstances + numScalingInstances),


### PR DESCRIPTION
Repacking was reusing global task ids (i.e., restarting from 1) for new instnaces added. This caused strange tuple routing behavior.

Opened #1376 to not rely on `instanceIndex` parsed from `instanceId`.