### PR TITLE
Use std::vector for fields grouping indices

### DIFF
--- a/heron/stmgr/src/cpp/grouping/fields-grouping.cpp
+++ b/heron/stmgr/src/cpp/grouping/fields-grouping.cpp
@@ -48,7 +48,7 @@ void FieldsGrouping::GetListToSend(const proto::system::HeronDataTuple& _tuple,
                                    std::vector<sp_int32>& _return) {
   sp_int32 task_index = 0;
   size_t prime_num = 633910111UL;
-  for (std::list<sp_int32>::iterator iter = fields_grouping_indices_.begin();
+  for (auto iter = fields_grouping_indices_.begin();
        iter != fields_grouping_indices_.end(); ++iter) {
     CHECK(_tuple.values_size() > *iter);
     size_t h = str_hash_fn(_tuple.values(*iter));

--- a/heron/stmgr/src/cpp/grouping/fields-grouping.h
+++ b/heron/stmgr/src/cpp/grouping/fields-grouping.h
@@ -18,7 +18,6 @@
 #define SRC_CPP_SVCS_STMGR_SRC_GROUPING_FIELDS_GROUPING_H_
 
 #include <functional>
-#include <list>
 #include <vector>
 #include "grouping/grouping.h"
 #include "proto/messages.h"
@@ -37,7 +36,7 @@ class FieldsGrouping : public Grouping {
                              std::vector<sp_int32>& _return);
 
  private:
-  std::list<sp_int32> fields_grouping_indices_;
+  std::vector<sp_int32> fields_grouping_indices_;
   std::hash<sp_string> str_hash_fn;
 };
 

--- a/heron/stmgr/src/cpp/grouping/grouping.h
+++ b/heron/stmgr/src/cpp/grouping/grouping.h
@@ -17,7 +17,6 @@
 #ifndef SRC_CPP_SVCS_STMGR_SRC_GROUPING_GROUPING_H_
 #define SRC_CPP_SVCS_STMGR_SRC_GROUPING_GROUPING_H_
 
-#include <list>
 #include <vector>
 #include "proto/messages.h"
 #include "basics/basics.h"


### PR DESCRIPTION
We always push back, so std::vector is enough and faster than std::list.