### PR TITLE
More configurable Aurora

### DIFF
--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraContext.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraContext.java
@@ -14,16 +14,24 @@
 
 package com.twitter.heron.scheduler.aurora;
 
+import java.io.File;
+
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Context;
 
 public final class AuroraContext extends Context {
   public static final String JOB_LINK_TEMPLATE = "heron.scheduler.job.link.template";
+  public static final String JOB_TEMPLATE = "heron.scheduler.job.template";
 
   private AuroraContext() {
   }
 
   public static String getJobLinkTemplate(Config config) {
     return config.getStringValue(JOB_LINK_TEMPLATE);
+  }
+
+  public static String getHeronAuroraPath(Config config) {
+    return config.getStringValue(JOB_TEMPLATE,
+        new File(Context.heronConf(config), "heron.aurora").getPath());
   }
 }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
@@ -14,7 +14,6 @@
 
 package com.twitter.heron.scheduler.aurora;
 
-import java.io.File;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -98,7 +97,7 @@ public class AuroraScheduler implements IScheduler, IScalable {
 
     Map<String, String> auroraProperties = createAuroraProperties(updatedPackingPlan);
 
-    return controller.createJob(getHeronAuroraPath(), auroraProperties);
+    return controller.createJob(AuroraContext.getHeronAuroraPath(config), auroraProperties);
   }
 
   @Override
@@ -158,10 +157,6 @@ public class AuroraScheduler implements IScheduler, IScalable {
         javaOpts.getBytes(Charset.forName("UTF-8")));
 
     return String.format("\"%s\"", javaOptsBase64.replace("=", "&equals;"));
