### PR TITLE
Update the compiling doc web page.

### DIFF
--- a/website/content/docs/contributors/codebase.md
+++ b/website/content/docs/contributors/codebase.md
@@ -139,7 +139,7 @@ Heron has a tool called `heron` that is used to both provide a CLI interface
 for [managing topologies](../../operators/heron-cli) and to perform much of
 the heavy lifting behind assembling physical topologies in your cluster.
 The Python code for `heron` can be found in
-[`heron/cli`]({{% githubMaster %}}/heron/cli).
+[`heron/tools/cli`]({{% githubMaster %}}/heron/tools/cli).
 
 Sample configurations for different Heron schedulers
 
@@ -149,19 +149,19 @@ Sample configurations for different Heron schedulers
 ### Heron Tracker
 
 The Python code for the [Heron Tracker](../../operators/heron-tracker) can be
-found in [`heron/tracker`]({{% githubMaster %}}/heron/tracker).
+found in [`heron/tools/tracker`]({{% githubMaster %}}/heron/tools/tracker).
 
 The Tracker is a web server written in Python. It relies on the
 [Tornado](http://www.tornadoweb.org/en/stable/) framework. You can add new HTTP
 routes to the Tracker in
-[`main.py`]({{% githubMaster %}}/heron/tracker/src/python/main.py) and
+[`main.py`]({{% githubMaster %}}/heron/tools/tracker/src/python/main.py) and
 corresponding handlers in the
-[`handlers`]({{% githubMaster %}}/heron/tracker/src/python/handlers) directory.
+[`handlers`]({{% githubMaster %}}/heron/tools/tracker/src/python/handlers) directory.
 
 ### Heron UI
 
 The Python code for the [Heron UI](../../operators/heron-ui) can be found in
-[`heron/ui`]({{% githubMaster %}}/heron/ui).
+[`heron/tools/ui`]({{% githubMaster %}}/heron/tools/ui).
 
 Like Heron Tracker, Heron UI is a web server written in Python that relies on
 the [Tornado](http://www.tornadoweb.org/en/stable/) framework. You can add new

--- a/website/content/docs/developers/compiling/compiling.md
+++ b/website/content/docs/developers/compiling/compiling.md
@@ -87,6 +87,13 @@ packages:
 $ bazel build --config=darwin heron/...
 ```
 
+Production release packages include additional performance optimizations
+not enabled by default. Enabling these optimizations increases build time.
+To enable production optimizations, include the `opt` flag:
+```bash
+$ bazel build -c opt --config=PLATFORM heron/...
+```
+
 ### Building All Components
 
 The Bazel build process can produce either executable install scripts or
@@ -100,7 +107,7 @@ $ bazel build --config=PLATFORM scripts/packages:tarpkgs
 
 Resulting artifacts can be found in subdirectories below the `bazel-bin`
 directory. The `heron-tracker` executable, for example, can be found at
-`bazel-bin/heron/tracker/src/python/heron-tracker`.
+`bazel-bin/heron/tools/tracker/src/python/heron-tracker`.
 
 ### Building Specific Components
 
@@ -110,7 +117,7 @@ Tracker](../../../operators/heron-tracker)) by passing a target to the `bazel
 build` command. For example, the following command would build the [Heron Tracker](../../../operators/heron-tracker):
 
 ```bash
-$ bazel build --config=darwin heron/tracker/src/python:heron-tracker
+$ bazel build --config=darwin heron/tools/tracker/src/python:heron-tracker
 ```
 
 ## Testing Heron

--- a/website/content/docs/operators/heron-tracker.md
+++ b/website/content/docs/operators/heron-tracker.md
@@ -16,12 +16,12 @@ for heron.
 
 ```bash
 # Build heron-tracker
-$ bazel build heron/tracker/src/python:heron-tracker
+$ bazel build heron/tools/tracker/src/python:heron-tracker
 
 # The location of heron-tracker pex executable is
-# bazel-bin/heron/tracker/src/python/heron-tracker
+# bazel-bin/heron/tools/tracker/src/python/heron-tracker
 # To run using default options:
-$ ./bazel-bin/heron/tracker/src/python/heron-tracker
+$ ./bazel-bin/heron/tools/tracker/src/python/heron-tracker
 ```
 
 `heron-tracker` is a self executable

--- a/website/content/docs/operators/heron-ui.md
+++ b/website/content/docs/operators/heron-ui.md
@@ -18,12 +18,12 @@ for heron.
 
 ```bash
 # Build heron-ui
-$ bazel build heron/ui/src/python:heron-ui
+$ bazel build heron/tools/ui/src/python:heron-ui
 
 # The location of heron-ui pex executable is
-# bazel-bin/heron/ui/src/python/heron-ui
+# bazel-bin/heron/tools/ui/src/python/heron-ui
 # To run using default options:
-$ ./bazel-bin/heron/ui/src/python/heron-ui
+$ ./bazel-bin/heron/tools/ui/src/python/heron-ui
 ```
 
 `heron-ui` is a self executable


### PR DESCRIPTION
1. Add "How to build a production release with opt flag"
2. Fix outdated path, for instance, from "heron/tracker" to "heron/tools/tracker"