### PR TITLE
Refactor usage of PhysicalPlanHelper, dedup simulator code

### DIFF
--- a/heron/common/src/java/com/twitter/heron/common/utils/misc/CustomStreamGroupingHelper.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/misc/CustomStreamGroupingHelper.java
@@ -16,43 +16,39 @@ package com.twitter.heron.common.utils.misc;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
 import com.twitter.heron.api.grouping.CustomStreamGrouping;
 import com.twitter.heron.api.topology.TopologyContext;
 
-public class CustomStreamGroupingHelper {
+class CustomStreamGroupingHelper {
   // Mapping from steamid to a List of Targets
   private final Map<String, List<Target>> targets;
 
-  public CustomStreamGroupingHelper() {
+  CustomStreamGroupingHelper() {
     targets = new HashMap<>();
   }
 
-  public void add(
-      String streamId,
-      List<Integer> taskIds,
-      CustomStreamGrouping grouping,
-      String sourceComponentName) {
+  public void add(String streamId,
+                  List<Integer> taskIds,
+                  CustomStreamGrouping grouping,
+                  String sourceComponentName) {
     if (!targets.containsKey(streamId)) {
       targets.put(streamId, new ArrayList<Target>());
     }
     targets.get(streamId).add(new Target(taskIds, grouping, sourceComponentName));
   }
 
-  public void prepare(TopologyContext context) {
-    Iterator<Map.Entry<String, List<Target>>> iterator = targets.entrySet().iterator();
-    while (iterator.hasNext()) {
-      Map.Entry<String, List<Target>> entry = iterator.next();
-      for (Target target : entry.getValue()) {
-        target.prepare(context, entry.getKey());
+  void prepare(TopologyContext context) {
+    for (String streamId : targets.keySet()) {
+      for (Target target : targets.get(streamId)) {
+        target.prepare(context, streamId);
       }
     }
   }
 
-  public List<Integer> chooseTasks(String streamId, List<Object> values) {
+  List<Integer> chooseTasks(String streamId, List<Object> values) {
     List<Target> targetList = targets.get(streamId);
     if (targetList != null) {
       List<Integer> res = new ArrayList<>();
@@ -65,7 +61,7 @@ public class CustomStreamGroupingHelper {
     return null;
   }
 
-  public boolean isCustomGroupingEmpty() {
+  boolean isCustomGroupingEmpty() {
     return targets.isEmpty();
   }
 
@@ -96,7 +92,7 @@ public class CustomStreamGroupingHelper {
       grouping.prepare(context, componentName, streamId, taskIds);
     }
 
-    public List<Integer> chooseTasks(List<Object> values) {
+    private List<Integer> chooseTasks(List<Object> values) {
       return grouping.chooseTasks(values);
     }
   }

--- a/heron/common/src/java/com/twitter/heron/common/utils/misc/PhysicalPlanHelper.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/misc/PhysicalPlanHelper.java
@@ -94,13 +94,12 @@ public class PhysicalPlanHelper {
     // setup outputSchema
     outputSchema = new HashMap<String, Integer>();
     List<TopologyAPI.OutputStream> outputs;
-    TopologyAPI.Component comp;
     if (mySpout != null) {
       outputs = mySpout.getOutputsList();
-      comp = mySpout.getComp();
+      component = mySpout.getComp();
     } else {
       outputs = myBolt.getOutputsList();
-      comp = myBolt.getComp();
+      component = myBolt.getComp();
     }
     for (TopologyAPI.OutputStream outputStream : outputs) {
       outputSchema.put(outputStream.getStream().getId(),
@@ -112,8 +111,6 @@ public class PhysicalPlanHelper {
     } catch (UnknownHostException e) {
       throw new RuntimeException("GetHostName failed");
     }
-
-    component = comp;
 
     // Do some setup for any custom grouping
     customGrouper = new CustomStreamGroupingHelper();

--- a/heron/common/src/java/com/twitter/heron/common/utils/misc/PhysicalPlanHelper.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/misc/PhysicalPlanHelper.java
@@ -253,7 +253,6 @@ public class PhysicalPlanHelper {
   }
 
   private HashSet<String> getTerminatedComponentSet() {
-    Map<String, TopologyAPI.Bolt> bolts = new HashMap<>();
     Map<String, TopologyAPI.Spout> spouts = new HashMap<>();
     Map<String, HashSet<String>> prev = new HashMap<>();
 
@@ -266,7 +265,6 @@ public class PhysicalPlanHelper {
     // by looking only on bolts, since spout will not have parents
     for (TopologyAPI.Bolt bolt : pplan.getTopology().getBoltsList()) {
       String name = bolt.getComp().getName();
-      bolts.put(name, bolt);
 
       // To get the parent's component to construct a graph of topology structure
       for (TopologyAPI.InputStream inputStream : bolt.getInputsList()) {

--- a/heron/common/src/java/com/twitter/heron/common/utils/misc/PhysicalPlanHelper.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/misc/PhysicalPlanHelper.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.api.grouping.CustomStreamGrouping;
-import com.twitter.heron.api.topology.TopologyContext;
 import com.twitter.heron.api.utils.Utils;
 import com.twitter.heron.common.utils.metrics.MetricsCollector;
 import com.twitter.heron.common.utils.topology.TopologyContextImpl;
@@ -55,9 +54,7 @@ public class PhysicalPlanHelper {
   /**
    * Constructor for physical plan helper
    */
-  public PhysicalPlanHelper(
-      PhysicalPlans.PhysicalPlan pplan,
-      String instanceId) {
+  public PhysicalPlanHelper(PhysicalPlans.PhysicalPlan pplan, String instanceId) {
     this.pplan = pplan;
 
     // Get my instance
@@ -132,7 +129,7 @@ public class PhysicalPlanHelper {
               (CustomStreamGrouping) Utils.deserialize(
                   inputStream.getCustomGroupingObject().toByteArray());
           customGrouper.add(inputStream.getStream().getId(),
-              GetTaskIdsAsListForComponent(topo.getBolts(i).getComp().getName()),
+              getTaskIdsAsListForComponent(topo.getBolts(i).getComp().getName()),
               customStreamGrouping, myComponent);
         }
       }
@@ -233,7 +230,7 @@ public class PhysicalPlanHelper {
     return retval;
   }
 
-  private List<Integer> GetTaskIdsAsListForComponent(String comp) {
+  private List<Integer> getTaskIdsAsListForComponent(String comp) {
     List<Integer> retval = new LinkedList<Integer>();
     for (PhysicalPlans.Instance instance : pplan.getInstancesList()) {
       if (instance.getInfo().getComponentName().equals(comp)) {
@@ -243,8 +240,8 @@ public class PhysicalPlanHelper {
     return retval;
   }
 
-  public void prepareForCustomStreamGrouping(TopologyContext context) {
-    customGrouper.prepare(context);
+  public void prepareForCustomStreamGrouping() {
+    customGrouper.prepare(topologyContext);
   }
 
   public List<Integer> chooseTasksForCustomStreamGrouping(String streamId, List<Object> values) {

--- a/heron/instance/src/java/com/twitter/heron/instance/OutgoingTupleCollection.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/OutgoingTupleCollection.java
@@ -18,7 +18,6 @@ import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.basics.SingletonRegistry;
 import com.twitter.heron.common.config.SystemConfig;
-import com.twitter.heron.common.utils.misc.PhysicalPlanHelper;
 import com.twitter.heron.proto.system.HeronTuples;
 
 /**
@@ -30,7 +29,7 @@ import com.twitter.heron.proto.system.HeronTuples;
  * In fact, when talking about to send out tuples, we mean we push them to the out queues.
  */
 public class OutgoingTupleCollection {
-  protected final PhysicalPlanHelper helper;
+  protected final String componentName;
   // We have just one outQueue responsible for both control tuples and data tuples
   private final Communicator<HeronTuples.HeronTupleSet> outQueue;
   private final SystemConfig systemConfig;
@@ -50,10 +49,10 @@ public class OutgoingTupleCollection {
   private int controlTupleSetCapacity;
 
   public OutgoingTupleCollection(
-      PhysicalPlanHelper helper,
+      String componentName,
       Communicator<HeronTuples.HeronTupleSet> outQueue) {
     this.outQueue = outQueue;
-    this.helper = helper;
+    this.componentName = componentName;
     this.systemConfig =
         (SystemConfig) SingletonRegistry.INSTANCE.getSingleton(SystemConfig.HERON_SYSTEM_CONFIG);
 
@@ -119,7 +118,7 @@ public class OutgoingTupleCollection {
 
     TopologyAPI.StreamId.Builder sbldr = TopologyAPI.StreamId.newBuilder();
     sbldr.setId(streamId);
-    sbldr.setComponentName(helper.getMyComponent());
+    sbldr.setComponentName(componentName);
     currentDataTuple = HeronTuples.HeronDataTupleSet.newBuilder();
     currentDataTuple.setStream(sbldr);
   }

--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
@@ -16,7 +16,6 @@ package com.twitter.heron.instance.bolt;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Logger;
 
 import com.twitter.heron.api.Config;
 import com.twitter.heron.api.bolt.IBolt;
@@ -41,19 +40,19 @@ import com.twitter.heron.instance.IInstance;
 import com.twitter.heron.proto.system.HeronTuples;
 
 public class BoltInstance implements IInstance {
-  private static final Logger LOG = Logger.getLogger(BoltInstance.class.getName());
 
   private final PhysicalPlanHelper helper;
-  private final IBolt bolt;
-  private final BoltOutputCollectorImpl collector;
-  private final IPluggableSerializer serializer;
-  private final BoltMetrics boltMetrics;
+  protected final IBolt bolt;
+  protected final BoltOutputCollectorImpl collector;
+  protected final IPluggableSerializer serializer;
+  protected final BoltMetrics boltMetrics;
   // The bolt will read Data tuples from streamInQueue
   private final Communicator<HeronTuples.HeronTupleSet> streamInQueue;
 
   private final SlaveLooper looper;
 
   private final SystemConfig systemConfig;
+  private TopologyContextImpl topologyContext;
 
   public BoltInstance(PhysicalPlanHelper helper,
                       Communicator<HeronTuples.HeronTupleSet> streamInQueue,
@@ -62,17 +61,16 @@ public class BoltInstance implements IInstance {
     this.helper = helper;
     this.looper = looper;
     this.streamInQueue = streamInQueue;
-
     this.boltMetrics = new BoltMetrics();
     this.boltMetrics.initMultiCountMetrics(helper);
+    this.topologyContext = helper.getTopologyContext();
+    this.serializer = SerializeDeSerializeHelper.getSerializer(topologyContext.getTopologyConfig());
+    this.systemConfig = (SystemConfig) SingletonRegistry.INSTANCE.getSingleton(
+        SystemConfig.HERON_SYSTEM_CONFIG);
 
     if (helper.getMyBolt() == null) {
       throw new RuntimeException("HeronBoltInstance has no bolt in physical plan.");
     }
-    TopologyContextImpl topologyContext = helper.getTopologyContext();
-    serializer = SerializeDeSerializeHelper.getSerializer(topologyContext.getTopologyConfig());
-    systemConfig = (SystemConfig) SingletonRegistry.INSTANCE.getSingleton(
-        SystemConfig.HERON_SYSTEM_CONFIG);
 
     // Get the bolt. Notice, in fact, we will always use the deserialization way to get bolt.
     if (helper.getMyBolt().getComp().hasSerializedObject()) {
@@ -97,7 +95,6 @@ public class BoltInstance implements IInstance {
 
   @Override
   public void start() {
-    TopologyContextImpl topologyContext = helper.getTopologyContext();
 
     // Initialize the GlobalMetrics
     GlobalMetrics.init(topologyContext, systemConfig.getHeronMetricsExportIntervalSec());
@@ -112,7 +109,7 @@ public class BoltInstance implements IInstance {
     topologyContext.invokeHookPrepare();
 
     // Init the CustomStreamGrouping
-    helper.prepareForCustomStreamGrouping(topologyContext);
+    helper.prepareForCustomStreamGrouping();
 
     addBoltTasks();
   }
@@ -120,7 +117,7 @@ public class BoltInstance implements IInstance {
   @Override
   public void stop() {
     // Invoke clean up hook before clean() is called
-    helper.getTopologyContext().invokeHookCleanup();
+    topologyContext.invokeHookCleanup();
 
     // Delegate to user-defined clean-up method
     bolt.cleanup();
@@ -169,7 +166,6 @@ public class BoltInstance implements IInstance {
     while (!inQueue.isEmpty()) {
       HeronTuples.HeronTupleSet tuples = inQueue.poll();
 
-      TopologyContextImpl topologyContext = helper.getTopologyContext();
       // Handle the tuples
       if (tuples.hasControl()) {
         throw new RuntimeException("Bolt cannot get acks/fails from other components");
@@ -218,17 +214,15 @@ public class BoltInstance implements IInstance {
 
   @Override
   public void activate() {
-
   }
 
   @Override
   public void deactivate() {
-
   }
 
   private void PrepareTickTupleTimer() {
     Object tickTupleFreqSecs =
-        helper.getTopologyContext().getTopologyConfig().get(Config.TOPOLOGY_TICK_TUPLE_FREQ_SECS);
+        topologyContext.getTopologyConfig().get(Config.TOPOLOGY_TICK_TUPLE_FREQ_SECS);
 
     if (tickTupleFreqSecs != null) {
       int freq = TypeUtils.getInteger(tickTupleFreqSecs);

--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltOutputCollectorImpl.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltOutputCollectorImpl.java
@@ -31,7 +31,6 @@ import com.twitter.heron.api.tuple.Tuple;
 import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.utils.metrics.BoltMetrics;
 import com.twitter.heron.common.utils.misc.PhysicalPlanHelper;
-import com.twitter.heron.common.utils.topology.TopologyContextImpl;
 import com.twitter.heron.common.utils.tuple.TupleImpl;
 import com.twitter.heron.instance.OutgoingTupleCollection;
 import com.twitter.heron.proto.system.HeronTuples;
@@ -62,8 +61,7 @@ public class BoltOutputCollectorImpl implements IOutputCollector {
 
   // Reference to update the bolt metrics
   private final BoltMetrics boltMetrics;
-  private final PhysicalPlanHelper helper;
-  private final TopologyContextImpl topologyContext;
+  private PhysicalPlanHelper helper;
 
   private final boolean ackEnabled;
 
@@ -77,11 +75,10 @@ public class BoltOutputCollectorImpl implements IOutputCollector {
     }
 
     this.serializer = serializer;
-    this.helper = helper;
     this.boltMetrics = boltMetrics;
-    this.topologyContext = helper.getTopologyContext();
+    updatePhysicalPlanHelper(helper);
 
-    Map<String, Object> config = topologyContext.getTopologyConfig();
+    Map<String, Object> config = helper.getTopologyContext().getTopologyConfig();
     if (config.containsKey(Config.TOPOLOGY_ENABLE_ACKING)
         && config.get(Config.TOPOLOGY_ENABLE_ACKING) != null) {
       this.ackEnabled = Boolean.parseBoolean(config.get(Config.TOPOLOGY_ENABLE_ACKING).toString());
@@ -89,7 +86,11 @@ public class BoltOutputCollectorImpl implements IOutputCollector {
       this.ackEnabled = false;
     }
 
-    this.outputter = new OutgoingTupleCollection(helper, streamOutQueue);
+    this.outputter = new OutgoingTupleCollection(helper.getMyComponent(), streamOutQueue);
+  }
+
+  public void updatePhysicalPlanHelper(PhysicalPlanHelper physicalPlanHelper) {
+    this.helper = physicalPlanHelper;
   }
 
   /////////////////////////////////////////////////////////
@@ -181,7 +182,7 @@ public class BoltOutputCollectorImpl implements IOutputCollector {
     }
 
     // Invoke user-defined emit task hook
-    topologyContext.invokeHookEmit(tuple, streamId, customGroupingTargetTaskIds);
+    helper.getTopologyContext().invokeHookEmit(tuple, streamId, customGroupingTargetTaskIds);
 
     // Set the anchors for a tuple
     if (anchors != null) {
@@ -240,7 +241,7 @@ public class BoltOutputCollectorImpl implements IOutputCollector {
     }
 
     // Invoke user-defined boltAck task hook
-    topologyContext.invokeHookBoltAck(tuple, latency);
+    helper.getTopologyContext().invokeHookBoltAck(tuple, latency);
 
     boltMetrics.ackedTuple(tuple.getSourceStreamId(), tuple.getSourceComponent(), latency);
   }
@@ -267,7 +268,7 @@ public class BoltOutputCollectorImpl implements IOutputCollector {
     }
 
     // Invoke user-defined boltFail task hook
-    topologyContext.invokeHookBoltFail(tuple, latency);
+    helper.getTopologyContext().invokeHookBoltFail(tuple, latency);
 
     boltMetrics.failedTuple(tuple.getSourceStreamId(), tuple.getSourceComponent(), latency);
   }

--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltOutputCollectorImpl.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltOutputCollectorImpl.java
@@ -89,7 +89,7 @@ public class BoltOutputCollectorImpl implements IOutputCollector {
     this.outputter = new OutgoingTupleCollection(helper.getMyComponent(), streamOutQueue);
   }
 
-  public void updatePhysicalPlanHelper(PhysicalPlanHelper physicalPlanHelper) {
+  void updatePhysicalPlanHelper(PhysicalPlanHelper physicalPlanHelper) {
     this.helper = physicalPlanHelper;
   }
 

--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltOutputCollectorImpl.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltOutputCollectorImpl.java
@@ -104,7 +104,7 @@ public class BoltOutputCollectorImpl implements IOutputCollector {
       String streamId,
       Collection<Tuple> anchors,
       List<Object> tuple) {
-    admitBoltTuple(taskId, streamId, anchors, tuple);
+    throw new RuntimeException("emitDirect not supported");
   }
 
   @Override
@@ -213,11 +213,6 @@ public class BoltOutputCollectorImpl implements IOutputCollector {
 
     // TODO:- remove this after changing the api
     return null;
-  }
-
-  private void admitBoltTuple(
-      int taskId, String streamId, Collection<Tuple> anchors, List<Object> tuple) {
-    throw new RuntimeException("emitDirect not supported");
   }
 
   private void admitAckTuple(Tuple tuple) {

--- a/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutOutputCollectorImpl.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutOutputCollectorImpl.java
@@ -116,7 +116,7 @@ public class SpoutOutputCollectorImpl implements ISpoutOutputCollector {
 
   @Override
   public void emitDirect(int taskId, String streamId, List<Object> tuple, Object messageId) {
-    admitSpoutTuple(taskId, streamId, tuple, messageId);
+    throw new RuntimeException("emitDirect Not implemented");
   }
 
   // Log the report error and also send the stack trace to metrics manager.
@@ -247,10 +247,6 @@ public class SpoutOutputCollectorImpl implements ISpoutOutputCollector {
 
     // TODO:- remove this after changing the api
     return null;
-  }
-
-  private void admitSpoutTuple(int taskId, String streamId, List<Object> tuple, Object messageId) {
-    throw new RuntimeException("emitDirect Not implemented");
   }
 
   private HeronTuples.RootId.Builder EstablishRootId(RootTupleInfo tupleInfo) {

--- a/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutOutputCollectorImpl.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutOutputCollectorImpl.java
@@ -79,7 +79,6 @@ public class SpoutOutputCollectorImpl implements ISpoutOutputCollector {
     }
 
     this.serializer = serializer;
-    this.helper = helper;
     this.spoutMetrics = spoutMetrics;
     this.keyGenerator = new TupleKeyGenerator();
     updatePhysicalPlanHelper(helper);
@@ -105,7 +104,7 @@ public class SpoutOutputCollectorImpl implements ISpoutOutputCollector {
     this.outputter = new OutgoingTupleCollection(helper.getMyComponent(), streamOutQueue);
   }
 
-  public void updatePhysicalPlanHelper(PhysicalPlanHelper physicalPlanHelper) {
+  void updatePhysicalPlanHelper(PhysicalPlanHelper physicalPlanHelper) {
     this.helper = physicalPlanHelper;
   }
 

--- a/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutOutputCollectorImpl.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutOutputCollectorImpl.java
@@ -33,10 +33,8 @@ import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.utils.metrics.SpoutMetrics;
 import com.twitter.heron.common.utils.misc.PhysicalPlanHelper;
 import com.twitter.heron.common.utils.misc.TupleKeyGenerator;
-import com.twitter.heron.common.utils.topology.TopologyContextImpl;
 import com.twitter.heron.instance.OutgoingTupleCollection;
 import com.twitter.heron.proto.system.HeronTuples;
-
 
 /**
  * SpoutOutputCollectorImpl is used by bolt to emit tuples, it contains:
@@ -60,9 +58,7 @@ public class SpoutOutputCollectorImpl implements ISpoutOutputCollector {
   private final TupleKeyGenerator keyGenerator;
 
   private final SpoutMetrics spoutMetrics;
-  private final PhysicalPlanHelper helper;
-  private final TopologyContextImpl topologyContext;
-  private final int myTaskId;
+  private PhysicalPlanHelper helper;
 
   private final boolean ackingEnabled;
   // When acking is not enabled, if the spout does an emit with a anchor
@@ -86,13 +82,12 @@ public class SpoutOutputCollectorImpl implements ISpoutOutputCollector {
     this.helper = helper;
     this.spoutMetrics = spoutMetrics;
     this.keyGenerator = new TupleKeyGenerator();
-    this.topologyContext = helper.getTopologyContext();
-    this.myTaskId = helper.getMyTaskId();
+    updatePhysicalPlanHelper(helper);
 
     // with default capacity, load factor and insertion order
     inFlightTuples = new LinkedHashMap<Long, RootTupleInfo>();
 
-    Map<String, Object> config = topologyContext.getTopologyConfig();
+    Map<String, Object> config = helper.getTopologyContext().getTopologyConfig();
     if (config.containsKey(Config.TOPOLOGY_ENABLE_ACKING)
         && config.get(Config.TOPOLOGY_ENABLE_ACKING) != null) {
       this.ackingEnabled =
@@ -107,7 +102,11 @@ public class SpoutOutputCollectorImpl implements ISpoutOutputCollector {
       immediateAcks = null;
     }
 
-    this.outputter = new OutgoingTupleCollection(helper, streamOutQueue);
+    this.outputter = new OutgoingTupleCollection(helper.getMyComponent(), streamOutQueue);
+  }
+
+  public void updatePhysicalPlanHelper(PhysicalPlanHelper physicalPlanHelper) {
+    this.helper = physicalPlanHelper;
   }
 
   /////////////////////////////////////////////////////////
@@ -222,7 +221,7 @@ public class SpoutOutputCollectorImpl implements ISpoutOutputCollector {
     }
 
     // Invoke user-defined emit task hook
-    topologyContext.invokeHookEmit(tuple, streamId, customGroupingTargetTaskIds);
+    helper.getTopologyContext().invokeHookEmit(tuple, streamId, customGroupingTargetTaskIds);
 
     if (messageId != null) {
       RootTupleInfo tupleInfo = new RootTupleInfo(streamId, messageId);
@@ -258,7 +257,7 @@ public class SpoutOutputCollectorImpl implements ISpoutOutputCollector {
     // This message is rooted
     long rootId = keyGenerator.next();
     HeronTuples.RootId.Builder rtbldr = HeronTuples.RootId.newBuilder();
-    rtbldr.setTaskid(myTaskId);
+    rtbldr.setTaskid(helper.getMyTaskId());
     rtbldr.setKey(rootId);
     inFlightTuples.put(rootId, tupleInfo);
     return rtbldr;

--- a/heron/simulator/src/java/BUILD
+++ b/heron/simulator/src/java/BUILD
@@ -9,6 +9,7 @@ simulator_deps_files = \
         "//heron/api/src/java:api-java",
         "//heron/spi/src/java:utils-spi-java",
         "//heron/common/src/java:common-java",
+        "//heron/instance/src/java:instance-java",
         "@org_yaml_snakeyaml//jar",
     ]
 

--- a/heron/simulator/src/java/com/twitter/heron/simulator/executors/InstanceExecutor.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/executors/InstanceExecutor.java
@@ -100,14 +100,8 @@ public class InstanceExecutor implements Runnable {
 
   protected IInstance createInstance() {
     return (physicalPlanHelper.getMySpout() != null)
-        ? new SpoutInstance(physicalPlanHelper,
-        streamInQueue,
-        streamOutQueue,
-        looper)
-        : new BoltInstance(physicalPlanHelper,
-        streamInQueue,
-        streamOutQueue,
-        looper);
+        ? new SpoutInstance(physicalPlanHelper, streamInQueue, streamOutQueue, looper)
+        : new BoltInstance(physicalPlanHelper, streamInQueue, streamOutQueue, looper);
   }
 
   protected PhysicalPlanHelper createPhysicalPlanHelper(PhysicalPlans.PhysicalPlan physicalPlan,

--- a/heron/simulator/src/java/com/twitter/heron/simulator/instance/BoltInstance.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/instance/BoltInstance.java
@@ -26,7 +26,6 @@ import com.twitter.heron.common.basics.SingletonRegistry;
 import com.twitter.heron.common.basics.SlaveLooper;
 import com.twitter.heron.common.config.SystemConfig;
 import com.twitter.heron.common.utils.misc.PhysicalPlanHelper;
-import com.twitter.heron.common.utils.topology.TopologyContextImpl;
 import com.twitter.heron.common.utils.tuple.TupleImpl;
 import com.twitter.heron.proto.system.HeronTuples;
 
@@ -35,14 +34,12 @@ public class BoltInstance
 
   private final long instanceExecuteBatchTime;
   private final long instanceExecuteBatchSize;
-  private TopologyContextImpl topologyContext;
 
   public BoltInstance(PhysicalPlanHelper helper,
                       Communicator<HeronTuples.HeronTupleSet> streamInQueue,
                       Communicator<HeronTuples.HeronTupleSet> streamOutQueue,
                       SlaveLooper looper) {
     super(helper, streamInQueue, streamOutQueue, looper);
-    this.topologyContext = helper.getTopologyContext();
     SystemConfig systemConfig =
         (SystemConfig) SingletonRegistry.INSTANCE.getSingleton(SystemConfig.HERON_SYSTEM_CONFIG);
 
@@ -62,7 +59,7 @@ public class BoltInstance
     }
 
     // Decode the tuple
-    TupleImpl t = new TupleImpl(topologyContext, stream, dataTuple.getKey(),
+    TupleImpl t = new TupleImpl(helper.getTopologyContext(), stream, dataTuple.getKey(),
         dataTuple.getRootsList(), values);
 
     long deserializedTime = System.nanoTime();
@@ -73,7 +70,7 @@ public class BoltInstance
     long executeLatency = System.nanoTime() - deserializedTime;
 
     // Invoke user-defined execute task hook
-    topologyContext.invokeHookBoltExecute(t, executeLatency);
+    helper.getTopologyContext().invokeHookBoltExecute(t, executeLatency);
 
     boltMetrics.deserializeDataTuple(stream.getId(), stream.getComponentName(),
         deserializedTime - startTime);

--- a/heron/simulator/src/java/com/twitter/heron/simulator/instance/BoltInstance.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/instance/BoltInstance.java
@@ -16,152 +16,43 @@ package com.twitter.heron.simulator.instance;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Logger;
 
 import com.google.protobuf.ByteString;
 
-import com.twitter.heron.api.Config;
-import com.twitter.heron.api.bolt.IBolt;
-import com.twitter.heron.api.bolt.OutputCollector;
 import com.twitter.heron.api.generated.TopologyAPI;
-import com.twitter.heron.api.metric.GlobalMetrics;
-import com.twitter.heron.api.serializer.IPluggableSerializer;
-import com.twitter.heron.api.utils.Utils;
 import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.basics.Constants;
 import com.twitter.heron.common.basics.SingletonRegistry;
 import com.twitter.heron.common.basics.SlaveLooper;
-import com.twitter.heron.common.basics.TypeUtils;
 import com.twitter.heron.common.config.SystemConfig;
-import com.twitter.heron.common.utils.metrics.BoltMetrics;
 import com.twitter.heron.common.utils.misc.PhysicalPlanHelper;
-import com.twitter.heron.common.utils.misc.SerializeDeSerializeHelper;
 import com.twitter.heron.common.utils.topology.TopologyContextImpl;
-import com.twitter.heron.common.utils.tuple.TickTuple;
 import com.twitter.heron.common.utils.tuple.TupleImpl;
 import com.twitter.heron.proto.system.HeronTuples;
 
-public class BoltInstance implements IInstance {
-  private static final Logger LOG = Logger.getLogger(BoltInstance.class.getName());
+public class BoltInstance
+    extends com.twitter.heron.instance.bolt.BoltInstance implements IInstance {
 
-  private final PhysicalPlanHelper helper;
-  private final IBolt bolt;
-  private final BoltOutputCollectorImpl collector;
-  private final IPluggableSerializer serializer;
-  private final BoltMetrics boltMetrics;
-  // The bolt will read Data tuples from streamInQueue
-  private final Communicator<HeronTuples.HeronTupleSet> streamInQueue;
-
-  private final SlaveLooper looper;
-
-  private final SystemConfig systemConfig;
+  private final long instanceExecuteBatchTime;
+  private final long instanceExecuteBatchSize;
+  private TopologyContextImpl topologyContext;
 
   public BoltInstance(PhysicalPlanHelper helper,
                       Communicator<HeronTuples.HeronTupleSet> streamInQueue,
                       Communicator<HeronTuples.HeronTupleSet> streamOutQueue,
                       SlaveLooper looper) {
-    this.helper = helper;
-    this.looper = looper;
-    this.streamInQueue = streamInQueue;
+    super(helper, streamInQueue, streamOutQueue, looper);
+    this.topologyContext = helper.getTopologyContext();
+    SystemConfig systemConfig =
+        (SystemConfig) SingletonRegistry.INSTANCE.getSingleton(SystemConfig.HERON_SYSTEM_CONFIG);
 
-    this.boltMetrics = new BoltMetrics();
-    this.boltMetrics.initMultiCountMetrics(helper);
+    this.instanceExecuteBatchTime
+        = systemConfig.getInstanceExecuteBatchTimeMs() * Constants.MILLISECONDS_TO_NANOSECONDS;
+    this.instanceExecuteBatchSize = systemConfig.getInstanceExecuteBatchSizeBytes();
 
-    if (helper.getMyBolt() == null) {
-      throw new RuntimeException("HeronBoltInstance has no bolt in physical plan.");
-    }
-    TopologyContextImpl topologyContext = helper.getTopologyContext();
-    serializer = SerializeDeSerializeHelper.getSerializer(topologyContext.getTopologyConfig());
-    systemConfig = (SystemConfig) SingletonRegistry.INSTANCE.getSingleton(
-        SystemConfig.HERON_SYSTEM_CONFIG);
-
-    // Get the bolt. Notice, in fact, we will always use the deserialization way to get bolt.
-    if (helper.getMyBolt().getComp().hasSerializedObject()) {
-      bolt = (IBolt) Utils.deserialize(
-          helper.getMyBolt().getComp().getSerializedObject().toByteArray());
-    } else if (helper.getMyBolt().getComp().hasClassName()) {
-      try {
-        String boltClassName = helper.getMyBolt().getComp().getClassName();
-        bolt = (IBolt) Class.forName(boltClassName).newInstance();
-      } catch (ClassNotFoundException ex) {
-        throw new RuntimeException(ex + " Bolt class must be in class path.");
-      } catch (InstantiationException ex) {
-        throw new RuntimeException(ex + " Bolt class must be concrete.");
-      } catch (IllegalAccessException ex) {
-        throw new RuntimeException(ex + " Bolt class must have a no-arg constructor.");
-      }
-    } else {
-      throw new RuntimeException("Neither java_object nor java_class_name set for bolt");
-    }
-    collector = new BoltOutputCollectorImpl(serializer, helper, streamOutQueue, boltMetrics);
-  }
-
-  @Override
-  public void start() {
-    TopologyContextImpl topologyContext = helper.getTopologyContext();
-
-    // Initialize the GlobalMetrics
-    GlobalMetrics.init(topologyContext, systemConfig.getHeronMetricsExportIntervalSec());
-
-    boltMetrics.registerMetrics(topologyContext);
-
-    // Delegate
-    bolt.prepare(topologyContext.getTopologyConfig(), topologyContext,
-        new OutputCollector(collector));
-
-    // Invoke user-defined prepare task hook
-    topologyContext.invokeHookPrepare();
-
-    // Init the CustomStreamGrouping
-    helper.prepareForCustomStreamGrouping(topologyContext);
-
-    addBoltTasks();
-  }
-
-  @Override
-  public void stop() {
-    // Invoke clean up hook before clean() is called
-    helper.getTopologyContext().invokeHookCleanup();
-
-    // Delegate to user-defined clean-up method
-    bolt.cleanup();
-
-    // Clean the resources we own
-    looper.exitLoop();
-    streamInQueue.clear();
-    collector.clear();
-  }
-
-  private void addBoltTasks() {
-    // add the readTupleAndExecute() to tasks
-    Runnable boltTasks = new Runnable() {
-      @Override
-      public void run() {
-        // Back-pressure -- only when we could send out tuples will we read & execute tuples
-        if (collector.isOutQueuesAvailable()) {
-          readTuplesAndExecute(streamInQueue);
-
-          // Though we may execute MAX_READ tuples, finally we will packet it as
-          // one outgoingPacket and push to out queues
-          collector.sendOutTuples();
-          // Here we need to inform the Gateway
-        } else {
-          boltMetrics.updateOutQueueFullCount();
-        }
-
-        // If there are more to read, we will wake up itself next time when it doWait()
-        if (collector.isOutQueuesAvailable() && !streamInQueue.isEmpty()) {
-          looper.wakeUp();
-        }
-      }
-    };
-    looper.addTasksOnWakeup(boltTasks);
-
-    PrepareTickTupleTimer();
   }
 
   private void handleDataTuple(HeronTuples.HeronDataTuple dataTuple,
-                               TopologyContextImpl topologyContext,
                                TopologyAPI.StreamId stream) {
     long startTime = System.nanoTime();
 
@@ -197,16 +88,10 @@ public class BoltInstance implements IInstance {
 
     long totalDataEmittedInBytesBeforeCycle = collector.getTotalDataEmittedInBytes();
 
-    long instanceExecuteBatchTime
-        = systemConfig.getInstanceExecuteBatchTimeMs() * Constants.MILLISECONDS_TO_NANOSECONDS;
-
-    long instanceExecuteBatchSize = systemConfig.getInstanceExecuteBatchSizeBytes();
-
     // Read data from in Queues
     while (!inQueue.isEmpty()) {
       HeronTuples.HeronTupleSet tuples = inQueue.poll();
 
-      TopologyContextImpl topologyContext = helper.getTopologyContext();
       // Handle the tuples
       if (tuples.hasControl()) {
         throw new RuntimeException("Bolt cannot get acks/fails from other components");
@@ -214,7 +99,7 @@ public class BoltInstance implements IInstance {
       TopologyAPI.StreamId stream = tuples.getData().getStream();
 
       for (HeronTuples.HeronDataTuple dataTuple : tuples.getData().getTuplesList()) {
-        handleDataTuple(dataTuple, topologyContext, stream);
+        handleDataTuple(dataTuple, stream);
       }
 
       // To avoid spending too much time
@@ -228,44 +113,5 @@ public class BoltInstance implements IInstance {
         break;
       }
     }
-  }
-
-  @Override
-  public void activate() {
-
-  }
-
-  @Override
-  public void deactivate() {
-
-  }
-
-  private void PrepareTickTupleTimer() {
-    Object tickTupleFreqSecs =
-        helper.getTopologyContext().getTopologyConfig().get(Config.TOPOLOGY_TICK_TUPLE_FREQ_SECS);
-
-    if (tickTupleFreqSecs != null) {
-      int freq = TypeUtils.getInteger(tickTupleFreqSecs);
-
-      Runnable r = new Runnable() {
-        public void run() {
-          SendTickTuple();
-        }
-      };
-
-      looper.registerTimerEventInSeconds(freq, r);
-    }
-  }
-
-  private void SendTickTuple() {
-    TickTuple t = new TickTuple();
-    long startTime = System.nanoTime();
-    bolt.execute(t);
-    long latency = System.nanoTime() - startTime;
-    boltMetrics.executeTuple(t.getSourceStreamId(), t.getSourceComponent(), latency);
-
-    collector.sendOutTuples();
-    // reschedule ourselves again
-    PrepareTickTupleTimer();
   }
 }

--- a/heron/simulator/src/java/com/twitter/heron/simulator/instance/BoltOutputCollectorImpl.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/instance/BoltOutputCollectorImpl.java
@@ -47,7 +47,7 @@ import com.twitter.heron.proto.system.HeronTuples;
  * 2. Pack the tuple and submit the OutgoingTupleCollection's addDataTuple
  * 3. Update the metrics
  * <p>
- * For Control tuples (ack&amp;fail):
+ * For Control tuples (ack &amp; fail):
  * 1. Set the anchors for a tuple
  * 2. Pack the tuple and submit the OutgoingTupleCollection's addDataTuple
  * 3. Update the metrics
@@ -103,7 +103,7 @@ public class BoltOutputCollectorImpl implements IOutputCollector {
       String streamId,
       Collection<Tuple> anchors,
       List<Object> tuple) {
-    admitBoltTuple(taskId, streamId, anchors, tuple);
+    throw new RuntimeException("emitDirect not supported");
   }
 
   @Override
@@ -215,13 +215,6 @@ public class BoltOutputCollectorImpl implements IOutputCollector {
 
     // TODO:- remove this after changing the api
     return null;
-  }
-
-  private void admitBoltTuple(
-      int taskId,
-      String streamId,
-      Collection<Tuple> anchors, List<Object> tuple) {
-    throw new RuntimeException("emitDirect not supported");
   }
 
   private void admitAckTuple(Tuple tuple) {

--- a/heron/simulator/src/java/com/twitter/heron/simulator/instance/OutgoingTupleCollection.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/instance/OutgoingTupleCollection.java
@@ -18,7 +18,6 @@ import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.basics.SingletonRegistry;
 import com.twitter.heron.common.config.SystemConfig;
-import com.twitter.heron.common.utils.misc.PhysicalPlanHelper;
 import com.twitter.heron.proto.system.HeronTuples;
 
 /**
@@ -30,7 +29,7 @@ import com.twitter.heron.proto.system.HeronTuples;
  * In fact, when talking about to send out tuples, we mean we push them to the out queues.
  */
 public class OutgoingTupleCollection {
-  protected final PhysicalPlanHelper helper;
+  protected final String componentName;
   // We have just one outQueue responsible for both control tuples and data tuples
   private final Communicator<HeronTuples.HeronTupleSet> outQueue;
   private final SystemConfig systemConfig;
@@ -50,10 +49,10 @@ public class OutgoingTupleCollection {
   private int controlTupleSetCapacity;
 
   public OutgoingTupleCollection(
-      PhysicalPlanHelper helper,
+      String componentName,
       Communicator<HeronTuples.HeronTupleSet> outQueue) {
     this.outQueue = outQueue;
-    this.helper = helper;
+    this.componentName = componentName;
     this.systemConfig =
         (SystemConfig) SingletonRegistry.INSTANCE.getSingleton(SystemConfig.HERON_SYSTEM_CONFIG);
 
@@ -119,7 +118,7 @@ public class OutgoingTupleCollection {
 
     TopologyAPI.StreamId.Builder sbldr = TopologyAPI.StreamId.newBuilder();
     sbldr.setId(streamId);
-    sbldr.setComponentName(helper.getMyComponent());
+    sbldr.setComponentName(componentName);
     currentDataTuple = HeronTuples.HeronDataTupleSet.newBuilder();
     currentDataTuple.setStream(sbldr);
   }

--- a/heron/simulator/src/java/com/twitter/heron/simulator/instance/SpoutInstance.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/instance/SpoutInstance.java
@@ -24,9 +24,7 @@ import com.twitter.heron.common.basics.SlaveLooper;
 import com.twitter.heron.common.basics.TypeUtils;
 import com.twitter.heron.common.config.SystemConfig;
 import com.twitter.heron.common.utils.misc.PhysicalPlanHelper;
-import com.twitter.heron.common.utils.topology.TopologyContextImpl;
 import com.twitter.heron.proto.system.HeronTuples;
-
 
 public class SpoutInstance
     extends com.twitter.heron.instance.spout.SpoutInstance implements IInstance {
@@ -40,8 +38,7 @@ public class SpoutInstance
                        Communicator<HeronTuples.HeronTupleSet> streamInQueue,
                        Communicator<HeronTuples.HeronTupleSet> streamOutQueue, SlaveLooper looper) {
     super(helper, streamInQueue, streamOutQueue, looper);
-    TopologyContextImpl topologyContext = helper.getTopologyContext();
-    Map<String, Object> config = topologyContext.getTopologyConfig();
+    Map<String, Object> config = helper.getTopologyContext().getTopologyConfig();
     SystemConfig systemConfig =
         (SystemConfig) SingletonRegistry.INSTANCE.getSingleton(SystemConfig.HERON_SYSTEM_CONFIG);
 

--- a/heron/simulator/src/java/com/twitter/heron/simulator/instance/SpoutInstance.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/instance/SpoutInstance.java
@@ -14,250 +14,53 @@
 
 package com.twitter.heron.simulator.instance;
 
-import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
 
 import com.twitter.heron.api.Config;
-import com.twitter.heron.api.generated.TopologyAPI;
-import com.twitter.heron.api.metric.GlobalMetrics;
-import com.twitter.heron.api.serializer.IPluggableSerializer;
-import com.twitter.heron.api.spout.ISpout;
-import com.twitter.heron.api.spout.SpoutOutputCollector;
-import com.twitter.heron.api.utils.Utils;
 import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.basics.Constants;
 import com.twitter.heron.common.basics.SingletonRegistry;
 import com.twitter.heron.common.basics.SlaveLooper;
 import com.twitter.heron.common.basics.TypeUtils;
 import com.twitter.heron.common.config.SystemConfig;
-import com.twitter.heron.common.utils.metrics.SpoutMetrics;
 import com.twitter.heron.common.utils.misc.PhysicalPlanHelper;
-import com.twitter.heron.common.utils.misc.SerializeDeSerializeHelper;
 import com.twitter.heron.common.utils.topology.TopologyContextImpl;
 import com.twitter.heron.proto.system.HeronTuples;
 
 
-public class SpoutInstance implements IInstance {
-  private static final Logger LOG = Logger.getLogger(SpoutInstance.class.getName());
-
-  private final ISpout spout;
-  private final SpoutOutputCollectorImpl collector;
-  private final IPluggableSerializer serializer;
-  private final SpoutMetrics spoutMetrics;
-  // The spout will read Control tuples from streamInQueue
-  private final Communicator<HeronTuples.HeronTupleSet> streamInQueue;
+public class SpoutInstance
+    extends com.twitter.heron.instance.spout.SpoutInstance implements IInstance {
 
   private final boolean ackEnabled;
-  private final boolean enableMessageTimeouts;
+  private final int maxSpoutPending;
+  private final long instanceEmitBatchTime;
+  private final long instanceEmitBatchSize;
 
-  private final SlaveLooper looper;
-
-  private final SystemConfig systemConfig;
-
-  // The reference to topology's config
-  private final Map<String, Object> config;
-
-  private PhysicalPlanHelper helper;
-
-  private TopologyAPI.TopologyState topologyState;
-
-  /**
-   * Spout instance constructor
-   */
   public SpoutInstance(PhysicalPlanHelper helper,
                        Communicator<HeronTuples.HeronTupleSet> streamInQueue,
-                       Communicator<HeronTuples.HeronTupleSet> streamOutQueue,
-                       SlaveLooper looper) {
-    this.helper = helper;
-    this.looper = looper;
-    this.streamInQueue = streamInQueue;
-
-    this.spoutMetrics = new SpoutMetrics();
-    this.spoutMetrics.initMultiCountMetrics(helper);
-
+                       Communicator<HeronTuples.HeronTupleSet> streamOutQueue, SlaveLooper looper) {
+    super(helper, streamInQueue, streamOutQueue, looper);
     TopologyContextImpl topologyContext = helper.getTopologyContext();
-    config = topologyContext.getTopologyConfig();
-    systemConfig = (SystemConfig) SingletonRegistry.INSTANCE.getSingleton(
-        SystemConfig.HERON_SYSTEM_CONFIG);
+    Map<String, Object> config = topologyContext.getTopologyConfig();
+    SystemConfig systemConfig =
+        (SystemConfig) SingletonRegistry.INSTANCE.getSingleton(SystemConfig.HERON_SYSTEM_CONFIG);
+
+    this.maxSpoutPending = TypeUtils.getInteger(config.get(Config.TOPOLOGY_MAX_SPOUT_PENDING));
+    this.instanceEmitBatchTime =
+        systemConfig.getInstanceEmitBatchTimeMs() * Constants.MILLISECONDS_TO_NANOSECONDS;
+    this.instanceEmitBatchSize = systemConfig.getInstanceEmitBatchSizeBytes();
     this.ackEnabled = Boolean.parseBoolean((String) config.get(Config.TOPOLOGY_ENABLE_ACKING));
-    this.enableMessageTimeouts = Boolean.parseBoolean(
-        (String) config.get(Config.TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS));
-    LOG.info("Enable Ack: " + this.ackEnabled);
-    LOG.info("EnableMessageTimeouts: " + this.enableMessageTimeouts);
-
-    if (helper.getMySpout() == null) {
-      throw new RuntimeException("HeronSpoutInstance has no spout in physical plan");
-    }
-    serializer = SerializeDeSerializeHelper.getSerializer(config);
-    // Get the spout. Notice, in fact, we will always use the deserialization way to get bolt.
-    if (helper.getMySpout().getComp().hasSerializedObject()) {
-      spout = (ISpout) Utils.deserialize(
-          helper.getMySpout().getComp().getSerializedObject().toByteArray());
-    } else if (helper.getMySpout().getComp().hasClassName()) {
-      String spoutClassName = helper.getMySpout().getComp().getClassName();
-      try {
-        spout = (ISpout) Class.forName(spoutClassName).newInstance();
-      } catch (ClassNotFoundException ex) {
-        throw new RuntimeException(ex + " Spout class must be in class path.");
-      } catch (InstantiationException ex) {
-        throw new RuntimeException(ex + " Spout class must be concrete.");
-      } catch (IllegalAccessException ex) {
-        throw new RuntimeException(ex + " Spout class must have a no-arg constructor.");
-      }
-    } else {
-      throw new RuntimeException("Neither java_object nor java_class_name set for spout");
-    }
-
-    collector = new SpoutOutputCollectorImpl(serializer, helper, streamOutQueue, spoutMetrics);
   }
 
   @Override
-  public void start() {
-    TopologyContextImpl topologyContext = helper.getTopologyContext();
-
-    // Initialize the GlobalMetrics
-    GlobalMetrics.init(topologyContext, systemConfig.getHeronMetricsExportIntervalSec());
-
-    spoutMetrics.registerMetrics(topologyContext);
-
-    spout.open(topologyContext.getTopologyConfig(), topologyContext,
-        new SpoutOutputCollector(collector));
-
-    // Invoke user-defined prepare task hook
-    topologyContext.invokeHookPrepare();
-
-    // Init the CustomStreamGrouping
-    helper.prepareForCustomStreamGrouping(topologyContext);
-
-    // Tasks happen in every time looper is waken up
-    addSpoutsTasks();
-
-    topologyState = TopologyAPI.TopologyState.RUNNING;
-  }
-
-  @Override
-  public void stop() {
-    // Invoke clean up hook before clean() is called
-    helper.getTopologyContext().invokeHookCleanup();
-
-    // Delegate to user-defined clean-up method
-    spout.close();
-
-    // Clean the resources we own
-    looper.exitLoop();
-    streamInQueue.clear();
-    collector.clear();
-  }
-
-  @Override
-  public void activate() {
-    LOG.info("Spout is activated");
-    spout.activate();
-    topologyState = TopologyAPI.TopologyState.RUNNING;
-  }
-
-  @Override
-  public void deactivate() {
-    LOG.info("Spout is deactivated");
-    spout.deactivate();
-    topologyState = TopologyAPI.TopologyState.PAUSED;
-  }
-
-  // Tasks happen in every time looper is waken up
-  private void addSpoutsTasks() {
-    // Register spoutTasks
-    Runnable spoutTasks = new Runnable() {
-      @Override
-      public void run() {
-        // Check whether we should produce more tuples
-        if (isProduceTuple()) {
-          produceTuple();
-          // Though we may execute MAX_READ tuples, finally we will packet it as
-          // one outgoingPacket and push to out queues
-          // Notice: Tuples are not necessary emitted during nextTuple methods. We could emit
-          // tuples as long as we invoke collector.emit(...)
-          collector.sendOutTuples();
-        }
-
-        if (!collector.isOutQueuesAvailable()) {
-          spoutMetrics.updateOutQueueFullCount();
-        }
-
-        if (ackEnabled) {
-          readTuplesAndExecute(streamInQueue);
-
-          // Update the pending-to-be-acked tuples counts
-          spoutMetrics.updatePendingTuplesCount(collector.numInFlight());
-        } else {
-          doImmediateAcks();
-        }
-
-        // If we have more work to do
-        if (isContinueWork()) {
-          looper.wakeUp();
-        }
-      }
-    };
-    looper.addTasksOnWakeup(spoutTasks);
-
-    // Look for the timeout's tuples
-    if (enableMessageTimeouts) {
-      lookForTimeouts();
-    }
-  }
-
-  /**
-   * Check whether we still need to do more work.
-   * When the topology state is in RUNNING:
-   * 1. If the out Queue is not full and ack is not enabled, we could just wake up next time
-   * to produce more tuples and push to the out Queue
-   * <p>
-   * 2. It the out Queue is not full but the ack is enabled, we also need to make sure the
-   * tuples waiting smaller than msp
-   * <p>
-   * 3. If there are more to read, we will wake up itself next time when it doWait()
-   *
-   * @return true Wake up itself directly in next looper.doWait()
-   */
-  private boolean isContinueWork() {
-    long maxSpoutPending = TypeUtils.getLong(config.get(Config.TOPOLOGY_MAX_SPOUT_PENDING));
-    return topologyState.equals(TopologyAPI.TopologyState.RUNNING)
-        && ((!ackEnabled && collector.isOutQueuesAvailable())
-        || (ackEnabled && collector.isOutQueuesAvailable()
-        && collector.numInFlight() < maxSpoutPending)
-        || (ackEnabled && !streamInQueue.isEmpty()));
-  }
-
-  /**
-   * Check whether we could produce tuples, i.e. invoke spout.nextTuple()
-   * It is allowed in:
-   * 1. Outgoing Stream queue is available
-   * 2. Topology State is RUNNING
-   *
-   * @return true to allow produceTuple() to be invoked
-   */
-  private boolean isProduceTuple() {
-    return collector.isOutQueuesAvailable()
-        && topologyState.equals(TopologyAPI.TopologyState.RUNNING);
-  }
-
-  private void produceTuple() {
-    int maxSpoutPending = TypeUtils.getInteger(config.get(Config.TOPOLOGY_MAX_SPOUT_PENDING));
-
+  protected void produceTuple() {
     long totalTuplesEmitted = collector.getTotalTuplesEmitted();
 
     long totalDataEmittedInBytesBeforeCycle = collector.getTotalDataEmittedInBytes();
 
-    long instanceEmitBatchTime =
-        systemConfig.getInstanceEmitBatchTimeMs() * Constants.MILLISECONDS_TO_NANOSECONDS;
-
-    long instanceEmitBatchSize = systemConfig.getInstanceEmitBatchSizeBytes();
-
     long startOfCycle = System.nanoTime();
 
-    while ((ackEnabled && (maxSpoutPending > collector.numInFlight()))
-        || !ackEnabled) {
+    while (!ackEnabled || (maxSpoutPending > collector.numInFlight())) {
       // Delegate to the use defined spout
       long startTime = System.nanoTime();
       spout.nextTuple();
@@ -282,114 +85,5 @@ public class SpoutInstance implements IInstance {
         break;
       }
     }
-  }
-
-  private void handleAckTuple(HeronTuples.AckTuple ackTuple, boolean isSuccess) {
-    for (HeronTuples.RootId rt : ackTuple.getRootsList()) {
-      if (rt.getTaskid() != helper.getMyTaskId()) {
-        throw new RuntimeException(String.format("Receiving tuple for task %d in task %d",
-            rt.getTaskid(), helper.getMyTaskId()));
-      } else {
-        long rootId = rt.getKey();
-        RootTupleInfo rootTupleInfo = collector.retireInFlight(rootId);
-
-        // This tuple has been removed due to time-out
-        if (rootTupleInfo == null) {
-          return;
-        }
-        Object messageId = rootTupleInfo.getMessageId();
-        if (messageId != null) {
-          long latency = System.nanoTime() - rootTupleInfo.getInsertionTime();
-          if (isSuccess) {
-            invokeAck(messageId, rootTupleInfo.getStreamId(), latency);
-          } else {
-            invokeFail(messageId, rootTupleInfo.getStreamId(), latency);
-          }
-        }
-      }
-    }
-  }
-
-  private void lookForTimeouts() {
-    long timeoutInSeconds = TypeUtils.getLong(config.get(Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS));
-    long timeoutInNs = timeoutInSeconds * Constants.SECONDS_TO_NANOSECONDS;
-    int nBucket = systemConfig.getInstanceAcknowledgementNbuckets();
-    List<RootTupleInfo> expiredObjects = collector.retireExpired(timeoutInNs);
-    for (RootTupleInfo rootTupleInfo : expiredObjects) {
-      spoutMetrics.timeoutTuple(rootTupleInfo.getStreamId());
-      invokeFail(rootTupleInfo.getMessageId(), rootTupleInfo.getStreamId(), timeoutInNs);
-    }
-
-    Runnable lookForTimeoutsTask = new Runnable() {
-      @Override
-      public void run() {
-        lookForTimeouts();
-      }
-    };
-    looper.registerTimerEventInNanoSeconds(timeoutInNs / nBucket, lookForTimeoutsTask);
-  }
-
-  @Override
-  public void readTuplesAndExecute(Communicator<HeronTuples.HeronTupleSet> inQueue) {
-    // Read data from in Queues
-    long startOfCycle = System.nanoTime();
-    long spoutAckBatchTime = systemConfig.getInstanceAckBatchTimeMs()
-        * Constants.MILLISECONDS_TO_NANOSECONDS;
-
-    while (!inQueue.isEmpty()) {
-      HeronTuples.HeronTupleSet tuples = inQueue.poll();
-      // For spout, it should read only control tuples(ack&fail)
-      if (tuples.hasData()) {
-        throw new RuntimeException("Spout cannot get incoming data tuples from other components");
-      }
-
-      if (tuples.hasControl()) {
-        for (HeronTuples.AckTuple aT : tuples.getControl().getAcksList()) {
-          handleAckTuple(aT, true);
-        }
-        for (HeronTuples.AckTuple aT : tuples.getControl().getFailsList()) {
-          handleAckTuple(aT, false);
-        }
-      }
-
-      // To avoid spending too much time
-      if (System.nanoTime() - startOfCycle - spoutAckBatchTime > 0) {
-        break;
-      }
-    }
-  }
-
-  private void doImmediateAcks() {
-    // In this iteration, we will only look at the immediateAcks size
-    // Otherwise, it could be that eveytime we do an ack, the spout is
-    // doing generating another tuple leading to an infinite loop
-    int s = collector.getImmediateAcks().size();
-    for (int i = 0; i < s; ++i) {
-      RootTupleInfo tupleInfo = collector.getImmediateAcks().poll();
-      invokeAck(tupleInfo.getMessageId(), tupleInfo.getStreamId(), 0L);
-    }
-  }
-
-  private void invokeAck(Object messageId, String streamId, Long completeLatencyNs) {
-    // delegate to user-defined methods
-    spout.ack(messageId);
-
-    // Invoke user-defined task hooks
-    helper.getTopologyContext().invokeHookSpoutAck(messageId, completeLatencyNs);
-
-    // Update metrics
-    spoutMetrics.ackedTuple(streamId, completeLatencyNs);
-  }
-
-  private void invokeFail(Object messageId, String streamId, Long failLatencyNs) {
-    // delegate to user-defined methods
-    spout.fail(messageId);
-
-    // Invoke user-defined task hooks
-    helper.getTopologyContext().
-        invokeHookSpoutFail(messageId, failLatencyNs);
-
-    // Update metrics
-    spoutMetrics.failedTuple(streamId, failLatencyNs);
   }
 }

--- a/heron/simulator/src/java/com/twitter/heron/simulator/instance/SpoutOutputCollectorImpl.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/instance/SpoutOutputCollectorImpl.java
@@ -89,8 +89,8 @@ public class SpoutOutputCollectorImpl implements ISpoutOutputCollector {
     Map<String, Object> config = helper.getTopologyContext().getTopologyConfig();
     if (config.containsKey(Config.TOPOLOGY_ENABLE_ACKING)
         && config.get(Config.TOPOLOGY_ENABLE_ACKING) != null) {
-      this.ackingEnabled = Boolean.parseBoolean(
-          config.get(Config.TOPOLOGY_ENABLE_ACKING).toString());
+      this.ackingEnabled =
+          Boolean.parseBoolean(config.get(Config.TOPOLOGY_ENABLE_ACKING).toString());
     } else {
       this.ackingEnabled = false;
     }
@@ -115,7 +115,7 @@ public class SpoutOutputCollectorImpl implements ISpoutOutputCollector {
 
   @Override
   public void emitDirect(int taskId, String streamId, List<Object> tuple, Object messageId) {
-    admitSpoutTuple(taskId, streamId, tuple, messageId);
+    throw new RuntimeException("emitDirect Not implemented");
   }
 
   // Log the report error and also send the stack trace to metrics manager.
@@ -248,10 +248,6 @@ public class SpoutOutputCollectorImpl implements ISpoutOutputCollector {
 
     // TODO:- remove this after changing the api
     return null;
-  }
-
-  private void admitSpoutTuple(int taskId, String streamId, List<Object> tuple, Object messageId) {
-    throw new RuntimeException("emitDirect Not implemented");
   }
 
   private HeronTuples.RootId.Builder EstablishRootId(RootTupleInfo tupleInfo) {

--- a/heron/simulator/src/java/com/twitter/heron/simulator/instance/SpoutOutputCollectorImpl.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/instance/SpoutOutputCollectorImpl.java
@@ -33,8 +33,8 @@ import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.utils.metrics.SpoutMetrics;
 import com.twitter.heron.common.utils.misc.PhysicalPlanHelper;
 import com.twitter.heron.common.utils.misc.TupleKeyGenerator;
+import com.twitter.heron.common.utils.topology.TopologyContextImpl;
 import com.twitter.heron.proto.system.HeronTuples;
-
 
 /**
  * SpoutOutputCollectorImpl is used by bolt to emit tuples, it contains:
@@ -59,6 +59,8 @@ public class SpoutOutputCollectorImpl implements ISpoutOutputCollector {
 
   private final SpoutMetrics spoutMetrics;
   private final PhysicalPlanHelper helper;
+  private final TopologyContextImpl topologyContext;
+  private final int myTaskId;
 
   private final boolean ackingEnabled;
   // When acking is not enabled, if the spout does an emit with a anchor
@@ -82,11 +84,13 @@ public class SpoutOutputCollectorImpl implements ISpoutOutputCollector {
     this.helper = helper;
     this.spoutMetrics = spoutMetrics;
     this.keyGenerator = new TupleKeyGenerator();
+    this.topologyContext = helper.getTopologyContext();
+    this.myTaskId = helper.getMyTaskId();
 
     // with default capacity, load factor and insertion order
     inFlightTuples = new LinkedHashMap<Long, RootTupleInfo>();
 
-    Map<String, Object> config = helper.getTopologyContext().getTopologyConfig();
+    Map<String, Object> config = topologyContext.getTopologyConfig();
     if (config.containsKey(Config.TOPOLOGY_ENABLE_ACKING)
         && config.get(Config.TOPOLOGY_ENABLE_ACKING) != null) {
       this.ackingEnabled =
@@ -200,7 +204,7 @@ public class SpoutOutputCollectorImpl implements ISpoutOutputCollector {
         helper.chooseTasksForCustomStreamGrouping(streamId, tuple);
 
     // Invoke user-defined emit task hook
-    helper.getTopologyContext().invokeHookEmit(tuple, streamId, customGroupingTargetTaskIds);
+    topologyContext.invokeHookEmit(tuple, streamId, customGroupingTargetTaskIds);
 
     // Start construct the data tuple
     HeronTuples.HeronDataTuple.Builder bldr = HeronTuples.HeronDataTuple.newBuilder();
@@ -254,7 +258,7 @@ public class SpoutOutputCollectorImpl implements ISpoutOutputCollector {
     // This message is rooted
     long rootId = keyGenerator.next();
     HeronTuples.RootId.Builder rtbldr = HeronTuples.RootId.newBuilder();
-    rtbldr.setTaskid(helper.getMyTaskId());
+    rtbldr.setTaskid(myTaskId);
     rtbldr.setKey(rootId);
     inFlightTuples.put(rootId, tupleInfo);
     return rtbldr;

--- a/website/content/docs/developers/simulator-mode.md
+++ b/website/content/docs/developers/simulator-mode.md
@@ -9,10 +9,10 @@ Simulator mode simulates a heron cluster in a single JVM process, which is usefu
 testing topologies. Running topologies under simulator mode is similar to running topologies on a 
 cluster.
 
-# Develop topology with simulator mode
+# Develop a topology using simulator mode
 
-To use simulator mode, simply use the ``SimulatorMode`` class, which is
-in ``storm-compatibility-unshaded_deploy.jar``  (currently under ``bazel-bin/heron/storm/src/java``).
+To run in simulator mode, use the ``SimulatorMode`` class, which is
+in ``storm-compatibility-unshaded_deploy.jar``  (under ``bazel-bin/heron/storm/src/java``).
 
 For example:
 
@@ -49,12 +49,12 @@ corresponding behaviors interactively.
 # Debug topology using IntelliJ
 
 Bolts and Spouts run as separate threads in simulator. To add breakpoints inside a bolt/spout, the 
-Suspend Policy of the breakpoint needs to be set as Thread. To change the Suspend Policy, right 
+Suspend Policy of the breakpoint needs to be set to Thread. To change the Suspend Policy, right 
 click on the breakpoint as shown in the following image:
 
 ![Set Breakpoint](/img/intellij-set-breakpoint.jpg)
 
-If it's not convenient to check the output and logs in IntelliJ console, save them to a local file 
+If it's not convenient to check the output and logs in the IntelliJ console, save them to a local file 
 by choosing `Run -> Edit Configurations....` as shown in the following image:
 
 ![Save Console](/img/intellij-save-console.jpg)


### PR DESCRIPTION
No new functionality here, refactoring how `PhysicalPlanHelper` is used by `SpoutInstance` and `BoltInstnance` to make it easier to update the `TopologyContext`, which is required for #1509. I encountered a lot of duplicate code between the instance classes and the simulator classes so I removed much of that as well.