### PR TITLE
Add ability to submit topology to the specific YARN queue on YARN mode #1427

### DIFF
--- a/heron/config/src/yaml/conf/yarn/scheduler.yaml
+++ b/heron/config/src/yaml/conf/yarn/scheduler.yaml
@@ -9,3 +9,6 @@ heron.scheduler.local.working.directory:     ${HOME}/.herondata/topologies/${CLU
 
 # location of java - pick it up from shell environment
 heron.directory.sandbox.java.home:           ${JAVA_HOME}
+
+# yarn queue for submitting and launching the topology
+heron.scheduler.yarn.queue:                  default

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/HeronDriverConfiguration.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/HeronDriverConfiguration.java
@@ -15,6 +15,7 @@
 package com.twitter.heron.scheduler.yarn;
 
 import org.apache.reef.client.DriverConfiguration;
+import org.apache.reef.runtime.yarn.client.YarnDriverConfiguration;
 import org.apache.reef.tang.formats.ConfigurationModule;
 import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
 import org.apache.reef.tang.formats.OptionalParameter;
@@ -56,5 +57,6 @@ public class HeronDriverConfiguration extends ConfigurationModuleBuilder {
       .bindNamedParameter(Role.class, ROLE)
       .bindNamedParameter(HttpPort.class, HTTP_PORT)
       .bindNamedParameter(VerboseLogMode.class, VERBOSE)
+      .merge(YarnDriverConfiguration.CONF)
       .build();
 }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/YarnContext.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/YarnContext.java
@@ -1,0 +1,29 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.twitter.heron.scheduler.yarn;
+
+import com.twitter.heron.spi.common.Config;
+import com.twitter.heron.spi.common.Context;
+
+public final class YarnContext extends Context {
+  public static final String HERON_SCHEDULER_YARN_QUEUE = "heron.scheduler.yarn.queue";
+
+  private YarnContext() {
+  }
+
+  public static String heronYarnQueue(Config cfg) {
+    return cfg.getStringValue(HERON_SCHEDULER_YARN_QUEUE, "default");
+  }
+}

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/YarnLauncher.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/YarnLauncher.java
@@ -25,6 +25,7 @@ import org.apache.reef.client.ClientConfiguration;
 import org.apache.reef.client.DriverConfiguration;
 import org.apache.reef.client.REEF;
 import org.apache.reef.runtime.yarn.client.YarnClientConfiguration;
+import org.apache.reef.runtime.yarn.client.YarnDriverConfiguration;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Injector;
 import org.apache.reef.tang.Tang;
@@ -59,6 +60,7 @@ public class YarnLauncher implements ILauncher {
   private String cluster;
   private String role;
   private String env;
+  private String queue;
   private ArrayList<String> libJars = new ArrayList<>();
 
   @Override
@@ -69,6 +71,7 @@ public class YarnLauncher implements ILauncher {
     cluster = Context.cluster(config);
     role = Context.role(config);
     env = Context.environ(config);
+    queue = YarnContext.heronYarnQueue(config);
 
     try {
       Class<?> packingClass = Class.forName(Context.packingClass(config));
@@ -149,6 +152,7 @@ public class YarnLauncher implements ILauncher {
         .set(HeronDriverConfiguration.CLUSTER, cluster)
         .set(HeronDriverConfiguration.HTTP_PORT, 0)
         .set(HeronDriverConfiguration.VERBOSE, false)
+        .set(YarnDriverConfiguration.QUEUE, queue)
         .build();
   }
 

--- a/website/content/docs/operators/deployment/schedulers/yarn.md
+++ b/website/content/docs/operators/deployment/schedulers/yarn.md
@@ -84,7 +84,9 @@ deployment on a multi-node YARN cluster.
 
 >**Tips**
 >
->More details for using the `--extra-launch-classpath` argument in 0.14.3 version. It supports both a single directory which including all `hadoop-lib-jars` and multiple directories separated by colon such as what `hadoop classpath` gives. ***The submit operation will fail if any path is invalid or if any file is missing.***
+>1. More details for using the `--extra-launch-classpath` argument in 0.14.3 version. It supports both a single directory which including all `hadoop-lib-jars` and multiple directories separated by colon such as what `hadoop classpath` gives. ***The submit operation will fail if any path is invalid or if any file is missing.***
+>2. if you want to submit a topology to a specific YARN queue, you can set the `heron.scheduler.yarn.queue` argument in `--config-property`. For instance, `--config-property heron.scheduler.yarn.queue=test`. This configuration could be found in the [conf/yarn/scheduler]
+(https://github.com/twitter/heron/blob/master/heron/config/src/yaml/conf/yarn/scheduler.yaml) file too. `default` would be the YARN default queue as YARN provided.
 
 **Sample Output**
 


### PR DESCRIPTION
Heron supports submitting topology to the YARN `default` queue now. I was wondering if Heron should support submitting topology to the specific YARN queue? I try to use the `--config-property` arg to implements this function.

if user wants to submit topology to YARN with the `test` queue. The submitting command could be
`heron submit yarn ~/.heron/examples/heron-examples.jar com.twitter.heron.examples.ExclamationTopology ExclamationTopology --deploy-deactivated --config-property heron.scheduler.yarn.queue=test`

And the results would be
![image](https://cloud.githubusercontent.com/assets/4719414/18825567/b19aebb0-83fb-11e6-958b-87ee566eb4a7.png)

This PR fixes #1427 and the changes are following:
* added `heron.scheduler.yarn.queue` args in the `com.twitter.heron.spi.common.keys.yaml` file
* supports submitting topology to the specific yarn queue by parsing configs in the `com.twitter.heron.scheduler.yarn.YarnLauncher` class.