### PR TITLE
Add the ability to store state as json in http_server for testing

### DIFF
--- a/integration-test/src/python/test_runner/main.py
+++ b/integration-test/src/python/test_runner/main.py
@@ -162,7 +162,7 @@ def run_tests(conf, args):
   ''' Run the test for each topology specified in the conf file '''
   successes = []
   failures = []
-  timestamp = str(int(time.time()))
+  timestamp = time.strftime('%Y%m%d%H%M%S')
 
   if args.tests_bin_path.endswith(".jar"):
     test_topologies = conf["javaTopologies"]

--- a/integration-test/src/python/test_runner/main.py
+++ b/integration-test/src/python/test_runner/main.py
@@ -84,7 +84,7 @@ def fetch_result_from_server(server_address, server_port, topology_name):
   ''' Make a http get request to fetch actual results from http server '''
   for i in range(0, RETRY_ATTEMPTS):
     logging.info("Fetching results for topology %s, retry count: %d", topology_name, i)
-    response = get_http_response(server_address, int(server_port), topology_name)
+    response = get_http_response(server_address, server_port, topology_name)
     if response.status == 200:
       return (response.status, response.read())
     elif i != RETRY_ATTEMPTS:
@@ -100,7 +100,7 @@ def get_http_response(server_address, server_port, topology_name):
   # pylint: disable=unused-variable
   for i in range(0, RETRY_ATTEMPTS):
     try:
-      connection = HTTPConnection(server_address, int(server_port))
+      connection = HTTPConnection(server_address, server_port)
       connection.request('GET', '/results/' + topology_name)
       response = connection.getresponse()
       return response


### PR DESCRIPTION
To test scaling remotely the local client and the topology spouts need a way to exchange state. Adding a new http endpoint to permit storing and retrieving json on `http_server`.