### PR TITLE
Reduce logging during packing plan change

### DIFF
--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -679,7 +679,7 @@ class HeronExecutor(object):
     # pylint: disable=unused-argument
     def on_packing_plan_watch(state_manager, new_packing_plan):
       Log.debug("State watch triggered for PackingPlan update on shard %s. Existing: %s, New: %s" %
-               (self.shard, str(self.packing_plan), str(new_packing_plan)))
+                (self.shard, str(self.packing_plan), str(new_packing_plan)))
 
       if self.packing_plan != new_packing_plan:
         Log.info("PackingPlan change detected on shard %s, relaunching effected processes."
@@ -690,7 +690,7 @@ class HeronExecutor(object):
         self.launch()
       else:
         Log.info(
-          "State watch triggered for PackingPlan update but plan not changed so not relaunching.")
+            "State watch triggered for PackingPlan update but plan not changed so not relaunching.")
 
     for state_manager in self.state_managers:
       # The callback function with the bound

--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -678,22 +678,19 @@ class HeronExecutor(object):
 
     # pylint: disable=unused-argument
     def on_packing_plan_watch(state_manager, new_packing_plan):
-      Log.info(
-          "State watch triggered for packing plan change. New PackingPlan: %s" %
-          str(new_packing_plan))
+      Log.debug("State watch triggered for PackingPlan update on shard %s. Existing: %s, New: %s" %
+               (self.shard, str(self.packing_plan), str(new_packing_plan)))
 
       if self.packing_plan != new_packing_plan:
-        Log.info("State watch triggered for PackingPlan update, PackingPlan change detected on "\
-                 "shard %s, relaunching. Existing: %s, New: %s" %
-                 (self.shard, str(self.packing_plan), str(new_packing_plan)))
+        Log.info("PackingPlan change detected on shard %s, relaunching effected processes."
+                 % self.shard)
         self.update_packing_plan(new_packing_plan)
 
         Log.info("Updating executor processes")
         self.launch()
       else:
-        Log.info("State watch triggered for PackingPlan update but PackingPlan not changed so "\
-                 "not relaunching. Existing: %s, New: %s" %
-                 (str(self.packing_plan), str(new_packing_plan)))
+        Log.info(
+          "State watch triggered for PackingPlan update but plan not changed so not relaunching.")
 
     for state_manager in self.state_managers:
       # The callback function with the bound

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
@@ -187,8 +187,7 @@ public class UpdateTopologyManager implements Closeable {
     long deactivateSleepSeconds = TopologyUtils.getConfigWithDefault(
         topologyConfig, TOPOLOGY_UPDATE_DEACTIVATE_WAIT_SECS, 0L);
 
-    logInfo("Deactivating topology %s before handling update request: %d",
-        topology.getName(), deactivateSleepSeconds);
+    logInfo("Deactivating topology %s before handling update request", topology.getName());
     NetworkUtils.TunnelConfig tunnelConfig =
         NetworkUtils.TunnelConfig.build(config, NetworkUtils.HeronSystem.SCHEDULER);
     assertTrue(TMasterUtils.transitionTopologyState(
@@ -271,7 +270,7 @@ public class UpdateTopologyManager implements Closeable {
       PhysicalPlans.PhysicalPlan physicalPlan = stateManager.getPhysicalPlan(topologyName);
 
       if (physicalPlan != null) {
-        logInfo("Received packing plan for topology %s. "
+        logInfo("Received physical plan for topology %s. "
             + "Reactivating topology after scaling event", topologyName);
         NetworkUtils.TunnelConfig tunnelConfig =
             NetworkUtils.TunnelConfig.build(config, NetworkUtils.HeronSystem.SCHEDULER);
@@ -290,14 +289,15 @@ public class UpdateTopologyManager implements Closeable {
               topologyName, removableContainerCount);
         }
         return;
-      } else {
-        logInfo("Received null packing plan for topology %s.", topologyName);
       }
 
       if (System.currentTimeMillis() > this.timeoutTime) {
-        LOG.warning(String.format("New packing plan not received within configured timeout for "
+        LOG.warning(String.format("New physical plan not received within configured timeout for "
             + "topology %s. Not reactivating", topologyName));
         cancel();
+      } else {
+        logInfo("Couldn't fetch physical plan for topology %s. "
+            + " Will sleep and try again", topologyName);
       }
     }
   }


### PR DESCRIPTION
The PackingPlan can be really large for big topologies so changing logging for that to debug from info. Also fixing some typos where we referenced packing instead of physical plan.