### PR TITLE
local state manager to check for path before trying to read file

### DIFF
--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
@@ -103,7 +103,10 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
                                                                 String path,
                                                                 Message.Builder builder) {
     final SettableFuture<M> future = SettableFuture.create();
-    byte[] data = FileUtils.readFromFile(path);
+    byte[] data = new byte[]{};
+    if (FileUtils.isFileExists(path)) {
+      data = FileUtils.readFromFile(path);
+    }
     if (data.length == 0) {
       future.set(null);
       return future;

--- a/heron/statemgrs/tests/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManagerTest.java
+++ b/heron/statemgrs/tests/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManagerTest.java
@@ -93,6 +93,7 @@ public class LocalFileSystemStateManagerTest {
         .setTopologyName(TOPOLOGY_NAME)
         .build();
     PowerMockito.spy(FileUtils.class);
+    PowerMockito.doReturn(true).when(FileUtils.class, "isFileExists", Matchers.anyString());
     PowerMockito.doReturn(location.toByteArray()).
         when(FileUtils.class, "readFromFile", Matchers.anyString());
 


### PR DESCRIPTION
Trying to read from a node that doesn't exist throws a `FilePathNotFoundException` instead of returning an empty byte array.