### PR TITLE
Return valid json when converting topology config in tracker's 

### DIFF
--- a/heron/tools/tracker/src/python/tracker.py
+++ b/heron/tools/tracker/src/python/tracker.py
@@ -351,7 +351,8 @@ class Tracker(object):
           except Exception:
             Log.exception("Failed to parse data as java object")
             physicalPlan["config"][kvs.key] = {
-                'value' : 'A Java Object',
+                # The value should be a valid json object
+                'value' : '{}',
                 'raw' : utils.hex_escape(kvs.serialized_value)}
     for spout in spouts:
       spout_name = spout.comp.name


### PR DESCRIPTION
When getting config of a topology, tracker should always return valid json object, which is expected by the ui page. Otherwise, the ui page for topology config would crash.