### PR TITLE
Replacing colon-delimited Instance.id with typed InstanceId object

### DIFF
--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -375,9 +375,8 @@ class HeronExecutor(object):
     instance_plans = self._get_instance_plans(self.packing_plan, self.shard)
     instance_info = []
     for instance_plan in instance_plans:
-      tokens = instance_plan.id.split(":")
-      global_task_id = tokens[2]
-      component_index = tokens[3]
+      global_task_id = instance_plan.task_id
+      component_index = instance_plan.component_index
       component_name = instance_plan.component_name
       instance_id = "container_%s_%s_%s" % (str(self.shard), component_name, str(global_task_id))
       instance_info.append((instance_id, component_name, global_task_id, component_index))

--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -331,8 +331,8 @@ class HeronExecutor(object):
                            self.topology_id,
                            instance_id,
                            component_name,
-                           global_task_id,
-                           component_index,
+                           str(global_task_id),
+                           str(component_index),
                            self.stmgr_ids[self.shard - 1],
                            self.master_port,
                            self.metricsmgr_port,
@@ -352,8 +352,8 @@ class HeronExecutor(object):
                       self.topology_id,
                       instance_id,
                       component_name,
-                      global_task_id,
-                      component_index,
+                      str(global_task_id),
+                      str(component_index),
                       self.stmgr_ids[self.shard - 1],
                       self.master_port,
                       self.metricsmgr_port,
@@ -378,7 +378,7 @@ class HeronExecutor(object):
       global_task_id = instance_plan.task_id
       component_index = instance_plan.component_index
       component_name = instance_plan.component_name
