### PR TITLE
Avoid duplicated exception wrapper during reportError()

### DIFF
--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltOutputCollectorImpl.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltOutputCollectorImpl.java
@@ -109,8 +109,7 @@ public class BoltOutputCollectorImpl implements IOutputCollector {
 
   @Override
   public void reportError(Throwable error) {
-    Exception currentStack = new Exception("Reporting an error in topology code", error);
-    LOG.log(Level.SEVERE, "Error stack trace ", currentStack);
+    LOG.log(Level.SEVERE, "Reporting an error in topology code ", error);
   }
 
   @Override

--- a/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutOutputCollectorImpl.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutOutputCollectorImpl.java
@@ -122,8 +122,7 @@ public class SpoutOutputCollectorImpl implements ISpoutOutputCollector {
   // Log the report error and also send the stack trace to metrics manager.
   @Override
   public void reportError(Throwable error) {
-    Exception currentStack = new Exception("Reporting an error in topology code", error);
-    LOG.log(Level.SEVERE, "Error stack trace ", currentStack);
+    LOG.log(Level.SEVERE, "Reporting an error in topology code ", error);
   }
 
 

--- a/heron/simulator/src/java/com/twitter/heron/simulator/instance/BoltOutputCollectorImpl.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/instance/BoltOutputCollectorImpl.java
@@ -108,8 +108,7 @@ public class BoltOutputCollectorImpl implements IOutputCollector {
 
   @Override
   public void reportError(Throwable error) {
-    Exception currentStack = new Exception("Reporting an error in topology code", error);
-    LOG.log(Level.SEVERE, "Error stack trace ", currentStack);
+    LOG.log(Level.SEVERE, "Reporting an error in topology code ", error);
   }
 
   @Override

--- a/heron/simulator/src/java/com/twitter/heron/simulator/instance/SpoutOutputCollectorImpl.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/instance/SpoutOutputCollectorImpl.java
@@ -121,8 +121,7 @@ public class SpoutOutputCollectorImpl implements ISpoutOutputCollector {
   // Log the report error and also send the stack trace to metrics manager.
   @Override
   public void reportError(Throwable error) {
-    Exception currentStack = new Exception("Reporting an error in topology code", error);
-    LOG.log(Level.SEVERE, "Error stack trace ", currentStack);
+    LOG.log(Level.SEVERE, "Reporting an error in topology code ", error);
   }
 
 


### PR DESCRIPTION
Earlier during reportError(Throwable error), heron would wrap the error into another Exception.

This is bad, since:
1. It introduces extra stack trace which is useless and makes debug harder.
2. It hides the actual exception point into the detailed stack trace, and
replace the exception message (exception.toString()) with the wrapped one,
which makes debug harder.
3. It also introduces extra cost to report and transfer this error.