### PR TITLE
Clean up ZK lock resources upon kill

### DIFF
--- a/heron/common/src/java/com/twitter/heron/common/basics/FileUtils.java
+++ b/heron/common/src/java/com/twitter/heron/common/basics/FileUtils.java
@@ -108,6 +108,10 @@ public final class FileUtils {
     return Files.exists(new File(file).toPath());
   }
 
+  public static boolean hasChildren(String file) {
+    return isDirectoryExists(file) && new File(file).list().length > 0;
+  }
+
   public static boolean isOriginalPackageJar(String packageFilename) {
     return packageFilename.endsWith(".jar");
   }

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
@@ -240,6 +240,11 @@ public class RuntimeManagerRunner implements Callable<Boolean> {
       LOG.warning("Failed to clear scheduler location. Check whether Scheduler set it correctly.");
     }
 
+    result = statemgr.deleteLocks(topologyName);
+    if (result == null || !result) {
+      LOG.warning("Failed to delete locks. It's possible that the topology never created any.");
+    }
+
     result = statemgr.deleteExecutionState(topologyName);
     if (result == null || !result) {
       LOG.severe("Failed to clear execution state");

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
@@ -39,6 +39,7 @@ import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.packing.PackingPlanProtoDeserializer;
 import com.twitter.heron.spi.scheduler.IScalable;
+import com.twitter.heron.spi.statemgr.IStateManager;
 import com.twitter.heron.spi.statemgr.Lock;
 import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
 import com.twitter.heron.spi.utils.NetworkUtils;
@@ -89,7 +90,7 @@ public class UpdateTopologyManager implements Closeable {
       throws ExecutionException, InterruptedException, ConcurrentModificationException {
     String topologyName = Runtime.topologyName(runtime);
     SchedulerStateManagerAdaptor stateManager = Runtime.schedulerStateManagerAdaptor(runtime);
-    Lock lock = stateManager.getLock(topologyName, "updateTopology");
+    Lock lock = stateManager.getLock(topologyName, IStateManager.LockName.UPDATE_TOPOLOGY);
 
     if (lock.tryLock(5, TimeUnit.SECONDS)) {
       try {

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/UpdateTopologyManagerTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/UpdateTopologyManagerTest.java
@@ -49,6 +49,7 @@ import com.twitter.heron.spi.common.Keys;
 import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.packing.PackingPlanProtoSerializer;
 import com.twitter.heron.spi.scheduler.IScalable;
+import com.twitter.heron.spi.statemgr.IStateManager;
 import com.twitter.heron.spi.statemgr.Lock;
 import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
 import com.twitter.heron.spi.utils.NetworkUtils;
@@ -106,7 +107,8 @@ public class UpdateTopologyManagerTest {
         .thenReturn(PhysicalPlans.PhysicalPlan.getDefaultInstance());
     when(stateManager.getTopology(TOPOLOGY_NAME)).thenReturn(topology);
     when(stateManager.getPackingPlan(eq(TOPOLOGY_NAME))).thenReturn(packingPlan);
-    when(stateManager.getLock(eq(TOPOLOGY_NAME), eq("updateTopology"))).thenReturn(lock);
+    when(stateManager.getLock(eq(TOPOLOGY_NAME), eq(IStateManager.LockName.UPDATE_TOPOLOGY)))
+        .thenReturn(lock);
     return stateManager;
   }
 

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraController.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraController.java
@@ -115,9 +115,16 @@ class AuroraController {
   // Utils method for unit tests
   @VisibleForTesting
   boolean runProcess(List<String> auroraCmd) {
-    return 0 == ShellUtils.runProcess(
-        isVerbose, auroraCmd.toArray(new String[auroraCmd.size()]),
-        new StringBuilder(), new StringBuilder());
+    StringBuilder stdout = new StringBuilder();
+    StringBuilder stderr = new StringBuilder();
+    int status =
+        ShellUtils.runProcess(auroraCmd.toArray(new String[auroraCmd.size()]), stdout, stderr);
+
+    if (status != 0) {
+      LOG.severe(String.format(
+          "Failed to run process. Command=%s, STDOUT=%s, STDERR=%s", auroraCmd, stdout, stderr));
+    }
+    return status == 0;
   }
 
   private static String getInstancesIdsToKill(Set<PackingPlan.ContainerPlan> containersToRemove) {

--- a/heron/spi/src/java/BUILD
+++ b/heron/spi/src/java/BUILD
@@ -133,6 +133,7 @@ java_library(
     srcs = glob([
         "**/spi/utils/ShellUtils.java",
     ]),
+    deps = [ "@com_google_guava_guava//jar" ],
 )
 
 java_library(

--- a/heron/spi/src/java/BUILD
+++ b/heron/spi/src/java/BUILD
@@ -87,6 +87,7 @@ uploader_deps_files = [
 statemgr_deps_files = \
     heron_java_proto_files() + [
         ":common-spi-java",
+        "//heron/api/src/java:classification",
         "//heron/common/src/java:config-java",
         "@com_google_guava_guava//jar",
     ]

--- a/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
@@ -81,7 +81,7 @@ public class SchedulerStateManagerAdaptor {
     }
   }
 
-  public Lock getLock(String topologyName, String lockName) {
+  public Lock getLock(String topologyName, IStateManager.LockName lockName) {
     return delegate.getLock(topologyName, lockName);
   }
 
@@ -215,6 +215,10 @@ public class SchedulerStateManagerAdaptor {
    */
   public Boolean deleteSchedulerLocation(String topologyName) {
     return awaitResult(delegate.deleteSchedulerLocation(topologyName));
+  }
+
+  public Boolean deleteLocks(String topologyName) {
+    return awaitResult(delegate.deleteLocks(topologyName));
   }
 
   /**

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/NullStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/NullStateManager.java
@@ -44,7 +44,12 @@ public class NullStateManager implements IStateManager {
   }
 
   @Override
-  public Lock getLock(String topologyName, String lockName) {
+  public Lock getLock(String topologyName, LockName lockName) {
+    throw new RuntimeException(new OperationNotSupportedException());
+  }
+
+  @Override
+  public ListenableFuture<Boolean> deleteLocks(String topologyName) {
     throw new RuntimeException(new OperationNotSupportedException());
   }
 

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
@@ -33,6 +33,7 @@ import org.apache.curator.framework.api.DeleteBuilder;
 import org.apache.curator.framework.recipes.locks.InterProcessSemaphoreMutex;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.Watcher;
 
 import com.twitter.heron.api.generated.TopologyAPI;
@@ -263,6 +264,13 @@ public class CuratorStateManager extends FileSystemStateManager {
       deleteBuilder.withVersion(-1).forPath(path);
       LOG.info("Deleted node for path: " + path);
       result.set(true);
+
+    } catch (KeeperException e) {
+      if (KeeperException.Code.NONODE.equals(e.code())) {
+        result.set(true);
+      } else {
+        result.setException(new RuntimeException("Could not deleteNode", e));
+      }
 
       // Suppress it since forPath() throws Exception
       // SUPPRESS CHECKSTYLE IllegalCatch

--- a/heron/statemgrs/tests/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManagerTest.java
+++ b/heron/statemgrs/tests/java/com/twitter/heron/statemgr/localfs/LocalFileSystemStateManagerTest.java
@@ -36,6 +36,7 @@ import com.twitter.heron.proto.system.ExecutionEnvironment;
 import com.twitter.heron.proto.system.PackingPlans;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Keys;
+import com.twitter.heron.spi.statemgr.IStateManager;
 import com.twitter.heron.spi.statemgr.Lock;
 
 import static org.junit.Assert.assertEquals;
@@ -60,7 +61,7 @@ import static org.mockito.Mockito.verify;
 public class LocalFileSystemStateManagerTest {
 
   private static final String TOPOLOGY_NAME = "topologyName";
-  private static final String LOCK_NAME = "lockName";
+  private static final IStateManager.LockName LOCK_NAME = IStateManager.LockName.UPDATE_TOPOLOGY;
   private static final String ROOT_ADDR = "/";
   private LocalFileSystemStateManager manager;
 
@@ -86,6 +87,7 @@ public class LocalFileSystemStateManagerTest {
   private void initMocks() throws Exception {
     PowerMockito.spy(FileUtils.class);
     PowerMockito.doReturn(true).when(FileUtils.class, "createDirectory", anyString());
+    PowerMockito.doReturn(true).when(FileUtils.class, "isFileExists", anyString());
 
     assertTrue(manager.initTree());
 
@@ -214,7 +216,7 @@ public class LocalFileSystemStateManagerTest {
   @Test
   public void testGetLock() throws Exception {
     initMocks();
-    String expectedLockPath = String.format("//locks/%s__%s", TOPOLOGY_NAME, LOCK_NAME);
+    String expectedLockPath = String.format("//locks/%s__%s", TOPOLOGY_NAME, LOCK_NAME.getName());
     byte[] expectedContents = Thread.currentThread().getName().getBytes(Charset.defaultCharset());
 
     Lock lock = manager.getLock(TOPOLOGY_NAME, LOCK_NAME);
@@ -237,7 +239,7 @@ public class LocalFileSystemStateManagerTest {
 
   @Test
   public void testLockTaken() throws Exception {
-    String expectedLockPath = String.format("//locks/%s__%s", TOPOLOGY_NAME, LOCK_NAME);
+    String expectedLockPath = String.format("//locks/%s__%s", TOPOLOGY_NAME, LOCK_NAME.getName());
     byte[] expectedContents = Thread.currentThread().getName().getBytes(Charset.defaultCharset());
 
     PowerMockito.spy(FileUtils.class);

--- a/heron/statemgrs/tests/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManagerTest.java
+++ b/heron/statemgrs/tests/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManagerTest.java
@@ -49,6 +49,7 @@ import com.twitter.heron.statemgr.zookeeper.ZkContext;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
@@ -319,8 +320,7 @@ public class CuratorStateManagerTest {
 
     final SettableFuture<Boolean> fakeResult = SettableFuture.create();
     fakeResult.set(false);
-    doReturn(fakeResult)
-        .when(spyStateManager).deleteNode(anyString());
+    doReturn(fakeResult).when(spyStateManager).deleteNode(anyString(), anyBoolean());
 
     ListenableFuture<Boolean> result = spyStateManager.deleteSchedulerLocation(TOPOLOGY_NAME);
     assertTrue(result.get());


### PR DESCRIPTION
Releasing a ZK lock does not remove the node, since others might be contending for the same one. We need to clean all lock resources upon exit.

Fixes #1537. Relates to #1292.