### PR TITLE
Must delete packing plan before updating it

### DIFF
--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
@@ -93,13 +93,11 @@ public class UpdateTopologyManager {
 
     // update parallelism in updatedTopology since TMaster checks that
     // Sum(parallelism) == Sum(instances)
-    logFine("Deleted existing Topology: %s", stateManager.deleteTopology(topologyName));
-    logFine("Set new Topology: %s", stateManager.setTopology(updatedTopology, topologyName));
+    logFine("Update new Topology: %s", stateManager.updateTopology(updatedTopology, topologyName));
 
     // update packing plan to trigger the scaling event
-    logFine("Deleted existing packing plan: %s", stateManager.deletePackingPlan(topologyName));
-    logFine("Set new PackingPlan: %s",
-        stateManager.setPackingPlan(proposedProtoPackingPlan, topologyName));
+    logFine("Update new PackingPlan: %s",
+        stateManager.updatePackingPlan(proposedProtoPackingPlan, topologyName));
 
     // delete the physical plan so TMaster doesn't try to re-establish it on start-up.
     logFine("Deleted Physical Plan: %s", stateManager.deletePhysicalPlan(topologyName));

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
@@ -88,7 +88,12 @@ public class AuroraScheduler implements IScheduler, IScalable {
 
     LOG.info("Launching topology in aurora");
 
-    Map<String, String> auroraProperties = createAuroraProperties(packing);
+    // Align the cpu, ram, disk to the maximal one
+    PackingPlan updatedPackingPlan = packing.cloneWithHomogeneousScheduledResource();
+    SchedulerUtils.persistUpdatedPackingPlan(Runtime.topologyName(runtime), updatedPackingPlan,
+        Runtime.schedulerStateManagerAdaptor(runtime));
+
+    Map<String, String> auroraProperties = createAuroraProperties(updatedPackingPlan);
 
     return controller.createJob(getHeronAuroraPath(), auroraProperties);
   }
@@ -160,14 +165,7 @@ public class AuroraScheduler implements IScheduler, IScalable {
     Map<String, String> auroraProperties = new HashMap<>();
 
     TopologyAPI.Topology topology = Runtime.topology(runtime);
-
-    // Align the cpu, ram, disk to the maximal one
-    PackingPlan updatedPackingPlan = packing.cloneWithHomogeneousScheduledResource();
-    SchedulerUtils.persistUpdatedPackingPlan(topology.getName(), updatedPackingPlan,
-        Runtime.schedulerStateManagerAdaptor(runtime));
-
-    Resource containerResource = updatedPackingPlan.getContainers()
-        .iterator().next().getRequiredResource();
+    Resource containerResource = packing.getContainers().iterator().next().getRequiredResource();
 
     auroraProperties.put("SANDBOX_EXECUTOR_BINARY", Context.executorSandboxBinary(config));
     auroraProperties.put("TOPOLOGY_NAME", topology.getName());

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraSchedulerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraSchedulerTest.java
@@ -34,7 +34,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.twitter.heron.proto.scheduler.Scheduler;
 import com.twitter.heron.proto.system.PackingPlans;
-import com.twitter.heron.spi.common.ClusterDefaults;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Keys;
 import com.twitter.heron.spi.common.Misc;
@@ -87,11 +86,9 @@ public class AuroraSchedulerTest {
     Mockito.doReturn(controller).when(scheduler).getController();
 
     SchedulerStateManagerAdaptor stateManager = mock(SchedulerStateManagerAdaptor.class);
-    Config runtime = Config.newBuilder()
-        .put(Keys.topologyName(), TOPOLOGY_NAME)
-        .put(Keys.schedulerStateManagerAdaptor(), stateManager)
-        .putAll(ClusterDefaults.getDefaults())
-        .build();
+    Config runtime = Mockito.mock(Config.class);
+    Mockito.when(runtime.get(Keys.schedulerStateManagerAdaptor())).thenReturn(stateManager);
+    Mockito.when(runtime.getStringValue(Keys.topologyName())).thenReturn(TOPOLOGY_NAME);
 
     scheduler.initialize(Mockito.mock(Config.class), runtime);
 

--- a/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
@@ -107,6 +107,20 @@ public class SchedulerStateManagerAdaptor {
   }
 
   /**
+   * Update the topology definition for the given topology. If the topology doesn't exist,
+   * create it. If it does, update it.
+   *
+   * @param topologyName the name of the topology
+   * @return Boolean - Success or Failure
+   */
+  public Boolean updateTopology(TopologyAPI.Topology topology, String topologyName) {
+    if (getTopology(topologyName) != null) {
+      deleteTopology(topologyName);
+    }
+    return setTopology(topology, topologyName);
+  }
+
+  /**
    * Set the scheduler location for the given topology
    *
    * @return Boolean - Success or Failure
@@ -125,6 +139,20 @@ public class SchedulerStateManagerAdaptor {
    */
   public Boolean setPackingPlan(PackingPlans.PackingPlan packingPlan, String topologyName) {
     return awaitResult(delegate.setPackingPlan(packingPlan, topologyName));
+  }
+
+  /**
+   * Update the packing plan for the given topology. If the packing plan doesn't exist, create it.
+   * If it does, update it.
+   *
+   * @param packingPlan the packing plan of the topology
+   * @return Boolean - Success or Failure
+   */
+  public Boolean updatePackingPlan(PackingPlans.PackingPlan packingPlan, String topologyName) {
+    if (getPackingPlan(topologyName) != null) {
+      deletePackingPlan(topologyName);
+    }
+    return setPackingPlan(packingPlan, topologyName);
   }
 
   /**

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/SchedulerUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/SchedulerUtils.java
@@ -436,14 +436,10 @@ public final class SchedulerUtils {
                                                SchedulerStateManagerAdaptor stateManager) {
     LOG.log(Level.INFO, "Updating scheduled-resource in packing plan: {0}", topologyName);
     PackingPlanProtoSerializer serializer = new PackingPlanProtoSerializer();
-    if (stateManager.getPackingPlan(topologyName) != null) {
-      stateManager.deletePackingPlan(topologyName);
-    }
 
-    boolean result =
-        stateManager.setPackingPlan(serializer.toProto(updatedPackingPlan), topologyName);
-    if (!result) {
-      throw new RuntimeException(String.format("Failed to save %s's packing plan", topologyName));
+    if (!stateManager.updatePackingPlan(serializer.toProto(updatedPackingPlan), topologyName)) {
+      throw new RuntimeException(String.format(
+          "Failed to update packing plan for topology %s", topologyName));
     }
   }
 }

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/SchedulerUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/SchedulerUtils.java
@@ -436,6 +436,10 @@ public final class SchedulerUtils {
                                                SchedulerStateManagerAdaptor stateManager) {
     LOG.log(Level.INFO, "Updating scheduled-resource in packing plan: {0}", topologyName);
     PackingPlanProtoSerializer serializer = new PackingPlanProtoSerializer();
+    if (stateManager.getPackingPlan(topologyName) != null) {
+      stateManager.deletePackingPlan(topologyName);
+    }
+
     boolean result =
         stateManager.setPackingPlan(serializer.toProto(updatedPackingPlan), topologyName);
     if (!result) {

--- a/heron/spi/tests/java/com/twitter/heron/spi/utils/SchedulerUtilsTest.java
+++ b/heron/spi/tests/java/com/twitter/heron/spi/utils/SchedulerUtilsTest.java
@@ -34,6 +34,8 @@ import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
 
+import static org.mockito.Mockito.eq;
+
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({FileUtils.class, ShellUtils.class, SchedulerUtils.class})
 public class SchedulerUtilsTest {
@@ -42,6 +44,7 @@ public class SchedulerUtilsTest {
   private static final String CORE_RELEASE_DEST = "core";
   private static final String TOPOLOGY_URI = "mock://uri:121/ruo#xi";
   private static final String TOPOLOGY_DEST = "topology";
+  private static final String TOPOLOGY_NAME = "topology_name";
   private static final boolean IS_DELETE_PACKAGE = true;
   private static final boolean IS_VERBOSE = true;
 
@@ -178,7 +181,7 @@ public class SchedulerUtilsTest {
   public void persistUpdatedPackingPlanWillUpdatesStateManager() {
     SchedulerStateManagerAdaptor adaptor = Mockito.mock(SchedulerStateManagerAdaptor.class);
     Mockito.when(adaptor
-        .updatePackingPlan(Mockito.any(PackingPlans.PackingPlan.class), Mockito.eq("topology")))
+        .updatePackingPlan(Mockito.any(PackingPlans.PackingPlan.class), eq(TOPOLOGY_NAME)))
         .thenReturn(true);
 
     Set<PackingPlan.ContainerPlan> containers = new HashSet<>();
@@ -186,6 +189,6 @@ public class SchedulerUtilsTest {
     PackingPlan packing = new PackingPlan("id", containers);
     SchedulerUtils.persistUpdatedPackingPlan("topology", packing, adaptor);
     Mockito.verify(adaptor)
-        .updatePackingPlan(Mockito.any(PackingPlans.PackingPlan.class), Mockito.eq("topology"));
+        .updatePackingPlan(Mockito.any(PackingPlans.PackingPlan.class), eq(TOPOLOGY_NAME));
   }
 }

--- a/heron/spi/tests/java/com/twitter/heron/spi/utils/SchedulerUtilsTest.java
+++ b/heron/spi/tests/java/com/twitter/heron/spi/utils/SchedulerUtilsTest.java
@@ -177,15 +177,15 @@ public class SchedulerUtilsTest {
   @Test
   public void persistUpdatedPackingPlanWillUpdatesStateManager() {
     SchedulerStateManagerAdaptor adaptor = Mockito.mock(SchedulerStateManagerAdaptor.class);
-    Mockito.when(adaptor.setPackingPlan(Mockito.any(PackingPlans.PackingPlan.class),
-        Mockito.eq("topology"))).thenReturn(true);
+    Mockito.when(adaptor
+        .updatePackingPlan(Mockito.any(PackingPlans.PackingPlan.class), Mockito.eq("topology")))
+        .thenReturn(true);
 
-    PackingPlan.ContainerPlan container = PackingTestUtils.testContainerPlan(1, 0, 1, 2);
     Set<PackingPlan.ContainerPlan> containers = new HashSet<>();
-    containers.add(container);
+    containers.add(PackingTestUtils.testContainerPlan(1, 0, 1, 2));
     PackingPlan packing = new PackingPlan("id", containers);
     SchedulerUtils.persistUpdatedPackingPlan("topology", packing, adaptor);
-    Mockito.verify(adaptor).setPackingPlan(Mockito.any(PackingPlans.PackingPlan.class),
-        Mockito.eq("topology"));
+    Mockito.verify(adaptor)
+        .updatePackingPlan(Mockito.any(PackingPlans.PackingPlan.class), Mockito.eq("topology"));
   }
 }

--- a/heron/spi/tests/java/com/twitter/heron/spi/utils/SchedulerUtilsTest.java
+++ b/heron/spi/tests/java/com/twitter/heron/spi/utils/SchedulerUtilsTest.java
@@ -187,7 +187,7 @@ public class SchedulerUtilsTest {
     Set<PackingPlan.ContainerPlan> containers = new HashSet<>();
     containers.add(PackingTestUtils.testContainerPlan(1, 0, 1, 2));
     PackingPlan packing = new PackingPlan("id", containers);
-    SchedulerUtils.persistUpdatedPackingPlan("topology", packing, adaptor);
+    SchedulerUtils.persistUpdatedPackingPlan(TOPOLOGY_NAME, packing, adaptor);
     Mockito.verify(adaptor)
         .updatePackingPlan(Mockito.any(PackingPlans.PackingPlan.class), eq(TOPOLOGY_NAME));
   }


### PR DESCRIPTION
The scheduler updates the packing plan with the scheduled resources. When doing so it must delete the first packing plan, otherwise zookeeper will fail.

cc/ @ashvina 

Relates to #1292 