### PR TITLE
'./scripts/setup-intellji.sh' will check if 'scripts/compile/env_exec.sh' exists

### DIFF
--- a/scripts/setup-intellij.sh
+++ b/scripts/setup-intellij.sh
@@ -2,7 +2,7 @@
 
 # Make sure ./bazel_configure.py is run before runing this scripts
 if [[ ! -f ./scripts/compile/env_exec.sh ]] ; then
-  echo "ERR: File ./scripts/compile_env/env_exec.sh is not found!"
+  echo "ERROR: File ./scripts/compile_env/env_exec.sh is not found."
   echo "Run ./bazel_configure.py first."
   exit
 fi

--- a/scripts/setup-intellij.sh
+++ b/scripts/setup-intellij.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Make sure ./bazel_configure.py is run before runing this scripts
+if [[ ! -f ./scripts/compile/env_exec.sh ]] ; then
+  echo "ERR: File ./scripts/compile_env/env_exec.sh is not found!"
+  echo "Run ./bazel_configure.py first."
+  exit
+fi
+
 # Generates an IntelliJ project in heron
 
 set -o errexit


### PR DESCRIPTION
In this PR, ./scripts/setup-intellji.sh  will check if file ``scripts/compile/env_exec.sh`` exists. If not, it will exit with the following info:
```
ERR: File ./scripts/compile_env/env_exec.sh is not found!
Run ./bazel_configure.py first.
```

This solves #1417 .