### PR TITLE
Turn off Javadoc Checks for tests/.*

### DIFF
--- a/tools/java/src/com/twitter/bazel/checkstyle/suppressions.xml
+++ b/tools/java/src/com/twitter/bazel/checkstyle/suppressions.xml
@@ -14,5 +14,6 @@
   -->
 
   <suppress files="Empty.java" checks=".*"/>
+  <suppress files="tests/.*" checks="JavadocMethod|JavadocType|JavadocStyle" />
 
 </suppressions>

--- a/tools/java/src/com/twitter/bazel/checkstyle/suppressions.xml
+++ b/tools/java/src/com/twitter/bazel/checkstyle/suppressions.xml
@@ -14,6 +14,8 @@
   -->
 
   <suppress files="Empty.java" checks=".*"/>
-  <suppress files="tests/.*" checks="JavadocMethod|JavadocType|JavadocStyle" />
+
+  <!-- supress javadoc requirements on files in tests folders -->
+  <suppress files="tests/.*" checks="JavadocMethod|JavadocType" />
 
 </suppressions>


### PR DESCRIPTION
Turning off the Javadoc requirements for Tests (probably since I can't seem to reproduce checkstyle failures locally)