### PR TITLE
Adding distributed locking support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -82,13 +82,18 @@ maven_jar(
 )
 
 maven_jar(
+  name = "org_apache_curator_curator_client",
+  artifact = "org.apache.curator:curator-client:" + curator_version,
+)
+
+maven_jar(
   name = "org_apache_curator_curator_framework",
   artifact = "org.apache.curator:curator-framework:" + curator_version,
 )
 
 maven_jar(
-  name = "org_apache_curator_curator_client",
-  artifact = "org.apache.curator:curator-client:" + curator_version,
+  name = "org_apache_curator_curator_recipes",
+  artifact = "org.apache.curator:curator-recipes:" + curator_version,
 )
 
 maven_jar(

--- a/heron/common/src/java/com/twitter/heron/common/basics/FileUtils.java
+++ b/heron/common/src/java/com/twitter/heron/common/basics/FileUtils.java
@@ -19,8 +19,10 @@ import java.io.IOException;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -66,14 +68,13 @@ public final class FileUtils {
   }
 
   public static boolean writeToFile(String filename, byte[] contents, boolean overwrite) {
-    File f = new File(filename);
-    if (!overwrite && f.exists()) {
-      LOG.severe("File exists. Topology exists: " + filename);
-      return false;
-    }
+    // default Files behavior is to overwrite. If we specify no overwrite then CREATE_NEW fails
+    // if the file exist. This operation is atomic.
+    OpenOption[] options = overwrite
+        ? new OpenOption[]{} : new OpenOption[]{StandardOpenOption.CREATE_NEW};
 
     try {
-      Files.write(new File(filename).toPath(), contents);
+      Files.write(new File(filename).toPath(), contents, options);
     } catch (IOException e) {
       LOG.log(Level.SEVERE, "Failed to write content to file. ", e);
       return false;

--- a/heron/common/src/java/com/twitter/heron/common/basics/FileUtils.java
+++ b/heron/common/src/java/com/twitter/heron/common/basics/FileUtils.java
@@ -20,7 +20,6 @@ import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -118,9 +117,5 @@ public final class FileUtils {
 
   public static String getBaseName(String file) {
     return new File(file).getName();
-  }
-
-  public static String combinePaths(String path1, String path2) {
-    return Paths.get(path1, path2).toString();
   }
 }

--- a/heron/common/tests/java/com/twitter/heron/common/basics/FileUtilsTest.java
+++ b/heron/common/tests/java/com/twitter/heron/common/basics/FileUtilsTest.java
@@ -70,7 +70,7 @@ public class FileUtilsTest {
   @Test
   public void testWriteToFile() throws Exception {
     String currentWorkingDir = Paths.get("").toAbsolutePath().normalize().toString();
-    Assert.assertFalse(FileUtils.writeToFile(currentWorkingDir, null, false));
+    Assert.assertFalse(FileUtils.writeToFile(currentWorkingDir, new byte[]{}, false));
 
     PowerMockito.mockStatic(Files.class);
     String randomString = UUID.randomUUID().toString();

--- a/heron/spi/src/java/com/twitter/heron/spi/statemgr/IStateManager.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/statemgr/IStateManager.java
@@ -67,6 +67,16 @@ public interface IStateManager extends AutoCloseable {
   void close();
 
   /**
+   * Return a lock object backed by the state manager store.
+   *
+   * @param topologyName the name of the topology
+   * @param lockName any thread may get the {@code Lock} object bound to a given name, but only one
+   * thread may obtain the actual lock from that @{code Lock} object.
+   * @return an object representing an implementation of a lock.
+   */
+  Lock getLock(String topologyName, String lockName);
+
+  /**
    * Is the given topology in RUNNING state?
    *
    * @return Boolean

--- a/heron/spi/src/java/com/twitter/heron/spi/statemgr/Lock.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/statemgr/Lock.java
@@ -1,0 +1,33 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.twitter.heron.spi.statemgr;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Interface for a shared lock
+ */
+public interface Lock {
+
+  /**
+   * Wait until timeout for a lock to be available. Return true if lock is obtained or false if it
+   * can not be obtained.
+   */
+  boolean tryLock(long timeout, TimeUnit unit) throws InterruptedException;
+
+  /**
+   * Release the lock. Failure to call this method could result in an orphaned lock.
+   */
+  void unlock();
+}

--- a/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
@@ -81,6 +81,10 @@ public class SchedulerStateManagerAdaptor {
     }
   }
 
+  public Lock getLock(String topologyName, String lockName) {
+    return delegate.getLock(topologyName, lockName);
+  }
+
   /**
    * Is the given topology in RUNNING state?
    *

--- a/heron/statemgrs/src/java/BUILD
+++ b/heron/statemgrs/src/java/BUILD
@@ -21,6 +21,7 @@ zookeeper_deps_files = \
     localfs_deps_files + [
         "@org_apache_curator_curator_client//jar",
         "@org_apache_curator_curator_framework//jar",
+        "@org_apache_curator_curator_recipes//jar",
         "@org_apache_zookeeper_zookeeper//jar",
         "//third_party/java:logging"
     ]

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/FileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/FileSystemStateManager.java
@@ -45,7 +45,8 @@ public abstract class FileSystemStateManager implements IStateManager {
     PACKING_PLAN("packingplans", "Packing plan"),
     PHYSICAL_PLAN("pplans", "Physical plan"),
     EXECUTION_STATE("executionstate", "Execution state"),
-    SCHEDULER_LOCATION("schedulers", "Scheduler location");
+    SCHEDULER_LOCATION("schedulers", "Scheduler location"),
+    LOCKS("locks", "Distributed locks");
 
     private final String dir;
     private final String name;
@@ -65,6 +66,10 @@ public abstract class FileSystemStateManager implements IStateManager {
 
     public String getNodePath(String root, String topology) {
       return concatPath(getDirectory(root), topology);
+    }
+
+    public String getNodePath(String root, String topology, String extraToken) {
+      return concatPath(getNodePath(root, topology), extraToken);
     }
 
     private static String concatPath(String basePath, String appendPath) {

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/NullStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/NullStateManager.java
@@ -14,6 +14,8 @@
 
 package com.twitter.heron.statemgr;
 
+import javax.naming.OperationNotSupportedException;
+
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 
@@ -25,6 +27,7 @@ import com.twitter.heron.proto.system.PhysicalPlans;
 import com.twitter.heron.proto.tmaster.TopologyMaster;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.statemgr.IStateManager;
+import com.twitter.heron.spi.statemgr.Lock;
 import com.twitter.heron.spi.statemgr.WatchCallback;
 
 public class NullStateManager implements IStateManager {
@@ -38,6 +41,11 @@ public class NullStateManager implements IStateManager {
   @Override
   public void close() {
 
+  }
+
+  @Override
+  public Lock getLock(String topologyName, String lockName) {
+    throw new RuntimeException(new OperationNotSupportedException());
   }
 
   @Override

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
@@ -42,8 +42,7 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
 
   /**
    * Local filesystem implementation of a lock that mimics the file system behavior of the
-   * distributed lock. Only intended for local mode testing, not production. Not guaranteed to be
-   * truly atomic due to limitations in the underlying file system read/write semantics.
+   * distributed lock.
    */
   private final class FileSystemLock implements Lock {
     private String path;

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManager.java
@@ -14,7 +14,9 @@
 
 package com.twitter.heron.statemgr.localfs;
 
+import java.nio.charset.Charset;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 import com.google.common.util.concurrent.ListenableFuture;
@@ -31,11 +33,49 @@ import com.twitter.heron.proto.system.PhysicalPlans;
 import com.twitter.heron.proto.tmaster.TopologyMaster;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Keys;
+import com.twitter.heron.spi.statemgr.Lock;
 import com.twitter.heron.spi.statemgr.WatchCallback;
 import com.twitter.heron.statemgr.FileSystemStateManager;
 
 public class LocalFileSystemStateManager extends FileSystemStateManager {
   private static final Logger LOG = Logger.getLogger(LocalFileSystemStateManager.class.getName());
+
+  /**
+   * Local filesystem implementation of a lock that mimics the file system behavior of the
+   * distributed lock. Only intended for local mode testing, not production. Not guaranteed to be
+   * truly atomic due to limitations in the underlying file system read/write semantics.
+   */
+  private final class FileSystemLock implements Lock {
+    private String path;
+
+    private FileSystemLock(String path) {
+      this.path = path;
+    }
+
+    @Override
+    public boolean tryLock(long timeout, TimeUnit unit) throws InterruptedException {
+      long giveUpAtMillis = System.currentTimeMillis() + unit.toMillis(timeout);
+      byte[] fileContents = Thread.currentThread().getName().getBytes(Charset.defaultCharset());
+      while (true) {
+        try {
+          if (setData(this.path, fileContents, false).get()) {
+            return true;
+          } else if (System.currentTimeMillis() >= giveUpAtMillis) {
+            return false;
+          } else {
+            TimeUnit.SECONDS.sleep(2); // need to pole the filesystem for availability
+          }
+        } catch (ExecutionException e) {
+          // this is thrown when the file exists, which means the lock can't be obtained
+        }
+      }
+    }
+
+    @Override
+    public void unlock() {
+      deleteNode(this.path);
+    }
+  }
 
   @Override
   public void initialize(Config ipconfig) {
@@ -162,6 +202,12 @@ public class LocalFileSystemStateManager extends FileSystemStateManager {
     // This is because when running in simulator we control when a scheduler dies and
     // comes up deterministically.
     return setData(StateLocation.SCHEDULER_LOCATION, topologyName, location.toByteArray(), true);
+  }
+
+  @Override
+  public Lock getLock(String topologyName, String lockName) {
+    return new FileSystemLock(
+        StateLocation.LOCKS.getNodePath(this.rootAddress, topologyName, lockName));
   }
 
   @Override

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
@@ -29,6 +29,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.BackgroundCallback;
 import org.apache.curator.framework.api.CuratorEvent;
+import org.apache.curator.framework.recipes.locks.InterProcessSemaphoreMutex;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.Watcher;
@@ -43,6 +44,7 @@ import com.twitter.heron.proto.tmaster.TopologyMaster;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Context;
 import com.twitter.heron.spi.common.Keys;
+import com.twitter.heron.spi.statemgr.Lock;
 import com.twitter.heron.spi.statemgr.WatchCallback;
 import com.twitter.heron.spi.utils.NetworkUtils;
 import com.twitter.heron.statemgr.FileSystemStateManager;
@@ -99,6 +101,43 @@ public class CuratorStateManager extends FileSystemStateManager {
 
     if (ZkContext.isInitializeTree(newConfig)) {
       initTree();
+    }
+  }
+
+  /**
+   * Lock backed by {@code InterProcessSemaphoreMutex}. Guaranteed to atomically get a
+   * distributed ephemeral lock backed by zookeeper. The lock should be explicitly released to
+   * avoid unnecessary waiting by other threads waiting on it.
+   */
+  private final class DistributedLock implements Lock {
+    private String path;
+    private InterProcessSemaphoreMutex lock;
+
+    private DistributedLock(CuratorFramework client, String path) {
+      this.path = path;
+      this.lock = new InterProcessSemaphoreMutex(client, path);
+    }
+
+    @Override
+    public boolean tryLock(long timeout, TimeUnit unit) throws InterruptedException {
+      try {
+        return this.lock.acquire(timeout, unit);
+      } catch (InterruptedException e) {
+        throw e;
+        // SUPPRESS CHECKSTYLE IllegalCatch
+      } catch (Exception e) {
+        throw new RuntimeException("Error while trying to acquire distributed lock at " + path, e);
+      }
+    }
+
+    @Override
+    public void unlock() {
+      try {
+        this.lock.release();
+        // SUPPRESS CHECKSTYLE IllegalCatch
+      } catch (Exception e) {
+        throw new RuntimeException("Error while trying to release distributed lock at " + path, e);
+      }
     }
   }
 
@@ -262,6 +301,12 @@ public class CuratorStateManager extends FileSystemStateManager {
     }
 
     return future;
+  }
+
+  @Override
+  public Lock getLock(String topologyName, String lockName) {
+    return new DistributedLock(this.client,
+        StateLocation.LOCKS.getNodePath(this.rootAddress, topologyName, lockName));
   }
 
   @Override

--- a/heron/statemgrs/tests/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManagerTest.java
+++ b/heron/statemgrs/tests/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManagerTest.java
@@ -108,7 +108,7 @@ public class CuratorStateManagerTest {
     // Verify curator client is invoked
     Mockito.verify(mockClient).start();
     Mockito.verify(mockClient).blockUntilConnected(Mockito.anyInt(), Mockito.any(TimeUnit.class));
-    Mockito.verify(mockClient, Mockito.times(6)).createContainers(Mockito.anyString());
+    Mockito.verify(mockClient, Mockito.times(7)).createContainers(Mockito.anyString());
 
     // Verify initTree is called
     Mockito.verify(spyStateManager).initTree();


### PR DESCRIPTION
We need a distributed locking mechanism to assure that multiple Heron commands aren't be executed at the same time by different actors. This is required for the update command for scaling, but other commands could also leverage this approach.

Implemented as a new method on `StateManager` to get a `Lock` impl backed by the state manager impl. For ZK the lock is backed by curator, and for local file system the lock is backed by the file system.

Required for #1353 and #1459