### PR TITLE
Fix redirectErrorStream for runASyncProcess

### DIFF
--- a/heron/spi/src/java/com/twitter/heron/spi/utils/ShellUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/ShellUtils.java
@@ -202,7 +202,7 @@ public final class ShellUtils {
     // be guaranteed alive when children processing trying to flush to
     // parent processes's IO.
     ProcessBuilder pb = getProcessBuilder(false, command, workingDirectory, envs);
-    pb.redirectErrorStream();
+    pb.redirectErrorStream(true);
 
     if (logStderr) {
       String logFilePath = String.format("%s/%s-%s.stderr",


### PR DESCRIPTION
`Process. redirectErrorStream` is no-op. Should use `Process.redirectErrorStream(Boolean)` instead.

This PR also fixes the wrong unit test `testRunAsyncProcess`.