### PR TITLE
Refactor integration tests to share more code

### DIFF
--- a/integration-test/src/java/BUILD
+++ b/integration-test/src/java/BUILD
@@ -28,6 +28,7 @@ java_library(
         "//heron/storm/src/java:storm-compatibility-java",
         "//third_party/java:hadoop-core",
         "//third_party/java:jackson",
+        "@commons_cli_commons_cli//jar",
         ":core"
     ],
 )

--- a/integration-test/src/java/com/twitter/heron/integration_test/common/AbstractTestTopology.java
+++ b/integration-test/src/java/com/twitter/heron/integration_test/common/AbstractTestTopology.java
@@ -1,0 +1,94 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.twitter.heron.integration_test.common;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
+import com.twitter.heron.api.Config;
+import com.twitter.heron.api.HeronSubmitter;
+import com.twitter.heron.api.exception.AlreadyAliveException;
+import com.twitter.heron.api.exception.InvalidTopologyException;
+import com.twitter.heron.integration_test.core.TestTopologyBuilder;
+
+/**
+ * Class to abstract out the common parts of the test framework for submitting topologies.
+ * Subclasses can implement {@code buildTopology} and call {@code submit}.
+ */
+public abstract class AbstractTestTopology {
+  private static final String TOPOLOGY_OPTION = "topology_name";
+  private static final String RESULTS_URL_OPTION = "results_url";
+
+  private CommandLine cmd;
+  private URL httpServerResultsUrl;
+  private String topologyName;
+
+  protected AbstractTestTopology(String[] args) throws MalformedURLException {
+    CommandLineParser parser = new DefaultParser();
+    HelpFormatter formatter = new HelpFormatter();
+    Options options = getArgOptions();
+
+    try {
+      cmd = parser.parse(options, args);
+    } catch (ParseException e) {
+      formatter.setWidth(120);
+      formatter.printHelp("java " + getClass().getCanonicalName(), options, true);
+      throw new RuntimeException(e);
+    }
+
+    this.httpServerResultsUrl = new URL(cmd.getOptionValue(RESULTS_URL_OPTION));
+    this.topologyName = cmd.getOptionValue(TOPOLOGY_OPTION);
+  }
+
+  protected abstract TestTopologyBuilder buildTopology(TestTopologyBuilder builder);
+
+  protected Config buildConfig(Config config) {
+    return config;
+  }
+
+  protected CommandLine getCommandLine() {
+    return this.cmd;
+  }
+
+  protected Options getArgOptions() {
+    Options options = new Options();
+
+    Option topologyNameOption = new Option("t", TOPOLOGY_OPTION, true, "topology name");
+    topologyNameOption.setRequired(true);
+    options.addOption(topologyNameOption);
+
+    Option resultsUrlOption =
+        new Option("r", RESULTS_URL_OPTION, true, "url to post and get test data");
+    resultsUrlOption.setRequired(true);
+    options.addOption(resultsUrlOption);
+
+    return options;
+  }
+
+  public final void submit() throws AlreadyAliveException, InvalidTopologyException {
+    TestTopologyBuilder builder =
+        new TestTopologyBuilder(topologyName, httpServerResultsUrl.toString());
+
+    Config conf = buildConfig(new BasicConfig());
+    HeronSubmitter.submitTopology(topologyName, conf, buildTopology(builder).createTopology());
+  }
+}

--- a/integration-test/src/java/com/twitter/heron/integration_test/topology/all_grouping/AllGrouping.java
+++ b/integration-test/src/java/com/twitter/heron/integration_test/topology/all_grouping/AllGrouping.java
@@ -13,12 +13,10 @@
 // limitations under the License.
 package com.twitter.heron.integration_test.topology.all_grouping;
 
-import java.net.URL;
+import java.net.MalformedURLException;
 
-import com.twitter.heron.api.Config;
-import com.twitter.heron.api.HeronSubmitter;
 import com.twitter.heron.api.tuple.Fields;
-import com.twitter.heron.integration_test.common.BasicConfig;
+import com.twitter.heron.integration_test.common.AbstractTestTopology;
 import com.twitter.heron.integration_test.common.bolt.IdentityBolt;
 import com.twitter.heron.integration_test.common.spout.ABSpout;
 import com.twitter.heron.integration_test.core.TestTopologyBuilder;
@@ -26,30 +24,22 @@ import com.twitter.heron.integration_test.core.TestTopologyBuilder;
 /**
  * Topology to test allGrouping
  */
