### PR TITLE
Using common python logging for int tests

### DIFF
--- a/integration-test/README
+++ b/integration-test/README
@@ -31,4 +31,7 @@ the heron client:
   bazel run --config=darwin -- scripts/packages:heron-client-install.sh --user
 
 To run the local integration tests on your mac run the following from the heron repo's top dir:
-  python integration-test/src/python/local_test_runner/main.py
+  ./bazel-bin/integration-test/src/python/local_test_runner/local-test-runner
+
+To run just a single test include the module and test class:
+  ./bazel-bin/integration-test/src/python/local_test_runner/local-test-runner test_template.TestTemplate

--- a/integration-test/src/python/http_server/BUILD
+++ b/integration-test/src/python/http_server/BUILD
@@ -11,4 +11,7 @@ pex_binary(
     reqs = [
         "tornado==4.0.2",
     ],
+    deps = [
+        "//heron/common/src/python:common-py",
+    ],
 )

--- a/integration-test/src/python/http_server/main.py
+++ b/integration-test/src/python/http_server/main.py
@@ -6,6 +6,8 @@ import tornado.ioloop
 import tornado.escape
 import tornado.web
 
+from heron.common.src.python.utils import log
+
 RESULTS_DIRECTORY = "results"
 
 class MainHandler(tornado.web.RequestHandler):
