### PR TITLE
Added message id in spout in WordCountTopology example to enable ack

### DIFF
--- a/heron/examples/src/java/com/twitter/heron/examples/WordCountTopology.java
+++ b/heron/examples/src/java/com/twitter/heron/examples/WordCountTopology.java
@@ -183,6 +183,8 @@ public final class WordCountTopology {
     conf.setComponentRam("word", 2L * 1024 * 1024 * 1024);
     conf.setComponentRam("consumer", 3L * 1024 * 1024 * 1024);
     conf.setContainerCpuRequested(6);
+    // Enable Ack
+    conf.setEnableAcking(true);
 
     StormSubmitter.submitTopology(args[0], conf, builder.createTopology());
   }

--- a/heron/examples/src/java/com/twitter/heron/examples/WordCountTopology.java
+++ b/heron/examples/src/java/com/twitter/heron/examples/WordCountTopology.java
@@ -121,7 +121,7 @@ public final class WordCountTopology {
     @Override
     public void nextTuple() {
       int nextInt = rnd.nextInt(ARRAY_LENGTH);
-      collector.emit(new Values(words[nextInt]));
+      collector.emit(new Values(words[nextInt]), new Object());
     }
   }
 

--- a/heron/examples/src/java/com/twitter/heron/examples/WordCountTopology.java
+++ b/heron/examples/src/java/com/twitter/heron/examples/WordCountTopology.java
@@ -121,7 +121,8 @@ public final class WordCountTopology {
     @Override
     public void nextTuple() {
       int nextInt = rnd.nextInt(ARRAY_LENGTH);
-      collector.emit(new Values(words[nextInt]), new Object());
+      // To enable acking, we need to emit tuple with MessageId, which is an object
+      collector.emit(new Values(words[nextInt]), "MESSAGE_ID");
     }
   }
 


### PR DESCRIPTION
Since tuples are acked in ConsumerBolt, so we should call ``emit(List<Object> tuple, Object messageId) `` rather than ``emit(List<Object> tuple) `` in spout to enable ack.

This solves #1568 