### PR TITLE
changed the log from activateed to activated

### DIFF
--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
@@ -92,7 +92,7 @@ public class RuntimeManagerRunner implements Callable<Boolean> {
    */
   private boolean activateTopologyHandler(String topologyName) {
     return TMasterUtils.transitionTopologyState(
-        topologyName, "activate", Runtime.schedulerStateManagerAdaptor(runtime),
+        topologyName, "activat", Runtime.schedulerStateManagerAdaptor(runtime),
         TopologyAPI.TopologyState.PAUSED, TopologyAPI.TopologyState.RUNNING);
   }
 
@@ -101,7 +101,7 @@ public class RuntimeManagerRunner implements Callable<Boolean> {
    */
   private boolean deactivateTopologyHandler(String topologyName) {
     return TMasterUtils.transitionTopologyState(
-        topologyName, "deactivate", Runtime.schedulerStateManagerAdaptor(runtime),
+        topologyName, "deactivat", Runtime.schedulerStateManagerAdaptor(runtime),
         TopologyAPI.TopologyState.RUNNING, TopologyAPI.TopologyState.PAUSED);
   }
 


### PR DESCRIPTION
When you submit a topology the log comes as activateed and deactivateed
. this is done because of the placeholder here and ed is added in
transitiontopologystate function