### PR TITLE
Add metrics for stream manager queue size

### DIFF
--- a/heron/common/src/cpp/network/connection.h
+++ b/heron/common/src/cpp/network/connection.h
@@ -104,6 +104,10 @@ class Connection : public BaseConnection {
    */
   sp_int32 registerForBackPressure(VCallback<Connection*> cbStarter,
                                    VCallback<Connection*> cbReliever);
+  /**
+   * Invoke this callback when the connection buffer size changes.
+   */
+  void registerForBufferChange(VCallback<Connection*> cb);
 
   sp_int32 getOutstandingPackets() const { return mNumOutstandingPackets; }
   sp_int32 getOutstandingBytes() const { return mNumOutstandingBytes; }
@@ -160,6 +164,8 @@ class Connection : public BaseConnection {
   // This call back gets registered from the Server and gets called once the conneciton pipe
   // becomes full (outstanding bytes exceed threshold)
   VCallback<Connection*> mOnConnectionBufferFull;
+
+  VCallback<Connection*> mOnConnectionBufferChange;
 
   sp_int32 mIOVectorSize;
   struct iovec* mIOVector;

--- a/heron/common/src/cpp/network/server.cpp
+++ b/heron/common/src/cpp/network/server.cpp
@@ -88,6 +88,12 @@ BaseConnection* Server::CreateConnection(ConnectionEndPoint* _endpoint, Connecti
 
   conn->registerForBackPressure(std::move(backpressure_starter_),
                                 std::move(backpressure_reliever_));
+
+  auto buffer_size_change_ = [this](Connection* conn) {
+    this->ConnectionBufferChangeCb(conn);
+  };
+
+  conn->registerForBufferChange(std::move(buffer_size_change_));
   return conn;
 }
 
@@ -233,4 +239,8 @@ void Server::StartBackPressureConnectionCb(Connection* conn) {
 
 void Server::StopBackPressureConnectionCb(Connection* conn) {
   // Nothing to be done here. Should be handled by inheritors if they care about backpressure
+}
+
+void Server::ConnectionBufferChangeCb(Connection* conn) {
+  // Nothing to be done here. Should be handled by inheritors if they care about buffer size change
 }

--- a/heron/common/src/cpp/network/server.h
+++ b/heron/common/src/cpp/network/server.h
@@ -168,6 +168,9 @@ class Server : public BaseServer {
   // Backpressure Reliever
   virtual void StopBackPressureConnectionCb(Connection* _connection);
 
+  // Connection buffer size monitor
+  virtual void ConnectionBufferChangeCb(Connection* _connection);
+
   // Return the underlying EventLoop.
   EventLoop* getEventLoop() { return eventLoop_; }
 

--- a/heron/stmgr/src/cpp/manager/stmgr-server.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-server.cpp
@@ -409,10 +409,6 @@ void StMgrServer::SendToInstance(sp_int32 _task_id, const proto::stmgr::TupleMes
     }
     SendMessage(iter->second->conn_, _message);
   }
-
-  const sp_string& instance_id = instance_info_[_task_id]->instance_->instance_id();
-  sp_int32 bytes = iter->second->conn_->getOutstandingBytes();
-  queue_metric_map_[instance_id]->SetValue(bytes);
 }
 
 void StMgrServer::BroadcastNewPhysicalPlan(const proto::system::PhysicalPlan& _pplan) {

--- a/heron/stmgr/src/cpp/manager/stmgr-server.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-server.cpp
@@ -127,11 +127,9 @@ StMgrServer::~StMgrServer() {
     }
   }
 
-  QueueMetricMap::iterator qmmIter;
-  for (qmmIter = queue_metric_map_.begin(); qmmIter != queue_metric_map_.end(); ++qmmIter) {
-    sp_string instance_id = qmmIter->first;
-    for (TaskIdInstanceDataMap::iterator iter = instance_info_.begin();
-         iter != instance_info_.end(); ++iter) {
+  for (auto qmmIter = queue_metric_map_.begin(); qmmIter != queue_metric_map_.end(); ++qmmIter) {
+    const sp_string& instance_id = qmmIter->first;
+    for (auto iter = instance_info_.begin(); iter != instance_info_.end(); ++iter) {
       if (iter->second->instance_->instance_id() != instance_id) continue;
       InstanceData* data = iter->second;
       Connection* iConn = data->conn_;
@@ -331,7 +329,7 @@ void StMgrServer::HandleRegisterInstanceRequest(REQID _reqid, Connection* _conn,
         instance_metric_map_[instance_id] = instance_metric;
       }
       if (queue_metric_map_.find(instance_id) == queue_metric_map_.end()) {
-        heron::common::AssignableMetric* queue_metric = new heron::common::AssignableMetric(0);
+        auto queue_metric = new heron::common::AssignableMetric(0);
         metrics_manager_client_->register_metric(MakeQueueSizeCompIdMetricName(instance_id),
                                                  queue_metric);
         queue_metric_map_[instance_id] = queue_metric;

--- a/heron/stmgr/src/cpp/manager/stmgr-server.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-server.cpp
@@ -496,9 +496,10 @@ void StMgrServer::StopBackPressureConnectionCb(Connection* _connection) {
 void StMgrServer::ConnectionBufferChangeCb(Connection* _connection) {
   // Find the instance this connection belongs to
   const sp_string& instance_name = GetInstanceName(_connection);
-  CHECK_NE(instance_name, "");
-  sp_int32 bytes = _connection->getOutstandingBytes();
-  queue_metric_map_[instance_name]->SetValue(bytes);
+  if (instance_name != "") {
+    sp_int32 bytes = _connection->getOutstandingBytes();
+    queue_metric_map_[instance_name]->SetValue(bytes);
+  }
 }
 
 void StMgrServer::StartBackPressureClientCb(const sp_string& _other_stmgr_id) {

--- a/heron/stmgr/src/cpp/manager/stmgr-server.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-server.cpp
@@ -73,6 +73,8 @@ const sp_string METRIC_TIME_SPENT_BACK_PRESSURE_INIT =
 // appended
 // to the string below
 const sp_string METRIC_TIME_SPENT_BACK_PRESSURE_COMPID = "__time_spent_back_pressure_by_compid/";
+// Queue size in bytes sent to each instance
+const sp_string METRIC_QUEUE_SIZE_TO_INSTANCE_COMPID = "__queue_size_bytes_to_instance_by_compid/";
 
 StMgrServer::StMgrServer(EventLoop* eventLoop, const NetworkOptions& _options,
                          const sp_string& _topology_name, const sp_string& _topology_id,
@@ -124,6 +126,21 @@ StMgrServer::~StMgrServer() {
       delete immIter->second;
     }
   }
+
+  QueueMetricMap::iterator qmmIter;
+  for (qmmIter = queue_metric_map_.begin(); qmmIter != queue_metric_map_.end(); ++qmmIter) {
+    sp_string instance_id = qmmIter->first;
+    for (TaskIdInstanceDataMap::iterator iter = instance_info_.begin();
+         iter != instance_info_.end(); ++iter) {
+      if (iter->second->instance_->instance_id() != instance_id) continue;
+      InstanceData* data = iter->second;
+      Connection* iConn = data->conn_;
+      if (!iConn) break;
+      sp_string metric_name = MakeQueueSizeCompIdMetricName(instance_id);
+      metrics_manager_client_->unregister_metric(metric_name);
+      delete qmmIter->second;
+    }
+  }
   metrics_manager_client_->unregister_metric("__server");
   metrics_manager_client_->unregister_metric(METRIC_TIME_SPENT_BACK_PRESSURE_AGGR);
   metrics_manager_client_->unregister_metric(METRIC_TIME_SPENT_BACK_PRESSURE_INIT);
@@ -147,6 +164,10 @@ void StMgrServer::GetInstanceInfo(std::vector<proto::system::Instance*>& _return
 
 sp_string StMgrServer::MakeBackPressureCompIdMetricName(const sp_string& instanceid) {
   return METRIC_TIME_SPENT_BACK_PRESSURE_COMPID + instanceid;
+}
+
+sp_string StMgrServer::MakeQueueSizeCompIdMetricName(const sp_string& instanceid) {
+  return METRIC_QUEUE_SIZE_TO_INSTANCE_COMPID + instanceid;
 }
 
 void StMgrServer::HandleNewConnection(Connection* _conn) {
@@ -309,6 +330,12 @@ void StMgrServer::HandleRegisterInstanceRequest(REQID _reqid, Connection* _conn,
                                                  instance_metric);
         instance_metric_map_[instance_id] = instance_metric;
       }
+      if (queue_metric_map_.find(instance_id) == queue_metric_map_.end()) {
+        heron::common::AssignableMetric* queue_metric = new heron::common::AssignableMetric(0);
+        metrics_manager_client_->register_metric(MakeQueueSizeCompIdMetricName(instance_id),
+                                                 queue_metric);
+        queue_metric_map_[instance_id] = queue_metric;
+      }
     }
     instance_info_[task_id]->set_connection(_conn);
 
@@ -382,6 +409,10 @@ void StMgrServer::SendToInstance(sp_int32 _task_id, const proto::stmgr::TupleMes
     }
     SendMessage(iter->second->conn_, _message);
   }
+
+  const sp_string& instance_id = instance_info_[_task_id]->instance_->instance_id();
+  sp_int32 bytes = iter->second->conn_->getOutstandingBytes();
+  queue_metric_map_[instance_id]->SetValue(bytes);
 }
 
 void StMgrServer::BroadcastNewPhysicalPlan(const proto::system::PhysicalPlan& _pplan) {
@@ -460,6 +491,14 @@ void StMgrServer::StopBackPressureConnectionCb(Connection* _connection) {
   }
   LOG(INFO) << "We don't observe back pressure now on sending data to instance " << instance_name;
   AttemptStopBackPressureFromSpouts();
+}
+
+void StMgrServer::ConnectionBufferChangeCb(Connection* _connection) {
+  // Find the instance this connection belongs to
+  const sp_string& instance_name = GetInstanceName(_connection);
+  CHECK_NE(instance_name, "");
+  sp_int32 bytes = _connection->getOutstandingBytes();
+  queue_metric_map_[instance_name]->SetValue(bytes);
 }
 
 void StMgrServer::StartBackPressureClientCb(const sp_string& _other_stmgr_id) {

--- a/heron/stmgr/src/cpp/manager/stmgr-server.h
+++ b/heron/stmgr/src/cpp/manager/stmgr-server.h
@@ -30,6 +30,7 @@ namespace common {
 class MetricsMgrSt;
 class MultiCountMetric;
 class TimeSpentMetric;
+class AssignableMetric;
 }
 }
 
@@ -70,6 +71,7 @@ class StMgrServer : public Server {
 
  private:
   sp_string MakeBackPressureCompIdMetricName(const sp_string& instanceid);
+  sp_string MakeQueueSizeCompIdMetricName(const sp_string& instanceid);
   sp_string GetInstanceName(Connection* _connection);
 
   // Various handlers for different requests
@@ -97,6 +99,9 @@ class StMgrServer : public Server {
   void StartBackPressureConnectionCb(Connection* _connection);
   // Relieve back pressure
   void StopBackPressureConnectionCb(Connection* _connection);
+
+  // Connection buffer size metric
+  void ConnectionBufferChangeCb(Connection* _connection);
 
   // Can we free the back pressure on the spouts?
   void AttemptStopBackPressureFromSpouts();
@@ -139,6 +144,10 @@ class StMgrServer : public Server {
   // Used for back pressure metrics
   typedef std::map<sp_string, heron::common::TimeSpentMetric*> InstanceMetricMap;
   InstanceMetricMap instance_metric_map_;
+
+  // map of Instance_id/stmgrid to queue metric
+  typedef std::map<sp_string, heron::common::AssignableMetric*> QueueMetricMap;
+  QueueMetricMap queue_metric_map_;
 
   // instances/stream mgrs causing back pressure
   std::set<sp_string> remote_ends_who_caused_back_pressure_;


### PR DESCRIPTION
This adds metrics for stream manager queue size (in bytes) sent to each instance.

Sample output:
```
            "__queue_size_bytes_to_instance_by_compid/container_1_exclaim1_1": "50900906",
            "__queue_size_bytes_to_instance_by_compid/container_1_word_2": "0",
```