### PR TITLE
ZkStateManager configuration

### DIFF
--- a/heron/statemgrs/src/python/statemanager.py
+++ b/heron/statemgrs/src/python/statemanager.py
@@ -90,7 +90,7 @@ class StateManager:
         socket.create_connection(hostport, 2)
         return True
       except:
-        LOG.info("StateManager %s Unable to connect to host: %s port %i" % (self.name,hostport[0], hostport[1]))
+        LOG.info("StateManager %s Unable to connect to host: %s port %i" % (self.name, hostport[0], hostport[1]))
         continue
     return False
 

--- a/heron/statemgrs/src/python/statemanager.py
+++ b/heron/statemgrs/src/python/statemanager.py
@@ -109,6 +109,7 @@ class StateManager:
       self.tunnel.append(subprocess.Popen(
           ('ssh', self.tunnelhost, '-NL127.0.0.1:%d:%s:%d' % (localport, host, port))))
       localportlist.append(('127.0.0.1', localport))
+    print (localportlist)
     return localportlist
 
   def terminate_ssh_tunnel(self):

--- a/heron/statemgrs/src/python/statemanager.py
+++ b/heron/statemgrs/src/python/statemanager.py
@@ -71,14 +71,8 @@ class StateManager:
     """ Setter for the tunnelhost to create the tunnel if host is not accessible """
     self.__tunnelhost = newTunnelHost
 
-  @abc.abstractmethod
-  def __init__(self, hostportlist, rootpath, tunnelhost):
-    """
-    @param hostportlist - Hosts and ports where the states are stored
-    @param rootpath - Path where the heron states are stored
-    @param tunnelhost - Host to which to tunnel through if state host is not directly accessible
-    """
-    pass
+  def __init__(self):
+    self.tunnel = []
 
   def is_host_port_reachable(self):
     """
@@ -90,7 +84,8 @@ class StateManager:
         socket.create_connection(hostport, 2)
         return True
       except:
-        LOG.info("StateManager %s Unable to connect to host: %s port %i" % (self.name, hostport[0], hostport[1]))
+        LOG.info("StateManager %s Unable to connect to host: %s port %i"
+                 % (self.name, hostport[0], hostport[1]))
         continue
     return False
 
@@ -117,9 +112,8 @@ class StateManager:
     return localportlist
 
   def terminate_ssh_tunnel(self):
-    if hasattr(self, 'tunnel') and self.tunnel:
-      for tunnel in self.tunnel:
-        tunnel.terminate()
+    for tunnel in self.tunnel:
+      tunnel.terminate()
 
   @abc.abstractmethod
   def start(self):

--- a/heron/statemgrs/src/python/statemanager.py
+++ b/heron/statemgrs/src/python/statemanager.py
@@ -16,6 +16,8 @@ import abc
 import socket
 import subprocess
 
+from heron.statemgrs.src.python.log import Log as LOG
+
 HERON_EXECUTION_STATE_PREFIX = "{0}/executionstate/"
 HERON_PACKING_PLANS_PREFIX = "{0}/packingplans/"
 HERON_PPLANS_PREFIX = "{0}/pplans/"
@@ -88,6 +90,7 @@ class StateManager:
         socket.create_connection(hostport, 2)
         return True
       except:
+        LOG.info("StateManager %s Unable to connect to host: %s port %i" % (self.name,hostport[0], hostport[1]))
         continue
     return False
 

--- a/heron/statemgrs/src/python/statemanager.py
+++ b/heron/statemgrs/src/python/statemanager.py
@@ -117,7 +117,7 @@ class StateManager:
     return localportlist
 
   def terminate_ssh_tunnel(self):
-    if hasattr(self, 'tunnel'):
+    if hasattr(self, 'tunnel') and self.tunnel:
       for tunnel in self.tunnel:
         tunnel.terminate()
 

--- a/heron/statemgrs/src/python/statemanager.py
+++ b/heron/statemgrs/src/python/statemanager.py
@@ -83,9 +83,9 @@ class StateManager:
     Returns true if the host is reachable. In some cases, it may not be reachable a tunnel
     must be used.
     """
-    for (host,port) in self.hostportlist:
+    for hostport in self.hostportlist:
       try:
