### PR TITLE
Change location of local lock to be consistent depth with other state objects

### DIFF
--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/FileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/FileSystemStateManager.java
@@ -69,7 +69,7 @@ public abstract class FileSystemStateManager implements IStateManager {
     }
 
     public String getNodePath(String root, String topology, String extraToken) {
-      return concatPath(getNodePath(root, topology), extraToken);
+      return getNodePath(root, String.format("%s__%s", topology, extraToken));
     }
 
     private static String concatPath(String basePath, String appendPath) {

--- a/heron/statemgrs/tests/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManagerTest.java
+++ b/heron/statemgrs/tests/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManagerTest.java
@@ -209,7 +209,7 @@ public class LocalFileSystemStateManagerTest {
   @Test
   public void testGetLock() throws Exception {
     initMocks();
-    String expectedLockPath = String.format("//locks/%s/%s", TOPOLOGY_NAME, LOCK_NAME);
+    String expectedLockPath = String.format("//locks/%s__%s", TOPOLOGY_NAME, LOCK_NAME);
     byte[] expectedContents = Thread.currentThread().getName().getBytes(Charset.defaultCharset());
 
     Lock lock = manager.getLock(TOPOLOGY_NAME, LOCK_NAME);

--- a/heron/statemgrs/tests/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManagerTest.java
+++ b/heron/statemgrs/tests/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManagerTest.java
@@ -15,6 +15,8 @@
 package com.twitter.heron.statemgr.localfs;
 
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.util.concurrent.ListenableFuture;
@@ -52,18 +54,23 @@ import static org.mockito.Mockito.times;
 public class LocalFileSystemStateManagerTest {
 
   private static final String TOPOLOGY_NAME = "topologyName";
-  private static final String LOCK_NAME = "topologyName";
+  private static final String LOCK_NAME = "lockName";
   private static final String ROOT_ADDR = "/";
   private LocalFileSystemStateManager manager;
 
   @Before
   public void before() throws Exception {
+    manager = initMockManager(ROOT_ADDR, false);
+  }
+
+  private static LocalFileSystemStateManager initMockManager(String rootPath, boolean initTree) {
     Config config = Config.newBuilder()
-        .put(Keys.stateManagerRootPath(), ROOT_ADDR)
-        .put(LocalFileSystemKeys.initializeFileTree(), false)
+        .put(Keys.stateManagerRootPath(), rootPath)
+        .put(LocalFileSystemKeys.initializeFileTree(), initTree)
         .build();
-    manager = Mockito.spy(new LocalFileSystemStateManager());
+    LocalFileSystemStateManager manager = Mockito.spy(new LocalFileSystemStateManager());
     manager.initialize(config);
+    return manager;
   }
 
   @After
@@ -215,8 +222,17 @@ public class LocalFileSystemStateManagerTest {
   }
 
   @Test
+  public void testGetFilesystemLock() throws Exception {
+    Path tempDir = Files.createTempDirectory("heron-testGetFilesystemLock");
+    LocalFileSystemStateManager fsBackedManager = initMockManager(tempDir.toString(), true);
+    Lock lock = fsBackedManager.getLock(TOPOLOGY_NAME, LOCK_NAME);
+    Assert.assertTrue("Failed to get lock", lock.tryLock(0, TimeUnit.MILLISECONDS));
+    lock.unlock();
+  }
+
+  @Test
   public void testLockTaken() throws Exception {
-    String expectedLockPath = String.format("//locks/%s/%s", TOPOLOGY_NAME, LOCK_NAME);
+    String expectedLockPath = String.format("//locks/%s__%s", TOPOLOGY_NAME, LOCK_NAME);
     byte[] expectedContents = Thread.currentThread().getName().getBytes(Charset.defaultCharset());
 
     PowerMockito.spy(FileUtils.class);


### PR DESCRIPTION
This is required to fix tests in #1459.

Instead of storing local FS locks at:
```
/state/local/locks/topologyName/lockName
```
we will store them at:
```
/state/local/locks/topologyName__lockName
```