### PR TITLE
Adding exception handling to scheduler responses

### DIFF
--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/server/ExceptionalRequestHandler.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/server/ExceptionalRequestHandler.java
@@ -52,10 +52,10 @@ class ExceptionalRequestHandler implements HttpHandler {
       delegate.handle(exchange);
       sendResponse(exchange, true);
     } catch (TerminateSchedulerException e) {
-      handleFailure(exchange, e);
+      sendResponse(exchange, true);
 
       // tell the scheduler to shutdown
-      LOG.info("Kill request handler issuing a terminate request to scheduler");
+      LOG.info("Request handler issuing a terminate request to scheduler");
       try {
         scheduler.close();
       } finally {

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/server/ExceptionalRequestHandler.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/server/ExceptionalRequestHandler.java
@@ -1,16 +1,16 @@
-//  Copyright 2016 Twitter. All rights reserved.
+// Copyright 2016 Twitter. All rights reserved.
 //
-//  Licensed under the Apache License, Version 2.0 (the "License");
-//  you may not use this file except in compliance with the License.
-//  You may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  http://www.apache.org/licenses/LICENSE-2.0
+//    http://www.apache.org/licenses/LICENSE-2.0
 //
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package com.twitter.heron.scheduler.server;
 
 import java.io.IOException;
@@ -45,6 +45,7 @@ class ExceptionalRequestHandler implements HttpHandler {
     this.scheduler = scheduler;
   }
 
+  @SuppressWarnings("IllegalCatch")
   @Override
   public void handle(HttpExchange exchange) throws IOException {
 
@@ -61,13 +62,12 @@ class ExceptionalRequestHandler implements HttpHandler {
       } finally {
         Runtime.schedulerShutdown(runtime).terminate();
       }
-    }
-    catch (Throwable e) {
+    } catch (Exception e) {
       handleFailure(exchange, e);
     }
   }
 
-  private static void handleFailure(HttpExchange exchange, Throwable e) {
+  private static void handleFailure(HttpExchange exchange, Exception e) {
     LOG.log(Level.SEVERE,
         String.format("Failed to handle %s request", exchange.getRequestURI()), e);
     sendResponse(exchange, false);

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/server/ExceptionalRequestHandler.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/server/ExceptionalRequestHandler.java
@@ -1,0 +1,80 @@
+//  Copyright 2016 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License
+package com.twitter.heron.scheduler.server;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import com.twitter.heron.proto.scheduler.Scheduler;
+import com.twitter.heron.spi.common.Config;
+import com.twitter.heron.spi.scheduler.IScheduler;
+import com.twitter.heron.spi.utils.NetworkUtils;
+import com.twitter.heron.spi.utils.Runtime;
+import com.twitter.heron.spi.utils.SchedulerUtils;
+
+/**
+ * {@code HttpHandler} decorator that returns an OK response unless an exception is caught, in
+ * which case a NOTOK response is returned. If the delegate throws a
+ * {@code TerminateSchedulerException}, the scheduler will be terminated after the response is
+ * handled.
+ */
+class ExceptionalRequestHandler implements HttpHandler {
+  private static final Logger LOG = Logger.getLogger(ExceptionalRequestHandler.class.getName());
+  private HttpHandler delegate;
+  private Config runtime;
+  private IScheduler scheduler;
+
+  ExceptionalRequestHandler(HttpHandler delegate, Config runtime, IScheduler scheduler) {
+    this.delegate = delegate;
+    this.runtime = runtime;
+    this.scheduler = scheduler;
+  }
+
+  @Override
+  public void handle(HttpExchange exchange) throws IOException {
+
+    try {
+      delegate.handle(exchange);
+      sendResponse(exchange, true);
+    } catch (TerminateSchedulerException e) {
+      handleFailure(exchange, e);
+
+      // tell the scheduler to shutdown
+      LOG.info("Kill request handler issuing a terminate request to scheduler");
+      try {
+        scheduler.close();
+      } finally {
+        Runtime.schedulerShutdown(runtime).terminate();
+      }
+    }
+    catch (Throwable e) {
+      handleFailure(exchange, e);
+    }
+  }
+
+  private static void handleFailure(HttpExchange exchange, Throwable e) {
+    LOG.log(Level.SEVERE,
+        String.format("Failed to handle %s request", exchange.getRequestURI()), e);
+    sendResponse(exchange, false);
+  }
+
+  private static void sendResponse(HttpExchange exchange, boolean success) {
+    Scheduler.SchedulerResponse response = SchedulerUtils.constructSchedulerResponse(success);
+    NetworkUtils.sendHttpResponse(exchange, response.toByteArray());
+  }
+}

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/server/KillRequestHandler.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/server/KillRequestHandler.java
@@ -15,27 +15,19 @@
 package com.twitter.heron.scheduler.server;
 
 import java.io.IOException;
-import java.util.logging.Logger;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 
 import com.twitter.heron.proto.scheduler.Scheduler;
-import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.scheduler.IScheduler;
 import com.twitter.heron.spi.utils.NetworkUtils;
-import com.twitter.heron.spi.utils.Runtime;
-import com.twitter.heron.spi.utils.SchedulerUtils;
 
 public class KillRequestHandler implements HttpHandler {
-  private static final Logger LOG = Logger.getLogger(KillRequestHandler.class.getName());
-
   private IScheduler scheduler;
-  private Config runtime;
 
-  public KillRequestHandler(Config runtime, IScheduler scheduler) {
+  KillRequestHandler(IScheduler scheduler) {
     this.scheduler = scheduler;
-    this.runtime = runtime;
   }
 
   @Override
@@ -50,18 +42,8 @@ public class KillRequestHandler implements HttpHandler {
             .mergeFrom(requestBody)
             .build();
 
-    // kill the topology
-    boolean isKillSuccessfully = scheduler.onKill(killTopologyRequest);
-
-    // prepare the response
-    Scheduler.SchedulerResponse response =
-        SchedulerUtils.constructSchedulerResponse(isKillSuccessfully);
-
-    // Send the response back
-    NetworkUtils.sendHttpResponse(exchange, response.toByteArray());
-
-    // tell the scheduler to shutdown
-    LOG.info("Kill request handler issuing a terminate request to scheduler");
-    Runtime.schedulerShutdown(runtime).terminate();
+    if (!scheduler.onKill(killTopologyRequest)) {
+      throw new TerminateSchedulerException("Failed to process killTopologyRequest");
+    }
   }
 }

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/server/KillRequestHandler.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/server/KillRequestHandler.java
@@ -43,7 +43,10 @@ public class KillRequestHandler implements HttpHandler {
             .build();
 
     if (!scheduler.onKill(killTopologyRequest)) {
-      throw new TerminateSchedulerException("Failed to process killTopologyRequest");
+      throw new RuntimeException("Failed to process killTopologyRequest");
+    } else {
+      throw new TerminateSchedulerException(
+          "Kill request handled successfully - terminating scheduler");
     }
   }
 }

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/server/RestartRequestHandler.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/server/RestartRequestHandler.java
@@ -20,15 +20,13 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 
 import com.twitter.heron.proto.scheduler.Scheduler;
-import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.scheduler.IScheduler;
 import com.twitter.heron.spi.utils.NetworkUtils;
-import com.twitter.heron.spi.utils.SchedulerUtils;
 
-public class RestartRequestHandler implements HttpHandler {
+class RestartRequestHandler implements HttpHandler {
   private IScheduler scheduler;
 
-  public RestartRequestHandler(Config runtime, IScheduler scheduler) {
+  RestartRequestHandler(IScheduler scheduler) {
     this.scheduler = scheduler;
   }
 
@@ -44,14 +42,8 @@ public class RestartRequestHandler implements HttpHandler {
             .mergeFrom(requestBody)
             .build();
 
-    // restart the topology
-    boolean isRestartSuccessfully = scheduler.onRestart(restartTopologyRequest);
-
-    // prepare the response
-    Scheduler.SchedulerResponse response =
-        SchedulerUtils.constructSchedulerResponse(isRestartSuccessfully);
-
-    // send the response back
-    NetworkUtils.sendHttpResponse(exchange, response.toByteArray());
+    if (!scheduler.onRestart(restartTopologyRequest)) {
+      throw new RuntimeException("Failed to process restartTopologyRequest");
+    }
   }
 }

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/server/TerminateSchedulerException.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/server/TerminateSchedulerException.java
@@ -1,0 +1,25 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.twitter.heron.scheduler.server;
+
+/**
+ * Throwing this indicates that the scheduler should be terminated after processing the request
+ */
+class TerminateSchedulerException extends RuntimeException {
+  private static final long serialVersionUID = -633975598105332890L;
+
+  TerminateSchedulerException(String message) {
+    super(message);
+  }
+}

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/server/UpdateRequestHandler.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/server/UpdateRequestHandler.java
@@ -19,15 +19,13 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 
 import com.twitter.heron.proto.scheduler.Scheduler;
-import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.scheduler.IScheduler;
 import com.twitter.heron.spi.utils.NetworkUtils;
-import com.twitter.heron.spi.utils.SchedulerUtils;
 
 class UpdateRequestHandler implements HttpHandler {
   private IScheduler scheduler;
 
-  UpdateRequestHandler(Config runtime, IScheduler scheduler) {
+  UpdateRequestHandler(IScheduler scheduler) {
     this.scheduler = scheduler;
   }
 
@@ -43,14 +41,8 @@ class UpdateRequestHandler implements HttpHandler {
             .mergeFrom(requestBody)
             .build();
 
-    // update the topology
-    boolean isUpdateSuccessfully = scheduler.onUpdate(updateTopologyRequest);
-
-    // prepare the response
-    Scheduler.SchedulerResponse response =
-        SchedulerUtils.constructSchedulerResponse(isUpdateSuccessfully);
-
-    // send the response back
-    NetworkUtils.sendHttpResponse(exchange, response.toByteArray());
+    if (!scheduler.onUpdate(updateTopologyRequest)) {
+      throw new RuntimeException("Failed to process updateTopologyRequest");
+    }
   }
 }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
@@ -57,8 +57,7 @@ public class AuroraScheduler implements IScheduler, IScalable {
     this.config = mConfig;
     this.runtime = mRuntime;
     this.controller = getController();
-    this.updateTopologyManager =
-        new UpdateTopologyManager(runtime, Optional.<IScalable>of(this));
+    this.updateTopologyManager = new UpdateTopologyManager(runtime, Optional.<IScalable>of(this));
   }
 
   /**

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalScheduler.java
@@ -126,7 +126,9 @@ public class LocalScheduler implements IScheduler, IScalable {
           // restart the container
           startExecutor(processToContainer.remove(containerExecutor));
         } catch (InterruptedException e) {
-          LOG.log(Level.SEVERE, "Process is interrupted: ", e);
+          if (!isTopologyKilled) {
+            LOG.log(Level.SEVERE, "Process is interrupted: ", e);
+          }
         }
       }
     };


### PR DESCRIPTION
If a handler throws an exception, the scheduler doesn't catch it. This causes the exception to disappear without being logged while a response never gets sent to the client. This fixes that.

It would be great to take this one step further and allow the server to pass an error message back to the client (in addition to the `NOTOK` status code) but that's a much larger refactor for another day.