### PR TITLE
Do not let external processes block on IO buffers in ShellUtils.runSyncProcess

### DIFF
--- a/heron/spi/src/java/com/twitter/heron/spi/utils/ShellUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/ShellUtils.java
@@ -94,7 +94,7 @@ public final class ShellUtils {
           try {
             input.close();
           } catch (IOException e) {
-            LOG.log(Level.SEVERE, "Failed to close the input stream", e);
+            LOG.log(Level.WARNING, "Failed to close the input stream", e);
           }
         }
       }

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/ShellUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/ShellUtils.java
@@ -94,7 +94,7 @@ public final class ShellUtils {
           try {
             input.close();
           } catch (IOException e) {
-            e.printStackTrace();
+            LOG.log(Level.SEVERE, "Failed to close the input stream", e);
           }
         }
       }
@@ -121,7 +121,7 @@ public final class ShellUtils {
     try {
       process = pb.start();
     } catch (IOException e) {
-      LOG.severe("Failed to run Sync Process " + e);
+      LOG.log(Level.SEVERE, "Failed to run Sync Process ", e);
       return -1;
     }
 
@@ -146,7 +146,7 @@ public final class ShellUtils {
       stdoutThread.interrupt();
       stderrThread.interrupt();
       process.destroy();
-      LOG.severe("Running Sync Process was interrupted" + e);
+      LOG.log(Level.SEVERE, "Running Sync Process was interrupted", e);
       // Reset the interrupt status to allow other codes noticing it.
       Thread.currentThread().interrupt();
       return -1;
@@ -214,7 +214,7 @@ public final class ShellUtils {
     try {
       process = pb.start();
     } catch (IOException e) {
-      LOG.severe("Failed to run Async Process " + e);
+      LOG.log(Level.SEVERE, "Failed to run Async Process ", e);
     }
 
     return process;

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/ShellUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/ShellUtils.java
@@ -82,13 +82,36 @@ public final class ShellUtils {
   }
 
   /**
+   * Start a daemon thread to read data from "input" to "out".
+   */
+  private static Thread asyncProcessStream(final InputStream input, final StringBuilder out) {
+    Thread thread = new Thread() {
+      @Override
+      public void run() {
+        try {
+          out.append(inputstreamToString(input));
+        } finally {
+          try {
+            input.close();
+          } catch (IOException e) {
+            e.printStackTrace();
+          }
+        }
+      }
+    };
+    thread.setDaemon(true);
+    thread.start();
+    return thread;
+  }
+
+  /**
    * run sync process
    */
   public static int runSyncProcess(
       boolean verbose, boolean isInheritIO, String[] cmdline, StringBuilder stdout,
       StringBuilder stderr, File workingDirectory, Map<String, String> envs) {
-    StringBuilder pStdOut = stdout;
-    StringBuilder pStdErr = stderr;
+    final StringBuilder pStdOut = stdout == null ? new StringBuilder() : stdout;
+    final StringBuilder pStdErr = stderr == null ? new StringBuilder() : stderr;
 
     // Log the command for debugging
     LOG.log(Level.FINE, "Process command: `$ {0}`", Arrays.toString(cmdline));
@@ -102,23 +125,32 @@ public final class ShellUtils {
       return -1;
     }
 
+    // Launching threads to consume stdout and stderr before "waitFor". Otherwise, output from the
+    // "process" can exhaust the available buffer for the output or error stream because neither
+    // stream is read while waiting for the process to complete. If either buffer becomes full, it
+    // can block the "process" as well, preventing all progress for both the "process" and the
+    // current thread.
+    Thread stdoutThread = asyncProcessStream(process.getInputStream(), pStdOut);
+    Thread stderrThread = asyncProcessStream(process.getErrorStream(), pStdErr);
+
     int exitValue;
 
     try {
       exitValue = process.waitFor();
+      // Make sure `pStdOut` and `pStdErr` get the buffered data
+      stdoutThread.join();
+      stderrThread.join();
     } catch (InterruptedException e) {
-      LOG.severe("Failed to check status of packer " + e);
+      // The current thread is interrupted, so try to interrupt reading threads and kill
+      // the process to return quickly.
+      stdoutThread.interrupt();
+      stderrThread.interrupt();
+      process.destroy();
+      LOG.severe("Running Sync Process was interrupted" + e);
+      // Reset the interrupt status to allow other codes noticing it.
+      Thread.currentThread().interrupt();
       return -1;
     }
-
-    if (pStdOut == null) {
-      pStdOut = new StringBuilder();
-    }
-    if (pStdErr == null) {
-      pStdErr = new StringBuilder();
-    }
-    pStdOut.append(inputstreamToString(process.getInputStream()));
-    pStdErr.append(inputstreamToString(process.getErrorStream()));
 
     String stdoutString = pStdOut.toString();
     String stderrString = pStdErr.toString();


### PR DESCRIPTION
In ShellUtils.runSyncProcess, "output from the external process can exhaust the available buffer for the output or error stream because neither stream is read while waiting for the process to complete. If either buffer becomes full, it can block the external process as well, preventing all progress for both the external process and the Java program." [1]

This PR just launches threads to read outputs asynchronously to fix this issue. The added unit tests can reproduce this bug.

[1] https://www.securecoding.cert.org/confluence/display/java/FIO07-J.+Do+not+let+external+processes+block+on+IO+buffers