-        socket.create_connection((host, port), 2)
+        socket.create_connection(hostport, 2)
         return True
       except:
         continue
@@ -106,11 +106,11 @@ class StateManager:
     that can be used to communicate with the state host.
     """
     localportlist = []
-    for (host,port) in self.hostportlist:
+    for (host, port) in self.hostportlist:
       localport = self.pick_unused_port()
       self.tunnel.append(subprocess.Popen(
           ('ssh', self.tunnelhost, '-NL127.0.0.1:%d:%s:%d' % (localport, host, port))))
-      localportlist.append(('127.0.0.1',localport))
+      localportlist.append(('127.0.0.1', localport))
     return localportlist
 
   def terminate_ssh_tunnel(self):

--- a/heron/statemgrs/src/python/statemanager.py
+++ b/heron/statemgrs/src/python/statemanager.py
@@ -109,7 +109,6 @@ class StateManager:
       self.tunnel.append(subprocess.Popen(
           ('ssh', self.tunnelhost, '-NL127.0.0.1:%d:%s:%d' % (localport, host, port))))
       localportlist.append(('127.0.0.1', localport))
-    print (localportlist)
     return localportlist
 
   def terminate_ssh_tunnel(self):

--- a/heron/statemgrs/src/python/statemanagerfactory.py
+++ b/heron/statemgrs/src/python/statemanagerfactory.py
@@ -47,19 +47,22 @@ def get_all_zk_state_managers(conf):
   for location in state_locations:
     name = location['name']
     hostport = location['hostport']
-    host = None
-    port = None
-    if ':' in hostport:
-      hostportlist = hostport.split(':')
-      if len(hostportlist) == 2:
-        host = hostportlist[0]
-        port = int(hostportlist[1])
-    if not host or not port:
-      raise Exception("Hostport for %s must be of the format 'host:port'." % (name))
+    hostportlist = []
+    for hostportPair in hostport.split(','):
+      host = None
+      port = None
+      if ':' in hostport:
+        hostandport = hostportPair.split(':')
+        if len(hostandport) == 2:
+          host = hostandport[0]
+          port = int(hostandport[1])
+      if not host or not port:
+        raise Exception("Hostport for %s must be of the format 'host:port'." % (name))
+      hostportlist.append((host,port))
     tunnelhost = location['tunnelhost']
     rootpath = location['rootpath']
-    LOG.info("Connecting to zk hostport: " + host + ":" + str(port) + " rootpath: " + rootpath)
-    state_manager = ZkStateManager(name, host, port, rootpath, tunnelhost)
+    LOG.info("Connecting to zk hostports: " + str(hostportlist) + " rootpath: " + rootpath)
+    state_manager = ZkStateManager(name, hostportlist, rootpath, tunnelhost)
     try:
       state_manager.start()
     except Exception:

--- a/heron/statemgrs/src/python/statemanagerfactory.py
+++ b/heron/statemgrs/src/python/statemanagerfactory.py
@@ -58,7 +58,7 @@ def get_all_zk_state_managers(conf):
           port = int(hostandport[1])
       if not host or not port:
         raise Exception("Hostport for %s must be of the format 'host:port'." % (name))
-      hostportlist.append((host,port))
+      hostportlist.append((host, port))
     tunnelhost = location['tunnelhost']
     rootpath = location['rootpath']
     LOG.info("Connecting to zk hostports: " + str(hostportlist) + " rootpath: " + rootpath)

--- a/heron/statemgrs/src/python/statemanagerfactory.py
+++ b/heron/statemgrs/src/python/statemanagerfactory.py
@@ -48,11 +48,11 @@ def get_all_zk_state_managers(conf):
     name = location['name']
     hostport = location['hostport']
     hostportlist = []
-    for hostportPair in hostport.split(','):
+    for hostportpair in hostport.split(','):
       host = None
       port = None
       if ':' in hostport:
-        hostandport = hostportPair.split(':')
+        hostandport = hostportpair.split(':')
         if len(hostandport) == 2:
           host = hostandport[0]
           port = int(hostandport[1])

--- a/heron/statemgrs/src/python/zkstatemanager.py
+++ b/heron/statemgrs/src/python/zkstatemanager.py
@@ -42,6 +42,7 @@ class ZkStateManager(StateManager):
   """
 
   def __init__(self, name, hostportlist, rootpath, tunnelhost):
