### PR TITLE
Include heron-py-instance in heron-core/bin for CentOS5

### DIFF
--- a/scripts/centos5/BUILD
+++ b/scripts/centos5/BUILD
@@ -34,6 +34,7 @@ genrule(
         ":hshell",
         ":hstmgr",
         ":htmaster",
+        ":hpyinstance",
         ":hscheduler",
         ":hscheduler-aurora",
         ":hscheduler-local",
@@ -55,6 +56,7 @@ genrule(
         "--cp $(location hshell)                   heron-core/bin/heron-shell",
         "--cp $(location hstmgr)                   heron-core/bin/heron-stmgr",
         "--cp $(location htmaster)                 heron-core/bin/heron-tmaster",
+        "--cp $(location hpyinstance")             heron-core/bin/heron-python-instance",
         "--cp $(location hscheduler)               heron-core/lib/scheduler/heron-scheduler.jar",
         "--cp $(location hscheduler-aurora)        heron-core/lib/scheduler/heron-aurora-scheduler.jar",
         "--cp $(location hscheduler-local)         heron-core/lib/scheduler/heron-local-scheduler.jar",
@@ -230,6 +232,11 @@ filegroup(
 filegroup(
     name = "htmaster",
     srcs = ["//heron/tmaster/src/cpp:heron-tmaster"],
+)
+
+filegroup(
+    name = "hpyinstance",
+    srcs = ["//heron/instance/src/python/instance:heron-python-instance"],
 )
 
 filegroup(


### PR DESCRIPTION
This PR includes `heron-py-instance` in `heron-core/bin` for CentOS 5. This PR can be considered as a follow-up of https://github.com/twitter/heron/commit/872ba262bf7cffb9971da8c56ac54b89a84579a3#diff-3e725585fbf57518c1e7209b1b18e401R13, which only includes `heron-py-instance` for Darwin.

Tested on internal dev machine.