### PR TITLE
Add PackingPlanBuilder

### DIFF
--- a/heron/packing/src/java/com/twitter/heron/packing/Container.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/Container.java
@@ -26,7 +26,7 @@ import com.twitter.heron.spi.packing.Resource;
  * Class that describes a container used to place Heron Instances with specific memory, Cpu and disk
  * requirements. Each container has limited ram, CpuCores and disk resources.
  */
-public class Container {
+class Container {
 
   private HashSet<PackingPlan.InstancePlan> instances;
 
@@ -53,7 +53,7 @@ public class Container {
    * @param capacity the capacity of the container in terms of cpu, ram and disk
    * @param paddingPercentage the padding percentage
    */
-  public Container(Resource capacity, int paddingPercentage) {
+  Container(Resource capacity, int paddingPercentage) {
     this.capacity = capacity;
     this.instances = new HashSet<PackingPlan.InstancePlan>();
     this.paddingPercentage = paddingPercentage;

--- a/heron/packing/src/java/com/twitter/heron/packing/Container.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/Container.java
@@ -70,9 +70,11 @@ public class Container {
     long newRam = usedResources.getRam() + resource.getRam();
     double newCpu = usedResources.getCpu() + resource.getCpu();
     long newDisk = usedResources.getDisk() + resource.getDisk();
-    return PackingUtils.increaseBy(newRam, paddingPercentage) <= this.capacity.getRam()
-        && Math.round(PackingUtils.increaseBy(newCpu, paddingPercentage)) <= this.capacity.getCpu()
-        && PackingUtils.increaseBy(newDisk, paddingPercentage) <= this.capacity.getDisk();
+    boolean ramOk = PackingUtils.increaseBy(newRam, paddingPercentage) <= this.capacity.getRam();
+    boolean cpuOk =
+        Math.round(PackingUtils.increaseBy(newCpu, paddingPercentage)) <= this.capacity.getCpu();
+    boolean diskOk = PackingUtils.increaseBy(newDisk, paddingPercentage) <= this.capacity.getDisk();
+    return ramOk && cpuOk && diskOk;
   }
 
   /**

--- a/heron/packing/src/java/com/twitter/heron/packing/PackingException.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/PackingException.java
@@ -14,12 +14,13 @@
 package com.twitter.heron.packing;
 
 /**
- * Thrown to indicate that the resources required are not available
+ * Thrown to indicate that an error occurred while creating a packing plan
  */
-public class ResourceExceededException extends Exception {
-  private static final long serialVersionUID = -3662229190395580148L;
+public class PackingException extends RuntimeException {
 
-  public ResourceExceededException(String message) {
+  private static final long serialVersionUID = -7361943148478221250L;
+
+  public PackingException(String message) {
     super(message);
   }
 }

--- a/heron/packing/src/java/com/twitter/heron/packing/PackingException.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/PackingException.java
@@ -17,7 +17,6 @@ package com.twitter.heron.packing;
  * Thrown to indicate that an error occurred while creating a packing plan
  */
 public class PackingException extends RuntimeException {
-
   private static final long serialVersionUID = -7361943148478221250L;
 
   public PackingException(String message) {

--- a/heron/packing/src/java/com/twitter/heron/packing/PackingPlanBuilder.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/PackingPlanBuilder.java
@@ -1,0 +1,187 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.twitter.heron.packing;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import com.google.common.base.Optional;
+
+import com.twitter.heron.spi.common.Constants;
+import com.twitter.heron.spi.packing.InstanceId;
+import com.twitter.heron.spi.packing.PackingPlan;
+import com.twitter.heron.spi.packing.Resource;
+
+/**
+ * Class the help with building packing plans.
+ */
+public class PackingPlanBuilder {
+  private static final Logger LOG = Logger.getLogger(PackingPlanBuilder.class.getName());
+  private static final long MIN_RAM_PER_INSTANCE = 192L * Constants.MB;
+
+  private final String topologyId;
+  private final PackingPlan existingPacking;
+  private Resource defaultInstanceResource;
+  private Resource maxContainerResource;
+  private Map<String, Long> componentRamMap;
+  private int requestedContainerPadding;
+  private int numContainers;
+
+  private Map<Integer, List<InstanceId>> containerInstances;
+  private List<Container> containers;
+
+  public PackingPlanBuilder(String topologyId) {
+    this(topologyId, null);
+  }
+
+  public PackingPlanBuilder(String topologyId, PackingPlan existingPacking) {
+    this.topologyId = topologyId;
+    this.existingPacking = existingPacking;
+    this.containerInstances = new HashMap<Integer, List<InstanceId>>();
+  }
+
+  // set resource settings
+  public PackingPlanBuilder setDefaultInstanceResource(Resource resource) {
+    this.defaultInstanceResource = resource;
+    return this;
+  }
+
+  public PackingPlanBuilder setMaxContainerResource(Resource resource) {
+    this.maxContainerResource = resource;
+    return this;
+  }
+
+  public PackingPlanBuilder setRequestedComponentRam(Map<String, Long> ramMap) {
+    this.componentRamMap = ramMap;
+    return this;
+  }
+
+  public PackingPlanBuilder setRequestedContainerPadding(int percent) {
+    this.requestedContainerPadding = percent;
+    return this;
+  }
+
+  public PackingPlanBuilder resetNumContainers(int count) { // can be called repeatedly
+    this.containers = null;
+    this.numContainers = count;
+    return this;
+  }
+
+  // add or remove instances
+  public PackingPlanBuilder addInstance(Integer containerId,
+                                        InstanceId instanceId) throws ResourceExceededException {
+    initContainers();
+    if (containerInstances.get(containerId) == null) {
+      containerInstances.put(containerId, new ArrayList<InstanceId>());
+    }
+
+    long ramRequirement = getRamRequirement(instanceId.getComponentName());
+    Resource instanceResource = this.defaultInstanceResource.cloneWithRam(ramRequirement);
+    if (!containers.get(containerId - 1)
+        .add(new PackingPlan.InstancePlan(instanceId, instanceResource))) {
+      throw new ResourceExceededException(); //TODO
+    }
+    containerInstances.get(containerId).add(instanceId);
+    LOG.info(String.format("Added to container %d instance %s", containerId, instanceId));
+    return this;
+  }
+
+  public boolean removeInstance(Integer containerId, String componentName) {
+    initContainers();
+    Optional<PackingPlan.InstancePlan> instancePlan =
+        containers.get(containerId - 1).removeAnyInstanceOfComponent(componentName);
+    if (!instancePlan.isPresent()) {
+      return false;
+    }
+
+    InstanceId instanceId = new InstanceId(instancePlan.get().getComponentName(),
+                                           instancePlan.get().getTaskId(),
+                                           instancePlan.get().getComponentIndex());
+    containerInstances.get(containerId).remove(instanceId);
+    return true;
+  }
+
+  // build container plan sets by summing up instance resources
+  // mostly impl from PackingUtils.buildContainerPlans
+  public PackingPlan build() {
+    PackingUtils.removeEmptyContainers(this.containerInstances);
+    Set<PackingPlan.ContainerPlan> containerPlans = PackingUtils.buildContainerPlans(
+        this.containerInstances, this.componentRamMap,
+        this.defaultInstanceResource, this.requestedContainerPadding);
+
+    return new PackingPlan(topologyId, containerPlans);
+  }
+
+  private void initContainers() {
+    // TODO: verify required fields like numContainers are set
+    if (this.containers != null) {
+      return;
+    }
+
+    Map<Integer, List<InstanceId>> newContainerInstances;
+    ArrayList<Container> newContainers;
+    if (this.existingPacking == null) {
+      newContainerInstances = new HashMap<Integer, List<InstanceId>>();
+      newContainers = new ArrayList<>();
+
+      for (int i = 0; i <= numContainers - 1; i++) {
+        if (newContainerInstances.get(i) == null) {
+          newContainerInstances.put(i, new ArrayList<InstanceId>());
+        }
+        PackingUtils.allocateNewContainer(
+            newContainers, this.maxContainerResource, this.requestedContainerPadding);
+      }
+    } else {
+      newContainerInstances = PackingUtils.getAllocation(this.existingPacking);
+
+      newContainers =
+          PackingUtils.getContainers(this.existingPacking, this.requestedContainerPadding);
+      for (int i = newContainers.size(); i <= numContainers - 1; i++) {
+        PackingUtils.allocateNewContainer(
+            newContainers, newContainers.get(0).getCapacity(), this.requestedContainerPadding);
+      }
+    }
+
+    this.containerInstances = newContainerInstances;
+    this.containers = newContainers;
+  }
+
+  // TODO: exception handling
+  private long getRamRequirement(String component) {
+    if (componentRamMap.containsKey(component)) {
+      if (!PackingUtils.isValidInstance(
+          this.defaultInstanceResource.cloneWithRam(componentRamMap.get(component)),
+          MIN_RAM_PER_INSTANCE, this.maxContainerResource, this.requestedContainerPadding)) {
+        throw new RuntimeException("The topology configuration does not have "
+            + "valid resource requirements. Please make sure that the instance resource "
+            + "requirements do not exceed the maximum per-container resources.");
+      } else {
+        return componentRamMap.get(component);
+      }
+    } else {
+      if (!PackingUtils.isValidInstance(this.defaultInstanceResource,
+          MIN_RAM_PER_INSTANCE, this.maxContainerResource, this.requestedContainerPadding)) {
+        throw new RuntimeException("The topology configuration does not have "
+            + "valid resource requirements. Please make sure that the instance resource "
+            + "requirements do not exceed the maximum per-container resources.");
+      } else {
+        return this.defaultInstanceResource.getRam();
+      }
+    }
+  }
+}

--- a/heron/packing/src/java/com/twitter/heron/packing/PackingUtils.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/PackingUtils.java
@@ -113,14 +113,17 @@ public final class PackingUtils {
    * @return container plans
    */
   public static Set<PackingPlan.ContainerPlan> buildContainerPlans(
-      Map<Integer, List<InstanceId>> containerInstances,
+      Map<Integer, Container> containerInstances,
       Map<String, Long> ramMap,
       Resource instanceDefaults,
       double paddingPercentage) {
     Set<PackingPlan.ContainerPlan> containerPlans = new HashSet<>();
 
     for (Integer containerId : containerInstances.keySet()) {
-      List<InstanceId> instanceList = containerInstances.get(containerId);
+      Container container = containerInstances.get(containerId);
+      if (container.getInstances().size() == 0) {
+        continue;
+      }
 
       long containerRam = 0;
       long containerDiskInBytes = 0;
@@ -129,8 +132,10 @@ public final class PackingUtils {
       // Calculate the resource required for single instance
       Set<PackingPlan.InstancePlan> instancePlans = new HashSet<>();
 
-      for (InstanceId instanceId : instanceList) {
-        long instanceRam = 0;
+      for (PackingPlan.InstancePlan instancePlan : container.getInstances()) {
+        InstanceId instanceId = new InstanceId(instancePlan.getComponentName(),
+            instancePlan.getTaskId(), instancePlan.getComponentIndex());
+        long instanceRam;
         if (ramMap.containsKey(instanceId.getComponentName())) {
           instanceRam = ramMap.get(instanceId.getComponentName());
         } else {

--- a/heron/packing/src/java/com/twitter/heron/packing/PackingUtils.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/PackingUtils.java
@@ -182,7 +182,7 @@ public final class PackingUtils {
    *
    * @return the number of containers
    */
-  public static int allocateNewContainer(ArrayList<Container> containers, Resource capacity,
+  public static int allocateNewContainer(List<Container> containers, Resource capacity,
                                          int paddingPercentage) {
     containers.add(new Container(capacity, paddingPercentage));
     return containers.size();
@@ -278,6 +278,7 @@ public final class PackingUtils {
    *
    * @return Map &lt; containerId, list of InstanceId belonging to this container &gt;
    */
+  // TODO: this gets moved into the PackingPlanBuilder impl
   public static Map<Integer, List<InstanceId>> getAllocation(PackingPlan currentPackingPlan) {
     Map<Integer, List<InstanceId>> allocation = new HashMap<Integer, List<InstanceId>>();
     for (PackingPlan.ContainerPlan containerPlan : currentPackingPlan.getContainers()) {

--- a/heron/packing/src/java/com/twitter/heron/packing/PackingUtils.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/PackingUtils.java
@@ -274,24 +274,23 @@ public final class PackingUtils {
    * Generates the containers that correspond to the current packing plan
    * along with their associated instances.
    *
-   * @return List of containers for the current packing plan
+   * @return Map of containers for the current packing plan, keyed by containerId
    */
-  public static ArrayList<Container> getContainers(PackingPlan currentPackingPlan,
-                                                   int paddingPercentage) {
-    ArrayList<Container> containers = new ArrayList<>();
+  static Map<Integer, Container> getContainers(PackingPlan currentPackingPlan,
+                                               int paddingPercentage) {
+    Map<Integer, Container> containers = new HashMap<>();
 
     //sort containers based on containerIds;
-    PackingPlan.ContainerPlan[] currentContainers =
+    PackingPlan.ContainerPlan[] currentContainerPlans =
         PackingUtils.sortOnContainerId(currentPackingPlan.getContainers());
 
     Resource capacity = currentPackingPlan.getMaxContainerResources();
-    for (int i = 0; i < currentContainers.length; i++) {
-      int containerId = PackingUtils.allocateNewContainer(
-          containers, capacity, paddingPercentage);
-      for (PackingPlan.InstancePlan instancePlan
-          : currentContainers[i].getInstances()) {
-        containers.get(containerId - 1).add(instancePlan);
+    for (PackingPlan.ContainerPlan currentContainerPlan : currentContainerPlans) {
+      Container container = new Container(capacity, paddingPercentage);
+      for (PackingPlan.InstancePlan instancePlan : currentContainerPlan.getInstances()) {
+        container.add(instancePlan);
       }
+      containers.put(currentContainerPlan.getId(), container);
     }
     return containers;
   }

--- a/heron/packing/src/java/com/twitter/heron/packing/PackingUtils.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/PackingUtils.java
@@ -295,26 +295,6 @@ public final class PackingUtils {
     return containers;
   }
 
-
-  /**
-   * Generates an instance allocation for the current packing plan
-   *
-   * @return Map &lt; containerId, list of InstanceId belonging to this container &gt;
-   */
-  // TODO: this gets moved into the PackingPlanBuilder impl
-  public static Map<Integer, List<InstanceId>> getAllocation(PackingPlan currentPackingPlan) {
-    Map<Integer, List<InstanceId>> allocation = new HashMap<Integer, List<InstanceId>>();
-    for (PackingPlan.ContainerPlan containerPlan : currentPackingPlan.getContainers()) {
-      ArrayList<InstanceId> instances = new ArrayList<InstanceId>();
-      for (PackingPlan.InstancePlan instance : containerPlan.getInstances()) {
-        instances.add(new InstanceId(instance.getComponentName(), instance.getTaskId(),
-            instance.getComponentIndex()));
-      }
-      allocation.put(containerPlan.getId(), instances);
-    }
-    return allocation;
-  }
-
   public enum ScalingDirection {
     UP,
     DOWN;

--- a/heron/packing/src/java/com/twitter/heron/packing/ResourceExceededException.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/ResourceExceededException.java
@@ -1,0 +1,21 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.twitter.heron.packing;
+
+/**
+ * Thrown to indicate that the resources required are not available
+ */
+public class ResourceExceededException extends Exception {
+  private static final long serialVersionUID = -3662229190395580148L;
+}

--- a/heron/packing/src/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPacking.java
@@ -235,7 +235,6 @@ public class FirstFitDecreasingPacking implements IPacking, IRepacking {
    *
    * @return Map &lt; containerId, list of InstanceId belonging to this container &gt;
    */
-
   private Map<Integer, List<InstanceId>> getFFDAllocation(PackingPlan currentPackingPlan,
                                                           Map<String, Integer> componentChanges) {
     Map<String, Integer> componentsToScaleDown =
@@ -275,50 +274,6 @@ public class FirstFitDecreasingPacking implements IPacking, IRepacking {
         containerIds.remove();
       }
     }
-  }
-
-  /**
-   * Generates the containers that correspond to the current packing plan
-   * along with their associated instances.
-   *
-   * @return List of containers for the current packing plan
-   */
-  private ArrayList<Container> getContainers(PackingPlan currentPackingPlan) {
-    ArrayList<Container> containers = new ArrayList<>();
-
-    //sort containers based on containerIds;
-    PackingPlan.ContainerPlan[] currentContainers =
-        PackingUtils.sortOnContainerId(currentPackingPlan.getContainers());
-
-    Resource capacity = currentPackingPlan.getMaxContainerResources();
-    for (int i = 0; i < currentContainers.length; i++) {
-      int containerId = PackingUtils.allocateNewContainer(
-          containers, capacity, this.paddingPercentage);
-      for (PackingPlan.InstancePlan instancePlan
-          : currentContainers[i].getInstances()) {
-        containers.get(containerId - 1).add(instancePlan);
-      }
-    }
-    return containers;
-  }
-
-  /**
-   * Generates an instance allocation for the current packing plan
-   *
-   * @return Map &lt; containerId, list of InstanceId belonging to this container &gt;
-   */
-  private Map<Integer, List<InstanceId>> getAllocation(PackingPlan currentPackingPlan) {
-    Map<Integer, List<InstanceId>> allocation = new HashMap<Integer, List<InstanceId>>();
-    for (PackingPlan.ContainerPlan containerPlan : currentPackingPlan.getContainers()) {
-      ArrayList<InstanceId> instances = new ArrayList<InstanceId>();
-      for (PackingPlan.InstancePlan instance : containerPlan.getInstances()) {
-        instances.add(new InstanceId(instance.getComponentName(), instance.getTaskId(),
-            instance.getComponentIndex()));
-      }
-      allocation.put(containerPlan.getId(), instances);
-    }
-    PackingUtils.removeEmptyContainers(allocation);
-    return allocation;
   }
 
   /**

--- a/heron/packing/src/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPacking.java
@@ -16,22 +16,19 @@ package com.twitter.heron.packing.binpacking;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.google.common.base.Optional;
-
 import com.twitter.heron.api.generated.TopologyAPI;
-import com.twitter.heron.common.basics.Pair;
-import com.twitter.heron.packing.Container;
+import com.twitter.heron.packing.PackingException;
+import com.twitter.heron.packing.PackingPlanBuilder;
 import com.twitter.heron.packing.PackingUtils;
 import com.twitter.heron.packing.RamRequirement;
+import com.twitter.heron.packing.ResourceExceededException;
 import com.twitter.heron.spi.common.Config;
-import com.twitter.heron.spi.common.Constants;
 import com.twitter.heron.spi.common.Context;
 import com.twitter.heron.spi.packing.IPacking;
 import com.twitter.heron.spi.packing.IRepacking;
@@ -92,17 +89,17 @@ import static com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_PADDING_PERCENTAGE
  */
 public class FirstFitDecreasingPacking implements IPacking, IRepacking {
 
-  private static final long MIN_RAM_PER_INSTANCE = 192L * Constants.MB;
   private static final int DEFAULT_CONTAINER_PADDING_PERCENTAGE = 10;
   private static final int DEFAULT_NUMBER_INSTANCES_PER_CONTAINER = 4;
 
   private static final Logger LOG = Logger.getLogger(FirstFitDecreasingPacking.class.getName());
-  private TopologyAPI.Topology topology;
 
+  private TopologyAPI.Topology topology;
   private Resource defaultInstanceResources;
   private Resource maxContainerResources;
-
   private int paddingPercentage;
+
+  private int numContainers = 0;
 
   @Override
   public void initialize(Config config, TopologyAPI.Topology inputTopology) {
@@ -140,6 +137,14 @@ public class FirstFitDecreasingPacking implements IPacking, IRepacking {
             PackingUtils.increaseBy(defaultDisk, paddingPercentage)));
   }
 
+  private PackingPlanBuilder newPackingPlanBuilder(PackingPlan existingPackingPlan) {
+    return new PackingPlanBuilder(topology.getId(), existingPackingPlan)
+        .setMaxContainerResource(maxContainerResources)
+        .setDefaultInstanceResource(defaultInstanceResources)
+        .setRequestedContainerPadding(paddingPercentage)
+        .setRequestedComponentRam(TopologyUtils.getComponentRamMapConfig(topology));
+  }
+
   /**
    * Get a packing plan using First Fit Decreasing
    *
@@ -147,15 +152,17 @@ public class FirstFitDecreasingPacking implements IPacking, IRepacking {
    */
   @Override
   public PackingPlan pack() {
+    PackingPlanBuilder planBuilder = newPackingPlanBuilder(null);
+
     // Get the instances using FFD allocation
-    Map<Integer, List<InstanceId>> ffdAllocation = getFFDAllocation();
-    // Construct the PackingPlan
-    Map<String, Long> ramMap = TopologyUtils.getComponentRamMapConfig(topology);
+    try {
+      planBuilder = getFFDAllocation(planBuilder);
+    } catch (ResourceExceededException e) {
+      LOG.log(Level.SEVERE, "Could not allocate all instances to packing plan", e);
+      return null; // TODO: should throw packing exception
+    }
 
-    Set<PackingPlan.ContainerPlan> containerPlans = PackingUtils.buildContainerPlans(
-        ffdAllocation, ramMap, this.defaultInstanceResources, this.paddingPercentage);
-
-    return new PackingPlan(topology.getId(), containerPlans);
+    return planBuilder.build();
   }
 
   /**
@@ -163,16 +170,17 @@ public class FirstFitDecreasingPacking implements IPacking, IRepacking {
    * @return new packing plan
    */
   public PackingPlan repack(PackingPlan currentPackingPlan, Map<String, Integer> componentChanges) {
+    PackingPlanBuilder planBuilder = newPackingPlanBuilder(currentPackingPlan);
+
     // Get the instances using FFD allocation
-    Map<Integer, List<InstanceId>> ffdAllocation =
-        getFFDAllocation(currentPackingPlan, componentChanges);
+    try {
+      planBuilder = getFFDAllocation(planBuilder, currentPackingPlan, componentChanges);
+    } catch (ResourceExceededException e) {
+      LOG.log(Level.SEVERE, "Could not allocate all instances to packing plan", e);
+      return null; // TODO: should throw packing exception
+    }
 
-    // Construct the PackingPlan
-    Map<String, Long> ramMap = TopologyUtils.getComponentRamMapConfig(topology);
-
-    Set<PackingPlan.ContainerPlan> containerPlans = PackingUtils.buildContainerPlans(
-        ffdAllocation, ramMap, defaultInstanceResources, paddingPercentage);
-    return new PackingPlan(topology.getId(), containerPlans);
+    return planBuilder.build();
   }
 
   @Override
@@ -185,32 +193,15 @@ public class FirstFitDecreasingPacking implements IPacking, IRepacking {
    *
    * @return The sorted list of components and their RAM requirements
    */
-  private ArrayList<RamRequirement> getSortedRAMInstances(Map<String, Integer> parallelismMap) {
+  private ArrayList<RamRequirement> getSortedRAMInstances(Set<String> componentNames) {
     ArrayList<RamRequirement> ramRequirements = new ArrayList<>();
     Map<String, Long> ramMap = TopologyUtils.getComponentRamMapConfig(topology);
 
-    for (String component : parallelismMap.keySet()) {
-      if (ramMap.containsKey(component)) {
-        if (!PackingUtils.isValidInstance(
-            this.defaultInstanceResources.cloneWithRam(ramMap.get(component)),
-            MIN_RAM_PER_INSTANCE, maxContainerResources, this.paddingPercentage)) {
-          throw new RuntimeException("The topology configuration does not have "
-              + "valid resource requirements. Please make sure that the instance resource "
-              + "requirements do not exceed the maximum per-container resources.");
-        } else {
-          ramRequirements.add(new RamRequirement(component, ramMap.get(component)));
-        }
-      } else {
-        if (!PackingUtils.isValidInstance(this.defaultInstanceResources,
-            MIN_RAM_PER_INSTANCE, maxContainerResources, this.paddingPercentage)) {
-          throw new RuntimeException("The topology configuration does not have "
-              + "valid resource requirements. Please make sure that the instance resource "
-              + "requirements do not exceed the maximum per-container resources.");
-        } else {
-          ramRequirements.add(
-              new RamRequirement(component, this.defaultInstanceResources.getRam()));
-        }
-      }
+    for (String componentName : componentNames) {
+      Resource requiredResource = PackingUtils.getResourceRequirement(
+          componentName, ramMap, this.defaultInstanceResources,
+          this.maxContainerResources, this.paddingPercentage);
+      ramRequirements.add(new RamRequirement(componentName, requiredResource.getRam()));
     }
     Collections.sort(ramRequirements, Collections.reverseOrder());
 
@@ -222,12 +213,11 @@ public class FirstFitDecreasingPacking implements IPacking, IRepacking {
    *
    * @return Map &lt; containerId, list of InstanceId belonging to this container &gt;
    */
-  private Map<Integer, List<InstanceId>> getFFDAllocation() {
+  private PackingPlanBuilder getFFDAllocation(PackingPlanBuilder planBuilder)
+      throws ResourceExceededException {
     Map<String, Integer> parallelismMap = TopologyUtils.getComponentParallelism(topology);
-    HashMap<Integer, List<InstanceId>> allocation = new HashMap<>();
-    assignInstancesToContainers(new ArrayList<Container>(), allocation, parallelismMap, 1,
-        maxContainerResources);
-    return allocation;
+    assignInstancesToContainers(planBuilder, parallelismMap, 1);
+    return planBuilder;
   }
 
   /**
@@ -235,74 +225,52 @@ public class FirstFitDecreasingPacking implements IPacking, IRepacking {
    *
    * @return Map &lt; containerId, list of InstanceId belonging to this container &gt;
    */
-  private Map<Integer, List<InstanceId>> getFFDAllocation(PackingPlan currentPackingPlan,
-                                                          Map<String, Integer> componentChanges) {
+  private PackingPlanBuilder getFFDAllocation(PackingPlanBuilder packingPlanBuilder,
+                                              PackingPlan currentPackingPlan,
+                                              Map<String, Integer> componentChanges)
+      throws ResourceExceededException {
+    this.numContainers = currentPackingPlan.getContainers().size();
+
     Map<String, Integer> componentsToScaleDown =
         PackingUtils.getComponentsToScale(componentChanges, PackingUtils.ScalingDirection.DOWN);
     Map<String, Integer> componentsToScaleUp =
         PackingUtils.getComponentsToScale(componentChanges, PackingUtils.ScalingDirection.UP);
 
-    ArrayList<Container> containers = PackingUtils.getContainers(currentPackingPlan,
-        this.paddingPercentage);
-    Map<Integer, List<InstanceId>> allocation = PackingUtils.getAllocation(currentPackingPlan);
-
-    int maxInstanceIndex = 0;
-    for (PackingPlan.ContainerPlan containerPlan : currentPackingPlan.getContainers()) {
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
-        maxInstanceIndex = Math.max(maxInstanceIndex, instancePlan.getTaskId());
-      }
-    }
     if (!componentsToScaleDown.isEmpty()) {
-      removeInstancesFromContainers(containers, allocation, componentsToScaleDown);
+      removeInstancesFromContainers(packingPlanBuilder, componentsToScaleDown);
     }
-    if (!componentsToScaleUp.isEmpty()) {
-      assignInstancesToContainers(containers, allocation, componentsToScaleUp,
-          maxInstanceIndex + 1, containers.get(0).getCapacity());
-    }
-    removeEmptyContainers(allocation);
-    return allocation;
-  }
 
-  /**
-   * Removes containers from tha allocation that do not contain any instances
-   */
-  private void removeEmptyContainers(Map<Integer, List<InstanceId>> allocation) {
-    Iterator<Integer> containerIds = allocation.keySet().iterator();
-    while (containerIds.hasNext()) {
-      Integer containerId = containerIds.next();
-      if (allocation.get(containerId).isEmpty()) {
-        containerIds.remove();
+    if (!componentsToScaleUp.isEmpty()) {
+      int maxInstanceIndex = 0;
+      for (PackingPlan.ContainerPlan containerPlan : currentPackingPlan.getContainers()) {
+        for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
+          maxInstanceIndex = Math.max(maxInstanceIndex, instancePlan.getTaskId());
+        }
       }
+
+      assignInstancesToContainers(packingPlanBuilder, componentsToScaleUp, maxInstanceIndex + 1);
     }
+
+    return packingPlanBuilder;
   }
 
   /**
    * Assigns instances to containers
    *
-   * @param containers helper data structure that describes the containers' status
-   * @param allocation existing packing plan
+   * @param planBuilder existing packing plan
    * @param parallelismMap component parallelism
    * @param firstTaskIndex first taskId to use for the new instances
    */
-  private void assignInstancesToContainers(
-      ArrayList<Container> containers, Map<Integer, List<InstanceId>> allocation,
-      Map<String, Integer> parallelismMap, int firstTaskIndex, Resource containerCapacity) {
-    ArrayList<RamRequirement> ramRequirements = getSortedRAMInstances(parallelismMap);
+  private void assignInstancesToContainers(PackingPlanBuilder planBuilder,
+      Map<String, Integer> parallelismMap, int firstTaskIndex) throws ResourceExceededException {
+    ArrayList<RamRequirement> ramRequirements = getSortedRAMInstances(parallelismMap.keySet());
     int globalTaskIndex = firstTaskIndex;
     for (RamRequirement ramRequirement : ramRequirements) {
       String component = ramRequirement.getComponentName();
       int numInstance = parallelismMap.get(component);
       for (int j = 0; j < numInstance; j++) {
-        Resource instanceResource =
-            this.defaultInstanceResources.cloneWithRam(ramRequirement.getRamRequirement());
-        int containerId = placeFFDInstance(containers, new PackingPlan.InstancePlan(new InstanceId(
-            component, globalTaskIndex, j), instanceResource), containerCapacity);
-        List<InstanceId> instances = allocation.get(containerId);
-        if (instances == null) {
-          instances = new ArrayList<>();
-        }
-        instances.add(new InstanceId(component, globalTaskIndex++, j));
-        allocation.put(containerId, instances);
+        placeFFDInstance(planBuilder, new InstanceId(component, globalTaskIndex, j));
+        globalTaskIndex++;
       }
     }
   }
@@ -310,23 +278,20 @@ public class FirstFitDecreasingPacking implements IPacking, IRepacking {
   /**
    * Removes instances from containers during scaling down
    *
-   * @param containers helper data structure that describes the containers' status
-   * @param allocation existing packing plan
+   * @param packingPlanBuilder existing packing plan
    * @param componentsToScaleDown scale down factor for the components.
    */
-  private void removeInstancesFromContainers(
-      ArrayList<Container> containers, Map<Integer, List<InstanceId>> allocation,
-      Map<String, Integer> componentsToScaleDown) {
+  private void removeInstancesFromContainers(PackingPlanBuilder packingPlanBuilder,
+                                             Map<String, Integer> componentsToScaleDown) {
 
-    ArrayList<RamRequirement> ramRequirements = getSortedRAMInstances(componentsToScaleDown);
+    ArrayList<RamRequirement> ramRequirements =
+        getSortedRAMInstances(componentsToScaleDown.keySet());
+
     for (RamRequirement ramRequirement : ramRequirements) {
       String component = ramRequirement.getComponentName();
       int numInstancesToRemove = -componentsToScaleDown.get(component);
       for (int j = 0; j < numInstancesToRemove; j++) {
-        Pair<Integer, InstanceId> idPair = removeFFDInstance(containers, component);
-        List<InstanceId> instances = allocation.get(idPair.first);
-        instances.remove(idPair.second);
-        allocation.put(idPair.first, instances);
+        removeFFDInstance(packingPlanBuilder, component);
       }
     }
   }
@@ -334,50 +299,36 @@ public class FirstFitDecreasingPacking implements IPacking, IRepacking {
   /**
    * Assign a particular instance to an existing container or to a new container
    *
-   * @return the container Id that incorporated the instance
    */
-  private int placeFFDInstance(ArrayList<Container> containers,
-                               PackingPlan.InstancePlan instancePlan,
-                               Resource containerCapacity) {
-    boolean placed = false;
-    int containerId = 0;
-    for (int i = 0; i < containers.size() && !placed; i++) {
-      if (containers.get(i).add(instancePlan)) {
-        placed = true;
-        containerId = i + 1;
+  private void placeFFDInstance(PackingPlanBuilder planBuilder,
+                                InstanceId instanceId) throws ResourceExceededException {
+    if (this.numContainers == 0) {
+      planBuilder.updateNumContainers(++numContainers);
+    }
+    for (int containerId = 1; containerId <= numContainers; containerId++) {
+      try {
+        planBuilder.addInstance(containerId, instanceId);
+        return;
+      } catch (ResourceExceededException e) {
+        // ignore since we'll continue trying
       }
     }
-    if (!placed) {
-      containerId = PackingUtils.allocateNewContainer(containers, containerCapacity,
-          this.paddingPercentage);
-      containers.get(containerId - 1).add(instancePlan);
-    }
-    return containerId;
+    planBuilder.updateNumContainers(++numContainers);
+    planBuilder.addInstance(numContainers, instanceId);
   }
 
   /**
    * Remove an instance of a particular component from the containers
    *
-   * @return the pairId that captures the corresponding container and instance id.
    */
-  private Pair<Integer, InstanceId> removeFFDInstance(ArrayList<Container> containers,
-                                                      String component)
+  private void removeFFDInstance(PackingPlanBuilder packingPlanBuilder, String component)
       throws RuntimeException {
-    boolean removed = false;
-    int containerId = 0;
-    for (int i = 0; i < containers.size() && !removed; i++) {
-      Optional<PackingPlan.InstancePlan> instancePlan =
-          containers.get(i).removeAnyInstanceOfComponent(component);
-      if (instancePlan.isPresent()) {
-        removed = true;
-        containerId = i + 1;
-        PackingPlan.InstancePlan plan = instancePlan.get();
-        return new Pair<Integer, InstanceId>(containerId, new InstanceId(plan.getComponentName(),
-            plan.getTaskId(), plan.getComponentIndex()));
+    for (int containerId = 1; containerId <= numContainers; containerId++) {
+      if (packingPlanBuilder.removeInstance(containerId, component)) {
+        return;
       }
     }
-    throw new RuntimeException("Cannot remove instance."
-        + " No more instances of component " + component + " exist"
-        + " in the containers.");
+    throw new PackingException("Cannot remove instance. No more instances of component "
+        + component + " exist in the containers.");
   }
 }

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
@@ -105,10 +105,6 @@ public class ResourceCompliantRRPacking implements IPacking, IRepacking {
     this.numContainers += additionalContainers;
   }
 
-  private void addContainer() {
-
-  }
-
   private void resetState() {
     this.containerId = 1;
     this.numAdjustments = 0;

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
@@ -14,20 +14,14 @@
 
 package com.twitter.heron.packing.roundrobin;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.logging.Logger;
 
-import com.google.common.base.Optional;
-
 import com.twitter.heron.api.generated.TopologyAPI;
-import com.twitter.heron.common.basics.Pair;
-import com.twitter.heron.packing.Container;
+import com.twitter.heron.packing.PackingPlanBuilder;
 import com.twitter.heron.packing.PackingUtils;
-import com.twitter.heron.packing.RamRequirement;
+import com.twitter.heron.packing.ResourceExceededException;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Constants;
 import com.twitter.heron.spi.common.Context;
@@ -153,28 +147,28 @@ public class ResourceCompliantRRPacking implements IPacking, IRepacking {
 
   @Override
   public PackingPlan pack() {
-    int adjustments = this.numAdjustments;
-    // Get the instances using a resource compliant round robin allocation
-    Optional<Map<Integer, List<InstanceId>>> resourceCompliantRRAllocation =
-        getResourceCompliantRRAllocation();
+    PackingPlanBuilder planBuilder =
+        new PackingPlanBuilder(topology.getId())
+            .setMaxContainerResource(maxContainerResources)
+            .setDefaultInstanceResource(defaultInstanceResources)
+            .setRequestedContainerPadding(paddingPercentage)
+            .setRequestedComponentRam(TopologyUtils.getComponentRamMapConfig(topology));
 
-    while (!resourceCompliantRRAllocation.isPresent()) {
-      //The number of containers has been updated
-      if (this.numAdjustments > adjustments) {
+    int adjustments = this.numAdjustments;
+    while (adjustments <= this.numAdjustments) {
+      try {
+        planBuilder.resetNumContainers(numContainers);
+        planBuilder = getResourceCompliantRRAllocation(planBuilder);
+        return planBuilder.build();
+      } catch (ResourceExceededException e) {
+        //Not enough containers. Adjust the number of containers.
+        LOG.info(String.format("Increasing the number of containers to "
+            + "%s and attempting packing again.", this.numContainers + 1));
+        adjustNumContainers(1);
         adjustments++;
-        //Invoke again the resourceCompliantRRAllocation with the updated number of containers
-        resourceCompliantRRAllocation = getResourceCompliantRRAllocation();
-      } else {
-        //The number of containers is the same. No valid allocation was found.
-        return null;
       }
     }
-    // Construct the PackingPlan
-    Map<String, Long> ramMap = TopologyUtils.getComponentRamMapConfig(topology);
-    Set<PackingPlan.ContainerPlan> containerPlans = PackingUtils.buildContainerPlans(
-        resourceCompliantRRAllocation.get(), ramMap, this.defaultInstanceResources,
-        paddingPercentage);
-    return new PackingPlan(topology.getId(), containerPlans);
+    return null; // TODO: should throw instead
   }
 
   /**
@@ -183,75 +177,42 @@ public class ResourceCompliantRRPacking implements IPacking, IRepacking {
    * @return new packing plan
    */
   public PackingPlan repack(PackingPlan currentPackingPlan, Map<String, Integer> componentChanges) {
-    int adjustments = 0;
     this.numContainers = currentPackingPlan.getContainers().size();
     resetState();
 
     int additionalContainers = computeNumAdditionalContainers(componentChanges, currentPackingPlan);
     increaseNumContainers(additionalContainers);
-    LOG.info(String.format("Allocated "
-            + "%s additional containers for repack bring the number of containers to %s.",
+    LOG.info(String.format(
+        "Allocated %s additional containers for repack bring the number of containers to %s.",
         additionalContainers, this.numContainers));
-    // Get the instances using Resource Compliant Round Robin allocation
-    Optional<Map<Integer, List<InstanceId>>> resourceCompliantRRAllocation =
-        getResourceCompliantRRAllocation(currentPackingPlan, componentChanges);
 
-    while (!resourceCompliantRRAllocation.isPresent()) {
-      //The number of containers has been updated
-      if (this.numAdjustments > adjustments) {
+    PackingPlanBuilder planBuilder =
+        new PackingPlanBuilder(topology.getId(), currentPackingPlan)
+            .setMaxContainerResource(maxContainerResources)
+            .setDefaultInstanceResource(defaultInstanceResources)
+            .setRequestedContainerPadding(paddingPercentage)
+            .setRequestedComponentRam(TopologyUtils.getComponentRamMapConfig(topology));
+
+    int adjustments = 0;
+    while (adjustments <= this.numAdjustments) {
+      try {
+        planBuilder.resetNumContainers(numContainers);
+        planBuilder = getResourceCompliantRRAllocation(
+            planBuilder, currentPackingPlan, componentChanges);
+        return planBuilder.build();
+      } catch (ResourceExceededException e) {
+        //Not enough containers. Adjust the number of containers.
+        LOG.info(String.format("Increasing the number of containers to "
+            + "%s and attempting packing again.", this.numContainers + 1));
+        adjustNumContainers(1);
         adjustments++;
-        //Invoke again the resourceCompliantRRAllocation with the updated number of containers
-        resourceCompliantRRAllocation = getResourceCompliantRRAllocation(currentPackingPlan,
-            componentChanges);
-      } else {
-        //The number of containers is the same. No valid allocation was found.
-        return null;
       }
     }
-    // Construct the PackingPlan
-    Map<String, Long> ramMap = TopologyUtils.getComponentRamMapConfig(topology);
-    Set<PackingPlan.ContainerPlan> containerPlans = PackingUtils.buildContainerPlans(
-        resourceCompliantRRAllocation.get(), ramMap, defaultInstanceResources, paddingPercentage);
-    return new PackingPlan(topology.getId(), containerPlans);
+    return null; // TODO: should throw instead
   }
 
   @Override
   public void close() {
-  }
-
-  /**
-   * Get the RAM requirements of all the components
-   *
-   * @return The list of components and their RAM requirements. Returns null if one or more
-   * instances do not have valid resource requirements.
-   */
-  protected ArrayList<RamRequirement> getRAMInstances(Map<String, Integer> parallelismMap) {
-    ArrayList<RamRequirement> ramRequirements = new ArrayList<>();
-    Map<String, Long> ramMap = TopologyUtils.getComponentRamMapConfig(topology);
-    for (String component : parallelismMap.keySet()) {
-      if (ramMap.containsKey(component)) {
-        if (!PackingUtils.isValidInstance(
-            this.defaultInstanceResources.cloneWithRam(ramMap.get(component)),
-            MIN_RAM_PER_INSTANCE, this.maxContainerResources, this.paddingPercentage)) {
-          throw new RuntimeException("The topology configuration does not have "
-              + "valid resource requirements. Please make sure that the instance resource "
-              + "requirements do not exceed the maximum per-container resources.");
-        } else {
-          ramRequirements.add(new RamRequirement(component, ramMap.get(component)));
-        }
-      } else {
-        if (!PackingUtils.isValidInstance(this.defaultInstanceResources,
-            MIN_RAM_PER_INSTANCE, this.maxContainerResources, this.paddingPercentage)) {
-          throw new RuntimeException("The topology configuration does not have "
-              + "valid resource requirements. Please make sure that the instance resource "
-              + "requirements do not exceed the maximum per-container resources.");
-        } else {
-          ramRequirements.add(
-              new RamRequirement(component, this.defaultInstanceResources.getRam()));
-        }
-      }
-    }
-    return ramRequirements;
   }
 
   /**
@@ -271,37 +232,19 @@ public class ResourceCompliantRRPacking implements IPacking, IRepacking {
     return (int) additionalResource.divideBy(packingPlan.getMaxContainerResources());
   }
 
-  /**
-   * Get the instances' allocation based on the Resource Compliant Round Robin algorithm
-   *
-   * @return Map &lt; containerId, list of InstanceId belonging to this container &gt;
-   */
-  private Optional<Map<Integer, List<InstanceId>>> getResourceCompliantRRAllocation() {
-    HashMap<Integer, List<InstanceId>> allocation = new HashMap<>();
-    Map<String, Integer> parallelismMap = TopologyUtils.getComponentParallelism(topology);
-    ArrayList<Container> containers = new ArrayList<>();
+  private PackingPlanBuilder getResourceCompliantRRAllocation(
+      PackingPlanBuilder planBuilder) throws ResourceExceededException {
 
+    Map<String, Integer> parallelismMap = TopologyUtils.getComponentParallelism(topology);
     int totalInstance = TopologyUtils.getTotalInstance(topology);
 
     if (numContainers > totalInstance) {
       throw new RuntimeException("More containers allocated than instances."
           + numContainers + " allocated to host " + totalInstance + " instances.");
     }
-    for (int i = 1; i <= numContainers; ++i) {
-      allocation.put(i, new ArrayList<InstanceId>());
-    }
-    for (int i = 0; i <= numContainers - 1; i++) {
-      PackingUtils.allocateNewContainer(containers, maxContainerResources, this.paddingPercentage);
-    }
-    if (!assignInstancesToContainers(containers, allocation, parallelismMap, 1,
-        PolicyType.STRICT)) {
-      //Not enough containers. Adjust the number of containers.
-      LOG.info(String.format("Increasing the number of containers to "
-          + "%s and attempting packing again.", this.numContainers + 1));
-      adjustNumContainers(1);
-      return Optional.absent();
-    }
-    return Optional.of((Map<Integer, List<InstanceId>>) allocation);
+
+    assignInstancesToContainers(planBuilder, parallelismMap, 1, PolicyType.STRICT);
+    return planBuilder;
   }
 
   /**
@@ -309,239 +252,164 @@ public class ResourceCompliantRRPacking implements IPacking, IRepacking {
    *
    * @return Map &lt; containerId, list of InstanceId belonging to this container &gt;
    */
-  private Optional<Map<Integer, List<InstanceId>>> getResourceCompliantRRAllocation(
-      PackingPlan currentPackingPlan, Map<String, Integer> componentChanges) {
+  private PackingPlanBuilder getResourceCompliantRRAllocation(
+      PackingPlanBuilder planBuilder, PackingPlan currentPackingPlan,
+      Map<String, Integer> componentChanges) throws ResourceExceededException {
     Map<String, Integer> componentsToScaleDown =
         PackingUtils.getComponentsToScale(componentChanges, PackingUtils.ScalingDirection.DOWN);
     Map<String, Integer> componentsToScaleUp =
         PackingUtils.getComponentsToScale(componentChanges, PackingUtils.ScalingDirection.UP);
 
-    ArrayList<Container> containers = PackingUtils.getContainers(currentPackingPlan,
-        this.paddingPercentage);
-    Map<Integer, List<InstanceId>> allocation = PackingUtils.getAllocation(currentPackingPlan);
-
-    //Allocate additional containers.
-    for (int i = containers.size() + 1; i <= numContainers; ++i) {
-      allocation.put(i, new ArrayList<InstanceId>());
-    }
-    for (int i = containers.size(); i <= numContainers - 1; i++) {
-      PackingUtils.allocateNewContainer(containers, containers.get(0).getCapacity(),
-          this.paddingPercentage);
-    }
-    int maxInstanceIndex = 0;
-    for (PackingPlan.ContainerPlan containerPlan : currentPackingPlan.getContainers()) {
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
-        maxInstanceIndex = Math.max(maxInstanceIndex, instancePlan.getTaskId());
-      }
-    }
     if (!componentsToScaleDown.isEmpty()) {
       this.containerId = 1;
-      removeInstancesFromContainers(containers, allocation, componentsToScaleDown);
+      removeInstancesFromContainers(planBuilder, componentsToScaleDown);
     }
+
     if (!componentsToScaleUp.isEmpty()) {
       this.containerId = 1;
-      if (!assignInstancesToContainers(containers, allocation, componentsToScaleUp,
-          maxInstanceIndex + 1, PolicyType.FLEXIBLE)) {
-        //Not enough containers. Adjust the number of containers.
-        LOG.info(String.format("Increasing the number of containers to "
-            + "%s and attempting packing again.", this.numContainers + 1));
-        adjustNumContainers(1);
-        return Optional.absent();
+      int maxInstanceIndex = 0;
+      for (PackingPlan.ContainerPlan containerPlan : currentPackingPlan.getContainers()) {
+        for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
+          maxInstanceIndex = Math.max(maxInstanceIndex, instancePlan.getTaskId());
+        }
       }
+      assignInstancesToContainers(
+          planBuilder, componentsToScaleUp, maxInstanceIndex + 1, PolicyType.FLEXIBLE);
     }
-    PackingUtils.removeEmptyContainers(allocation);
-    return Optional.of(allocation);
+    return planBuilder;
   }
 
   /**
    * Assigns instances to containers.
    *
-   * @param containers helper data structure that describes the containers' status
-   * @param allocation existing packing plan
+   * @param planBuilder packing plan builder
    * @param parallelismMap component parallelism
    * @param firstTaskIndex first taskId to use for the new instances
-   * @return true if the instances fit in the existing set of containers, false otherwise.
    */
-  private boolean assignInstancesToContainers(
-      ArrayList<Container> containers, Map<Integer, List<InstanceId>> allocation,
-      Map<String, Integer> parallelismMap, int firstTaskIndex, PolicyType policyType) {
-    ArrayList<RamRequirement> ramRequirements = getRAMInstances(parallelismMap);
+  private void assignInstancesToContainers(PackingPlanBuilder planBuilder,
+                                           Map<String, Integer> parallelismMap,
+                                           int firstTaskIndex,
+                                           PolicyType policyType) throws ResourceExceededException {
     int globalTaskIndex = firstTaskIndex;
-    int componentIndex = 0;
-    for (String component : parallelismMap.keySet()) {
-      long ramRequirement = ramRequirements.get(componentIndex).getRamRequirement();
-      int numInstance = parallelismMap.get(component);
+    for (String componentName : parallelismMap.keySet()) {
+      int numInstance = parallelismMap.get(componentName);
       for (int i = 0; i < numInstance; ++i) {
-        Resource instanceResource = this.defaultInstanceResources.cloneWithRam(ramRequirement);
-        boolean sufficientNumContainers = true;
-        InstanceId instanceId = new InstanceId(component, globalTaskIndex, i);
-        sufficientNumContainers =
-            policyType.invokePolicy(allocation, containers, instanceId, instanceResource, this);
-        if (!sufficientNumContainers) {
-          return false;
-        }
+        InstanceId instanceId = new InstanceId(componentName, globalTaskIndex, i);
+        policyType.assignInstance(planBuilder, instanceId, this);
         globalTaskIndex++;
       }
-      componentIndex++;
     }
-    return true;
   }
 
   /**
    * Performs a RR placement. If the placement cannot be performed on the existing number of containers
    * then it will request for an increase in the number of containers
    *
-   * @param allocation existing packing plan
-   * @param containers helper data structure that describes the containers' status
+   * @param planBuilder packing plan builder
    * @param instanceId the instance that needs to be placed in the container
-   * @param instanceResource the resources required for that instance
    * @return true if the existing number of containers is sufficient, false otherwise
    */
-  private boolean strictRRpolicy(Map<Integer, List<InstanceId>> allocation,
-                                 ArrayList<Container> containers, InstanceId instanceId,
-                                 Resource instanceResource) {
-    if (placeResourceCompliantRRInstance(containers, containerId,
-        new PackingPlan.InstancePlan(instanceId, instanceResource))) {
-      allocation.get(containerId).add(instanceId);
-      containerId = (containerId == numContainers) ? 1 : containerId + 1;
+  private boolean strictRRpolicy(PackingPlanBuilder planBuilder,
+                                 InstanceId instanceId) throws ResourceExceededException {
+    try {
+      planBuilder.addInstance(containerId, instanceId);
+      containerId = nextContainerId(containerId);
       return true;
-    } else {
+    } catch (ResourceExceededException e) {
       //Automatically adjust the number of containers
       containerId = 1;
-      return false;
+      throw e;
     }
+  }
+
+  private int nextContainerId(int afterId) {
+    return (afterId == numContainers) ? 1 : afterId + 1;
   }
 
   /**
    * Performs a RR placement. If the placement cannot be performed on the existing number of containers
    * then it will request for an increase in the number of containers
    *
-   * @param allocation existing packing plan
-   * @param containers helper data structure that describes the containers' status
+   * @param planBuilder packing plan builder
    * @param instanceId the instance that needs to be placed in the container
-   * @param instanceResource the resources required for that instance
-   * @return true if the existing number of containers is sufficient, false otherwise
    */
-  private boolean flexibleRRpolicy(Map<Integer, List<InstanceId>> allocation,
-                                   ArrayList<Container> containers, InstanceId instanceId,
-                                   Resource instanceResource) {
-    //Attempt to place on containerId
-    if (placeResourceCompliantRRInstance(containers, containerId,
-        new PackingPlan.InstancePlan(instanceId, instanceResource))) {
-      allocation.get(containerId).add(instanceId);
-      containerId = (containerId == numContainers) ? 1 : containerId + 1;
-      return true;
-    } else {
-      //If there is not enough space on containerId look at other containers in a RR fashion
-      // starting from containerId.
-      boolean containersChecked = false;
-      int currentContainer = (containerId == numContainers) ? 1 : containerId + 1;
-      while (!containersChecked) {
-        if (placeResourceCompliantRRInstance(containers, currentContainer,
-            new PackingPlan.InstancePlan(instanceId, instanceResource))) {
-          allocation.get(currentContainer).add(instanceId);
-          containerId = (currentContainer == numContainers) ? 1 : currentContainer + 1;
-          return true;
-        }
-        currentContainer = (currentContainer == numContainers) ? 1 : currentContainer + 1;
+  private void flexibleRRpolicy(PackingPlanBuilder planBuilder,
+                                InstanceId instanceId) throws ResourceExceededException {
+    //If there is not enough space on containerId look at other containers in a RR fashion
+    // starting from containerId.
+    boolean containersChecked = false;
+    int currentContainer = containerId;
+    while (!containersChecked) {
+      try {
+        planBuilder.addInstance(currentContainer, instanceId);
+        containerId = nextContainerId(currentContainer);
+        return;
+      } catch (ResourceExceededException e) {
+        currentContainer = nextContainerId(currentContainer);
         if (currentContainer == containerId) {
           containersChecked = true;
         }
       }
     }
+
     //Not enough containers.
-    containerId = 1;
-    return false;
+    containerId = 1; // TODO: necessary?
+    throw new ResourceExceededException(); //TODO
   }
 
   /**
    * Removes instances from containers during scaling down
    *
-   * @param containers helper data structure that describes the containers' status
-   * @param allocation existing packing plan
+   * @param packingPlanBuilder packing plan builder
    * @param componentsToScaleDown scale down factor for the components.
    */
-  private void removeInstancesFromContainers(
-      ArrayList<Container> containers, Map<Integer, List<InstanceId>> allocation,
+  private void removeInstancesFromContainers(PackingPlanBuilder packingPlanBuilder,
       Map<String, Integer> componentsToScaleDown) {
-    ArrayList<RamRequirement> ramRequirements = getRAMInstances(componentsToScaleDown);
-    for (RamRequirement ramRequirement : ramRequirements) {
-      String component = ramRequirement.getComponentName();
+    for (String component : componentsToScaleDown.keySet()) {
       int numInstancesToRemove = -componentsToScaleDown.get(component);
       for (int j = 0; j < numInstancesToRemove; j++) {
-        Pair<Integer, InstanceId> idPair = removeRRInstance(containers, component);
-        List<InstanceId> instances = allocation.get(idPair.first);
-        instances.remove(idPair.second);
-        allocation.put(idPair.first, instances);
+        removeRRInstance(packingPlanBuilder, component);
       }
     }
-  }
-
-  /**
-   * Assign a particular instance to a container with a given containerId
-   *
-   * @return true if the container incorporated the instance, otherwise return false
-   */
-  private boolean placeResourceCompliantRRInstance(ArrayList<Container> containers, int container,
-                                                   PackingPlan.InstancePlan instancePlan) {
-    return containers.get(container - 1).add(instancePlan);
   }
 
   /**
    * Remove an instance of a particular component from the containers
    *
-   * @return the pairId that captures the corresponding container and instance id.
    */
-  private Pair<Integer, InstanceId> removeRRInstance(ArrayList<Container> containers,
-                                                     String component) throws RuntimeException {
-    int currentContainer = this.containerId - 1;
-    Optional<PackingPlan.InstancePlan> instancePlan =
-        containers.get(currentContainer).removeAnyInstanceOfComponent(component);
-    if (instancePlan.isPresent()) {
-      containerId = (containerId == numContainers) ? 1 : containerId + 1;
-      PackingPlan.InstancePlan plan = instancePlan.get();
-      return new Pair<Integer, InstanceId>(currentContainer + 1,
-          new InstanceId(plan.getComponentName(), plan.getTaskId(), plan.getComponentIndex()));
-    } else {
-      boolean containersChecked = false;
-      currentContainer = (containerId == numContainers) ? 0 : containerId;
-      while (!containersChecked) {
-        instancePlan = containers.get(currentContainer).removeAnyInstanceOfComponent(component);
-        if (instancePlan.isPresent()) {
-          containerId = (currentContainer == numContainers - 1) ? 1 : currentContainer + 2;
-          PackingPlan.InstancePlan plan = instancePlan.get();
-          return new Pair<Integer, InstanceId>(currentContainer + 1,
-              new InstanceId(plan.getComponentName(),
-                  plan.getTaskId(), plan.getComponentIndex()));
-        }
-        currentContainer = (currentContainer == numContainers - 1) ? 0 : currentContainer + 1;
-        if (currentContainer == containerId - 1) {
-          containersChecked = true;
-        }
+  private void removeRRInstance(PackingPlanBuilder packingPlanBuilder,
+                                String component) throws RuntimeException {
+    boolean containersChecked = false;
+    int currentContainer = this.containerId;
+    while (!containersChecked) {
+      if (packingPlanBuilder.removeInstance(currentContainer, component)) {
+        containerId = nextContainerId(currentContainer);
+        return;
       }
-      throw new RuntimeException("Cannot remove instance."
-          + " No more instances of component " + component + " exist"
-          + " in the containers.");
+      currentContainer = nextContainerId(currentContainer);
+      if (currentContainer == containerId) {
+        containersChecked = true;
+      }
     }
+    throw new RuntimeException("Cannot remove instance."
+        + " No more instances of component " + component + " exist"
+        + " in the containers.");
   }
 
   private enum PolicyType {
     STRICT, FLEXIBLE;
 
-    private boolean invokePolicy(Map<Integer, List<InstanceId>> allocation,
-                                 ArrayList<Container> containers, InstanceId instanceId,
-                                 Resource instanceResource, ResourceCompliantRRPacking packing)
-        throws RuntimeException {
-      boolean sufficientNumContainers = true;
+    private void assignInstance(PackingPlanBuilder planBuilder,
+                                InstanceId instanceId,
+                                ResourceCompliantRRPacking packing)
+        throws ResourceExceededException, RuntimeException {
       switch (this) {
         case STRICT:
-          sufficientNumContainers = packing.strictRRpolicy(allocation, containers,
-              instanceId, instanceResource);
-          return sufficientNumContainers;
+          packing.strictRRpolicy(planBuilder, instanceId);
+          break;
         case FLEXIBLE:
-          sufficientNumContainers = packing.flexibleRRpolicy(allocation, containers,
-              instanceId, instanceResource);
-          return sufficientNumContainers;
+          packing.flexibleRRpolicy(planBuilder, instanceId);
+          break;
         default:
           throw new RuntimeException("Not valid policy type");
       }

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
@@ -16,7 +16,6 @@ package com.twitter.heron.packing.roundrobin;
 
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.twitter.heron.api.generated.TopologyAPI;

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
@@ -23,7 +23,6 @@ import com.twitter.heron.packing.PackingPlanBuilder;
 import com.twitter.heron.packing.PackingUtils;
 import com.twitter.heron.packing.ResourceExceededException;
 import com.twitter.heron.spi.common.Config;
-import com.twitter.heron.spi.common.Constants;
 import com.twitter.heron.spi.common.Context;
 import com.twitter.heron.spi.packing.IPacking;
 import com.twitter.heron.spi.packing.IRepacking;
@@ -82,7 +81,6 @@ import static com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED;
  */
 public class ResourceCompliantRRPacking implements IPacking, IRepacking {
 
-  private static final long MIN_RAM_PER_INSTANCE = 192L * Constants.MB;
   private static final int DEFAULT_CONTAINER_PADDING_PERCENTAGE = 10;
   private static final int DEFAULT_NUMBER_INSTANCES_PER_CONTAINER = 4;
 

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
@@ -143,14 +143,17 @@ public class ResourceCompliantRRPacking implements IPacking, IRepacking {
             PackingUtils.increaseBy(defaultDisk, paddingPercentage)));
   }
 
+  private PackingPlanBuilder newPackingPlanBuilder(PackingPlan existingPackingPlan) {
+    return new PackingPlanBuilder(topology.getId(), existingPackingPlan)
+        .setMaxContainerResource(maxContainerResources)
+        .setDefaultInstanceResource(defaultInstanceResources)
+        .setRequestedContainerPadding(paddingPercentage)
+        .setRequestedComponentRam(TopologyUtils.getComponentRamMapConfig(topology));
+  }
+
   @Override
   public PackingPlan pack() {
-    PackingPlanBuilder planBuilder =
-        new PackingPlanBuilder(topology.getId())
-            .setMaxContainerResource(maxContainerResources)
-            .setDefaultInstanceResource(defaultInstanceResources)
-            .setRequestedContainerPadding(paddingPercentage)
-            .setRequestedComponentRam(TopologyUtils.getComponentRamMapConfig(topology));
+    PackingPlanBuilder planBuilder = newPackingPlanBuilder(null);
 
     int adjustments = this.numAdjustments;
     while (adjustments <= this.numAdjustments) {
@@ -184,12 +187,7 @@ public class ResourceCompliantRRPacking implements IPacking, IRepacking {
         "Allocated %s additional containers for repack bring the number of containers to %s.",
         additionalContainers, this.numContainers));
 
-    PackingPlanBuilder planBuilder =
-        new PackingPlanBuilder(topology.getId(), currentPackingPlan)
-            .setMaxContainerResource(maxContainerResources)
-            .setDefaultInstanceResource(defaultInstanceResources)
-            .setRequestedContainerPadding(paddingPercentage)
-            .setRequestedComponentRam(TopologyUtils.getComponentRamMapConfig(topology));
+    PackingPlanBuilder planBuilder = newPackingPlanBuilder(currentPackingPlan);
 
     int adjustments = 0;
     while (adjustments <= this.numAdjustments) {

--- a/heron/packing/tests/java/com/twitter/heron/packing/PackingUtilsTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/PackingUtilsTest.java
@@ -201,20 +201,21 @@ public class PackingUtilsTest {
 
     int paddingPercentage = 10;
     Map<Integer, List<InstanceId>> packing = new HashMap<>();
-    packing.put(1, Arrays.asList(
+    packing.put(7, Arrays.asList(
         new InstanceId("spout", 1, 0),
         new InstanceId("bolt", 2, 0)));
-    packing.put(2, Arrays.asList(
+    packing.put(3, Arrays.asList(
         new InstanceId("spout", 3, 0),
         new InstanceId("bolt", 4, 0)));
 
     PackingPlan packingPlan = generatePacking(packing);
-    ArrayList<Container> containers = PackingUtils.getContainers(packingPlan, paddingPercentage);
-    Assert.assertEquals(2, containers.size());
-    for (int i = 0; i < 2; i++) {
-      Assert.assertEquals(paddingPercentage, containers.get(i).getPaddingPercentage());
-      Assert.assertEquals(packingPlan.getMaxContainerResources(), containers.get(i).getCapacity());
-      Assert.assertEquals(2, containers.get(i).getInstances().size());
+    Map<Integer, Container> containers = PackingUtils.getContainers(packingPlan, paddingPercentage);
+    Assert.assertEquals(packing.size(), containers.size());
+    for (Integer containerId : packing.keySet()) {
+      Container foundContainer = containers.get(containerId);
+      Assert.assertEquals(paddingPercentage, foundContainer.getPaddingPercentage());
+      Assert.assertEquals(packingPlan.getMaxContainerResources(), foundContainer.getCapacity());
+      Assert.assertEquals(2, foundContainer.getInstances().size());
     }
   }
 

--- a/heron/packing/tests/java/com/twitter/heron/packing/PackingUtilsTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/PackingUtilsTest.java
@@ -219,36 +219,6 @@ public class PackingUtilsTest {
     }
   }
 
-  /**
-   * Tests the getAllocation method.
-   */
-  @Test
-  public void testGetAllocation() {
-
-    Map<Integer, List<InstanceId>> packing = new HashMap<>();
-    packing.put(1, Arrays.asList(
-        new InstanceId("spout", 2, 0),
-        new InstanceId("bolt", 2, 0)));
-    packing.put(2, Arrays.asList(
-        new InstanceId("spout", 3, 0),
-        new InstanceId("bolt", 3, 0)));
-
-    PackingPlan packingPlan = generatePacking(packing);
-    Map<Integer, List<InstanceId>> allocation = PackingUtils.getAllocation(packingPlan);
-    Assert.assertEquals(2, allocation.size());
-    for (int i = 1; i <= 2; i++) {
-      Assert.assertEquals(2, allocation.get(i).size());
-    }
-    for (int container = 1; container <= 2; container++) {
-      Assert.assertEquals("spout", allocation.get(container).get(0).getComponentName());
-      Assert.assertEquals("bolt", allocation.get(container).get(1).getComponentName());
-      for (int i = 0; i < 2; i++) {
-        Assert.assertEquals(0, allocation.get(container).get(i).getComponentIndex());
-        Assert.assertEquals(container + 1, allocation.get(container).get(i).getTaskId());
-      }
-    }
-  }
-
   @Test
   public void testResourceScaleDown() {
     int noSpouts = 6;

--- a/heron/packing/tests/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPackingTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPackingTest.java
@@ -523,7 +523,7 @@ public class FirstFitDecreasingPackingTest {
   }
 
   @Test(expected = RuntimeException.class)
-  public void testScaleXDownInvalidComponent() throws Exception {
+  public void testScaleDownInvalidComponent() throws Exception {
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put("SPOUT_FAKE", -10); //try to remove a component that does not exist
     int numContainersBeforeRepack = 2;

--- a/heron/packing/tests/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPackingTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPackingTest.java
@@ -523,7 +523,7 @@ public class FirstFitDecreasingPackingTest {
   }
 
   @Test(expected = RuntimeException.class)
-  public void testScaleDownInvalidComponent() throws Exception {
+  public void testScaleXDownInvalidComponent() throws Exception {
     Map<String, Integer> componentChanges = new HashMap<>();
     componentChanges.put("SPOUT_FAKE", -10); //try to remove a component that does not exist
     int numContainersBeforeRepack = 2;

--- a/heron/spi/src/java/com/twitter/heron/spi/packing/InstanceId.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/packing/InstanceId.java
@@ -66,7 +66,7 @@ public final class InstanceId {
 
   @Override
   public String toString() {
-    return String.format("Component Name: %s, Task Id: %d, Component Index: %d",
+    return String.format("{componentName: %s, taskId: %d, componentIndex: %d}",
         componentName, taskId, componentIndex);
   }
 }


### PR DESCRIPTION
Adds `PackingPlanBuilder` to fix #946. This reduces almost all container state management code (i.e., map/list manipulation) from the packing algorithms and leaves just the algorithm logic itself.

There are a few more edits I'd need to make (possibly in others PR) but wanted to share this to get feedback on the approach:
- Add checking that all required setters were called before adding/removing instances (DONE)
- `Packing.pack` and `Packing.repack` should throw `PackingException` instead of returning null. I'd do this in another PR.
- Some of the `PackingUtils` code is now only used by `PackingPlanBuilder`, so it could move there as internal utils.
- Some unit tests for just `PackingPlanBuilder`.

cc/ @avflor @ashvina @maosongfu 