+    super(ZkStateManager, self).__init__()
     self.name = name
     self.hostportlist = hostportlist
     self.tunnelhost = tunnelhost

--- a/heron/statemgrs/src/python/zkstatemanager.py
+++ b/heron/statemgrs/src/python/zkstatemanager.py
@@ -31,6 +31,9 @@ from kazoo.exceptions import NoNodeError
 from kazoo.exceptions import NotEmptyError
 from kazoo.exceptions import ZookeeperError
 
+def _makehostportlist(hostportlist):
+  return ','.join(map(lambda hp: "%s:%i" % hp, hostportlist))
+
 # pylint: disable=attribute-defined-outside-init
 class ZkStateManager(StateManager):
   """
@@ -44,11 +47,8 @@ class ZkStateManager(StateManager):
     self.tunnelhost = tunnelhost
     self.rootpath = rootpath
 
-  def _makehostportlist(hostportlist):
-    return ','.join(map(lambda hp: "%s:%i" % hp, hostportlist))
-
   # pylint: disable=no-self-use
-  def _kazoo_client(self,hostportlist):
+  def _kazoo_client(self, hostportlist):
     """
     For Unit testing, replace this method to not
     Actually return a client

--- a/heron/statemgrs/tests/python/BUILD
+++ b/heron/statemgrs/tests/python/BUILD
@@ -15,6 +15,6 @@ pex_test(
         "pytest==2.6.4",
         "unittest2==0.5.1",
     ],
-    size = "small",
+    size = "medium",
 )
 

--- a/heron/statemgrs/tests/python/BUILD
+++ b/heron/statemgrs/tests/python/BUILD
@@ -2,7 +2,10 @@ load("/tools/rules/pex_rules", "pex_test")
 
 pex_test(
     name = "statemanager_unittest",
-    srcs = ["configloader_unittest.py"],
+    srcs = [
+        "configloader_unittest.py",
+        "zkstatemanager_unittest.py",
+    ],
     deps = [
         "//heron/statemgrs/src/python:statemgr-py",
     ],
@@ -13,3 +16,4 @@ pex_test(
     ],
     size = "small",
 )
+

--- a/heron/statemgrs/tests/python/BUILD
+++ b/heron/statemgrs/tests/python/BUILD
@@ -5,6 +5,7 @@ pex_test(
     srcs = [
         "configloader_unittest.py",
         "zkstatemanager_unittest.py",
+        "statemanagerfactory_unittest.py",
     ],
     deps = [
         "//heron/statemgrs/src/python:statemgr-py",

--- a/heron/statemgrs/tests/python/BUILD
+++ b/heron/statemgrs/tests/python/BUILD
@@ -1,10 +1,40 @@
 load("/tools/rules/pex_rules", "pex_test")
 
 pex_test(
-    name = "statemanager_unittest",
+    name = "configloader_unittest",
     srcs = [
         "configloader_unittest.py",
+    ],
+    deps = [
+        "//heron/statemgrs/src/python:statemgr-py",
+    ],
+    reqs = [
+        "py==1.4.27",
+        "pytest==2.6.4",
+        "unittest2==0.5.1",
+    ],
+    size = "small",
+)
+
+pex_test(
+    name = "zkstatemanager_unittest",
+    srcs = [
         "zkstatemanager_unittest.py",
+    ],
+    deps = [
+        "//heron/statemgrs/src/python:statemgr-py",
+    ],
+    reqs = [
+        "py==1.4.27",
+        "pytest==2.6.4",
+        "unittest2==0.5.1",
+    ],
+    size = "small",
+)
+
+pex_test(
+    name = "statemanagerfactory_unittest",
+    srcs = [
         "statemanagerfactory_unittest.py",
     ],
     deps = [
@@ -15,6 +45,6 @@ pex_test(
         "pytest==2.6.4",
         "unittest2==0.5.1",
     ],
-    size = "medium",
+    size = "small",
 )
 

--- a/heron/statemgrs/tests/python/statemanagerfactory_unittest.py
+++ b/heron/statemgrs/tests/python/statemanagerfactory_unittest.py
@@ -1,0 +1,35 @@
+# Copyright 2016 Twitter. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+'''state manager factory unittest'''
+import unittest2 as unittest
+
+from heron.statemgrs.src.python.config import Config
+from heron.statemgrs.src.python import statemanagerfactory
+
+class StateManagerFacotryTest(unittest.TestCase):
+  """Unittest for statemanagerfactory"""
+
+  def test_all_zk_supports_comma_separated_hostports(self):
+    """Verify that a comma separated list of host ports is ok"""
+    conf = Config()
+    conf.set_state_locations([{'type':'zookeeper', 'name':'zk', 'hostport':'localhost:2181,localhost:2281',
+                              'rootpath':'/heron', 'tunnelhost':'localhost'}])
+    statemanagers = statemanagerfactory.get_all_zk_state_managers(conf)
+    # 1 state_location should result in 1 state manager
+    self.assertEquals(1,len(statemanagers))
+
+    statemanager = statemanagers[0]
+    # statemanager.hostportlist should contain both host port pairs
+    self.assertTrue(('localhost', 2181) in statemanager.hostportlist)
+    self.assertTrue(('localhost', 2281) in statemanager.hostportlist)

--- a/heron/statemgrs/tests/python/statemanagerfactory_unittest.py
+++ b/heron/statemgrs/tests/python/statemanagerfactory_unittest.py
@@ -27,7 +27,7 @@ class StateManagerFacotryTest(unittest.TestCase):
                               'rootpath':'/heron', 'tunnelhost':'localhost'}])
     statemanagers = statemanagerfactory.get_all_zk_state_managers(conf)
     # 1 state_location should result in 1 state manager
