### PR TITLE
Proper check of the existence of SSH tunnel attribute

### DIFF
--- a/heron/statemgrs/src/python/statemanager.py
+++ b/heron/statemgrs/src/python/statemanager.py
@@ -122,7 +122,7 @@ class StateManager:
     return localport
 
   def terminate_ssh_tunnel(self):
-    if hasattr(self, 'tunnel'):
+    if hasattr(self, 'tunnel') and self.tunnel:
       self.tunnel.terminate()
 
   @abc.abstractmethod

--- a/heron/statemgrs/src/python/statemanager.py
+++ b/heron/statemgrs/src/python/statemanager.py
@@ -122,7 +122,7 @@ class StateManager:
     return localport
 
   def terminate_ssh_tunnel(self):
-    if self.tunnel:
+    if hasattr(self, 'tunnel'):
       self.tunnel.terminate()
 
   @abc.abstractmethod


### PR DESCRIPTION
The attribute `tunnel` is [only added](https://github.com/twitter/heron/search?utf8=%E2%9C%93&q=%22self.tunnel%22&type=Code) to the (Zookeeper) StateManager object [when socket connection cannot be established and SSH is used instead](https://github.com/twitter/heron/blob/master/heron/statemgrs/src/python/zkstatemanager.py#L50). 

When one is trying to shutdown the tracker, the (Zookeeper) state manager will be shutdown first. However, the original way of check if SSH tunnel has been establish is wrong. If one wants to check if the attribute `tunnel` exists in the StateManager object, he should use `hasattr` instead of `if self.tunnel`. The latter one assumes the attribute `tunnel` already exists in the object.

This PR should fix #1379 