### PR TITLE
Allow server to discard large packets

### DIFF
--- a/heron/common/src/java/com/twitter/heron/common/config/SystemConfig.java
+++ b/heron/common/src/java/com/twitter/heron/common/config/SystemConfig.java
@@ -311,6 +311,13 @@ public class SystemConfig {
   public static final String METRICSMGR_NETWORK_OPTIONS_SOCKET_SEND_BUFFER_SIZE_BYTES
       = "heron.metricsmgr.network.options.socket.send.buffer.size.bytes";
 
+  /**
+   * The maximum packet size to handle by metrics mgr in bytes
+   */
+  public static final String METRICSMGR_SERVER_MAX_PACKET_SIZE_BYTES
+      = "heron.metricsmgr.server.max.packet.size.bytes";
+
+
   private Map<String, Object> config = new HashMap<>();
 
   public SystemConfig() {
@@ -538,6 +545,12 @@ public class SystemConfig {
     return TypeUtils.
         getInteger(this.config.get(
             SystemConfig.METRICSMGR_NETWORK_OPTIONS_SOCKET_SEND_BUFFER_SIZE_BYTES));
+  }
+
+  public int getMetricsmgrServerMaxPacketSizeBytes() {
+    Object value = this.config.get(
+        SystemConfig.METRICSMGR_SERVER_MAX_PACKET_SIZE_BYTES);
+    return value == null ? Integer.MAX_VALUE : TypeUtils.getInteger(value);
   }
 
   public Object put(String key, Object value) {

--- a/heron/common/src/java/com/twitter/heron/common/network/HeronServer.java
+++ b/heron/common/src/java/com/twitter/heron/common/network/HeronServer.java
@@ -66,7 +66,8 @@ public abstract class HeronServer implements ISelectHandler {
    * @param s the NIOLooper bind with this socket server
    * @param host the host of remote endpoint to communicate with
    * @param port the port of remote endpoint to communicate with
-   * @param maxPacketSize, the maximum size of IncomingPacket in bytes to handle;
+   * @param options the HeronSocketOptions for the server
+   * @param maxPacketSize the maximum size of IncomingPacket in bytes to handle;
    * server will ignore the packet if its size exceeds this value
    */
   public HeronServer(NIOLooper s, String host, int port,

--- a/heron/config/src/yaml/conf/aurora/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/aurora/heron_internals.yaml
@@ -150,6 +150,9 @@ heron.metricsmgr.network.options.socket.send.buffer.size.bytes: 6553600
 # The maximum socket's received buffer size in bytes of metricsmgr's network options
 heron.metricsmgr.network.options.socket.received.buffer.size.bytes: 8738000
 
+# The maximum packet size to handle by metrics mgr in bytes
+heron.metricsmgr.server.max.packet.size.bytes: 131072
+
 ################################################################################
 # Configs related to Heron Instance, starts with heron.instance.*
 ################################################################################

--- a/heron/config/src/yaml/conf/examples/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/examples/heron_internals.yaml
@@ -150,6 +150,9 @@ heron.metricsmgr.network.options.socket.send.buffer.size.bytes: 6553600
 # The maximum socket's received buffer size in bytes of metricsmgr's network options
 heron.metricsmgr.network.options.socket.received.buffer.size.bytes: 8738000
 
+# The maximum packet size to handle by metrics mgr in bytes
+heron.metricsmgr.server.max.packet.size.bytes: 131072
+
 ################################################################################
 # Configs related to Heron Instance, starts with heron.instance.*
 ################################################################################

--- a/heron/config/src/yaml/conf/local/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/local/heron_internals.yaml
@@ -150,6 +150,9 @@ heron.metricsmgr.network.options.socket.send.buffer.size.bytes: 655360
 # The maximum socket's received buffer size in bytes of metricsmgr's network options
 heron.metricsmgr.network.options.socket.received.buffer.size.bytes: 873800
 
+# The maximum packet size to handle by metrics mgr in bytes
+heron.metricsmgr.server.max.packet.size.bytes: 131072
+
 ################################################################################
 # Configs related to Heron Instance, starts with heron.instance.*
 ################################################################################

--- a/heron/config/src/yaml/conf/localzk/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/localzk/heron_internals.yaml
@@ -150,6 +150,9 @@ heron.metricsmgr.network.options.socket.send.buffer.size.bytes: 6553600
 # The maximum socket's received buffer size in bytes of metricsmgr's network options
 heron.metricsmgr.network.options.socket.received.buffer.size.bytes: 8738000
 
+# The maximum packet size to handle by metrics mgr in bytes
+heron.metricsmgr.server.max.packet.size.bytes: 131072
+
 ################################################################################
 # Configs related to Heron Instance, starts with heron.instance.*
 ################################################################################

--- a/heron/config/src/yaml/conf/marathon/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/marathon/heron_internals.yaml
@@ -150,6 +150,9 @@ heron.metricsmgr.network.options.socket.send.buffer.size.bytes: 6553600
 # The maximum socket's received buffer size in bytes of metricsmgr's network options
 heron.metricsmgr.network.options.socket.received.buffer.size.bytes: 8738000
 
+# The maximum packet size to handle by metrics mgr in bytes
+heron.metricsmgr.server.max.packet.size.bytes: 131072
+
 ################################################################################
 # Configs related to Heron Instance, starts with heron.instance.*
 ################################################################################

--- a/heron/config/src/yaml/conf/mesos/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/mesos/heron_internals.yaml
@@ -150,6 +150,9 @@ heron.metricsmgr.network.options.socket.send.buffer.size.bytes: 6553600
 # The maximum socket's received buffer size in bytes of metricsmgr's network options
 heron.metricsmgr.network.options.socket.received.buffer.size.bytes: 8738000
 
+# The maximum packet size to handle by metrics mgr in bytes
+heron.metricsmgr.server.max.packet.size.bytes: 131072
+
 ################################################################################
 # Configs related to Heron Instance, starts with heron.instance.*
 ################################################################################

--- a/heron/config/src/yaml/conf/slurm/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/slurm/heron_internals.yaml
@@ -150,6 +150,9 @@ heron.metricsmgr.network.options.socket.send.buffer.size.bytes: 6553600
 # The maximum socket's received buffer size in bytes of metricsmgr's network options
 heron.metricsmgr.network.options.socket.received.buffer.size.bytes: 8738000 
 
+# The maximum packet size to handle by metrics mgr in bytes
+heron.metricsmgr.server.max.packet.size.bytes: 131072
+
 ################################################################################
 # Configs related to Heron Instance, starts with heron.instance.*
 ################################################################################

--- a/heron/config/src/yaml/conf/test/test_heron_internals.yaml
+++ b/heron/config/src/yaml/conf/test/test_heron_internals.yaml
@@ -131,6 +131,9 @@ heron.metricsmgr.network.options.socket.send.buffer.size.bytes: 6553600
 # The maximum socket's received buffer size in bytes of metricsmgr's network options
 heron.metricsmgr.network.options.socket.received.buffer.size.bytes: 8738000
 
+# The maximum packet size to handle by metrics mgr in bytes
+heron.metricsmgr.server.max.packet.size.bytes: 131072
+
 # Attempts to restart IMetricsSink once failure ia occurred
 # heron.metricsmgr.sink.retry.attempts: 10
 

--- a/heron/config/src/yaml/conf/yarn/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/yarn/heron_internals.yaml
@@ -150,6 +150,9 @@ heron.metricsmgr.network.options.socket.send.buffer.size.bytes: 6553600
 # The maximum socket's received buffer size in bytes of metricsmgr's network options
 heron.metricsmgr.network.options.socket.received.buffer.size.bytes: 8738000
 
+# The maximum packet size to handle by metrics mgr in bytes
+heron.metricsmgr.server.max.packet.size.bytes: 131072
+
 ################################################################################
 # Configs related to Heron Instance, starts with heron.instance.*
 ################################################################################

--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/MetricsManager.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/MetricsManager.java
@@ -146,7 +146,8 @@ public class MetricsManager {
 
     // Construct the MetricsManagerServer
     metricsManagerServer = new MetricsManagerServer(metricsManagerServerLoop, serverHost,
-        serverPort, serverSocketOptions, serverCounters);
+        serverPort, serverSocketOptions, serverCounters,
+        systemConfig.getMetricsmgrServerMaxPacketSizeBytes());
 
     executors = Executors.newFixedThreadPool(config.getNumberOfSinks());
     sinkExecutors = new ConcurrentHashMap<>(config.getNumberOfSinks());
@@ -192,8 +193,8 @@ public class MetricsManager {
     if (args.length != 6) {
       throw new RuntimeException(
           "Invalid arguments; Usage: java com.twitter.heron.metricsmgr.MetricsManager "
-          + "<id> <port> <topname> <topid> <heron_internals_config_filename> "
-          + "<metrics_sinks_config_filename>");
+              + "<id> <port> <topname> <topid> <heron_internals_config_filename> "
+              + "<metrics_sinks_config_filename>");
     }
 
     String metricsmgrId = args[0];
@@ -221,7 +222,7 @@ public class MetricsManager {
     LoggingHelper.addLoggingHandler(new ErrorReportLoggingHandler());
 
     LOG.info(String.format("Starting Metrics Manager for topology %s with topologyId %s with "
-        + "Metrics Manager Id %s, Merics Manager Port: %d.",
+            + "Metrics Manager Id %s, Merics Manager Port: %d.",
         topologyName, topologyId, metricsmgrId, metricsPort));
 
     LOG.info("System Config: " + systemConfig);

--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/MetricsManagerServer.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/MetricsManagerServer.java
@@ -80,7 +80,7 @@ public class MetricsManagerServer extends HeronServer {
    * @param port the port of endpoint to bind with
    * @param options the HeronSocketOption for HeronServer
    * @param serverMetricsCounters The MultiCountMetric to update Metircs for MetricsManagerServer
-   * @param maxPacketSize, the maximum size of IncomingPacket in bytes to handle;
+   * @param maxPacketSize the maximum size of IncomingPacket in bytes to handle;
    * server will ignore the packet if its size exceeds this value
    */
   public MetricsManagerServer(NIOLooper s, String host,

--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/MetricsManagerServer.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/MetricsManagerServer.java
@@ -66,6 +66,12 @@ public class MetricsManagerServer extends HeronServer {
   // Internal MultiCountMetric Counters
   private final MultiCountMetric serverMetricsCounters;
 
+  public MetricsManagerServer(NIOLooper s, String host,
+                              int port, HeronSocketOptions options,
+                              MultiCountMetric serverMetricsCounters) {
+    this(s, host, port, options, serverMetricsCounters, Integer.MAX_VALUE);
+  }
+
   /**
    * Constructor
    *
@@ -74,11 +80,14 @@ public class MetricsManagerServer extends HeronServer {
    * @param port the port of endpoint to bind with
    * @param options the HeronSocketOption for HeronServer
    * @param serverMetricsCounters The MultiCountMetric to update Metircs for MetricsManagerServer
+   * @param maxPacketSize, the maximum size of IncomingPacket in bytes to handle;
+   * server will ignore the packet if its size exceeds this value
    */
   public MetricsManagerServer(NIOLooper s, String host,
                               int port, HeronSocketOptions options,
-                              MultiCountMetric serverMetricsCounters) {
-    super(s, host, port, options);
+                              MultiCountMetric serverMetricsCounters,
+                              int maxPacketSize) {
+    super(s, host, port, options, maxPacketSize);
 
     if (serverMetricsCounters == null) {
       throw new IllegalArgumentException("Server Metrics Counters is needed.");
@@ -160,7 +169,7 @@ public class MetricsManagerServer extends HeronServer {
   @Override
   public void onClose(SocketChannel channel) {
     LOG.log(Level.SEVERE, "Got a connection close from remote socket address: {0}",
-        new Object[] {channel.socket().getRemoteSocketAddress()});
+        new Object[]{channel.socket().getRemoteSocketAddress()});
 
     // Unregister the Publisher
     Metrics.MetricPublisher request =
@@ -169,9 +178,9 @@ public class MetricsManagerServer extends HeronServer {
       LOG.severe("Unknown connection closed");
     } else {
       LOG.log(Level.SEVERE, "Un-register publish from hostname: {0},"
-          + " component_name: {1}, port: {2}, instance_id: {3}, instance_index: {4}",
-          new Object[] {request.getHostname(), request.getComponentName(), request.getPort(),
-          request.getInstanceId(), request.getInstanceIndex()});
+              + " component_name: {1}, port: {2}, instance_id: {3}, instance_index: {4}",
+          new Object[]{request.getHostname(), request.getComponentName(), request.getPort(),
+              request.getInstanceId(), request.getInstanceIndex()});
     }
 
     // Update Metrics
@@ -186,13 +195,13 @@ public class MetricsManagerServer extends HeronServer {
   }
 
   private void handleRegisterRequest(
-        REQID rid,
-        SocketChannel channel,
-        Metrics.MetricPublisherRegisterRequest request) {
+      REQID rid,
+      SocketChannel channel,
+      Metrics.MetricPublisherRegisterRequest request) {
     Metrics.MetricPublisher publisher = request.getPublisher();
     LOG.log(Level.SEVERE, "Got a new register publisher from hostname: {0},"
-        + " component_name: {1}, port: {2}, instance_id: {3}, instance_index: {4} from {5}",
-        new Object[] {publisher.getHostname(), publisher.getComponentName(), publisher.getPort(),
+            + " component_name: {1}, port: {2}, instance_id: {3}, instance_index: {4} from {5}",
+        new Object[]{publisher.getHostname(), publisher.getComponentName(), publisher.getPort(),
             publisher.getInstanceId(), publisher.getInstanceIndex(),
             channel.socket().getRemoteSocketAddress()});
 
@@ -201,8 +210,8 @@ public class MetricsManagerServer extends HeronServer {
 
     if (publisherMap.containsKey(channel.socket().getRemoteSocketAddress())) {
       LOG.log(Level.SEVERE, "Metrics publisher already exists for hostname: {0},"
-          + " component_name: {1}, port: {2}, instance_id: {3}, instance_index: {4}",
-          new Object[] {publisher.getHostname(), publisher.getComponentName(), publisher.getPort(),
+              + " component_name: {1}, port: {2}, instance_id: {3}, instance_index: {4}",
+          new Object[]{publisher.getHostname(), publisher.getComponentName(), publisher.getPort(),
               publisher.getInstanceId(), publisher.getInstanceIndex()});
     } else {
       publisherMap.put(channel.socket().getRemoteSocketAddress(), publisher);
@@ -226,8 +235,8 @@ public class MetricsManagerServer extends HeronServer {
     if (message.getMetricsCount() <= 0 && message.getExceptionsCount() <= 0) {
       LOG.log(Level.SEVERE,
           "Publish message has no metrics nor exceptions for message from hostname: {0},"
-          + " component_name: {1}, port: {2}, instance_id: {3}, instance_index: {4}",
-          new Object[] {request.getHostname(), request.getComponentName(), request.getPort(),
+              + " component_name: {1}, port: {2}, instance_id: {3}, instance_index: {4}",
+          new Object[]{request.getHostname(), request.getComponentName(), request.getPort(),
               request.getInstanceId(), request.getInstanceIndex()});
       return;
     }


### PR DESCRIPTION
- Allow server to discard large packets. Integrated tested locally.

Sometimes client can send large packet to server, and destroy the server. For instance, a client can send a very large MetricsMessage (due to it contains huge amount of exception stack trace), and the MetricsManager will throw OutOfMemoryError and crash when trying to deserialize the byte[].

This pull request allows server to discard large packets.

- It is a bug reported by Twitter internally.