-    self.assertEquals(1,len(statemanagers))
+    self.assertEquals(1, len(statemanagers))
 
     statemanager = statemanagers[0]
     # statemanager.hostportlist should contain both host port pairs

--- a/heron/statemgrs/tests/python/zkstatemanager_unittest.py
+++ b/heron/statemgrs/tests/python/zkstatemanager_unittest.py
@@ -20,7 +20,7 @@ from heron.statemgrs.src.python.zkstatemanager import ZkStateManager
 class ZkStateManagerTest(unittest.TestCase):
   """Unittest for ZkStateManager"""
 
-  class NoseFlute:
+  class MockKazooClient:
     def __init__(self):
       self.start_calls = 0
       self.stop_calls = 0
@@ -35,7 +35,7 @@ class ZkStateManagerTest(unittest.TestCase):
     # Create a a ZkStateManager that we will test with
     self.statemanager = ZkStateManager('zk', [('localhost', 2181), ('localhost', 2281)], 'heron', 'reachable.host')
     # replace creation of a KazooClient
-    self.mock_kazoo = NoseFlute()
+    self.mock_kazoo = MockKazooClient()
     self.opened_host_ports = []
 
     def kazoo_client(hostport):

--- a/heron/statemgrs/tests/python/zkstatemanager_unittest.py
+++ b/heron/statemgrs/tests/python/zkstatemanager_unittest.py
@@ -31,21 +31,24 @@ class ZkStateManagerTest(unittest.TestCase):
     def stop(self):
       self.stop_calls = self.stop_calls + 1
 
+    def add_listener(self,listener):
+      pass
+
   def setUp(self):
     # Create a a ZkStateManager that we will test with
     self.statemanager = ZkStateManager('zk', [('localhost', 2181), ('localhost', 2281)], 'heron', 'reachable.host')
     # replace creation of a KazooClient
-    self.mock_kazoo = MockKazooClient()
+    self.mock_kazoo = ZkStateManagerTest.MockKazooClient()
     self.opened_host_ports = []
 
     def kazoo_client(hostport):
-      global self
       self.opened_host_ports.append(hostport)
       return self.mock_kazoo
 
     self.statemanager._kazoo_client = kazoo_client
 
   def test_start_checks_for_connection(self):
+    global did_connection_check
     did_connection_check = False
 
     def connection_check():
@@ -68,11 +71,12 @@ class ZkStateManagerTest(unittest.TestCase):
     def connection_check():
       return False
 
