### PR TITLE
Check for null before Slave stops instance

### DIFF
--- a/heron/instance/src/java/com/twitter/heron/instance/Slave.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/Slave.java
@@ -179,6 +179,8 @@ public class Slave implements Runnable, AutoCloseable {
     LOG.info("Closing the Slave Thread");
     this.metricsCollector.forceGatherAllMetrics();
     LOG.info("Cleaning up the instance");
-    instance.stop();
+    if (instance != null) {
+      instance.stop();
+    }
   }
 }


### PR DESCRIPTION
If the `Slave` dies due to an unexpected exception before it initializes and starts the instance, we see this during `instance.stop()` in the `close()` method:
```
java.lang.NullPointerException at com.twitter.heron.instance.Slave.close(Slave.java:182) at com.twitter.heron.common.basics.SysUtils.closeIgnoringExceptions(SysUtils.java:68) at com.twitter.heron.instance.HeronInstance$SlaveExitTask.run(HeronInstance.java:267) at com.twitter.heron.instance.HeronInstance$DefaultExceptionHandler.uncaughtException(HeronInstance.java:235) at java.lang.ThreadGroup.uncaughtException(ThreadGroup.java:1057) at java.lang.ThreadGroup.uncaughtException(ThreadGroup.java:1052) at java.lang.Thread.dispatchUncaughtException(Thread.java:1956)
```