### PR TITLE
Make Python topology adapt to GPR 1421.

### DIFF
--- a/scripts/travis/test.sh
+++ b/scripts/travis/test.sh
@@ -49,14 +49,14 @@ trap "kill -9 $http_server_id" SIGINT SIGTERM EXIT
   -cl local -rl heron-staging -ev devel
 end_timer "$T"
 
-# temporarily disable python integration test since it is not ready
-#T="heron integration-test python"
-#start_timer "$T"
-#./bazel-bin/integration-test/src/python/test_runner/test-runner.pex \
-#  -hc heron -tb ${PYTHON_INTEGRATION_TESTS_BIN} \
-#  -rh localhost -rp 8080\
-#  -tp integration-test/src/python/integration_test/topology/ \
-#  -cl local -rl heron-staging -ev devel
-#end_timer "$T"
+# run the python integration test
+T="heron integration-test python"
+start_timer "$T"
+./bazel-bin/integration-test/src/python/test_runner/test-runner.pex \
+  -hc heron -tb ${PYTHON_INTEGRATION_TESTS_BIN} \
+  -rh localhost -rp 8080\
+  -tp integration-test/src/python/integration_test/topology/ \
+  -cl local -rl heron-staging -ev devel
+end_timer "$T"
 
 print_timer_summary


### PR DESCRIPTION
This PR involves the following changes

1. Adapt to #1421. When Python instance sends tuples to stream manager, it sends raw byte. And when it receives raw bytes from stream manager, it deserializes raw bytes back to tuples. Python integration test in Travis CI is re-enabled.

2. Add the missing `update_sent_packet` function. It will be called when instance sends tuples to stream manager.

3. Other small changes including using lazy logging as much as possible.

Local integration test has passed. Also manually submit example topology and can confirm everything works normally via heron-ui.

cc @maosongfu @taishi8117 