+    global did_open_proxy
     did_open_proxy = False
     def open_proxy():
       global did_open_proxy
       did_open_proxy = True
-      return None
+      return [('proxy', 2181), ('proxy-2', 2281)]
 
     self.statemanager.is_host_port_reachable = connection_check
     self.statemanager.establish_ssh_tunnel = open_proxy

--- a/heron/statemgrs/tests/python/zkstatemanager_unittest.py
+++ b/heron/statemgrs/tests/python/zkstatemanager_unittest.py
@@ -1,0 +1,91 @@
+# Copyright 2016 Twitter. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+'''ZkStateManager unittest'''
+import unittest2 as unittest
+
+from heron.statemgrs.src.python.zkstatemanager import ZkStateManager
+
+
+class ZkStateManagerTest(unittest.TestCase):
+  """Unittest for ZkStateManager"""
+
+  class NoseFlute:
+    def __init__(self):
+      self.start_calls = 0
+      self.stop_calls = 0
+
+    def start(self):
+      self.start_calls = self.start_calls + 1
+
+    def stop(self):
+      self.stop_calls = self.stop_calls + 1
+
+  def setUp(self):
+    # Create a a ZkStateManager that we will test with
+    self.statemanager = ZkStateManager('zk', [('localhost', 2181), ('localhost', 2281)], 'heron', 'reachable.host')
+    # replace creation of a KazooClient
+    self.mock_kazoo = NoseFlute()
+    self.opened_host_ports = []
+
+    def kazoo_client(hostport):
+      global self
+      self.opened_host_ports.append(hostport)
+      return self.mock_kazoo
+
+    self.statemanager._kazoo_client = kazoo_client
+
+  def test_start_checks_for_connection(self):
+    did_connection_check = False
+
+    def connection_check():
+      global did_connection_check
+      did_connection_check = True
+      return True
+
+    self.statemanager.is_host_port_reachable = connection_check
+    self.statemanager.start()
+    self.assertTrue(did_connection_check)
+
+  def test_start_uses_host_ports(self):
+    def connection_check():
+      return True
+    self.statemanager.is_host_port_reachable = connection_check
+    self.statemanager.start()
+    self.assertEqual('localhost:2181,localhost:2281',self.opened_host_ports[0])
+
+  def test_start_opens_proxy_if_no_connection(self):
+    def connection_check():
+      return False
+
+    did_open_proxy = False
+    def open_proxy():
+      global did_open_proxy
+      did_open_proxy = True
+      return None
+
+    self.statemanager.is_host_port_reachable = connection_check
+    self.statemanager.establish_ssh_tunnel = open_proxy
+    self.statemanager.start()
+    self.assertTrue(did_open_proxy)
+
+  def test_proxied_start_uses_connection(self):
+    def connection_check():
+      return False
+    def open_proxy():
+      return [('smorgasboard',2200),('smorgasboard',2201)]
+
+    self.statemanager.is_host_port_reachable = connection_check
+    self.statemanager.establish_ssh_tunnel = open_proxy
+    self.statemanager.start()
+    self.assertEqual('smorgasboard:2200,smorgasboard:2201',self.opened_host_ports[0])

--- a/heron/tools/config/src/yaml/tracker/heron_tracker.yaml
+++ b/heron/tools/config/src/yaml/tracker/heron_tracker.yaml
@@ -25,6 +25,15 @@ statemgrs:
 #    rootpath: "/heron"
 #    tunnelhost: "localhost"
 
+#
+# To specify multiple Zookeeper Nodes for fallback
+# -
+#    type: "zookeeper"
+#    name: "zk"
+#    hostport: "remote-zk-1:2181,remote-zk-2:2181,remote-zk-3:2181"
+#    rootpath: "/heron"
+#    tunnelhost: "remote-tunnel"
+
 # The URL that points to a topology's metrics dashboard.
 # This value can use following parameters to create a valid
 # URL based on the topology. All parameters are self-explanatory.


### PR DESCRIPTION
Changing ZkStateManager and StateManager to accept a set of host, port pairs rather than a single host port. This allows us to specify all the members of a ZK Quorum rather than needing to choose 1 member which is potentially more fragile.