-  }
-
-  protected String getHeronAuroraPath() {
-    return new File(Context.heronConf(config), "heron.aurora").getPath();
   }
 
   protected Map<String, String> createAuroraProperties(PackingPlan packing) {

--- a/heron/schedulers/tests/java/BUILD
+++ b/heron/schedulers/tests/java/BUILD
@@ -70,6 +70,7 @@ java_tests(
     "com.twitter.heron.scheduler.aurora.AuroraSchedulerTest",
     "com.twitter.heron.scheduler.aurora.AuroraLauncherTest",
     "com.twitter.heron.scheduler.aurora.AuroraControllerTest",
+    "com.twitter.heron.scheduler.aurora.AuroraContextTest",
   ],
   runtime_deps = [ ":aurora-tests" ],
   size = "small",

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraContextTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraContextTest.java
@@ -23,13 +23,13 @@ public class AuroraContextTest {
 
   @Test
   public void testUsesConfigString() {
-    final String aurora_template = "/dir/test.aurora";
+    final String auroraTemplate = "/dir/test.aurora";
     Config config = Config.newBuilder()
-        .put(AuroraContext.JOB_TEMPLATE, aurora_template)
+        .put(AuroraContext.JOB_TEMPLATE, auroraTemplate)
         .put(ConfigKeys.get("HERON_CONF"), "/test")
         .build();
     Assert.assertEquals("Expected to use value from JOB_TEMPLATE config",
-        aurora_template, AuroraContext.getHeronAuroraPath(config));
+        auroraTemplate, AuroraContext.getHeronAuroraPath(config));
   }
 
   @Test

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraContextTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraContextTest.java
@@ -1,5 +1,3 @@
-package com.twitter.heron.scheduler.aurora;
-
 // Copyright 2016 Twitter. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +11,7 @@ package com.twitter.heron.scheduler.aurora;
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+package com.twitter.heron.scheduler.aurora;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -23,7 +22,7 @@ import com.twitter.heron.spi.common.ConfigKeys;
 public class AuroraContextTest {
 
   @Test
-  public void testUsesConfigString(){
+  public void testUsesConfigString() {
     final String aurora_template = "/dir/test.aurora";
     Config config = Config.newBuilder()
         .put(AuroraContext.JOB_TEMPLATE, aurora_template)
@@ -34,9 +33,9 @@ public class AuroraContextTest {
   }
 
   @Test
-  public void testFallback(){
+  public void testFallback() {
     Config config = Config.newBuilder()
-        .put(ConfigKeys.get("HERON_CONF"),"/test")
+        .put(ConfigKeys.get("HERON_CONF"), "/test")
         .build();
     Assert.assertEquals("Expected to use heron_conf/heron.aurora", "/test/heron.aurora",
         AuroraContext.getHeronAuroraPath(config));

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraContextTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraContextTest.java
@@ -1,0 +1,46 @@
+package com.twitter.heron.scheduler.aurora;
+
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.twitter.heron.spi.common.Config;
+import com.twitter.heron.spi.common.ConfigKeys;
+
+public class AuroraContextTest {
+
+  @Test
+  public void testUsesConfigString(){
+    final String aurora_template = "/dir/test.aurora";
+    Config config = Config.newBuilder()
+        .put(AuroraContext.JOB_TEMPLATE, aurora_template)
+        .put(ConfigKeys.get("HERON_CONF"), "/test")
+        .build();
+    Assert.assertEquals("Expected to use value from JOB_TEMPLATE config",
+        aurora_template, AuroraContext.getHeronAuroraPath(config));
+  }
+
+  @Test
+  public void testFallback(){
+    Config config = Config.newBuilder()
+        .put(ConfigKeys.get("HERON_CONF"),"/test")
+        .build();
+    Assert.assertEquals("Expected to use heron_conf/heron.aurora", "/test/heron.aurora",
+        AuroraContext.getHeronAuroraPath(config));
+  }
+
+
+}

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraSchedulerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraSchedulerTest.java
@@ -91,7 +91,8 @@ public class AuroraSchedulerTest {
     Mockito.when(runtime.getStringValue(Keys.topologyName())).thenReturn(TOPOLOGY_NAME);
 
     Config mConfig = Mockito.mock(Config.class);
-    Mockito.when(mConfig.getStringValue(eq(AuroraContext.JOB_TEMPLATE), anyString())).thenReturn(AURORA_PATH);
+    Mockito.when(mConfig.getStringValue(eq(AuroraContext.JOB_TEMPLATE),
+        anyString())).thenReturn(AURORA_PATH);
 
     scheduler.initialize(mConfig, runtime);
 

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraSchedulerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraSchedulerTest.java
@@ -41,6 +41,7 @@ import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
 import com.twitter.heron.spi.utils.PackingTestUtils;
 
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -69,7 +70,6 @@ public class AuroraSchedulerTest {
     Mockito.doReturn(new HashMap<String, String>()).when(
         scheduler).createAuroraProperties(
         Mockito.any(PackingPlan.class));
-    Mockito.doReturn(AURORA_PATH).when(scheduler).getHeronAuroraPath();
   }
 
   @AfterClass
@@ -90,7 +90,10 @@ public class AuroraSchedulerTest {
     Mockito.when(runtime.get(Keys.schedulerStateManagerAdaptor())).thenReturn(stateManager);
     Mockito.when(runtime.getStringValue(Keys.topologyName())).thenReturn(TOPOLOGY_NAME);
 
-    scheduler.initialize(Mockito.mock(Config.class), runtime);
+    Config mConfig = Mockito.mock(Config.class);
+    Mockito.when(mConfig.getStringValue(eq(AuroraContext.JOB_TEMPLATE), anyString())).thenReturn(AURORA_PATH);
+
+    scheduler.initialize(mConfig, runtime);
 
     // Fail to schedule due to null PackingPlan
     Assert.assertFalse(scheduler.onSchedule(null));


### PR DESCRIPTION
We'd like to keep using the builtin Aurora scheduler but we'd like to.
1) Move the default file to a different location, and not have it be named heron.aurora (we're using json for other aurora jobs)
2) Sometimes specify a different file for different topologies.

This PR is intended to enable this workflow by allowing configs to override the location and/or name of the default aurora template. Additionally it looks for a System Property which if set will take precedence. Because this method falls back to the old behavior if the properties aren't set this should be a non-breaking change however there is a very small possibility that someone is running the Heron CLI with the environment property HERON_SCHEDULER_JOB_TEMPLATE set to some garbage. I think the risk is minimal enough that it's not required to require a config be turned on to check the environment property.