### PR TITLE
Refactor test_runner to use status classes instead of success/fail

### DIFF
--- a/integration-test/src/java/com/twitter/heron/integration_test/core/AggregatorBolt.java
+++ b/integration-test/src/java/com/twitter/heron/integration_test/core/AggregatorBolt.java
@@ -43,7 +43,6 @@ public class AggregatorBolt extends BaseBatchBolt implements ITerminalBolt {
   private final List<String> result;
 
   public AggregatorBolt(String httpPostUrl) {
-    LOG.info("HttpPostUrl : " + httpPostUrl);
     this.httpPostUrl = httpPostUrl;
     this.result = new ArrayList<String>();
   }

--- a/integration-test/src/java/com/twitter/heron/integration_test/topology/serialization/CustomCheckBolt.java
+++ b/integration-test/src/java/com/twitter/heron/integration_test/topology/serialization/CustomCheckBolt.java
@@ -13,6 +13,8 @@
 // limitations under the License.
 package com.twitter.heron.integration_test.topology.serialization;
 
+import java.util.logging.Logger;
+
 import com.twitter.heron.api.bolt.BaseBasicBolt;
 import com.twitter.heron.api.bolt.BasicOutputCollector;
 import com.twitter.heron.api.topology.OutputFieldsDeclarer;
@@ -23,6 +25,7 @@ import com.twitter.heron.api.tuple.Tuple;
  * A bolt that checks deserialization works fine
  */
 public class CustomCheckBolt extends BaseBasicBolt {
+  private static final Logger LOG = Logger.getLogger(CustomCheckBolt.class.getName());
   private static final long serialVersionUID = 3404960992657778759L;
   private int nItems;
   private CustomObject[] inputObjects;
@@ -34,7 +37,7 @@ public class CustomCheckBolt extends BaseBasicBolt {
 
   @Override
   public void execute(Tuple input, BasicOutputCollector collector) {
-    System.out.println("Received input tuple: " + input.getValueByField("custom").toString());
+    LOG.info("Received input tuple: " + input.getValueByField("custom").toString());
     if (input.getValueByField("custom")
         .equals(inputObjects[(nItems++) % inputObjects.length])) {
       collector.emit(input.getValues());

--- a/integration-test/src/python/common/BUILD
+++ b/integration-test/src/python/common/BUILD
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+load("/tools/rules/pex_rules", "pex_library")
+
+pex_library(
+    name = "common",
+    srcs = glob(["*.py"]),
+)

--- a/integration-test/src/python/common/status.py
+++ b/integration-test/src/python/common/status.py
@@ -1,0 +1,30 @@
+# Copyright 2016 Twitter. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#!/usr/bin/env python2.7
+
+"""Classes to represent the success or failure of an integration test"""
+import logging
+
+class TestFailure(Exception):
+  def __init__(self, message, error=None):
+    Exception.__init__(self, message, error)
+    if error:
+      logging.error("%s :: %s", message, str(error))
+    else:
+      logging.error(message)
+
+class TestSuccess(object):
+  def __init__(self, message=None):
+    if message:
+      logging.info(message)

--- a/integration-test/src/python/local_test_runner/BUILD
+++ b/integration-test/src/python/local_test_runner/BUILD
@@ -12,5 +12,6 @@ pex_binary(
     reqs = ["argparse==1.4.0"],
     deps = [
         "//heron/common/src/python:common-py",
-    ],
+        "//integration-test/src/python/common",
+    ]
 )

--- a/integration-test/src/python/local_test_runner/main.py
+++ b/integration-test/src/python/local_test_runner/main.py
@@ -25,7 +25,7 @@ import subprocess
 import sys
 from collections import namedtuple
 
-import status
+from ..common import status
 from heron.common.src.python.utils import log
 
 # import test_kill_bolt

--- a/integration-test/src/python/local_test_runner/test_scale_up.py
+++ b/integration-test/src/python/local_test_runner/test_scale_up.py
@@ -16,7 +16,7 @@
 import logging
 import subprocess
 
-import status
+from ..common import status
 import test_template
 
 class TestScaleUp(test_template.TestTemplate):

--- a/integration-test/src/python/local_test_runner/test_template.py
+++ b/integration-test/src/python/local_test_runner/test_template.py
@@ -21,7 +21,7 @@ import signal
 import subprocess
 from collections import namedtuple
 
-import status
+from ..common import status
 
 # Test input. Please set each variable as it's own line, ended with \n, otherwise the value of lines
 # passed into the topology will be incorrect, and the test will fail.

--- a/integration-test/src/python/test_runner/BUILD
+++ b/integration-test/src/python/test_runner/BUILD
@@ -14,5 +14,6 @@ pex_binary(
     reqs = ["argparse==1.4.0"],
     deps = [
         "//heron/common/src/python:common-py",
+        "//integration-test/src/python/common",
     ],
 )

--- a/integration-test/src/python/test_runner/main.py
+++ b/integration-test/src/python/test_runner/main.py
@@ -8,9 +8,9 @@ import re
 import sys
 import time
 import uuid
-# pylint: disable=unused-wildcard-import
-from httplib import *
+from httplib import HTTPConnection
 
+from ..common import status
 from heron.common.src.python.utils import log
 
 # The location of default configure file
@@ -28,13 +28,12 @@ class FileBasedExpectedResultsHandler(object):
     # Read expected result from the expected result file
     try:
       if not os.path.exists(self.file_path):
-        raise RuntimeError(" %s does not exist" % self.file_path)
+        raise status.TestFailure("Expected results file %s does not exist" % self.file_path)
       else:
         with open(self.file_path, "r") as expected_result_file:
           return expected_result_file.read().rstrip()
     except Exception as e:
-      logging.error("Failed to read expected result file %s: %s", self.file_path, str(e))
-      return "fail"
+      raise status.TestFailure("Failed to read expected result file %s: %s" % self.file_path, e)
 
 class HttpBasedExpectedResultsHandler(object):
   def __init__(self, server_host_port, topology_name, task_count):
@@ -56,15 +55,15 @@ class HttpBasedExpectedResultsHandler(object):
         result = result + json_result
 
       if len(result) == 0:
-        raise RuntimeError("Expected result set is empty for topology %s", self.topology_name)
+        raise status.TestFailure(
+            "Expected result set is empty for topology %s" % self.topology_name)
 
       # need to convert from a list of json objects to a string of a python list,
       # without the unicode using double quotes, not single quotes.
       return str(map(lambda x: str(x), result)).replace("'", '"')
     except Exception as e:
-      logging.error(
-          "Fetching expected result failed for %s topology: %s", self.topology_name, str(e))
-      return "fail"
+      raise status.TestFailure(
+          "Fetching expected result failed for %s topology: %s" % self.topology_name, e)
 
 class HttpBasedActualResultsHandler(object):
   def __init__(self, server_host_port, topology_name):
@@ -76,8 +75,8 @@ class HttpBasedActualResultsHandler(object):
       return fetch_from_server(self.server_host_port, self.topology_name,
                                'results', '/results/%s' % self.topology_name)
     except Exception as e:
-      logging.error("Fetching result failed for %s topology: %s", self.topology_name, str(e))
-      return "fail"
+      raise status.TestFailure(
+          "Fetching result failed for %s topology: %s" % self.topology_name, e)
 
 # pylint: disable=unnecessary-lambda
 class ExactlyOnceResultsChecker(object):
@@ -107,16 +106,15 @@ class ExactlyOnceResultsChecker(object):
   def _compare(self, expected_results, actual_results):
     # Compare the actual and expected result
     if actual_results == expected_results:
-      logging.info(
-          "Topology %s result matches expected result: %s expected tuples found exactly once",
-          len(expected_results), self.topology_name)
-      return "success"
+      return status.TestSuccess(
+          "Topology %s result matches expected result: %s expected tuples found exactly once" %
+          (len(expected_results), self.topology_name))
     else:
-      logging.error("Actual result did not match expected result")
+      failure = status.TestFailure("Actual result did not match expected result")
       # lambda required below to remove the unicode 'u' from the output
       logging.info("Actual result ---------- \n" + str(map(lambda x: str(x), actual_results)))
       logging.info("Expected result ---------- \n" + str(map(lambda x: str(x), expected_results)))
-      return "fail"
+      raise failure
 
 class AtLeastOnceResultsChecker(ExactlyOnceResultsChecker):
   """Compares what results we found against what was expected. Verifies and exact match"""
@@ -135,18 +133,17 @@ class AtLeastOnceResultsChecker(ExactlyOnceResultsChecker):
         missed_counts[expected_value] = expected_count
 
     if len(missed_counts) == 0:
-      logging.info(
-          "Topology %s result matches expected result: %s expected tuples found at least once",
-          self.topology_name, len(expected_counts))
-      return "success"
+      return status.TestSuccess(
+          "Topology %s result matches expected result: %s expected tuples found at least once" %
+          (self.topology_name, len(expected_counts)))
     else:
-      logging.error("Actual result did not match expected result")
+      failure = status.TestFailure("Actual result did not match expected result")
       # lambda required below to remove the unicode 'u' from the output
       logging.info("Actual value frequencies ---------- \n" + ', '.join(
           map(lambda (k, v): "%s(%s)" % (str(k), v), actual_counts.iteritems())))
       logging.info("Expected value frequencies ---------- \n" + ', '.join(
           map(lambda (k, v): "%s(%s)" % (str(k), v), expected_counts.iteritems())))
-      return "fail"
+      raise failure
 
 def _frequency_dict(values):
   frequency = {}
@@ -169,8 +166,7 @@ def run_test(topology_name, classpath, results_checker,
                     params.env, params.tests_bin_path, classpath,
                     params.release_package_uri, args)
   except Exception as e:
-    logging.error("Failed to submit %s topology: %s", topology_name, str(e))
-    return "fail"
+    raise status.TestFailure("Failed to submit %s topology: %s" % topology_name, e)
 
   logging.info("Successfully submitted %s topology", topology_name)
 
@@ -189,8 +185,7 @@ def run_test(topology_name, classpath, results_checker,
     return results_checker.check_results()
 
   except Exception as e:
-    logging.error("Checking result failed for %s topology: %s", topology_name, str(e))
-    return "fail"
+    raise status.TestFailure("Checking result failed for %s topology: %s" % topology_name, e)
   finally:
     kill_topology(params.heron_cli_path, params.cli_config_path, params.cluster,
                   params.role, params.env, topology_name)
@@ -217,13 +212,11 @@ def fetch_from_server(server_host_port, topology_name, data_name, path):
                    data_name, response.status, response.reason, response.read())
       time.sleep(RETRY_INTERVAL)
 
-  logging.error("Failed to fetch %s after %d attempts", data_name, RETRY_ATTEMPTS)
-  raise RuntimeError("exceeded fetching %s retry attempts", data_name)
+  raise status.TestFailure("Failed to fetch %s after %d attempts" % (data_name, RETRY_ATTEMPTS))
 
 def get_http_response(server_host_port, path):
   ''' get HTTP response '''
-  # pylint: disable=unused-variable
-  for i in range(0, RETRY_ATTEMPTS):
+  for _ in range(0, RETRY_ATTEMPTS):
     try:
       connection = HTTPConnection(server_host_port)
       connection.request('GET', path)
@@ -233,8 +226,7 @@ def get_http_response(server_host_port, path):
       time.sleep(RETRY_INTERVAL)
       continue
 
-  logging.error("Failed to get HTTP Response after %d attempts", RETRY_ATTEMPTS)
-  raise RuntimeError("Failed to get HTTP response")
+  raise status.TestFailure("Failed to get HTTP Response after %d attempts" % RETRY_ATTEMPTS)
 
 def cluster_token(cluster, role, env):
   if cluster == "local":
@@ -256,10 +248,8 @@ def submit_topology(heron_cli_path, cli_config_path, cluster, role,
 
   logging.info("Submitting topology: %s", cmd)
 
-  if os.system(cmd) == 0:
-    return
-
-  raise RuntimeError("Unable to submit the topology")
+  if os.system(cmd) != 0:
+    raise status.TestFailure("Unable to submit the topology")
 
 def kill_topology(heron_cli_path, cli_config_path, cluster, role, env, topology_name):
   ''' Kill a topology using heron-cli '''
@@ -267,12 +257,10 @@ def kill_topology(heron_cli_path, cli_config_path, cluster, role, env, topology_
         (heron_cli_path, cli_config_path, cluster_token(cluster, role, env), topology_name)
 
   logging.info("Killing topology: %s", cmd)
-  if os.system(cmd) == 0:
-    logging.info("Successfully killed topology %s", topology_name)
-    return
+  if os.system(cmd) != 0:
+    raise status.TestFailure("Failed to kill topology %s" % topology_name)
 
-  logging.error("Failed to kill topology %s", topology_name)
-  raise RuntimeError("Unable to kill the topology")
+  logging.info("Successfully killed topology %s", topology_name)
 
 def update_topology(heron_cli_path, cli_config_path, cluster,
                     role, env, topology_name, update_args):
@@ -281,13 +269,23 @@ def update_topology(heron_cli_path, cli_config_path, cluster,
          cluster_token(cluster, role, env), update_args, topology_name)
 
   logging.info("Update topology: %s", cmd)
-  if os.system(cmd) == 0:
-    logging.info("Successfully updated topology %s", topology_name)
-    return
+  if os.system(cmd) != 0:
+    raise status.TestFailure("Failed to update topology %s" % topology_name)
 
-  raise RuntimeError("Failed to update topology %s", topology_name)
+  logging.info("Successfully updated topology %s", topology_name)
 
-# pylint: disable=too-many-locals
+def filter_test_topologies(test_topologies, test_pattern):
+  initial_topologies = test_topologies
+  if test_pattern:
+    pattern = re.compile(test_pattern)
+    test_topologies = filter(lambda x: pattern.match(x['topologyName']), test_topologies)
+
+  if len(test_topologies) == 0:
+    logging.error("Test filter '%s' did not match any configured test names:\n%s",
+                  test_pattern, '\n'.join(map(lambda x: x['topologyName'], initial_topologies)))
+    sys.exit(1)
+  return test_topologies
+
 def run_tests(conf, args):
   ''' Run the test for each topology specified in the conf file '''
   successes = []
@@ -297,30 +295,17 @@ def run_tests(conf, args):
   http_server_host_port = "%s:%d" % (args.http_server_hostname, args.http_server_port)
 
   if args.tests_bin_path.endswith(".jar"):
-    test_topologies = conf["javaTopologies"]
+    test_topologies = filter_test_topologies(conf["javaTopologies"], args.test_topology_pattern)
     topology_classpath_prefix = conf["topologyClasspathPrefix"]
     extra_topology_args = "-s http://%s/state" % http_server_host_port
   elif args.tests_bin_path.endswith(".pex"):
-    test_topologies = conf["pythonTopologies"]
+    test_topologies = filter_test_topologies(conf["pythonTopologies"], args.test_topology_pattern)
     topology_classpath_prefix = ""
     extra_topology_args = ""
   else:
     raise ValueError("Unrecognized binary file type: %s" % args.tests_bin_path)
 
-  initial_topologies = test_topologies
-  if args.test_topology_pattern:
-    pattern = re.compile(args.test_topology_pattern)
-    test_topologies = filter(lambda x: pattern.match(x['topologyName']), test_topologies)
-
-  total = len(test_topologies)
   current = 1
-
-  if total == 0:
-    logging.error("Test filter '%s' did not match any configured test names:\n%s",
-                  args.test_topology_pattern,
-                  '\n'.join(map(lambda x: x['topologyName'], initial_topologies)))
-    sys.exit(1)
-
   for topology_conf in test_topologies:
     topology_name = ("%s_%s_%s") % (timestamp, topology_conf["topologyName"], str(uuid.uuid4()))
     classpath = topology_classpath_prefix + topology_conf["classPath"]
@@ -340,21 +325,32 @@ def run_tests(conf, args):
                          + topology_name)
       topology_args = "%s %s" % (topology_args, topology_conf["topologyArgs"])
 
-    actual_result_handler = HttpBasedActualResultsHandler(http_server_host_port, topology_name)
-    expected_result_handler =\
-      load_expected_result_handler(topology_name, topology_conf, args, http_server_host_port)
     results_checker = load_result_checker(
-        topology_name, topology_conf, expected_result_handler, actual_result_handler)
+        topology_name, topology_conf,
+        load_expected_result_handler(topology_name, topology_conf, args, http_server_host_port),
+        HttpBasedActualResultsHandler(http_server_host_port, topology_name))
 
-    logging.info("==== Starting test %s of %s: %s ====", current, total, topology_name)
+    logging.info("==== Starting test %s of %s: %s ====",
+                 current, len(test_topologies), topology_name)
     start_secs = int(time.time())
-    if run_test(topology_name, classpath, results_checker,
-                args, http_server_host_port, update_args, topology_args) == "success":
-      successes += [(topology_name, int(time.time()) - start_secs)]
-    else:
-      failures += [(topology_name, int(time.time()) - start_secs)]
+    try:
+      result = run_test(topology_name, classpath, results_checker,
+                        args, http_server_host_port, update_args, topology_args)
+      test_tuple = (topology_name, int(time.time()) - start_secs)
+      if isinstance(result, status.TestSuccess):
+        successes += [test_tuple]
+      elif isinstance(result, status.TestFailure):
+        failures += [test_tuple]
+      else:
+        logging.error("Unrecognized test response returned for test %s: %s",
+                      topology_name, str(result))
+        failures += [test_tuple]
+    except status.TestFailure:
+      test_tuple = (topology_name, int(time.time()) - start_secs)
+      failures += [test_tuple]
+
     current += 1
-  return (successes, failures)
+  return successes, failures
 
 def load_result_checker(topology_name, topology_conf,
                         expected_result_handler, actual_result_handler):
@@ -377,8 +373,8 @@ def load_expected_result_handler(topology_name, topology_conf, args, http_server
     return HttpBasedExpectedResultsHandler(
         http_server_host_port, topology_name, topology_conf["expectedHttpResultTaskCount"])
   else:
-    raise RuntimeError("Either expectedResultRelativePath or expectedHttpResultTaskCount "
-                       + "must be specified for test %s " % topology_name)
+    raise status.TestFailure("Either expectedResultRelativePath or expectedHttpResultTaskCount "
+                             + "must be specified for test %s " % topology_name)
 
 def main():
   ''' main '''


### PR DESCRIPTION
Instread of returning `"success"`/`"fail"` strings, `test_runner` should return `TestSuccess` or raise `TestFailure`.

Moved the `status` module classes to the `common` module to share between test frameworks.