### PR TITLE
Use pipe to properly block clients when server hasn't entered event loop.

### DIFF
--- a/heron/common/tests/cpp/network/http_server_unittest.cpp
+++ b/heron/common/tests/cpp/network/http_server_unittest.cpp
@@ -82,7 +82,7 @@ void TestHttpServer::HandleTerminateRequest(IncomingHTTPRequest* _request) {
   server_->getEventLoop()->loopExit();
 }
 
-void start_http_server(sp_uint32 _port, sp_uint32 _nkeys) {
+void start_http_server(sp_uint32 _port, sp_uint32 _nkeys, int fd, int sent) {
   nkeys = _nkeys;
 
   EventLoopImpl ss;
@@ -95,5 +95,9 @@ void start_http_server(sp_uint32 _port, sp_uint32 _nkeys) {
 
   // start the server
   TestHttpServer http_server(&ss, options);
+
+  // use pipe to block clients before server enters event loop
+  write(fd, &sent, sizeof(int));
+
   ss.loop();
 }

--- a/heron/common/tests/cpp/network/http_server_unittest.cpp
+++ b/heron/common/tests/cpp/network/http_server_unittest.cpp
@@ -82,7 +82,7 @@ void TestHttpServer::HandleTerminateRequest(IncomingHTTPRequest* _request) {
   server_->getEventLoop()->loopExit();
 }
 
-void start_http_server(sp_uint32 _port, sp_uint32 _nkeys, int fd, int sent) {
+void start_http_server(sp_uint32 _port, sp_uint32 _nkeys, int fd) {
   nkeys = _nkeys;
 
   EventLoopImpl ss;
@@ -97,6 +97,7 @@ void start_http_server(sp_uint32 _port, sp_uint32 _nkeys, int fd, int sent) {
   TestHttpServer http_server(&ss, options);
 
   // use pipe to block clients before server enters event loop
+  int sent;
   write(fd, &sent, sizeof(int));
 
   ss.loop();

--- a/heron/common/tests/cpp/network/http_unittest.cpp
+++ b/heron/common/tests/cpp/network/http_unittest.cpp
@@ -36,7 +36,7 @@ static const sp_uint32 SERVER_PORT = 60000;
 
 extern void start_http_client(sp_uint32 _port, sp_uint64 _requests, sp_uint32 _nkeys);
 
-extern void start_http_server(sp_uint32 _port, sp_uint32 _nkeys, int fd, int sent);
+extern void start_http_server(sp_uint32 _port, sp_uint32 _nkeys, int fd);
 
 void TerminateRequestDone(HTTPClient* client, IncomingHTTPResponse* response) {
   delete response;
@@ -68,13 +68,13 @@ void StartTest(sp_uint32 nclients, sp_uint64 requests, sp_uint32 nkeys) {
   int fds[2];
 
   // choose an arbitrary number for ``sent'' as token
-  int recv, sent = 19583;
+  int recv;
   if (::pipe(fds) < 0) {
     std::cerr << "Unable to open pipe" << std::endl;
     GTEST_FAIL();
   }
 
-  std::thread sthread(start_http_server, SERVER_PORT, nkeys, fds[1], sent);
+  std::thread sthread(start_http_server, SERVER_PORT, nkeys, fds[1]);
 
   // block clients from reading from server using pipe
   read(fds[0], &recv, sizeof(int));

--- a/heron/common/tests/cpp/network/http_unittest.cpp
+++ b/heron/common/tests/cpp/network/http_unittest.cpp
@@ -69,7 +69,7 @@ void StartTest(sp_uint32 nclients, sp_uint64 requests, sp_uint32 nkeys) {
 
   // choose an arbitrary number for ``sent'' as token
   int recv, sent = 19583;
-  if (pipe(fds) < 0) {
+  if (::pipe(fds) < 0) {
     std::cerr << "Unable to open pipe" << std::endl;
     GTEST_FAIL();
   }

--- a/heron/common/tests/cpp/network/http_unittest.cpp
+++ b/heron/common/tests/cpp/network/http_unittest.cpp
@@ -78,11 +78,6 @@ void StartTest(sp_uint32 nclients, sp_uint64 requests, sp_uint32 nkeys) {
 
   // block clients from reading from server using pipe
   read(fds[0], &recv, sizeof(int));
-  if (recv != sent) {
-    std::cerr << "Expecting receiving number " << sent << "from pipe. "
-              << "Received " << recv << " instead." << std::endl;
-    GTEST_FAIL();
-  }
 
   // start the client threads
   std::vector<std::thread> cthreads;

--- a/heron/common/tests/cpp/network/http_unittest.cpp
+++ b/heron/common/tests/cpp/network/http_unittest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <unistd.h>
 #include <cstddef>
 #include <iostream>
 #include <thread>
@@ -35,7 +36,7 @@ static const sp_uint32 SERVER_PORT = 60000;
 
 extern void start_http_client(sp_uint32 _port, sp_uint64 _requests, sp_uint32 _nkeys);
 
-extern void start_http_server(sp_uint32 _port, sp_uint32 _nkeys);
+extern void start_http_server(sp_uint32 _port, sp_uint32 _nkeys, int fd, int sent);
 
 void TerminateRequestDone(HTTPClient* client, IncomingHTTPResponse* response) {
   delete response;
@@ -64,9 +65,24 @@ void TerminateServer(sp_uint32 port) {
 
 void StartTest(sp_uint32 nclients, sp_uint64 requests, sp_uint32 nkeys) {
   // start the server thread
-  std::thread sthread(start_http_server, SERVER_PORT, nkeys);
+  int fds[2];
 
-  ::usleep(1000);
+  // choose an arbitrary number for ``sent'' as token
+  int recv, sent = 19583;
+  if (pipe(fds) < 0) {
+    std::cerr << "Unable to open pipe" << std::endl;
+    GTEST_FAIL();
+  }
+
+  std::thread sthread(start_http_server, SERVER_PORT, nkeys, fds[1], sent);
+
+  // block clients from reading from server using pipe
+  read(fds[0], &recv, sizeof(int));
+  if (recv != sent) {
+    std::cerr << "Expecting receiving number " << sent << "from pipe. "
+              << "Received " << recv << " instead." << std::endl;
+    GTEST_FAIL();
+  }
 
   // start the client threads
   std::vector<std::thread> cthreads;


### PR DESCRIPTION
The previous way of using `usleep` cannot guarantee the clients are blocked when server hasn't entered event loop, which makes``heron/common/tests/cpp/network:http_unittest`` flaky.

This PR switches to using pipe. Server will send a byte to pipe prior to entering event loop. Clients will wait(block) until the byte is read on the other side of the pipe. This makes sure that clients are properly blocked.

Test done via script
```Bash
#!/bin/sh

for i in `seq 1 1000`;
do
    bazel test --config=darwin --no_cache_test_results heron/common/tests/cpp/network:http_unittest
    if [[ $? != 0 ]]; then
      exit 1
    fi
done
```

Thanks @congwang for suggestions.