### PR TITLE
Add version in tracker and UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,10 @@ tools/cpp/gcc
 tools/cpp/g++
 tools/jdk/ijar
 .DS_Store
+
+# Vim
 .*.swp
+.*.swo
 
 # Compiled source #
 ###################

--- a/heron/tools/cli/src/python/main.py
+++ b/heron/tools/cli/src/python/main.py
@@ -115,7 +115,7 @@ def run(command, parser, command_args, unknown_args):
   if command in runners:
     return runners[command].run(command, parser, command_args, unknown_args)
   else:
-    Log.error('Unknown subcommand: %s' % command)
+    Log.error('Unknown subcommand: %s', command)
     return 1
 
 def cleanup(files):

--- a/heron/tools/cli/src/python/version.py
+++ b/heron/tools/cli/src/python/version.py
@@ -42,9 +42,5 @@ def run(command, parser, args, unknown_args):
   :param unknown_args:
   :return:
   '''
-  release_file = config.get_heron_release_file()
-  with open(release_file) as release_info:
-    for line in release_info:
-      print line,
-
+  config.print_build_info()
   return True

--- a/heron/tools/common/src/python/BUILD
+++ b/heron/tools/common/src/python/BUILD
@@ -16,5 +16,8 @@ pex_library(
     ),
     deps = [
         "//heron/common/src/python:common-py",
-    ]
+    ],
+    reqs = [
+        "pyyaml==3.10"
+    ],
 )

--- a/heron/tools/common/src/python/utils/config.py
+++ b/heron/tools/common/src/python/utils/config.py
@@ -137,6 +137,8 @@ def get_heron_dir():
   its real path is '/Users/heron-user/.heron/bin/heron/tools/common/src/python/utils/config.pyc',
   the internal variable ``path`` would be '/Users/heron-user/.heron', which is the heron directory
 
+  This means the variable `go_above_dirs` below is 9.
+
   :return: root location for heron-cli.
   """
   go_above_dirs = 9
@@ -147,6 +149,14 @@ def get_zipped_heron_dir():
   """
   This will extract heron directory from .pex file,
   with `zip_safe = False' Bazel flag added when building this .pex file
+
+  For example,
+  when __file__'s real path is
+    '/Users/heron-user/.pex/code/xxxyyy/heron/tools/common/src/python/utils/config.pyc', and
+  the internal variable ``path`` would be '/Users/heron-user/.pex/code/xxxyyy/',
+  which is the root PEX directory
+
+  This means the variable `go_above_dirs` below is 7.
 
   Specifically designed for heron-ui
 
@@ -159,18 +169,6 @@ def get_zipped_heron_dir():
 ################################################################################
 # Get the root of heron dir and various sub directories depending on platform
 ################################################################################
-def get_heron_dir_explorer():
-  """
-  This will extract heron directory from .pex file.
-  From heron-cli with modification since we need to reuse cli's conf
-  :return: root location for heron-cli.
-  """
-  go_above_dirs = 10
-  path_list = os.path.realpath(__file__).split('/')[:-go_above_dirs]
-  path_list.append(CLI_DIR)
-  path = "/".join(path_list)
-  return normalized_class_path(path)
-
 def get_heron_bin_dir():
   """
   This will provide heron bin directory from .pex file.

--- a/heron/tools/common/src/python/utils/config.py
+++ b/heron/tools/common/src/python/utils/config.py
@@ -139,7 +139,7 @@ def get_heron_dir():
 
   This means the variable `go_above_dirs` below is 9.
 
-  :return: root location for heron-cli.
+  :return: root location of the .pex file
   """
   go_above_dirs = 9
   path = "/".join(os.path.realpath(__file__).split('/')[:-go_above_dirs])
@@ -158,9 +158,7 @@ def get_zipped_heron_dir():
 
   This means the variable `go_above_dirs` below is 7.
 
-  Specifically designed for heron-ui
-
-  :return: root location for heron-ui.
+  :return: root location of the .pex file.
   """
   go_above_dirs = 7
   path = "/".join(os.path.realpath(__file__).split('/')[:-go_above_dirs])

--- a/heron/tools/explorer/src/python/args.py
+++ b/heron/tools/explorer/src/python/args.py
@@ -28,7 +28,7 @@ def add_config(parser):
   parser.add_argument(
       '--config-path',
       metavar='(a string; path to cluster config; default: "' + default_config_path + '")',
-      default=os.path.join(config.get_heron_dir_explorer(), default_config_path))
+      default=os.path.join(config.get_heron_dir(), default_config_path))
 
   return parser
 

--- a/heron/tools/explorer/src/python/main.py
+++ b/heron/tools/explorer/src/python/main.py
@@ -145,7 +145,7 @@ def extract_common_args(command, parser, cl_args):
     new_cl_args['environ'] = cluster_tuple[2]
     new_cl_args['config_path'] = config_path
   except Exception as e:
-    Log.error("Unable to get valid topology location: %s" % str(e))
+    Log.error("Unable to get valid topology location: %s", str(e))
     return dict()
 
   cl_args.update(new_cl_args)
@@ -174,7 +174,7 @@ def main(args):
   command = command_line_args['subcommand']
 
   if unknown_args:
-    Log.error('Unknown argument: %s' % unknown_args[0])
+    Log.error('Unknown argument: %s', unknown_args[0])
     # show help message
     command_line_args['help-command'] = command
     command = 'help'
@@ -195,7 +195,7 @@ def main(args):
 
   if command != 'help':
     sys.stdout.flush()
-    Log.info('Elapsed time: %.3fs.' % (end - start))
+    Log.info('Elapsed time: %.3fs.', (end - start))
 
   return 0 if ret else 1
 

--- a/heron/tools/explorer/src/python/version.py
+++ b/heron/tools/explorer/src/python/version.py
@@ -30,8 +30,5 @@ def create_parser(subparsers):
 # pylint: disable=unused-argument
 def run(command, parser, known_args, unknown_args):
   """ run command """
-  release_file = config.get_heron_release_file()
-  with open(release_file) as release_info:
-    for line in release_info:
-      print line,
+  config.print_build_info()
   return True

--- a/heron/tools/tracker/src/python/constants.py
+++ b/heron/tools/tracker/src/python/constants.py
@@ -17,7 +17,7 @@
 
 # Version Information
 
-API_VERSION = "1.0.0"
+API_VERSION = "0.14.5"
 
 
 # Handler Constants

--- a/heron/tools/tracker/src/python/constants.py
+++ b/heron/tools/tracker/src/python/constants.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ constants.py """
+
+import heron.tools.common.src.python.utils.config as common_config
+
 # This file contains all the constants used
 # across the tracker service.
 
 # Version Information
 
-API_VERSION = "0.14.5"
+API_VERSION = common_config.get_version_number()
 
 
 # Handler Constants

--- a/heron/tools/tracker/src/python/main.py
+++ b/heron/tools/tracker/src/python/main.py
@@ -188,7 +188,7 @@ def main():
     parser.exit()
 
   elif remaining == ['version']:
-    common_config.print_version()
+    common_config.print_build_info()
     parser.exit()
 
   elif remaining != []:

--- a/heron/tools/ui/src/python/BUILD
+++ b/heron/tools/ui/src/python/BUILD
@@ -15,6 +15,7 @@ pex_library(
     ],
     deps = [
         "//heron/common/src/python:common-py",
+        "//heron/tools/common/src/python:common-py",
         "//heron/tools/common/src/python:tracker-py",
     ]
 )
@@ -28,6 +29,7 @@ pex_binary(
     resources = [
         "//heron/tools/ui/resources:templates",
         "//heron/tools/ui/resources:static",
+        "//scripts/packages:release_files",
     ],
     zip_safe = False,
 )

--- a/heron/tools/ui/src/python/args.py
+++ b/heron/tools/ui/src/python/args.py
@@ -111,5 +111,11 @@ def create_parsers():
       help='Prints help',
       add_help=False)
 
+  version_parser = subparsers.add_parser(
+      'version',
+      help='Prints version',
+      add_help=True)
+
   help_parser.set_defaults(help=True)
+  version_parser.set_defaults(version=True)
   return (parser, child_parser)

--- a/heron/tools/ui/src/python/consts.py
+++ b/heron/tools/ui/src/python/consts.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ''' consts.py '''
+import heron.tools.common.src.python.utils.config as common_config
 
 # default parameter - address for the web to ui to listen on
 DEFAULT_ADDRESS = "0.0.0.0"
@@ -21,3 +22,5 @@ DEFAULT_PORT = 8889
 
 # default parameter - url to connect to heron tracker
 DEFAULT_TRACKER_URL = "http://localhost:8888"
+
+VERSION = common_config.get_version_number(zipped_pex=True)

--- a/heron/tools/ui/src/python/main.py
+++ b/heron/tools/ui/src/python/main.py
@@ -27,6 +27,7 @@ import tornado.template
 from tornado.options import define
 
 import heron.common.src.python.utils.log as log
+import heron.tools.common.src.python.utils.config as common_config
 from heron.tools.ui.src.python import handlers
 from heron.tools.ui.src.python import args
 
@@ -132,8 +133,12 @@ def main():
   (parsed_args, remaining) = parser.parse_known_args()
 
   if remaining:
-    child_parser.parse_args(args=remaining, namespace=parsed_args)
-    parser.print_help()
+    r = child_parser.parse_args(args=remaining, namespace=parsed_args)
+    namespace = vars(r)
+    if 'version' in namespace:
+      common_config.print_build_info(zipped_pex=True)
+    else:
+      parser.print_help()
     parser.exit()
 
   # log additional information

--- a/scripts/packages/BUILD
+++ b/scripts/packages/BUILD
@@ -32,6 +32,11 @@ generated_release_files = [
 ]
 
 filegroup(
+    name = "release_files",
+    srcs = generated_release_files,
+)
+
+filegroup(
     name = "tarpkgs",
     srcs = [
         ":heron-api",


### PR DESCRIPTION
This PR

1. Add `version` subcommand for `heron-tracker` and `heron-ui`
2. `API_VERSION` in `heron/tools/tracker/src/python/constants.py` picks up version number from `release.yaml`.
3. Add `VERSION` constant in `heron/tools/ui/src/python/consts.py`, which also picks up version number from `release.yaml`

The key to solve the long-existing problem that `heron-ui` built with `zip_safe = False` flag is agnostic about the location of `release.yaml` is to zip `release.yaml` into `heron-ui` PEX file at compile time. See [here1](https://github.com/twitter/heron/compare/tracker-ui-version?expand=1#diff-20422e673bb9505a470407f3d2397ed2R34) and [here2](https://github.com/twitter/heron/compare/tracker-ui-version?expand=1#diff-2030bd7a10d92365e9bb96545104d00fR32).

Can verify `heron`, `heron-explorer`, `heron-tracker`, and especially `heron-ui` work fine.

cc @billonahill @kramasamy @maosongfu 