### PR TITLE
Make metrics mgr fail fast when unexpected errors happen.

### DIFF
--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/MetricsManager.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/MetricsManager.java
@@ -375,7 +375,6 @@ public class MetricsManager {
         }
         sinksRetryAttempts.put(sinkId, thisSinkRetryAttempts);
 
-
         // Update the list of Communicator in Metrics Manager Server
         metricsManagerServer.addSinkCommunicator(newSinkExecutor.getCommunicator());
 


### PR DESCRIPTION
Make stream mgr fail fast when unexpected errors happen to avoid dangling process.

This is a bug reported by Twitter internally.