### PR TITLE
create serializer with default constructor

### DIFF
--- a/heron/storm/src/java/backtype/storm/serialization/SerializationFactory.java
+++ b/heron/storm/src/java/backtype/storm/serialization/SerializationFactory.java
@@ -163,6 +163,12 @@ public final class SerializationFactory {
       // do nothing
     }
 
+    try {
+      return serializerClass.newInstance();
+    } catch (InstantiationException | IllegalAccessException ex) {
+      // do nothing
+    }
+
     throw new IllegalArgumentException(
         String.format("Unable to create serializer \"%s\" for class: %s",
             serializerClass.getName(), superClass.getName()));

--- a/heron/storm/src/java/org/apache/storm/serialization/SerializationFactory.java
+++ b/heron/storm/src/java/org/apache/storm/serialization/SerializationFactory.java
@@ -164,6 +164,12 @@ public final class SerializationFactory {
       // do nothing
     }
 
+    try {
+        return serializerClass.newInstance();
+    } catch (InstantiationException | IllegalAccessException ex) {
+      // do nothing
+    }
+
     throw new IllegalArgumentException(
         String.format("Unable to create serializer \"%s\" for class: %s",
             serializerClass.getName(), superClass.getName()));

--- a/heron/storm/src/java/org/apache/storm/serialization/SerializationFactory.java
+++ b/heron/storm/src/java/org/apache/storm/serialization/SerializationFactory.java
@@ -165,7 +165,7 @@ public final class SerializationFactory {
     }
 
     try {
-        return serializerClass.newInstance();
+      return serializerClass.newInstance();
     } catch (InstantiationException | IllegalAccessException ex) {
       // do nothing
     }


### PR DESCRIPTION
As reported in [heron-users](https://groups.google.com/forum/#!topic/heron-users/LLmiQtxXMRM) google group, heron fails to create the serializer with default constructor. This PR fixed the issue.

