### PR TITLE
Remove unnecessary ack() in bolt

### DIFF
--- a/heron/examples/src/java/com/twitter/heron/examples/WordCountTopology.java
+++ b/heron/examples/src/java/com/twitter/heron/examples/WordCountTopology.java
@@ -149,7 +149,6 @@ public final class WordCountTopology {
         Integer val = countMap.get(key);
         countMap.put(key, ++val);
       }
-      collector.ack(tuple);
     }
 
     @Override


### PR DESCRIPTION
Since ack is not enabled and the message id is not given to the emitted tuples in spout, we should remove ``ack()`` statement in the ``ConsumerBolt`` to avoid confusing the user.

This RP solves #1568 