### PR TITLE
fix illegal format conversion in ScribeSink.java 

### DIFF
--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/ScribeSink.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/ScribeSink.java
@@ -263,7 +263,8 @@ public class ScribeSink implements IMetricsSink {
   }
 
   private String connectionString() {
-    return String.format("<%s:%d>", config.get(KEY_SCRIBE_HOST), config.get(KEY_SCRIBE_PORT));
+    return String.format("<%s:%d>", config.get(KEY_SCRIBE_HOST),
+            TypeUtils.getInteger(config.get(KEY_SCRIBE_PORT)));
   }
 
   private void flushCounters() {


### PR DESCRIPTION
When compiling on centos:
ERROR: /home/wicky/dev_local/heron/heron/metricsmgr/src/java/BUILD:5:1: Java compilation in rule '//heron/metricsmgr/src/java:metricsmgr-java' failed: Worker process sent response with exit code: 1.
heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/ScribeSink.java:266: error: [FormatString] illegal format conversion: 'java.lang.Object' cannot be formatted using '%d'
    return String.format("<%s:%d>", config.get(KEY_SCRIBE_HOST), config.get(KEY_SCRIBE_PORT));
                        ^
    (see http://errorprone.info/bugpattern/FormatString)
1 error