### PR TITLE
Fix wrong key type in LocalScheduler.addContainers

### DIFF
--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalScheduler.java
@@ -262,7 +262,7 @@ public class LocalScheduler implements IScheduler, IScalable {
   public void addContainers(Set<PackingPlan.ContainerPlan> containers) {
     synchronized (processToContainer) {
       for (PackingPlan.ContainerPlan container : containers) {
-        if (processToContainer.containsKey(container.getId())) {
+        if (processToContainer.values().contains(container.getId())) {
           throw new RuntimeException(String.format("Found active container for %s, "
               + "cannot launch a duplicate container.", container.getId()));
         }


### PR DESCRIPTION
The key type of `processToContainer` is `Process`, `addContainers` should use its values to check the container id instead.