-      instance_id = "container_%s_%s_%s" % (str(self.shard), component_name, str(global_task_id))
+      instance_id = "container_%s_%s_%d" % (str(self.shard), component_name, global_task_id)
       instance_info.append((instance_id, component_name, global_task_id, component_index))
 
     stmgr_cmd = [

--- a/heron/executor/tests/python/heron_executor_unittest.py
+++ b/heron/executor/tests/python/heron_executor_unittest.py
@@ -75,9 +75,9 @@ class HeronExecutorTest(unittest.TestCase):
       container_plan.id = int(container_id)
       for (component_name, global_task_id, component_index) in instance_distribution[container_id]:
         instance_plan = container_plan.instance_plans.add()
-        instance_plan.id = "%s:%s:%s:%s" %\
-                           (container_id, component_name, global_task_id, component_index)
         instance_plan.component_name = component_name
+        instance_plan.task_id = int(global_task_id)
+        instance_plan.component_index = int(component_index)
     return packing_plan
 
   # pylint: disable=no-self-argument

--- a/heron/packing/tests/java/com/twitter/heron/packing/AssertPacking.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/AssertPacking.java
@@ -52,7 +52,7 @@ public final class AssertPacking {
       }
       for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
         expectedInstanceIndecies.add(expectedInstanceIndex++);
-        foundInstanceIndecies.add(PackingUtils.getGlobalInstanceIndex(instancePlan.getId()));
+        foundInstanceIndecies.add(instancePlan.getTaskId());
         if (instancePlan.getComponentName().equals(boltName)) {
           Assert.assertEquals(expectedBoltRam, instancePlan.getResource().getRam());
           boltFound = true;

--- a/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPackingTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPackingTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.packing.AssertPacking;
-import com.twitter.heron.packing.PackingUtils;
 import com.twitter.heron.spi.common.ClusterDefaults;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Constants;
@@ -45,8 +44,8 @@ public class ResourceCompliantRRPackingTest {
 
   private int countComponent(String component, Set<PackingPlan.InstancePlan> instances) {
     int count = 0;
-    for (PackingPlan.InstancePlan pair : instances) {
-      if (component.equals(PackingUtils.getComponentName(pair.getId()))) {
+    for (PackingPlan.InstancePlan instancePlan : instances) {
+      if (component.equals(instancePlan.getComponentName())) {
         count++;
       }
     }

--- a/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/RoundRobinPackingTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/RoundRobinPackingTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.packing.AssertPacking;
-import com.twitter.heron.packing.PackingUtils;
 import com.twitter.heron.spi.common.ClusterDefaults;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Constants;
@@ -282,7 +281,7 @@ public class RoundRobinPackingTest {
       PackingPlan.ContainerPlan containerPlan, String componentName, int expectedCount) {
     int count = 0;
     for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
-      if (componentName.equals(PackingUtils.getComponentName(instancePlan.getId()))) {
+      if (componentName.equals(instancePlan.getComponentName())) {
         count++;
       }
     }

--- a/heron/proto/packing_plan.proto
+++ b/heron/proto/packing_plan.proto
@@ -13,9 +13,10 @@ message Resource {
 }
 
 message InstancePlan {
-  required string id = 1;
-  required string component_name = 2;
-  required Resource resource = 3;
+  required string component_name = 1;
+  required int32 task_id = 2;         // global
+  required int32 component_index = 3; // specific to this component
+  required Resource resource = 4;
 }
 
 message ContainerPlan {

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/SchedulerMainTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/SchedulerMainTest.java
@@ -37,6 +37,7 @@ import com.twitter.heron.proto.system.PackingPlans;
 import com.twitter.heron.scheduler.server.SchedulerServer;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.ConfigKeys;
+import com.twitter.heron.spi.packing.InstanceId;
 import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.packing.PackingPlanProtoSerializer;
 import com.twitter.heron.spi.packing.Resource;
@@ -122,7 +123,8 @@ public class SchedulerMainTest {
   // TODO reuse PackingTestUtils.createTestProtoPackingPlan once PR#1321 is merged
   private SettableFuture<PackingPlans.PackingPlan> getTestPacking() {
     Set<PackingPlan.InstancePlan> instances = new HashSet<>();
-    instances.add(new PackingPlan.InstancePlan("1:1:1:1", "dummy", new Resource(1, 1, 1)));
+    instances.add(
+        new PackingPlan.InstancePlan(new InstanceId("dummy", 1, 1), new Resource(1, 1, 1)));
     Set<PackingPlan.ContainerPlan> containers = new HashSet<>();
     containers.add(new PackingPlan.ContainerPlan(1, instances, new Resource(1, 1, 1)));
     PackingPlan packingPlan = new PackingPlan("packing-id", containers);

--- a/heron/spi/src/java/com/twitter/heron/spi/packing/InstanceId.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/packing/InstanceId.java
@@ -1,0 +1,66 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.twitter.heron.spi.packing;
+
+/**
+ * Encapsulates the unique components of an Instance identifier.
+ */
+public final class InstanceId {
+
+  private final String componentName;
+  private final int taskId;
+  private final int componentIndex;
+
+  public InstanceId(String componentName, int taskId, int componentIndex) {
+    this.componentName = componentName;
+    this.taskId = taskId;
+    this.componentIndex = componentIndex;
+  }
+
+  public String getComponentName() {
+    return componentName;
+  }
+
+  int getTaskId() {
+    return taskId;
+  }
+
+  int getComponentIndex() {
+    return componentIndex;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    InstanceId that = (InstanceId) o;
+
+    return taskId != that.taskId
+        && componentIndex == that.componentIndex
+        && componentName.equals(that.componentName);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = componentName.hashCode();
+    result = 31 * result + taskId;
+    result = 31 * result + componentIndex;
+    return result;
+  }
+}

--- a/heron/spi/src/java/com/twitter/heron/spi/packing/PackingPlan.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/packing/PackingPlan.java
@@ -84,9 +84,8 @@ public class PackingPlan {
       containerBuilder[index - 1] = new StringBuilder();
 
       for (PackingPlan.InstancePlan instance : container.getInstances()) {
-        String[] tokens = instance.getId().split(":");
-        containerBuilder[index - 1].append(
-            String.format("%s:%s:%s:", tokens[1], tokens[2], tokens[3]));
+        containerBuilder[index - 1].append(String.format("%s:%s:%s:",
+            instance.getComponentName(), instance.getTaskId(), instance.getComponentIndex()));
       }
       containerBuilder[index - 1].deleteCharAt(containerBuilder[index - 1].length() - 1);
     }
@@ -156,22 +155,28 @@ public class PackingPlan {
   }
 
   public static class InstancePlan {
-    private final String id;
     private final String componentName;
+    private final int taskId;
+    private final int componentIndex;
     private final Resource resource;
 
-    public InstancePlan(String id, String componentName, Resource resource) {
-      this.id = id;
-      this.componentName = componentName;
+    public InstancePlan(InstanceId instanceId, Resource resource) {
+      this.componentName = instanceId.getComponentName();
+      this.taskId = instanceId.getTaskId();
+      this.componentIndex = instanceId.getComponentIndex();
       this.resource = resource;
-    }
-
-    public String getId() {
-      return id;
     }
 
     public String getComponentName() {
       return componentName;
+    }
+
+    public int getTaskId() {
+      return taskId;
+    }
+
+    int getComponentIndex() {
+      return componentIndex;
     }
 
     public Resource getResource() {
@@ -189,23 +194,26 @@ public class PackingPlan {
 
       InstancePlan that = (InstancePlan) o;
 
-      return getId().equals(that.getId())
-          && getComponentName().equals(that.getComponentName())
+      return getComponentName().equals(that.getComponentName())
+          && getTaskId() == that.getTaskId()
+          && getComponentIndex() == that.getComponentIndex()
           && getResource().equals(that.getResource());
     }
 
     @Override
     public int hashCode() {
-      int result = getId().hashCode();
-      result = 31 * result + getComponentName().hashCode();
+      int result = getComponentName().hashCode();
+      result = 31 * result + ((Integer) getTaskId()).hashCode();
+      result = 31 * result + ((Integer) getComponentIndex()).hashCode();
       result = 31 * result + getResource().hashCode();
       return result;
     }
 
     @Override
     public String toString() {
-      return String.format("{instance-id: %s, componentName: %s, instance-resource: %s}",
-          getId(), getComponentName(), getResource().toString());
+      return String.format(
+          "{component-name: %s, task-id: %s, component-index: %s, instance-resource: %s}",
+          getComponentName(), getTaskId(), getComponentIndex(), getResource().toString());
     }
   }
 

--- a/heron/spi/src/java/com/twitter/heron/spi/packing/PackingPlanProtoDeserializer.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/packing/PackingPlanProtoDeserializer.java
@@ -39,15 +39,15 @@ public class PackingPlanProtoDeserializer {
     }
 
     return new PackingPlan.ContainerPlan(
-        containerPlan.getId(),
-        instances,
-        convert(containerPlan.getResource()));
+        containerPlan.getId(), instances, convert(containerPlan.getResource()));
   }
 
   private PackingPlan.InstancePlan convert(PackingPlans.InstancePlan instancePlan) {
     return new PackingPlan.InstancePlan(
-        instancePlan.getId(),
-        instancePlan.getComponentName(),
+        new InstanceId(
+            instancePlan.getComponentName(),
+            instancePlan.getTaskId(),
+            instancePlan.getComponentIndex()),
         convert(instancePlan.getResource()));
   }
 

--- a/heron/spi/src/java/com/twitter/heron/spi/packing/PackingPlanProtoSerializer.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/packing/PackingPlanProtoSerializer.java
@@ -45,8 +45,9 @@ public class PackingPlanProtoSerializer {
 
   private PackingPlans.InstancePlan.Builder builder(PackingPlan.InstancePlan instancePlan) {
     return PackingPlans.InstancePlan.newBuilder()
-        .setId(instancePlan.getId())
         .setComponentName(instancePlan.getComponentName())
+        .setTaskId(instancePlan.getTaskId())
+        .setComponentIndex(instancePlan.getComponentIndex())
         .setResource(builder(instancePlan.getResource()));
   }
 

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/PackingTestUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/PackingTestUtils.java
@@ -24,6 +24,7 @@ import com.twitter.heron.spi.common.ClusterDefaults;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Keys;
 import com.twitter.heron.spi.packing.IPacking;
+import com.twitter.heron.spi.packing.InstanceId;
 import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.packing.PackingPlanProtoSerializer;
 import com.twitter.heron.spi.packing.Resource;
@@ -74,16 +75,16 @@ public final class PackingTestUtils {
                                                             Integer... instanceIndices) {
     Resource resource = new Resource(7.5, 6, 9);
     Set<PackingPlan.InstancePlan> instancePlans = new HashSet<>();
-    for (int index : instanceIndices) {
-      String instanceId = "instance-" + index;
-      String componentName = "componentName-" + index;
-      instancePlans.add(testInstancePlan(instanceId, componentName));
+    for (int instanceIndex : instanceIndices) {
+      String componentName = "componentName-" + instanceIndex;
+      instancePlans.add(testInstancePlan(componentName, instanceIndex));
     }
     return new PackingPlan.ContainerPlan(containerId, instancePlans, resource);
   }
 
-  private static PackingPlan.InstancePlan testInstancePlan(String id, String componentName) {
+  private static PackingPlan.InstancePlan testInstancePlan(
+      String componentName, int instanceIndex) {
     Resource resource = new Resource(1.5, 2, 3);
-    return new PackingPlan.InstancePlan(id, componentName, resource);
+    return new PackingPlan.InstancePlan(new InstanceId(componentName, instanceIndex, 1), resource);
   }
 }


### PR DESCRIPTION
See #1376 for a more detailed description, but this removes the colon-delimited `InstancePlan.id` and replaces that with an `InstanceId` class. We no longer parse the colon-delimited id to pull things out of it. Key changes are seen in the following classes:

- `PackingPlan.InstancePlan`
- `InstanceId`
- `heron_executor.py`
- proto `PackingPlans.InstancePlan`
- `PackingUtils`
Fixes #1376.