### PR TITLE
Speed up local test runner and enhancements for scaling

### DIFF
--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -555,9 +555,12 @@ class HeronExecutor(object):
     # if the current command has a matching command in the updated commands we keep it
     # otherwise we kill it
     for current_name, current_command in current_commands.iteritems():
+      # Always restart tmaster to pick up new state. The stream manager is also restarted, but
+      # we shouldn't need to do that and work is being done to fix that on the steam manager
       if current_name in updated_commands.keys() and \
         current_command == updated_commands[current_name] and \
-        current_name != 'heron-tmaster': # always restart tmaster of instance dist has changed
+        current_name != 'heron-tmaster' and \
+        not current_name.startswith('stmgr-'):
         commands_to_keep[current_name] = current_command
       else:
         commands_to_kill[current_name] = current_command

--- a/integration-test/src/python/local_test_runner/main.py
+++ b/integration-test/src/python/local_test_runner/main.py
@@ -31,8 +31,10 @@ import test_kill_stmgr
 import test_kill_stmgr_metricsmgr
 import test_kill_tmaster
 import test_scale_up
+import test_template
 
 TEST_CLASSES = [
+    test_template.TestTemplate,
     test_kill_tmaster.TestKillTMaster,
     test_kill_stmgr.TestKillStmgr,
     test_kill_metricsmgr.TestKillMetricsMgr,

--- a/integration-test/src/python/local_test_runner/test_scale_up.py
+++ b/integration-test/src/python/local_test_runner/test_scale_up.py
@@ -13,34 +13,34 @@
 # limitations under the License.
 
 """test_scale_up.py"""
-import json
 import logging
 import subprocess
-import urllib
 
 import test_template
 
 class TestScaleUp(test_template.TestTemplate):
 
+  expected_container_count = 1
+  expected_instance_count = 3
+
+  def get_expected_container_count(self):
+    return self.expected_container_count
+
+  def get_expected_min_instance_count(self):
+    return self.expected_instance_count
+
   def execute_test_case(self):
     scale_up(self.params['cliPath'], self.params['cluster'], self.params['topologyName'])
+    self.expected_container_count += 1
+    self.expected_instance_count += 2
 
-  def pre_check_results(self):
-    url = 'http://localhost:%s/topologies/physicalplan?' % self.params['trackerPort']\
-          + 'cluster=local&environ=default&topology=IntegrationTest_LocalReadWriteTopology'
-    response = urllib.urlopen(url)
-    physical_plan_json = json.loads(response.read())
-    expected_instance_count = 5
+  def pre_check_results(self, physical_plan_json):
 
-    if 'result' not in physical_plan_json:
-      logging.error("Could not find result json in physical plan request to tracker: %s", url)
-      return False
-
-    instances = physical_plan_json['result']['instances']
+    instances = physical_plan_json['instances']
     instance_count = len(instances)
-    if instance_count != expected_instance_count:
+    if instance_count != self.expected_instance_count:
       logging.error("Found %s instances but expected %s: %s",
-                    instance_count, expected_instance_count, instances)
+                    instance_count, self.expected_instance_count, instances)
       return False
 
     return True

--- a/integration-test/src/python/local_test_runner/test_template.py
+++ b/integration-test/src/python/local_test_runner/test_template.py
@@ -103,9 +103,11 @@ class TestTemplate(object):
       logging.error("Failed to submit %s topology: %s", self.params['topologyName'], str(e))
       return False
 
+  # pylint: disable=no-self-use
   def get_expected_container_count(self):
     return 1
 
+  # pylint: disable=no-self-use
   def get_expected_min_instance_count(self):
     return 1
 
@@ -271,8 +273,8 @@ class TestTemplate(object):
           return packing_plan
         elif retries_left == 0:
           logging.error(
-            "Got pplan from tracker for test %s but the number of instances found (%d) was less" +\
-            "than min expected (%s).", self.testname, instances_found, min_instances)
+              "Got pplan from tracker for test %s but the number of instances found (%d) was " +\
+              "less than min expected (%s).", self.testname, instances_found, min_instances)
           self.cleanup_test()
           return None
 


### PR DESCRIPTION
Improved the local int tests:

- No longer just sleeping and trying, now polling for topology being up before continuing. This speeds up the tests.
- When checking for stream manager running, take into account possibility of multiple stream managers
- When checking for pplan, make sure expected instance count exists
- Fixed bug during scaling by restarting stream manager during scaling
- The test template framework now gets the pplan and injects it into the test case

Required for #1292.
