### PR TITLE
Simplify how to run aurora int tests locally

### DIFF
--- a/integration-test/README
+++ b/integration-test/README
@@ -24,10 +24,11 @@ The main components are:
    - Local test runner launches topologies locally, and polls for the actual results (from the
      local file system).
 
-To run the local integration tests on your mac run the following from the heron repo's top dir:
+To run integration tests on your mac first run the following to build the test package and install
+the heron client:
 
   bazel build --config=darwin integration-test/src/...
-
   bazel run --config=darwin -- scripts/packages:heron-client-install.sh --user
 
+To run the local integration tests on your mac run the following from the heron repo's top dir:
   python integration-test/src/python/local_test_runner/main.py

--- a/integration-test/src/python/test_runner/BUILD
+++ b/integration-test/src/python/test_runner/BUILD
@@ -9,7 +9,7 @@ pex_binary(
     ],
     main = "main.py",
     resources = [
-        "resources/test.conf",
+        "resources/test.json",
     ],
     reqs = ["argparse==1.4.0"],
 )

--- a/integration-test/src/python/test_runner/resources/test.json
+++ b/integration-test/src/python/test_runner/resources/test.json
@@ -4,6 +4,7 @@
   "role" : "dummy_role",
   "env" : "dummy_env",
   "resultsServerPort" : "80",
+  "cliConfigPath" : "$HOME/.heron/conf",
   "topologyClasspathPrefix" : "com.twitter.heron.integration_test.topology.",
   "releasePackageUri" : "scheme://role/name/version",
   "javaTopologies": [


### PR DESCRIPTION
Adds some features to the aurora integration tests:

- ability to specify a different cli config path
- ability to only run a subset of tests