@@ -75,8 +77,7 @@ def main():
   integration test json result get/post requests
   '''
 
-  root = logging.getLogger()
-  root.setLevel(logging.DEBUG)
+  log.configure(level=logging.DEBUG)
 
   if not os.path.exists(RESULTS_DIRECTORY):
     os.makedirs(RESULTS_DIRECTORY)

--- a/integration-test/src/python/local_test_runner/BUILD
+++ b/integration-test/src/python/local_test_runner/BUILD
@@ -10,4 +10,7 @@ pex_binary(
         "resources/test.conf",
     ],
     reqs = ["argparse==1.4.0"],
+    deps = [
+        "//heron/common/src/python:common-py",
+    ],
 )

--- a/integration-test/src/python/local_test_runner/README
+++ b/integration-test/src/python/local_test_runner/README
@@ -1,4 +1,9 @@
-Integration test for testing recovery from failure/restart in certain processes. Runs local-scheduler heron topology in local directory. Topology used spout which creates a file and blocks into files contents are filled. When file length !=0, spout emits each line to the bolt, which writes each line to another file. The integration-test framework tests the likeness of these two files. Currently, tests TMaster kill. 
+Integration test for testing various heron-cli and process failure scenarios. Runs a local-scheduler
+heron topology. The test creates an input file of test data, which a spout emits. A bolt writes each
+tuple to an output file and the two files are compared.
 
-Run main.py from heron root directory. 
-e.g. python integration-test/src/python/local_test_runner/main.py
+To run the tests:
+
+  bazel run --config=darwin -- scripts/packages:heron-client-install.sh --user
+  bazel build --config=darwin integration-test/src/...
+  ./bazel-bin/integration-test/src/python/local_test_runner/local-test-runner

--- a/integration-test/src/python/local_test_runner/main.py
+++ b/integration-test/src/python/local_test_runner/main.py
@@ -26,6 +26,7 @@ import sys
 from collections import namedtuple
 
 import status
+from heron.common.src.python.utils import log
 
 # import test_kill_bolt
 import test_kill_metricsmgr
@@ -46,7 +47,7 @@ TEST_CLASSES = [
 ]
 
 # The location of default configure file
-DEFAULT_TEST_CONF_FILE = "resources/test.conf"
+DEFAULT_TEST_CONF_FILE = "integration-test/src/python/local_test_runner/resources/test.conf"
 
 ProcessTuple = namedtuple('ProcessTuple', 'pid cmd')
 
@@ -100,8 +101,7 @@ def _random_port():
 
 def main():
   """ main """
-  root = logging.getLogger()
-  root.setLevel(logging.DEBUG)
+  log.configure(level=logging.DEBUG)
 
   # Read the configuration file from package
   conf_file = DEFAULT_TEST_CONF_FILE
@@ -110,9 +110,6 @@ def main():
 
   # Convert the conf file to a json format
   conf = decoder.decode(conf_string)
-
-  # Get the directory of the heron root, which should be the directory that the script is run from
-  heron_repo_directory = os.getcwd()
 
   args = dict()
   home_directory = os.path.expanduser("~")
@@ -132,16 +129,26 @@ def main():
   args['trackerPort'] = _random_port()
   args['outputFile'] = os.path.join(args['workingDirectory'], conf['topology']['outputFile'])
   args['readFile'] = os.path.join(args['workingDirectory'], conf['topology']['readFile'])
-  args['testJarPath'] = os.path.join(heron_repo_directory, conf['testJarPath'])
+  args['testJarPath'] = conf['testJarPath']
 
   test_classes = TEST_CLASSES
   if len(sys.argv) > 1:
     first_arg = sys.argv[1]
-    class_name = first_arg.split(".")
-    if first_arg == "-h" or len(class_name) < 2:
+    class_tokens = first_arg.split(".")
+    if first_arg == "-h" or len(class_tokens) < 2:
       usage()
+
     import importlib
-    test_classes = [getattr(importlib.import_module(class_name[0]), class_name[1])]
+    package_tokens = class_tokens[:-1]
+    test_class = class_tokens[-1]
+    if len(package_tokens) == 1: # prepend base packages for convenience
+      test_module = "integration-test.src.python.local_test_runner." + package_tokens[0]
+    else:
+      test_module = '.'.join(package_tokens)
+
+    logging.info("test_module %s", test_module)
+    logging.info("test_class %s", test_class)
+    test_classes = [getattr(importlib.import_module(test_module), test_class)]
 
   start_time = time.time()
   (successes, failures) = run_tests(test_classes, args)

--- a/integration-test/src/python/test_runner/BUILD
+++ b/integration-test/src/python/test_runner/BUILD
@@ -12,4 +12,7 @@ pex_binary(
         "resources/test.json",
     ],
     reqs = ["argparse==1.4.0"],
+    deps = [
+        "//heron/common/src/python:common-py",
+    ],
 )

--- a/integration-test/src/python/test_runner/main.py
+++ b/integration-test/src/python/test_runner/main.py
@@ -11,6 +11,8 @@ import uuid
 # pylint: disable=unused-wildcard-import
 from httplib import *
 
+from heron.common.src.python.utils import log
+
 # The location of default configure file
 DEFAULT_TEST_CONF_FILE = "integration-test/src/python/test_runner/resources/test.json"
 
@@ -380,8 +382,7 @@ def load_expected_result_handler(topology_name, topology_conf, args, http_server
 
 def main():
   ''' main '''
-  root = logging.getLogger()
-  root.setLevel(logging.DEBUG)
+  log.configure(level=logging.DEBUG)
   conf_file = DEFAULT_TEST_CONF_FILE
   # Read the configuration file from package
   conf_string = pkgutil.get_data(__name__, conf_file)

--- a/scripts/travis/test.sh
+++ b/scripts/travis/test.sh
@@ -32,7 +32,7 @@ end_timer "$T"
 # run local integration test
 T="heron integration-test local"
 start_timer "$T"
-python integration-test/src/python/local_test_runner/main.py
+python ./bazel-bin/integration-test/src/python/local_test_runner/local-test-runner
 end_timer "$T"
 
 # run the java integration test

--- a/website/content/docs/contributors/testing.md
+++ b/website/content/docs/contributors/testing.md
@@ -69,6 +69,5 @@ Integration tests are divided into two categories:
 
     ```bash
     $ bazel build --config=darwin integration-test/src/...
-
-    $ python integration-test/src/python/local_test_runner/main.py
+    $ ./bazel-bin/integration-test/src/python/local_test_runner/local-test-runner
     ```


### PR DESCRIPTION
Standardizing int test framework to use the common python logging format. This makes logs look much better because the int test logs and the heron cli logs are consistent. It also adds color-coding to the log level which helps when reviewing logs in CI on the console (thanks for that formatter @objmagic!).

This means the `local_test_runner`, can no longer be invoked directly due to the pex dep. Now we need to build and then run the pex, similar to what we currently do with `test_runner`.