-public final class AllGrouping {
+public final class AllGrouping extends AbstractTestTopology {
 
-  private  AllGrouping() {
+  private AllGrouping(String[] args) throws MalformedURLException {
+    super(args);
   }
 
-  public static void main(String[] args) throws Exception {
-    if (args.length < 2) {
-      throw new RuntimeException("HttpServerUrl and TopologyName "
-          + "are needed as command line arguments");
-    }
-
-    URL httpServerUrl = new URL(args[0]);
-    String topologyName = args[1];
-
-    TestTopologyBuilder builder = new TestTopologyBuilder(topologyName, httpServerUrl.toString());
-
+  @Override
+  protected TestTopologyBuilder buildTopology(TestTopologyBuilder builder) {
     builder.setSpout("ab-spout", new ABSpout(), 1);
     builder.setBolt("identity-bolt", new IdentityBolt(new Fields("word")), 2)
         .allGrouping("ab-spout");
+    return builder;
+  }
 
-    // Conf
-    Config conf = new BasicConfig();
-
-    // Submit it!
-    HeronSubmitter.submitTopology(topologyName, conf, builder.createTopology());
+  public static void main(String[] args) throws Exception {
+    AllGrouping topology = new AllGrouping(args);
+    topology.submit();
   }
 }

--- a/integration-test/src/java/com/twitter/heron/integration_test/topology/basic_topology_one_task/BasicTopologyOneTask.java
+++ b/integration-test/src/java/com/twitter/heron/integration_test/topology/basic_topology_one_task/BasicTopologyOneTask.java
@@ -13,12 +13,10 @@
 // limitations under the License.
 package com.twitter.heron.integration_test.topology.basic_topology_one_task;
 
-import java.net.URL;
+import java.net.MalformedURLException;
 
-import com.twitter.heron.api.Config;
-import com.twitter.heron.api.HeronSubmitter;
 import com.twitter.heron.api.tuple.Fields;
-import com.twitter.heron.integration_test.common.BasicConfig;
+import com.twitter.heron.integration_test.common.AbstractTestTopology;
 import com.twitter.heron.integration_test.common.bolt.IdentityBolt;
 import com.twitter.heron.integration_test.common.spout.ABSpout;
 import com.twitter.heron.integration_test.core.TestTopologyBuilder;
@@ -26,30 +24,22 @@ import com.twitter.heron.integration_test.core.TestTopologyBuilder;
 /**
  * Topology to test basic structure, single thread spout &amp; bolt, shuffleGrouping
  */
-public final class BasicTopologyOneTask {
+public final class BasicTopologyOneTask extends AbstractTestTopology {
 
-  private BasicTopologyOneTask() {
+  private BasicTopologyOneTask(String[] args) throws MalformedURLException {
+    super(args);
   }
 
-  public static void main(String[] args) throws Exception {
-    if (args.length < 2) {
-      throw new RuntimeException("HttpServerUrl and TopologyName are "
-          + "needed as command line arguments");
-    }
-
-    URL httpServerUrl = new URL(args[0]);
-    String topologyName = args[1];
-
-    TestTopologyBuilder builder = new TestTopologyBuilder(topologyName, httpServerUrl.toString());
-
+  @Override
+  protected TestTopologyBuilder buildTopology(TestTopologyBuilder builder) {
     builder.setSpout("ab-spout", new ABSpout(), 1);
     builder.setBolt("identity-bolt", new IdentityBolt(new Fields("word")), 1)
         .shuffleGrouping("ab-spout");
+    return builder;
+  }
 
-    // Conf
-    Config conf = new BasicConfig();
-
-    // Submit it!
-    HeronSubmitter.submitTopology(topologyName, conf, builder.createTopology());
+  public static void main(String[] args) throws Exception {
+    BasicTopologyOneTask topology = new BasicTopologyOneTask(args);
+    topology.submit();
   }
 }

--- a/integration-test/src/java/com/twitter/heron/integration_test/topology/bolt_double_emit_tuples/BoltDoubleEmitTuples.java
+++ b/integration-test/src/java/com/twitter/heron/integration_test/topology/bolt_double_emit_tuples/BoltDoubleEmitTuples.java
@@ -13,12 +13,10 @@
 // limitations under the License.
 package com.twitter.heron.integration_test.topology.bolt_double_emit_tuples;
 
-import java.net.URL;
+import java.net.MalformedURLException;
 
-import com.twitter.heron.api.Config;
-import com.twitter.heron.api.HeronSubmitter;
 import com.twitter.heron.api.tuple.Fields;
-import com.twitter.heron.integration_test.common.BasicConfig;
+import com.twitter.heron.integration_test.common.AbstractTestTopology;
 import com.twitter.heron.integration_test.common.bolt.DoubleTuplesBolt;
 import com.twitter.heron.integration_test.common.spout.ABSpout;
 import com.twitter.heron.integration_test.core.TestTopologyBuilder;
@@ -26,30 +24,22 @@ import com.twitter.heron.integration_test.core.TestTopologyBuilder;
 /**
  * Topology to test basic structure, single thread spout and bolt, shuffleGrouping
  */
-public final class BoltDoubleEmitTuples {
+public final class BoltDoubleEmitTuples extends AbstractTestTopology {
 
-  private BoltDoubleEmitTuples() {
+  private BoltDoubleEmitTuples(String[] args) throws MalformedURLException {
+    super(args);
   }
 
-  public static void main(String[] args) throws Exception {
-    if (args.length < 2) {
-      throw new RuntimeException("HttpServerUrl and TopologyName are "
-          + "needed as command line arguments");
-    }
-
-    URL httpServerUrl = new URL(args[0]);
-    String topologyName = args[1];
-
-    TestTopologyBuilder builder = new TestTopologyBuilder(topologyName, httpServerUrl.toString());
-
+  @Override
+  protected TestTopologyBuilder buildTopology(TestTopologyBuilder builder) {
     builder.setSpout("ab-spout", new ABSpout(), 1);
     builder.setBolt("double-tuples-bolt", new DoubleTuplesBolt(new Fields("word")), 1)
         .shuffleGrouping("ab-spout");
+    return builder;
+  }
 
-    // Conf
-    Config conf = new BasicConfig();
-
-    // Submit it!
-    HeronSubmitter.submitTopology(topologyName, conf, builder.createTopology());
+  public static void main(String[] args) throws Exception {
+    BoltDoubleEmitTuples topology = new BoltDoubleEmitTuples(args);
+    topology.submit();
   }
 }

--- a/integration-test/src/java/com/twitter/heron/integration_test/topology/global_grouping/GlobalGrouping.java
+++ b/integration-test/src/java/com/twitter/heron/integration_test/topology/global_grouping/GlobalGrouping.java
@@ -13,11 +13,9 @@
 // limitations under the License.
 package com.twitter.heron.integration_test.topology.global_grouping;
 
-import java.net.URL;
+import java.net.MalformedURLException;
 
-import com.twitter.heron.api.Config;
-import com.twitter.heron.api.HeronSubmitter;
-import com.twitter.heron.integration_test.common.BasicConfig;
+import com.twitter.heron.integration_test.common.AbstractTestTopology;
 import com.twitter.heron.integration_test.common.bolt.WordCountBolt;
 import com.twitter.heron.integration_test.common.spout.ABSpout;
 import com.twitter.heron.integration_test.core.TestTopologyBuilder;
@@ -25,30 +23,22 @@ import com.twitter.heron.integration_test.core.TestTopologyBuilder;
 /**
  * Topology to test Global Grouping
  */
-public final class GlobalGrouping {
+public final class GlobalGrouping extends AbstractTestTopology {
 
-  private GlobalGrouping() {
+  private GlobalGrouping(String[] args) throws MalformedURLException {
+    super(args);
   }
 
-  public static void main(String[] args) throws Exception {
-    if (args.length < 2) {
-      throw new RuntimeException("HttpServerUrl and TopologyName are "
-          + "needed as command line arguments");
-    }
-
-    URL httpServerUrl = new URL(args[0]);
-    String topologyName = args[1];
-
-    TestTopologyBuilder builder = new TestTopologyBuilder(topologyName, httpServerUrl.toString());
-
+  @Override
+  protected TestTopologyBuilder buildTopology(TestTopologyBuilder builder) {
     builder.setSpout("ab-spout", new ABSpout(), 1);
     builder.setBolt("count-bolt", new WordCountBolt(), 3)
         .globalGrouping("ab-spout");
+    return builder;
+  }
 
-    // Conf
-    Config conf = new BasicConfig();
-
-    // Submit it!
-    HeronSubmitter.submitTopology(topologyName, conf, builder.createTopology());
+  public static void main(String[] args) throws Exception {
+    GlobalGrouping topology = new GlobalGrouping(args);
+    topology.submit();
   }
 }

--- a/integration-test/src/java/com/twitter/heron/integration_test/topology/multi_spouts_multi_tasks/MultiSpoutsMultiTasks.java
+++ b/integration-test/src/java/com/twitter/heron/integration_test/topology/multi_spouts_multi_tasks/MultiSpoutsMultiTasks.java
@@ -13,12 +13,10 @@
 // limitations under the License.
 package com.twitter.heron.integration_test.topology.multi_spouts_multi_tasks;
 
-import java.net.URL;
+import java.net.MalformedURLException;
 
-import com.twitter.heron.api.Config;
-import com.twitter.heron.api.HeronSubmitter;
 import com.twitter.heron.api.tuple.Fields;
-import com.twitter.heron.integration_test.common.BasicConfig;
+import com.twitter.heron.integration_test.common.AbstractTestTopology;
 import com.twitter.heron.integration_test.common.bolt.IdentityBolt;
 import com.twitter.heron.integration_test.common.spout.ABSpout;
 import com.twitter.heron.integration_test.core.TestTopologyBuilder;
@@ -26,32 +24,24 @@ import com.twitter.heron.integration_test.core.TestTopologyBuilder;
 /**
  * Topology to test Spout with multiple threads
  */
-public final class MultiSpoutsMultiTasks {
+public final class MultiSpoutsMultiTasks extends AbstractTestTopology {
 
-  private MultiSpoutsMultiTasks() {
+  private MultiSpoutsMultiTasks(String[] args) throws MalformedURLException {
+    super(args);
   }
 
-  public static void main(String[] args) throws Exception {
-    if (args.length < 2) {
-      throw new RuntimeException("HttpServerUrl and TopologyName "
-          + "are needed as command line arguments");
-    }
-
-    URL httpServerUrl = new URL(args[0]);
-    String topologyName = args[1];
-
-    TestTopologyBuilder builder = new TestTopologyBuilder(topologyName, httpServerUrl.toString());
-
+  @Override
+  protected TestTopologyBuilder buildTopology(TestTopologyBuilder builder) {
     builder.setSpout("ab-spout-1", new ABSpout(), 3);
     builder.setSpout("ab-spout-2", new ABSpout(), 3);
     builder.setBolt("identity-bolt", new IdentityBolt(new Fields("word")), 1)
         .shuffleGrouping("ab-spout-1")
         .shuffleGrouping("ab-spout-2");
+    return builder;
+  }
 
-    // Conf
-    Config conf = new BasicConfig();
-
-    // Submit it!
-    HeronSubmitter.submitTopology(topologyName, conf, builder.createTopology());
+  public static void main(String[] args) throws Exception {
+    MultiSpoutsMultiTasks topology = new MultiSpoutsMultiTasks(args);
+    topology.submit();
   }
 }

--- a/integration-test/src/java/com/twitter/heron/integration_test/topology/non_grouping/NonGrouping.java
+++ b/integration-test/src/java/com/twitter/heron/integration_test/topology/non_grouping/NonGrouping.java
@@ -13,44 +13,33 @@
 // limitations under the License.
 package com.twitter.heron.integration_test.topology.non_grouping;
 
-import java.net.URL;
+import java.net.MalformedURLException;
 
-import com.twitter.heron.api.Config;
-import com.twitter.heron.api.HeronSubmitter;
 import com.twitter.heron.api.tuple.Fields;
-import com.twitter.heron.integration_test.common.BasicConfig;
+import com.twitter.heron.integration_test.common.AbstractTestTopology;
 import com.twitter.heron.integration_test.common.bolt.IdentityBolt;
 import com.twitter.heron.integration_test.common.spout.ABSpout;
 import com.twitter.heron.integration_test.core.TestTopologyBuilder;
 
-
 /**
  * Topology to test NonGrouping
  */
-public final class NonGrouping {
+public final class NonGrouping extends AbstractTestTopology {
 
-  private NonGrouping() {
+  private NonGrouping(String[] args) throws MalformedURLException {
+    super(args);
   }
 
-  public static void main(String[] args) throws Exception {
-    if (args.length < 2) {
-      throw new RuntimeException("HttpServerUrl and TopologyName are "
-          + "needed as command line arguments");
-    }
-
-    URL httpServerUrl = new URL(args[0]);
-    String topologyName = args[1];
-
-    TestTopologyBuilder builder = new TestTopologyBuilder(topologyName, httpServerUrl.toString());
-
+  @Override
+  protected TestTopologyBuilder buildTopology(TestTopologyBuilder builder) {
     builder.setSpout("ab-spout", new ABSpout(), 1);
     builder.setBolt("identity-bolt", new IdentityBolt(new Fields("word")), 3)
         .noneGrouping("ab-spout");
+    return builder;
+  }
 
-    // Conf
-    Config conf = new BasicConfig();
-
-    // Submit it!
-    HeronSubmitter.submitTopology(topologyName, conf, builder.createTopology());
+  public static void main(String[] args) throws Exception {
+    NonGrouping topology = new NonGrouping(args);
+    topology.submit();
   }
 }

--- a/integration-test/src/java/com/twitter/heron/integration_test/topology/one_bolt_multi_tasks/OneBoltMultiTasks.java
+++ b/integration-test/src/java/com/twitter/heron/integration_test/topology/one_bolt_multi_tasks/OneBoltMultiTasks.java
@@ -13,12 +13,10 @@
 // limitations under the License.
 package com.twitter.heron.integration_test.topology.one_bolt_multi_tasks;
 
-import java.net.URL;
+import java.net.MalformedURLException;
 
-import com.twitter.heron.api.Config;
-import com.twitter.heron.api.HeronSubmitter;
 import com.twitter.heron.api.tuple.Fields;
-import com.twitter.heron.integration_test.common.BasicConfig;
+import com.twitter.heron.integration_test.common.AbstractTestTopology;
 import com.twitter.heron.integration_test.common.bolt.IdentityBolt;
 import com.twitter.heron.integration_test.common.spout.ABSpout;
 import com.twitter.heron.integration_test.core.TestTopologyBuilder;
@@ -26,30 +24,23 @@ import com.twitter.heron.integration_test.core.TestTopologyBuilder;
 /**
  * Topology to test Bolt with multiple threads
  */
-public final class OneBoltMultiTasks {
+public final class OneBoltMultiTasks extends AbstractTestTopology {
 
-  private OneBoltMultiTasks() {
+  private OneBoltMultiTasks(String[] args) throws MalformedURLException {
+    super(args);
   }
 
-  public static void main(String[] args) throws Exception {
-    if (args.length < 2) {
-      throw new RuntimeException("HttpServerUrl and TopologyName are "
-          + "needed as command line arguments");
-    }
-
-    URL httpServerUrl = new URL(args[0]);
-    String topologyName = args[1];
-
-    TestTopologyBuilder builder = new TestTopologyBuilder(topologyName, httpServerUrl.toString());
+  @Override
+  protected TestTopologyBuilder buildTopology(TestTopologyBuilder builder) {
 
     builder.setSpout("ab-spout", new ABSpout(), 1);
     builder.setBolt("identity-bolt", new IdentityBolt(new Fields("word")), 3)
         .shuffleGrouping("ab-spout");
+    return builder;
+  }
 
-    // Conf
-    Config conf = new BasicConfig();
-
-    // Submit it!
-    HeronSubmitter.submitTopology(topologyName, conf, builder.createTopology());
+  public static void main(String[] args) throws Exception {
+    OneBoltMultiTasks topology = new OneBoltMultiTasks(args);
+    topology.submit();
   }
 }

--- a/integration-test/src/java/com/twitter/heron/integration_test/topology/one_spout_bolt_multi_tasks/OneSpoutBoltMultiTasks.java
+++ b/integration-test/src/java/com/twitter/heron/integration_test/topology/one_spout_bolt_multi_tasks/OneSpoutBoltMultiTasks.java
@@ -13,12 +13,10 @@
 // limitations under the License.
 package com.twitter.heron.integration_test.topology.one_spout_bolt_multi_tasks;
 
-import java.net.URL;
+import java.net.MalformedURLException;
 
-import com.twitter.heron.api.Config;
-import com.twitter.heron.api.HeronSubmitter;
 import com.twitter.heron.api.tuple.Fields;
-import com.twitter.heron.integration_test.common.BasicConfig;
+import com.twitter.heron.integration_test.common.AbstractTestTopology;
 import com.twitter.heron.integration_test.common.bolt.IdentityBolt;
 import com.twitter.heron.integration_test.common.spout.ABSpout;
 import com.twitter.heron.integration_test.core.TestTopologyBuilder;
@@ -26,30 +24,22 @@ import com.twitter.heron.integration_test.core.TestTopologyBuilder;
 /**
  * Topology to test "One spout, one bolt, both of which have multiple instances"
  */
-public final class OneSpoutBoltMultiTasks {
+public final class OneSpoutBoltMultiTasks extends AbstractTestTopology {
 
-  private OneSpoutBoltMultiTasks() {
+  private OneSpoutBoltMultiTasks(String[] args) throws MalformedURLException {
+    super(args);
   }
 
-  public static void main(String[] args) throws Exception {
-    if (args.length < 2) {
-      throw new RuntimeException("HttpServerUrl and TopologyName are "
-          + "needed as command line arguments");
-    }
-
-    URL httpServerUrl = new URL(args[0]);
-    String topologyName = args[1];
-
-    TestTopologyBuilder builder = new TestTopologyBuilder(topologyName, httpServerUrl.toString());
-
+  @Override
+  protected TestTopologyBuilder buildTopology(TestTopologyBuilder builder) {
     builder.setSpout("ab-spout", new ABSpout(), 3);
     builder.setBolt("identity-bolt", new IdentityBolt(new Fields("word")), 3)
         .shuffleGrouping("ab-spout");
+    return builder;
+  }
 
-    // Conf
-    Config conf = new BasicConfig();
-
-    // Submit it!
-    HeronSubmitter.submitTopology(topologyName, conf, builder.createTopology());
+  public static void main(String[] args) throws Exception {
+    OneSpoutBoltMultiTasks topology = new OneSpoutBoltMultiTasks(args);
+    topology.submit();
   }
 }

--- a/integration-test/src/java/com/twitter/heron/integration_test/topology/one_spout_multi_tasks/OneSpoutMultiTasks.java
+++ b/integration-test/src/java/com/twitter/heron/integration_test/topology/one_spout_multi_tasks/OneSpoutMultiTasks.java
@@ -13,12 +13,10 @@
 // limitations under the License.
 package com.twitter.heron.integration_test.topology.one_spout_multi_tasks;
 
-import java.net.URL;
+import java.net.MalformedURLException;
 
-import com.twitter.heron.api.Config;
-import com.twitter.heron.api.HeronSubmitter;
 import com.twitter.heron.api.tuple.Fields;
-import com.twitter.heron.integration_test.common.BasicConfig;
+import com.twitter.heron.integration_test.common.AbstractTestTopology;
 import com.twitter.heron.integration_test.common.bolt.IdentityBolt;
 import com.twitter.heron.integration_test.common.spout.ABSpout;
 import com.twitter.heron.integration_test.core.TestTopologyBuilder;
@@ -26,30 +24,22 @@ import com.twitter.heron.integration_test.core.TestTopologyBuilder;
 /**
  * Topology to test one spout with multiple tasks
  */
-public final class OneSpoutMultiTasks {
+public final class OneSpoutMultiTasks extends AbstractTestTopology {
 
-  private OneSpoutMultiTasks() {
+  private OneSpoutMultiTasks(String[] args) throws MalformedURLException {
+    super(args);
   }
 
-  public static void main(String[] args) throws Exception {
-    if (args.length < 2) {
-      throw new RuntimeException("HttpServerUrl and TopologyName are "
-          + "needed as command line arguments");
-    }
-
-    URL httpServerUrl = new URL(args[0]);
-    String topologyName = args[1];
-
-    TestTopologyBuilder builder = new TestTopologyBuilder(topologyName, httpServerUrl.toString());
-
+  @Override
+  protected TestTopologyBuilder buildTopology(TestTopologyBuilder builder) {
     builder.setSpout("ab-spout", new ABSpout(), 3);
     builder.setBolt("identity-bolt", new IdentityBolt(new Fields("word")), 1)
         .shuffleGrouping("ab-spout");
+    return builder;
+  }
 
-    // Conf
-    Config conf = new BasicConfig();
-
-    // Submit it!
-    HeronSubmitter.submitTopology(topologyName, conf, builder.createTopology());
+  public static void main(String[] args) throws Exception {
+    OneSpoutMultiTasks topology = new OneSpoutMultiTasks(args);
+    topology.submit();
   }
 }

--- a/integration-test/src/java/com/twitter/heron/integration_test/topology/one_spout_two_bolts/OneSpoutTwoBolts.java
+++ b/integration-test/src/java/com/twitter/heron/integration_test/topology/one_spout_two_bolts/OneSpoutTwoBolts.java
@@ -13,12 +13,10 @@
 // limitations under the License.
 package com.twitter.heron.integration_test.topology.one_spout_two_bolts;
 
-import java.net.URL;
+import java.net.MalformedURLException;
 
-import com.twitter.heron.api.Config;
-import com.twitter.heron.api.HeronSubmitter;
 import com.twitter.heron.api.tuple.Fields;
-import com.twitter.heron.integration_test.common.BasicConfig;
+import com.twitter.heron.integration_test.common.AbstractTestTopology;
 import com.twitter.heron.integration_test.common.bolt.IdentityBolt;
 import com.twitter.heron.integration_test.common.spout.ABSpout;
 import com.twitter.heron.integration_test.core.TestTopologyBuilder;
@@ -26,32 +24,24 @@ import com.twitter.heron.integration_test.core.TestTopologyBuilder;
 /**
  * Topology to test with one spout connected to two bolts
  */
-public final class OneSpoutTwoBolts {
+public final class OneSpoutTwoBolts extends AbstractTestTopology {
 
-  private OneSpoutTwoBolts() {
+  private OneSpoutTwoBolts(String[] args) throws MalformedURLException {
+    super(args);
   }
 
-  public static void main(String[] args) throws Exception {
-    if (args.length < 2) {
-      throw new RuntimeException("HttpServerUrl and TopologyName are "
-          + "needed as command line arguments");
-    }
-
-    URL httpServerUrl = new URL(args[0]);
-    String topologyName = args[1];
-
-    TestTopologyBuilder builder = new TestTopologyBuilder(topologyName, httpServerUrl.toString());
-
+  @Override
+  protected TestTopologyBuilder buildTopology(TestTopologyBuilder builder) {
     builder.setSpout("ab-spout", new ABSpout(), 1);
     builder.setBolt("identity-bolt-1", new IdentityBolt(new Fields("word")), 1)
         .shuffleGrouping("ab-spout");
     builder.setBolt("identity-bolt-2", new IdentityBolt(new Fields("word")), 1)
         .shuffleGrouping("ab-spout");
+    return builder;
+  }
 
-    // Conf
-    Config conf = new BasicConfig();
-
-    // Submit it!
-    HeronSubmitter.submitTopology(topologyName, conf, builder.createTopology());
+  public static void main(String[] args) throws Exception {
+    OneSpoutTwoBolts topology = new OneSpoutTwoBolts(args);
+    topology.submit();
   }
 }

--- a/integration-test/src/java/com/twitter/heron/integration_test/topology/shuffle_grouping/ShuffleGrouping.java
+++ b/integration-test/src/java/com/twitter/heron/integration_test/topology/shuffle_grouping/ShuffleGrouping.java
@@ -13,12 +13,10 @@
 // limitations under the License.
 package com.twitter.heron.integration_test.topology.shuffle_grouping;
 
-import java.net.URL;
+import java.net.MalformedURLException;
 
-import com.twitter.heron.api.Config;
-import com.twitter.heron.api.HeronSubmitter;
 import com.twitter.heron.api.tuple.Fields;
-import com.twitter.heron.integration_test.common.BasicConfig;
+import com.twitter.heron.integration_test.common.AbstractTestTopology;
 import com.twitter.heron.integration_test.common.bolt.IdentityBolt;
 import com.twitter.heron.integration_test.common.spout.ABSpout;
 import com.twitter.heron.integration_test.core.TestTopologyBuilder;
@@ -26,30 +24,22 @@ import com.twitter.heron.integration_test.core.TestTopologyBuilder;
 /**
  * Topology to test ShuffleGrouping
  */
-public final class ShuffleGrouping {
+public final class ShuffleGrouping extends AbstractTestTopology {
 
-  private ShuffleGrouping() {
+  private ShuffleGrouping(String[] args) throws MalformedURLException {
+    super(args);
   }
 
-  public static void main(String[] args) throws Exception {
-    if (args.length < 2) {
-      throw new RuntimeException("HttpServerUrl and TopologyName are "
-          + "needed as command line arguments");
-    }
-
-    URL httpServerUrl = new URL(args[0]);
-    String topologyName = args[1];
-
-    TestTopologyBuilder builder = new TestTopologyBuilder(topologyName, httpServerUrl.toString());
-
+  @Override
+  protected TestTopologyBuilder buildTopology(TestTopologyBuilder builder) {
     builder.setSpout("ab-spout", new ABSpout(), 1);
     builder.setBolt("identity-bolt", new IdentityBolt(new Fields("word")), 3)
         .localOrShuffleGrouping("ab-spout");
+    return builder;
+  }
 
-    // Conf
-    Config conf = new BasicConfig();
-
-    // Submit it!
-    HeronSubmitter.submitTopology(topologyName, conf, builder.createTopology());
+  public static void main(String[] args) throws Exception {
+    ShuffleGrouping topology = new ShuffleGrouping(args);
+    topology.submit();
   }
 }

--- a/integration-test/src/python/integration_test/topology/test_topology_main.py
+++ b/integration-test/src/python/integration_test/topology/test_topology_main.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 '''main method for integration test topology'''
 
+import argparse
 import sys
 
 from .basic_one_task import basic_one_task_builder
@@ -28,30 +29,32 @@ from .fields_grouping import fields_grouping_builder
 from .bolt_double_emit_tuples import bolt_double_emit_tuples_builder
 from .global_grouping import global_grouping_builder
 
-# pylint: disable=line-too-long
-TOPOLOGY_BUILDERS = {'PyHeron_IntegrationTest_BasicOneTask': basic_one_task_builder,
-                     'PyHeron_IntegrationTest_AllGrouping': all_grouping_buidler,
-                     'PyHeron_IntegrationTest_NoneGrouping': none_grouping_builder,
-                     'PyHeron_IntegrationTest_OneBoltMultiTasks': one_bolt_multi_tasks_builder,
-                     'PyHeron_IntegrationTest_OneSpoutBoltMultiTasks': one_spout_bolt_multi_tasks_builder,
-                     'PyHeron_IntegrationTest_ShuffleGrouping': shuffle_grouping_builder,
-                     'PyHeron_IntegrationTest_OneSpoutTwoBolts': one_spout_two_bolts_builder,
-                     'PyHeron_IntegrationTest_OneSpoutMultiTasks': one_spout_multi_tasks_builder,
-                     'PyHeron_IntegrationTest_MultiSpoutsMultiTasks': multi_spouts_multi_tasks_builder,
-                     'PyHeron_IntegrationTest_FieldsGrouping': fields_grouping_builder,
-                     'PyHeron_IntegrationTest_BoltDoubleEmitTuples': bolt_double_emit_tuples_builder,
-                     'PyHeron_IntegrationTest_GlobalGrouping': global_grouping_builder}
+TOPOLOGY_BUILDERS = {
+    'PyHeron_IntegrationTest_BasicOneTask': basic_one_task_builder,
+    'PyHeron_IntegrationTest_AllGrouping': all_grouping_buidler,
+    'PyHeron_IntegrationTest_NoneGrouping': none_grouping_builder,
+    'PyHeron_IntegrationTest_OneBoltMultiTasks': one_bolt_multi_tasks_builder,
+    'PyHeron_IntegrationTest_OneSpoutBoltMultiTasks': one_spout_bolt_multi_tasks_builder,
+    'PyHeron_IntegrationTest_ShuffleGrouping': shuffle_grouping_builder,
+    'PyHeron_IntegrationTest_OneSpoutTwoBolts': one_spout_two_bolts_builder,
+    'PyHeron_IntegrationTest_OneSpoutMultiTasks': one_spout_multi_tasks_builder,
+    'PyHeron_IntegrationTest_MultiSpoutsMultiTasks': multi_spouts_multi_tasks_builder,
+    'PyHeron_IntegrationTest_FieldsGrouping': fields_grouping_builder,
+    'PyHeron_IntegrationTest_BoltDoubleEmitTuples': bolt_double_emit_tuples_builder,
+    'PyHeron_IntegrationTest_GlobalGrouping': global_grouping_builder,
+}
 
 def main():
-  if len(sys.argv) != 3:
-    print "Usage: %s <http server url> <topology name>" % sys.argv[0]
-    sys.exit(1)
+  parser = argparse.ArgumentParser(description='Python topology submitter')
+  parser.add_argument('-r', '--results-server-url', dest='results_url', required=True)
+  parser.add_argument('-t', '--topology-name', dest='topology_name', required=True)
+  args = parser.parse_args()
 
-  http_server_url = sys.argv[1]
+  http_server_url = args.results_url
 
   # 1470884422_PyHeron_IntegrationTest_BasicOneTask_dca9bb1c-dd3b-4ea6-97dc-ea0cea265adc
   # --> PyHeron_IntegrationTest_BasicOneTask
-  topology_name_with_uuid = sys.argv[2]
+  topology_name_with_uuid = args.topology_name
   topology_name = '_'.join(topology_name_with_uuid.split('_')[1:-1])
 
   if topology_name not in TOPOLOGY_BUILDERS:

--- a/integration-test/src/python/integration_test/topology/test_topology_main.py
+++ b/integration-test/src/python/integration_test/topology/test_topology_main.py
@@ -14,6 +14,7 @@
 '''main method for integration test topology'''
 
 import argparse
+import logging
 import sys
 
 from .basic_one_task import basic_one_task_builder
@@ -44,11 +45,15 @@ TOPOLOGY_BUILDERS = {
     'PyHeron_IntegrationTest_GlobalGrouping': global_grouping_builder,
 }
 
+# pylint: disable=missing-docstring
 def main():
   parser = argparse.ArgumentParser(description='Python topology submitter')
   parser.add_argument('-r', '--results-server-url', dest='results_url', required=True)
   parser.add_argument('-t', '--topology-name', dest='topology_name', required=True)
-  args = parser.parse_args()
+  args, unknown_args = parser.parse_known_args()
+  if unknown_args:
+    logging.error('Unknown argument passed to %s: %s', sys.argv[0], unknown_args[0])
+    sys.exit(1)
 
   http_server_url = args.results_url
 
@@ -58,7 +63,7 @@ def main():
   topology_name = '_'.join(topology_name_with_uuid.split('_')[1:-1])
 
   if topology_name not in TOPOLOGY_BUILDERS:
-    print "%s not found in the list" % topology_name
+    logging.error("%s not found in the list", topology_name)
     sys.exit(2)
 
   builder = TOPOLOGY_BUILDERS[topology_name]

--- a/integration-test/src/python/test_runner/main.py
+++ b/integration-test/src/python/test_runner/main.py
@@ -162,7 +162,7 @@ def run_tests(conf, args):
   ''' Run the test for each topology specified in the conf file '''
   successes = []
   failures = []
-  timestamp = str(int(time.time()))
+  timestamp = time.strftime('%Y%m%d%H%M%S')
 
   if args.tests_bin_path.endswith(".jar"):
     test_topologies = conf["javaTopologies"]

--- a/integration-test/src/python/test_runner/main.py
+++ b/integration-test/src/python/test_runner/main.py
@@ -133,10 +133,9 @@ def submit_topology(heron_cli_path, cli_config_path, cluster, role,
 
   logging.info("Submitting command: %s", cmd)
 
-  for _ in range(0, RETRY_ATTEMPTS):
-    if os.system(cmd) == 0:
-      logging.info("Successfully submitted topology")
-      return
+  if os.system(cmd) == 0:
+    logging.info("Successfully submitted topology")
+    return
 
   raise RuntimeError("Unable to submit the topology")
 
@@ -235,7 +234,10 @@ def main():
   #parser.add_argument('-et', '--enable-topologies', dest='enableTopologies', default=None,
   #                    help='comma separated test case(classpath) name that will be run only')
 
-  args = parser.parse_args()
+  args, unknown_args = parser.parse_known_args()
+  if unknown_args:
+    logging.error('Unknown argument passed to %s: %s', sys.argv[0], unknown_args[0])
+    sys.exit(1)
 
   (successes, failures) = run_tests(conf, args)
   total = len(failures) + len(successes)

--- a/integration-test/src/python/test_runner/main.py
+++ b/integration-test/src/python/test_runner/main.py
@@ -14,7 +14,7 @@ from httplib import *
 # The location of default configure file
 DEFAULT_TEST_CONF_FILE = "integration-test/src/python/test_runner/resources/test.json"
 
-RETRY_ATTEMPTS = 25
+RETRY_ATTEMPTS = 15
 #seconds
 RETRY_INTERVAL = 10
 
@@ -205,7 +205,6 @@ def main():
   ''' main '''
   root = logging.getLogger()
   root.setLevel(logging.DEBUG)
-  print(os.path.join(os.path.dirname(sys.modules[__name__].__file__), DEFAULT_TEST_CONF_FILE), 'rb')
   conf_file = DEFAULT_TEST_CONF_FILE
   # Read the configuration file from package
   conf_string = pkgutil.get_data(__name__, conf_file)

--- a/integration-test/src/python/test_runner/main.py
+++ b/integration-test/src/python/test_runner/main.py
@@ -20,12 +20,12 @@ RETRY_INTERVAL = 10
 
 def run_test(topology_name, classpath, expected_result_file_path, params):
   ''' Runs the test for one topology '''
-  http_server_url = "http://%s:%d/results" %\
+  http_results_server_url = "http://%s:%d/results" %\
                     (params.results_server_hostname, params.results_server_port)
 
   #submit topology
   try:
-    args = http_server_url + " " + topology_name
+    args = "-r %s -t %s" % (http_results_server_url, topology_name)
     submit_topology(params.heron_cli_path, params.cli_config_path, params.cluster, params.role,
                     params.env, params.tests_bin_path, classpath,
                     params.release_package_uri, args)

--- a/integration-test/src/python/test_runner/main.py
+++ b/integration-test/src/python/test_runner/main.py
@@ -146,13 +146,12 @@ def kill_topology(heron_cli_path, cli_config_path, cluster, role, env, topology_
         (heron_cli_path, cli_config_path, cluster_token(cluster, role, env), topology_name)
 
   logging.info("Submitting command: %s", cmd)
-  for i in range(0, RETRY_ATTEMPTS):
-    if os.system(cmd) != 0:
-      time.sleep(RETRY_INTERVAL)
-      logging.warning("killing topology %s with %d attempts", topology_name, i)
-    else:
-      logging.info("Successfully killed topology %s", topology_name)
-      return
+  if os.system(cmd) != 0:
+    time.sleep(RETRY_INTERVAL)
+    logging.warning("killing topology %s with %d attempts", topology_name, i)
+  else:
+    logging.info("Successfully killed topology %s", topology_name)
+    return
 
   logging.error("Failed to kill topology %s", topology_name)
   raise RuntimeError("Unable to kill the topology")

--- a/integration-test/src/python/test_runner/main.py
+++ b/integration-test/src/python/test_runner/main.py
@@ -145,11 +145,8 @@ def kill_topology(heron_cli_path, cli_config_path, cluster, role, env, topology_
   cmd = "%s kill --config-path=%s %s %s --verbose" %\
         (heron_cli_path, cli_config_path, cluster_token(cluster, role, env), topology_name)
 
-  logging.info("Submitting command: %s", cmd)
-  if os.system(cmd) != 0:
-    time.sleep(RETRY_INTERVAL)
-    logging.warning("killing topology %s with %d attempts", topology_name, i)
-  else:
+  logging.info("Kill topology command: %s", cmd)
+  if os.system(cmd) == 0:
     logging.info("Successfully killed topology %s", topology_name)
     return
 


### PR DESCRIPTION
This refactor shares duplicate code, while allowing the ability to add custom logic to subclasses. It also changes to use proper arg parsing of topology arguments. This will simplify writing test with custom logic or args, like scaling tests.

Two main classes to look at, `AbstractTestTopology.java` and `main.py`. The rest are all basically the same refactor to all tests that now subclass `AbstractTestTopology.java`.