### PR TITLE
Remove usage of NullFoo objects

### DIFF
--- a/heron/config/src/yaml/conf/yarn/uploader.yaml
+++ b/heron/config/src/yaml/conf/yarn/uploader.yaml
@@ -1,5 +1,5 @@
 # uploader class for transferring the topology jar/tar files to storage
-heron.class.uploader:                            com.twitter.heron.uploader.NullUploader
+heron.class.uploader:                            com.twitter.heron.uploader.localfs.LocalFileSystemUploader
 
 # name of the directory to upload topologies for local file system uploader
 #heron.uploader.localfs.file.system.directory:    ${HOME}/.herondata/repository/topologies/${CLUSTER}/${ROLE}/${TOPOLOGY} 

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/RuntimeManagerMainTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/RuntimeManagerMainTest.java
@@ -16,16 +16,22 @@ package com.twitter.heron.scheduler;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.twitter.heron.proto.system.ExecutionEnvironment;
 import com.twitter.heron.scheduler.client.ISchedulerClient;
 import com.twitter.heron.spi.common.Command;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.ConfigKeys;
+import com.twitter.heron.spi.statemgr.IStateManager;
 import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
-import com.twitter.heron.statemgr.NullStateManager;
+import com.twitter.heron.spi.utils.ReflectionUtils;
 
+@RunWith(PowerMockRunner.class)
 public class RuntimeManagerMainTest {
   private static final String TOPOLOGY_NAME = "topologyName";
   private static final String TOPOLOGY_ID = "topologyId";
@@ -77,6 +83,7 @@ public class RuntimeManagerMainTest {
    * Test manageTopology()
    */
   @Test
+  @PrepareForTest(ReflectionUtils.class)
   public void testManageTopology() throws Exception {
     Config config = Mockito.mock(Config.class);
     Mockito.when(config.getStringValue(ConfigKeys.get("TOPOLOGY_NAME"))).thenReturn(TOPOLOGY_NAME);
@@ -92,7 +99,10 @@ public class RuntimeManagerMainTest {
 
     // Valid state manager class
     Mockito.when(config.getStringValue(ConfigKeys.get("STATE_MANAGER_CLASS"))).
-        thenReturn(NullStateManager.class.getName());
+        thenReturn(IStateManager.class.getName());
+    PowerMockito.mockStatic(ReflectionUtils.class);
+    PowerMockito.doReturn(Mockito.mock(IStateManager.class))
+        .when(ReflectionUtils.class, "newInstance", Mockito.eq(IStateManager.class.getName()));
 
     // Failed to valid
     Mockito.doReturn(false).when(runtimeManagerMain).

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/client/SchedulerClientFactoryTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/client/SchedulerClientFactoryTest.java
@@ -67,7 +67,7 @@ public class SchedulerClientFactoryTest {
     Config config = Mockito.mock(Config.class);
     Config runtime = Mockito.mock(Config.class);
 
-    // Return a NullScheduler
+    // Return a MockScheduler
     Mockito.when(config.getStringValue(ConfigKeys.get("SCHEDULER_CLASS")))
         .thenReturn(IScheduler.class.getName());
     PowerMockito.mockStatic(ReflectionUtils.class);

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/client/SchedulerClientFactoryTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/client/SchedulerClientFactoryTest.java
@@ -16,15 +16,21 @@ package com.twitter.heron.scheduler.client;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.twitter.heron.proto.scheduler.Scheduler;
-import com.twitter.heron.scheduler.NullScheduler;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.ConfigKeys;
 import com.twitter.heron.spi.common.Keys;
+import com.twitter.heron.spi.scheduler.IScheduler;
 import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
+import com.twitter.heron.spi.utils.ReflectionUtils;
 
+@RunWith(PowerMockRunner.class)
 public class SchedulerClientFactoryTest {
   private static final String TOPOLOGY_NAME = "shiwei_0924_jiayou";
 
@@ -55,14 +61,18 @@ public class SchedulerClientFactoryTest {
   }
 
   @Test
+  @PrepareForTest(ReflectionUtils.class)
   public void testGetLibrarySchedulerClient() throws Exception {
     // Instantiate mock objects
     Config config = Mockito.mock(Config.class);
     Config runtime = Mockito.mock(Config.class);
 
     // Return a NullScheduler
-    Mockito.when(config.getStringValue(ConfigKeys.get("SCHEDULER_CLASS"))).
-        thenReturn(NullScheduler.class.getName());
+    Mockito.when(config.getStringValue(ConfigKeys.get("SCHEDULER_CLASS")))
+        .thenReturn(IScheduler.class.getName());
+    PowerMockito.mockStatic(ReflectionUtils.class);
+    PowerMockito.doReturn(Mockito.mock(IScheduler.class))
+        .when(ReflectionUtils.class, "newInstance", Mockito.eq(IScheduler.class.getName()));
 
     // Get a LibrarySchedulerClient
     Mockito.when(config.getBooleanValue(ConfigKeys.get("SCHEDULER_IS_SERVICE"))).thenReturn(false);
@@ -72,6 +82,8 @@ public class SchedulerClientFactoryTest {
     final String SCHEDULER_CLASS_NOT_EXIST = "class_not_exist";
     Mockito.when(config.getStringValue(ConfigKeys.get("SCHEDULER_CLASS"))).
         thenReturn(SCHEDULER_CLASS_NOT_EXIST);
+    PowerMockito.doThrow(new ClassNotFoundException())
+        .when(ReflectionUtils.class, "newInstance", Mockito.eq(SCHEDULER_CLASS_NOT_EXIST));
     Assert.assertNull(new SchedulerClientFactory(config, runtime).getSchedulerClient());
   }
 }


### PR DESCRIPTION
For all `Foo` interfaces that use reflection, we implement a `NullFoo` object with an empty implementation so we can test classes that rely on reflection to load `Foo`s. Refactoring to use a more idiomatic approach using mock objects instead. This has the following benefits:

1. We don't need to maintain dummy classes. This is tedious when adding methods and refactoring and it clutters the code base
2. We don't need to maintain build targets and dependency chains for the dummy classes.
3. We can customize the expected method call behavior of the mock objects based on the context of their use, instead of relying on hard-coded implementations.

This pr only removes usage of the `NullFoo` objects. Removing the actual classes can happen in a follow-up. 