### PR TITLE
Set role to None if execution_state is None.

### DIFF
--- a/heron/tools/tracker/src/python/handlers/topologieshandler.py
+++ b/heron/tools/tracker/src/python/handlers/topologieshandler.py
@@ -64,7 +64,12 @@ class TopologiesHandler(BaseHandler):
     for topology in topologies:
       cluster = topology.cluster
       environ = topology.environ
-      topo_role = topology.execution_state.role
+
+      if topology.execution_state:
+        topo_role = topology.execution_state.role
+      else:
+        topo_role = None
+
       if not cluster or not topo_role or not environ:
         continue
 


### PR DESCRIPTION
because strangely, execution state of some topology is None. This only happens to one devel topology inside of Twitter environment. We can discuss more about this issue internally...

cc @nlu90 