### PR TITLE
Add back the "import StringIO" to javaobj.py

### DIFF
--- a/heron/tools/tracker/src/python/javaobj.py
+++ b/heron/tools/tracker/src/python/javaobj.py
@@ -21,6 +21,7 @@ library marshal, pickle and json modules.
 See: http://download.oracle.com/javase/6/docs/platform/serialization/spec/protocol.html
 """
 
+import StringIO
 import struct
 from heron.common.src.python.utils.log import Log
 

--- a/heron/tools/tracker/src/python/tracker.py
+++ b/heron/tools/tracker/src/python/tracker.py
@@ -349,6 +349,7 @@ class Tracker(object):
                                      indent=2),
                 'raw' : utils.hex_escape(kvs.serialized_value)}
           except Exception:
+            Log.exception("Failed to parse data as java object")
             physicalPlan["config"][kvs.key] = {
                 'value' : 'A Java Object',
                 'raw' : utils.hex_escape(kvs.serialized_value)}


### PR DESCRIPTION
Earlier, the import of StringIO was removed mistakenly, causing heron-tracker
failing to parse bytes into java object. Then the heron-ui would not be able to
fetch the correct topology_config value, and thus the config could not be displayed
normally.

This patch fixes the issue #1410.