### PR TITLE
Using static imports for Mockito and Assert in scheduler-core tests

### DIFF
--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/RuntimeManagerMainTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/RuntimeManagerMainTest.java
@@ -14,9 +14,7 @@
 
 package com.twitter.heron.scheduler;
 
-import org.junit.Assert;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import com.twitter.heron.proto.system.ExecutionEnvironment;
 import com.twitter.heron.scheduler.client.ISchedulerClient;
@@ -25,6 +23,15 @@ import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.ConfigKeys;
 import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
 import com.twitter.heron.statemgr.NullStateManager;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class RuntimeManagerMainTest {
   private static final String TOPOLOGY_NAME = "topologyName";
@@ -36,22 +43,22 @@ public class RuntimeManagerMainTest {
     final String CLUSTER = "cluster";
     final String ROLE = "role";
     final String ENVIRON = "env";
-    Config config = Mockito.mock(Config.class);
-    Mockito.when(config.getStringValue(ConfigKeys.get("CLUSTER"))).thenReturn(CLUSTER);
-    Mockito.when(config.getStringValue(ConfigKeys.get("ROLE"))).thenReturn(ROLE);
-    Mockito.when(config.getStringValue(ConfigKeys.get("ENVIRON"))).thenReturn(ENVIRON);
+    Config config = mock(Config.class);
+    when(config.getStringValue(ConfigKeys.get("CLUSTER"))).thenReturn(CLUSTER);
+    when(config.getStringValue(ConfigKeys.get("ROLE"))).thenReturn(ROLE);
+    when(config.getStringValue(ConfigKeys.get("ENVIRON"))).thenReturn(ENVIRON);
 
-    SchedulerStateManagerAdaptor adaptor = Mockito.mock(SchedulerStateManagerAdaptor.class);
+    SchedulerStateManagerAdaptor adaptor = mock(SchedulerStateManagerAdaptor.class);
     RuntimeManagerMain runtimeManagerMain = new RuntimeManagerMain(config, MOCK_COMMAND);
 
     // Topology is not running
-    Mockito.when(adaptor.isTopologyRunning(Mockito.eq(TOPOLOGY_NAME))).thenReturn(false);
-    Assert.assertFalse(runtimeManagerMain.validateRuntimeManage(adaptor, TOPOLOGY_NAME));
-    Mockito.when(adaptor.isTopologyRunning(Mockito.eq(TOPOLOGY_NAME))).thenReturn(null);
-    Assert.assertFalse(runtimeManagerMain.validateRuntimeManage(adaptor, TOPOLOGY_NAME));
+    when(adaptor.isTopologyRunning(eq(TOPOLOGY_NAME))).thenReturn(false);
+    assertFalse(runtimeManagerMain.validateRuntimeManage(adaptor, TOPOLOGY_NAME));
+    when(adaptor.isTopologyRunning(eq(TOPOLOGY_NAME))).thenReturn(null);
+    assertFalse(runtimeManagerMain.validateRuntimeManage(adaptor, TOPOLOGY_NAME));
 
     // Topology is running
-    Mockito.when(adaptor.isTopologyRunning(Mockito.eq(TOPOLOGY_NAME))).thenReturn(true);
+    when(adaptor.isTopologyRunning(eq(TOPOLOGY_NAME))).thenReturn(true);
     ExecutionEnvironment.ExecutionState.Builder stateBuilder =
         ExecutionEnvironment.ExecutionState.newBuilder().
             setTopologyName(TOPOLOGY_NAME).
@@ -62,15 +69,15 @@ public class RuntimeManagerMainTest {
     // cluster/role/environ not matched
     final String WRONG_ROLE = "wrong";
     ExecutionEnvironment.ExecutionState wrongState = stateBuilder.setRole(WRONG_ROLE).build();
-    Mockito.when(adaptor.getExecutionState(Mockito.eq(TOPOLOGY_NAME))).thenReturn(null);
-    Assert.assertFalse(runtimeManagerMain.validateRuntimeManage(adaptor, TOPOLOGY_NAME));
-    Mockito.when(adaptor.getExecutionState(Mockito.eq(TOPOLOGY_NAME))).thenReturn(wrongState);
-    Assert.assertFalse(runtimeManagerMain.validateRuntimeManage(adaptor, TOPOLOGY_NAME));
+    when(adaptor.getExecutionState(eq(TOPOLOGY_NAME))).thenReturn(null);
+    assertFalse(runtimeManagerMain.validateRuntimeManage(adaptor, TOPOLOGY_NAME));
+    when(adaptor.getExecutionState(eq(TOPOLOGY_NAME))).thenReturn(wrongState);
+    assertFalse(runtimeManagerMain.validateRuntimeManage(adaptor, TOPOLOGY_NAME));
 
     // Matched
     ExecutionEnvironment.ExecutionState correctState = stateBuilder.setRole(ROLE).build();
-    Mockito.when(adaptor.getExecutionState(Mockito.eq(TOPOLOGY_NAME))).thenReturn(correctState);
-    Assert.assertTrue(runtimeManagerMain.validateRuntimeManage(adaptor, TOPOLOGY_NAME));
+    when(adaptor.getExecutionState(eq(TOPOLOGY_NAME))).thenReturn(correctState);
+    assertTrue(runtimeManagerMain.validateRuntimeManage(adaptor, TOPOLOGY_NAME));
   }
 
   /**
@@ -78,51 +85,45 @@ public class RuntimeManagerMainTest {
    */
   @Test
   public void testManageTopology() throws Exception {
-    Config config = Mockito.mock(Config.class);
-    Mockito.when(config.getStringValue(ConfigKeys.get("TOPOLOGY_NAME"))).thenReturn(TOPOLOGY_NAME);
+    Config config = mock(Config.class);
+    when(config.getStringValue(ConfigKeys.get("TOPOLOGY_NAME"))).thenReturn(TOPOLOGY_NAME);
 
-    RuntimeManagerMain runtimeManagerMain =
-        Mockito.spy(new RuntimeManagerMain(config, MOCK_COMMAND));
+    RuntimeManagerMain runtimeManagerMain = spy(new RuntimeManagerMain(config, MOCK_COMMAND));
 
     // Failed to create state manager instance
     final String CLASS_NOT_EXIST = "class_not_exist";
-    Mockito.when(config.getStringValue(ConfigKeys.get("STATE_MANAGER_CLASS"))).
-        thenReturn(CLASS_NOT_EXIST);
-    Assert.assertFalse(runtimeManagerMain.manageTopology());
+    when(config.getStringValue(ConfigKeys.get("STATE_MANAGER_CLASS")))
+        .thenReturn(CLASS_NOT_EXIST);
+    assertFalse(runtimeManagerMain.manageTopology());
 
     // Valid state manager class
-    Mockito.when(config.getStringValue(ConfigKeys.get("STATE_MANAGER_CLASS"))).
-        thenReturn(NullStateManager.class.getName());
+    when(config.getStringValue(ConfigKeys.get("STATE_MANAGER_CLASS")))
+        .thenReturn(NullStateManager.class.getName());
 
     // Failed to valid
-    Mockito.doReturn(false).when(runtimeManagerMain).
-        validateRuntimeManage(Mockito.any(SchedulerStateManagerAdaptor.class),
-            Mockito.eq(TOPOLOGY_NAME));
-    Assert.assertFalse(runtimeManagerMain.manageTopology());
+    doReturn(false).when(runtimeManagerMain)
+        .validateRuntimeManage(any(SchedulerStateManagerAdaptor.class), eq(TOPOLOGY_NAME));
+    assertFalse(runtimeManagerMain.manageTopology());
 
     // Legal request
-    Mockito.doReturn(true).when(runtimeManagerMain).
-        validateRuntimeManage(Mockito.any(SchedulerStateManagerAdaptor.class),
-            Mockito.eq(TOPOLOGY_NAME));
+    doReturn(true).when(runtimeManagerMain)
+        .validateRuntimeManage(any(SchedulerStateManagerAdaptor.class), eq(TOPOLOGY_NAME));
 
     // Failed to get ISchedulerClient
-    Mockito.doReturn(null).when(runtimeManagerMain).
-        getSchedulerClient(Mockito.any(Config.class));
-    Assert.assertFalse(runtimeManagerMain.manageTopology());
+    doReturn(null).when(runtimeManagerMain).getSchedulerClient(any(Config.class));
+    assertFalse(runtimeManagerMain.manageTopology());
 
     // Successfully get ISchedulerClient
-    ISchedulerClient client = Mockito.mock(ISchedulerClient.class);
-    Mockito.doReturn(client).when(runtimeManagerMain).
-        getSchedulerClient(Mockito.any(Config.class));
+    ISchedulerClient client = mock(ISchedulerClient.class);
+    doReturn(client).when(runtimeManagerMain).getSchedulerClient(any(Config.class));
 
     // Failed to callRuntimeManagerRunner
-    Mockito.doReturn(false).when(runtimeManagerMain).
-        callRuntimeManagerRunner(Mockito.any(Config.class), Mockito.eq(client));
-    Assert.assertFalse(runtimeManagerMain.manageTopology());
+    doReturn(false).when(runtimeManagerMain)
+        .callRuntimeManagerRunner(any(Config.class), eq(client));
+    assertFalse(runtimeManagerMain.manageTopology());
 
     // Happy path
-    Mockito.doReturn(true).when(runtimeManagerMain).
-        callRuntimeManagerRunner(Mockito.any(Config.class), Mockito.eq(client));
-    Assert.assertTrue(runtimeManagerMain.manageTopology());
+    doReturn(true).when(runtimeManagerMain).callRuntimeManagerRunner(any(Config.class), eq(client));
+    assertTrue(runtimeManagerMain.manageTopology());
   }
 }

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/RuntimeManagerRunnerTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/RuntimeManagerRunnerTest.java
@@ -16,11 +16,9 @@ package com.twitter.heron.scheduler;
 
 import java.util.Map;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -38,110 +36,116 @@ import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
 import com.twitter.heron.spi.utils.PackingTestUtils;
 import com.twitter.heron.spi.utils.Runtime;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
 public class RuntimeManagerRunnerTest {
   private static final String TOPOLOGY_NAME = "testTopology";
-  private final Config config = Mockito.mock(Config.class);
-  private final Config runtime = Mockito.mock(Config.class);
+  private final Config config = mock(Config.class);
+  private final Config runtime = mock(Config.class);
 
   @Before
   public void setUp() throws Exception {
-    Mockito.when(config.getStringValue(ConfigKeys.get("TOPOLOGY_NAME"))).thenReturn(TOPOLOGY_NAME);
+    when(config.getStringValue(ConfigKeys.get("TOPOLOGY_NAME"))).thenReturn(TOPOLOGY_NAME);
   }
 
   private RuntimeManagerRunner newRuntimeManagerRunner(Command command) {
-    return newRuntimeManagerRunner(command, Mockito.mock(ISchedulerClient.class));
+    return newRuntimeManagerRunner(command, mock(ISchedulerClient.class));
   }
 
   private RuntimeManagerRunner newRuntimeManagerRunner(Command command, ISchedulerClient client) {
-    return Mockito.spy(new RuntimeManagerRunner(config, runtime, command, client));
+    return spy(new RuntimeManagerRunner(config, runtime, command, client));
   }
 
   @Test
   public void testCall() throws Exception {
     // Restart Runner
     RuntimeManagerRunner restartRunner = newRuntimeManagerRunner(Command.RESTART);
-    Mockito.doReturn(true).when(restartRunner).restartTopologyHandler(TOPOLOGY_NAME);
-    Assert.assertTrue(restartRunner.call());
-    Mockito.verify(restartRunner).restartTopologyHandler(TOPOLOGY_NAME);
+    doReturn(true).when(restartRunner).restartTopologyHandler(TOPOLOGY_NAME);
+    assertTrue(restartRunner.call());
+    verify(restartRunner).restartTopologyHandler(TOPOLOGY_NAME);
 
     // Kill Runner
     RuntimeManagerRunner killRunner = newRuntimeManagerRunner(Command.KILL);
-    Mockito.doReturn(true).when(killRunner).killTopologyHandler(TOPOLOGY_NAME);
-    Assert.assertTrue(killRunner.call());
-    Mockito.verify(killRunner).killTopologyHandler(TOPOLOGY_NAME);
+    doReturn(true).when(killRunner).killTopologyHandler(TOPOLOGY_NAME);
+    assertTrue(killRunner.call());
+    verify(killRunner).killTopologyHandler(TOPOLOGY_NAME);
   }
 
   @Test
   public void testRestartTopologyHandler() throws Exception {
-    ISchedulerClient client = Mockito.mock(ISchedulerClient.class);
-    SchedulerStateManagerAdaptor adaptor = Mockito.mock(SchedulerStateManagerAdaptor.class);
+    ISchedulerClient client = mock(ISchedulerClient.class);
+    SchedulerStateManagerAdaptor adaptor = mock(SchedulerStateManagerAdaptor.class);
     RuntimeManagerRunner runner = newRuntimeManagerRunner(Command.RESTART, client);
 
     // Restart container 1, not containing TMaster
     Scheduler.RestartTopologyRequest restartTopologyRequest =
         Scheduler.RestartTopologyRequest.newBuilder()
             .setTopologyName(TOPOLOGY_NAME).setContainerIndex(1).build();
-    Mockito.when(config.getIntegerValue(ConfigKeys.get("TOPOLOGY_CONTAINER_ID"))).thenReturn(1);
+    when(config.getIntegerValue(ConfigKeys.get("TOPOLOGY_CONTAINER_ID"))).thenReturn(1);
 
     // Failure case
-    Mockito.when(client.restartTopology(restartTopologyRequest)).thenReturn(false);
-    Assert.assertFalse(runner.restartTopologyHandler(TOPOLOGY_NAME));
+    when(client.restartTopology(restartTopologyRequest)).thenReturn(false);
+    assertFalse(runner.restartTopologyHandler(TOPOLOGY_NAME));
     // Should not invoke DeleteTMasterLocation
-    Mockito.verify(adaptor, Mockito.never()).deleteTMasterLocation(TOPOLOGY_NAME);
+    verify(adaptor, never()).deleteTMasterLocation(TOPOLOGY_NAME);
     // Success case
-    Mockito.when(client.restartTopology(restartTopologyRequest)).thenReturn(true);
-    Assert.assertTrue(runner.restartTopologyHandler(TOPOLOGY_NAME));
+    when(client.restartTopology(restartTopologyRequest)).thenReturn(true);
+    assertTrue(runner.restartTopologyHandler(TOPOLOGY_NAME));
     // Should not invoke DeleteTMasterLocation
-    Mockito.verify(adaptor, Mockito.never()).deleteTMasterLocation(TOPOLOGY_NAME);
+    verify(adaptor, never()).deleteTMasterLocation(TOPOLOGY_NAME);
 
 
     // Restart container 0, containing TMaster
-    Mockito.when(config.getIntegerValue(ConfigKeys.get("TOPOLOGY_CONTAINER_ID"))).thenReturn(0);
-    Mockito.when(runtime.get(Keys.schedulerStateManagerAdaptor())).thenReturn(adaptor);
-    Mockito.when(adaptor.deleteTMasterLocation(TOPOLOGY_NAME)).thenReturn(false);
-    Assert.assertFalse(runner.restartTopologyHandler(TOPOLOGY_NAME));
+    when(config.getIntegerValue(ConfigKeys.get("TOPOLOGY_CONTAINER_ID"))).thenReturn(0);
+    when(runtime.get(Keys.schedulerStateManagerAdaptor())).thenReturn(adaptor);
+    when(adaptor.deleteTMasterLocation(TOPOLOGY_NAME)).thenReturn(false);
+    assertFalse(runner.restartTopologyHandler(TOPOLOGY_NAME));
     // DeleteTMasterLocation should be invoked
-    Mockito.verify(adaptor).deleteTMasterLocation(TOPOLOGY_NAME);
+    verify(adaptor).deleteTMasterLocation(TOPOLOGY_NAME);
   }
 
   @Test
   public void testKillTopologyHandler() throws Exception {
     Scheduler.KillTopologyRequest killTopologyRequest = Scheduler.KillTopologyRequest.newBuilder()
         .setTopologyName(TOPOLOGY_NAME).build();
-    ISchedulerClient client = Mockito.mock(ISchedulerClient.class);
+    ISchedulerClient client = mock(ISchedulerClient.class);
     RuntimeManagerRunner runner = newRuntimeManagerRunner(Command.KILL, client);
 
     // Failed to invoke client's killTopology
-    Mockito.when(client.killTopology(killTopologyRequest)).thenReturn(false);
-    Assert.assertFalse(runner.killTopologyHandler(TOPOLOGY_NAME));
-    Mockito.verify(client).killTopology(killTopologyRequest);
+    when(client.killTopology(killTopologyRequest)).thenReturn(false);
+    assertFalse(runner.killTopologyHandler(TOPOLOGY_NAME));
+    verify(client).killTopology(killTopologyRequest);
 
     // Failed to clean states
-    Mockito.when(client.killTopology(killTopologyRequest)).thenReturn(true);
-    Mockito.doReturn(false).when(runner).cleanState(
-        Mockito.eq(TOPOLOGY_NAME), Mockito.any(SchedulerStateManagerAdaptor.class));
-    Assert.assertFalse(runner.killTopologyHandler(TOPOLOGY_NAME));
-    Mockito.verify(client, Mockito.times(2)).killTopology(killTopologyRequest);
+    when(client.killTopology(killTopologyRequest)).thenReturn(true);
+    doReturn(false).when(runner).cleanState(
+        eq(TOPOLOGY_NAME), any(SchedulerStateManagerAdaptor.class));
+    assertFalse(runner.killTopologyHandler(TOPOLOGY_NAME));
+    verify(client, times(2)).killTopology(killTopologyRequest);
 
     // Success case
-    Mockito.doReturn(true).when(runner).cleanState(
-        Mockito.eq(TOPOLOGY_NAME), Mockito.any(SchedulerStateManagerAdaptor.class));
-    Assert.assertTrue(runner.killTopologyHandler(TOPOLOGY_NAME));
-    Mockito.verify(client, Mockito.times(3)).killTopology(killTopologyRequest);
+    doReturn(true).when(runner).cleanState(
+        eq(TOPOLOGY_NAME), any(SchedulerStateManagerAdaptor.class));
+    assertTrue(runner.killTopologyHandler(TOPOLOGY_NAME));
+    verify(client, times(3)).killTopology(killTopologyRequest);
   }
 
   @PrepareForTest(Runtime.class)
   @Test
   public void testUpdateTopologyHandler() throws Exception {
-    ISchedulerClient client = Mockito.mock(ISchedulerClient.class);
+    ISchedulerClient client = mock(ISchedulerClient.class);
     SchedulerStateManagerAdaptor manager = mock(SchedulerStateManagerAdaptor.class);
     RuntimeManagerRunner runner = newRuntimeManagerRunner(Command.UPDATE, client);
 
@@ -159,7 +163,7 @@ public class RuntimeManagerRunnerTest {
 
     when(manager.getPackingPlan(eq(TOPOLOGY_NAME))).thenReturn(currentPlan);
     doReturn(proposedPlan).when(runner).buildNewPackingPlan(
-            eq(currentPlan), eq(changeRequests), any(TopologyAPI.Topology.class));
+        eq(currentPlan), eq(changeRequests), any(TopologyAPI.Topology.class));
 
     Scheduler.UpdateTopologyRequest updateTopologyRequest =
         Scheduler.UpdateTopologyRequest.newBuilder()
@@ -169,24 +173,24 @@ public class RuntimeManagerRunnerTest {
 
     // Success case
     when(client.updateTopology(updateTopologyRequest)).thenReturn(true);
-    Assert.assertTrue(runner.updateTopologyHandler(TOPOLOGY_NAME, newParallelism));
-    verify(client, Mockito.times(1)).updateTopology(updateTopologyRequest);
+    assertTrue(runner.updateTopologyHandler(TOPOLOGY_NAME, newParallelism));
+    verify(client, times(1)).updateTopology(updateTopologyRequest);
   }
 
   @Test
   public void testParseNewParallelismParam() {
     RuntimeManagerRunner runner = newRuntimeManagerRunner(Command.SUBMIT);
     Map<String, Integer> changes = runner.parseNewParallelismParam("foo:1,bar:2");
-    Assert.assertEquals(2, changes.size());
-    Assert.assertEquals(new Integer(1), changes.get("foo"));
-    Assert.assertEquals(new Integer(2), changes.get("bar"));
+    assertEquals(2, changes.size());
+    assertEquals(new Integer(1), changes.get("foo"));
+    assertEquals(new Integer(2), changes.get("bar"));
   }
 
   @Test
   public void testParseNewParallelismParamEmpty() {
     RuntimeManagerRunner runner = newRuntimeManagerRunner(Command.SUBMIT);
     Map<String, Integer> changes = runner.parseNewParallelismParam("");
-    Assert.assertEquals(0, changes.size());
+    assertEquals(0, changes.size());
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -196,7 +200,7 @@ public class RuntimeManagerRunnerTest {
     try {
       runner.parseNewParallelismParam("foo:1,bar2");
     } catch (IllegalArgumentException e) {
-      Assert.assertEquals(e.getMessage(), "Invalid parallelism parameter found. Expected: "
+      assertEquals(e.getMessage(), "Invalid parallelism parameter found. Expected: "
           + "<component>:<parallelism>[,<component>:<parallelism>], Found: foo:1,bar2");
       throw e;
     }
@@ -209,7 +213,7 @@ public class RuntimeManagerRunnerTest {
     try {
       runner.parseNewParallelismParam("foo:1bar:2");
     } catch (IllegalArgumentException e) {
-      Assert.assertEquals(e.getMessage(), "Invalid parallelism parameter found. Expected: "
+      assertEquals(e.getMessage(), "Invalid parallelism parameter found. Expected: "
           + "<component>:<parallelism>[,<component>:<parallelism>], Found: foo:1bar:2");
       throw e;
     }
@@ -227,7 +231,7 @@ public class RuntimeManagerRunnerTest {
     Map<String, Integer> initialCounts = runner.parseNewParallelismParam(initial);
     Map<String, Integer> changeRequest = runner.parseNewParallelismParam(changes);
 
-    Assert.assertEquals(runner.parseNewParallelismParam(delta),
+    assertEquals(runner.parseNewParallelismParam(delta),
         runner.parallelismDelta(initialCounts, changeRequest));
   }
 }

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/SchedulerMainTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/SchedulerMainTest.java
@@ -19,13 +19,11 @@ import java.util.Properties;
 
 import com.google.common.util.concurrent.SettableFuture;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -46,6 +44,22 @@ import com.twitter.heron.spi.utils.Shutdown;
 import com.twitter.heron.spi.utils.TopologyTests;
 import com.twitter.heron.spi.utils.TopologyUtils;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({
     TopologyUtils.class, ReflectionUtils.class, SchedulerUtils.class, TopologyAPI.Topology.class})
@@ -65,27 +79,24 @@ public class SchedulerMainTest {
    */
   @Before
   public void setUp() throws Exception {
-    Config config = Mockito.mock(Config.class);
-    Mockito.
-        when(config.getStringValue(ConfigKeys.get("STATE_MANAGER_CLASS"))).
+    Config config = mock(Config.class);
+    when(config.getStringValue(ConfigKeys.get("STATE_MANAGER_CLASS"))).
         thenReturn(STATE_MANAGER_CLASS);
-    Mockito.
-        when(config.getStringValue(ConfigKeys.get("SCHEDULER_CLASS"))).
+    when(config.getStringValue(ConfigKeys.get("SCHEDULER_CLASS"))).
         thenReturn(SCHEDULER_CLASS);
 
     int iSchedulerServerPort = 0;
 
-    TopologyAPI.Topology topology =
-        TopologyTests.createTopology(
-            iTopologyName, new com.twitter.heron.api.Config(),
-            new HashMap<String, Integer>(), new HashMap<String, Integer>());
+    TopologyAPI.Topology topology = TopologyTests.createTopology(
+        iTopologyName, new com.twitter.heron.api.Config(),
+        new HashMap<String, Integer>(), new HashMap<String, Integer>());
 
     // Mock objects to be verified
-    stateManager = Mockito.mock(IStateManager.class);
-    scheduler = Mockito.mock(IScheduler.class);
+    stateManager = mock(IStateManager.class);
+    scheduler = mock(IScheduler.class);
 
     final SettableFuture<PackingPlans.PackingPlan> future = getTestPacking();
-    Mockito.when(stateManager.getPackingPlan(null, iTopologyName)).thenReturn(future);
+    when(stateManager.getPackingPlan(null, iTopologyName)).thenReturn(future);
 
     // Mock ReflectionUtils stuff
     PowerMockito.spy(ReflectionUtils.class);
@@ -95,26 +106,22 @@ public class SchedulerMainTest {
         when(ReflectionUtils.class, "newInstance", SCHEDULER_CLASS);
 
     // Mock objects to be verified
-    schedulerMain =
-        Mockito.spy(
-            new SchedulerMain(
-                config, topology, iSchedulerServerPort, Mockito.mock(Properties.class)));
-    schedulerServer = Mockito.mock(SchedulerServer.class);
-    Mockito.doReturn(schedulerServer).when(schedulerMain).getServer(
-        Mockito.any(Config.class), Mockito.eq(scheduler), Mockito.eq(iSchedulerServerPort));
+    schedulerMain = spy(new SchedulerMain(
+        config, topology, iSchedulerServerPort, mock(Properties.class)));
+    schedulerServer = mock(SchedulerServer.class);
+    doReturn(schedulerServer).when(schedulerMain).getServer(
+        any(Config.class), eq(scheduler), eq(iSchedulerServerPort));
 
-    Mockito.doReturn(true).when(scheduler).onSchedule(Mockito.any(PackingPlan.class));
+    doReturn(true).when(scheduler).onSchedule(any(PackingPlan.class));
 
     // Mock SchedulerUtils stuff
     PowerMockito.spy(SchedulerUtils.class);
-    PowerMockito.doReturn(true).
-        when(SchedulerUtils.class, "setSchedulerLocation",
-            Mockito.any(Config.class),
-            Mockito.anyString(), Mockito.eq(scheduler));
+    PowerMockito.doReturn(true).when(SchedulerUtils.class, "setSchedulerLocation",
+        any(Config.class), anyString(), eq(scheduler));
 
     // Avoid infinite waiting
-    Shutdown shutdown = Mockito.mock(Shutdown.class);
-    Mockito.doReturn(shutdown).when(schedulerMain).getShutdown();
+    Shutdown shutdown = mock(Shutdown.class);
+    doReturn(shutdown).when(schedulerMain).getShutdown();
   }
 
   private SettableFuture<PackingPlans.PackingPlan> getTestPacking() {
@@ -132,12 +139,11 @@ public class SchedulerMainTest {
   public void testExceptionsInReflections() throws Exception {
     PowerMockito.doThrow(new ClassNotFoundException("")).
         when(ReflectionUtils.class, "newInstance", STATE_MANAGER_CLASS);
-    Assert.assertFalse(schedulerMain.runScheduler());
-    Mockito.verify(stateManager, Mockito.never()).initialize(Mockito.any(Config.class));
+    assertFalse(schedulerMain.runScheduler());
+    verify(stateManager, never()).initialize(any(Config.class));
 
-    Mockito.verify(stateManager, Mockito.never()).getPackingPlan(null, iTopologyName);
-    Mockito.verify(scheduler, Mockito.never()).
-        initialize(Mockito.any(Config.class), Mockito.any(Config.class));
+    verify(stateManager, never()).getPackingPlan(null, iTopologyName);
+    verify(scheduler, never()).initialize(any(Config.class), any(Config.class));
   }
 
   // Exceptions during initialize components --
@@ -146,13 +152,12 @@ public class SchedulerMainTest {
   public void testExceptionsInInit() throws Exception {
     PowerMockito.doReturn(stateManager).
         when(ReflectionUtils.class, "newInstance", STATE_MANAGER_CLASS);
-    Mockito.doThrow(new RuntimeException()).
-        when(stateManager).initialize(Mockito.any(Config.class));
+    doThrow(new RuntimeException()).when(stateManager).initialize(any(Config.class));
     exception.expect(RuntimeException.class);
     schedulerMain.runScheduler();
 
     // Should not be invoked; thread exited already
-    Assert.fail();
+    fail();
   }
 
   // Failed to IScheduler.onSchedule
@@ -161,13 +166,12 @@ public class SchedulerMainTest {
   // 3. SchedulerServer should not start
   @Test
   public void testOnSchedulerFailure() throws Exception {
-    Mockito.doNothing().
-        when(stateManager).initialize(Mockito.any(Config.class));
-    Mockito.doReturn(false).when(scheduler).onSchedule(Mockito.any(PackingPlan.class));
-    Assert.assertFalse(schedulerMain.runScheduler());
-    Mockito.verify(stateManager).close();
-    Mockito.verify(scheduler).close();
-    Mockito.verify(schedulerServer, Mockito.never()).start();
+    doNothing().when(stateManager).initialize(any(Config.class));
+    doReturn(false).when(scheduler).onSchedule(any(PackingPlan.class));
+    assertFalse(schedulerMain.runScheduler());
+    verify(stateManager).close();
+    verify(scheduler).close();
+    verify(schedulerServer, never()).start();
   }
 
   // Exceptions during start the server
@@ -175,13 +179,12 @@ public class SchedulerMainTest {
 
   @Test
   public void testExceptionsInStartingServer() throws Exception {
-    Mockito.doThrow(new RuntimeException()).
-        when(schedulerServer).start();
+    doThrow(new RuntimeException()).when(schedulerServer).start();
     exception.expect(RuntimeException.class);
     schedulerMain.runScheduler();
 
     // Should not be invoked; thread exited already
-    Assert.fail();
+    fail();
   }
 
   // Failed to set SchedulerLocation
@@ -190,20 +193,18 @@ public class SchedulerMainTest {
   // 3. SchedulerServer.stop() should be invoked
   @Test
   public void testSetSchedulerLocationFailure() throws Exception {
-    PowerMockito.doReturn(false).
-        when(SchedulerUtils.class, "setSchedulerLocation",
-            Mockito.any(Config.class),
-            Mockito.anyString(), Mockito.eq(scheduler));
-    Assert.assertFalse(schedulerMain.runScheduler());
+    PowerMockito.doReturn(false).when(SchedulerUtils.class, "setSchedulerLocation",
+        any(Config.class), anyString(), eq(scheduler));
+    assertFalse(schedulerMain.runScheduler());
 
-    Mockito.verify(stateManager).close();
-    Mockito.verify(scheduler).close();
-    Mockito.verify(schedulerServer).stop();
+    verify(stateManager).close();
+    verify(scheduler).close();
+    verify(schedulerServer).stop();
   }
 
   // Happy path
   @Test
   public void testRunScheduler() throws Exception {
-    Assert.assertTrue(schedulerMain.runScheduler());
+    assertTrue(schedulerMain.runScheduler());
   }
 }


### PR DESCRIPTION
This is just a clean up PR, no logic changes.

Using static imports for `Mockito` and `Assert` reduces the verbosity of our unit tests and makes them much more readable.