### PR TITLE
Add a scoring-based approach to modifying packing plan

### DIFF
--- a/heron/packing/src/java/BUILD
+++ b/heron/packing/src/java/BUILD
@@ -42,6 +42,7 @@ java_library(
     srcs = glob(["**/packing/builder/*.java","**/packing/ResourceExceededException.java"]),
     deps = heron_java_proto_files() + [
         "@com_google_guava_guava//jar",
+        "//heron/api/src/java:classification",
         "//heron/spi/src/java:packing-spi-java",
         ":utils",
     ],

--- a/heron/packing/src/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPacking.java
@@ -24,7 +24,7 @@ import java.util.logging.Logger;
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.packing.RamRequirement;
 import com.twitter.heron.packing.ResourceExceededException;
-import com.twitter.heron.packing.builder.IdBasedContainerScorer;
+import com.twitter.heron.packing.builder.ContainerIdScorer;
 import com.twitter.heron.packing.builder.PackingPlanBuilder;
 import com.twitter.heron.packing.utils.PackingUtils;
 import com.twitter.heron.spi.common.Config;
@@ -285,7 +285,7 @@ public class FirstFitDecreasingPacking implements IPacking, IRepacking {
     ArrayList<RamRequirement> ramRequirements =
         getSortedRAMInstances(componentsToScaleDown.keySet());
 
-    IdBasedContainerScorer scorer = new IdBasedContainerScorer(1, this.numContainers);
+    ContainerIdScorer scorer = new ContainerIdScorer();
 
     for (RamRequirement ramRequirement : ramRequirements) {
       String component = ramRequirement.getComponentName();
@@ -306,10 +306,8 @@ public class FirstFitDecreasingPacking implements IPacking, IRepacking {
       planBuilder.updateNumContainers(++numContainers);
     }
 
-    IdBasedContainerScorer scorer = new IdBasedContainerScorer(1, this.numContainers);
-
     try {
-      planBuilder.addInstance(scorer, instanceId);
+      planBuilder.addInstance(new ContainerIdScorer(), instanceId);
     } catch (ResourceExceededException e) {
       planBuilder.updateNumContainers(++numContainers);
       planBuilder.addInstance(numContainers, instanceId);

--- a/heron/packing/src/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPacking.java
@@ -305,15 +305,14 @@ public class FirstFitDecreasingPacking implements IPacking, IRepacking {
     if (this.numContainers == 0) {
       planBuilder.updateNumContainers(++numContainers);
     }
-    for (int containerId = 1; containerId <= numContainers; containerId++) {
-      try {
-        planBuilder.addInstance(containerId, instanceId);
-        return;
-      } catch (ResourceExceededException e) {
-        // ignore since we'll continue trying
-      }
+
+    IdBasedContainerScorer scorer = new IdBasedContainerScorer(1, this.numContainers);
+
+    try {
+      planBuilder.addInstance(scorer, instanceId);
+    } catch (ResourceExceededException e) {
+      planBuilder.updateNumContainers(++numContainers);
+      planBuilder.addInstance(numContainers, instanceId);
     }
-    planBuilder.updateNumContainers(++numContainers);
-    planBuilder.addInstance(numContainers, instanceId);
   }
 }

--- a/heron/packing/src/java/com/twitter/heron/packing/builder/Container.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/builder/Container.java
@@ -27,6 +27,7 @@ import com.twitter.heron.spi.packing.Resource;
  */
 class Container {
 
+  private int containerId;
   private HashSet<PackingPlan.InstancePlan> instances;
   private Resource capacity;
   private int paddingPercentage;
@@ -50,10 +51,15 @@ class Container {
    * @param capacity the capacity of the container in terms of cpu, ram and disk
    * @param paddingPercentage the padding percentage
    */
-  Container(Resource capacity, int paddingPercentage) {
+  Container(int containerId, Resource capacity, int paddingPercentage) {
+    this.containerId = containerId;
     this.capacity = capacity;
     this.instances = new HashSet<PackingPlan.InstancePlan>();
     this.paddingPercentage = paddingPercentage;
+  }
+
+  public int getContainerId() {
+    return containerId;
   }
 
   /**

--- a/heron/packing/src/java/com/twitter/heron/packing/builder/ContainerIdScorer.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/builder/ContainerIdScorer.java
@@ -14,14 +14,19 @@
 package com.twitter.heron.packing.builder;
 
 /**
- * Sorts containers ascending starting from container with id firstId and ending with id firstId - 1
+ * Sorts containers ascending by container id. Id firstId and maxId as passed, starte with
+ * container with id firstId and ends with id firstId - 1
  */
-public class IdBasedContainerScorer implements Scorer<Container> {
+public class ContainerIdScorer implements Scorer<Container> {
 
   private Integer firstId;
   private Integer maxId;
 
-  public IdBasedContainerScorer(Integer firstId, Integer maxId) {
+  public ContainerIdScorer() {
+    this(0, 0);
+  }
+
+  public ContainerIdScorer(Integer firstId, Integer maxId) {
     this.firstId = firstId;
     this.maxId = maxId;
   }

--- a/heron/packing/src/java/com/twitter/heron/packing/builder/ContainerIdScorer.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/builder/ContainerIdScorer.java
@@ -14,7 +14,7 @@
 package com.twitter.heron.packing.builder;
 
 /**
- * Sorts containers ascending by container id. Id firstId and maxId as passed, starte with
+ * Sorts containers ascending by container id. Id firstId and maxId as passed, start with
  * container with id firstId and ends with id firstId - 1
  */
 public class ContainerIdScorer implements Scorer<Container> {

--- a/heron/packing/src/java/com/twitter/heron/packing/builder/IdBasedContainerScorer.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/builder/IdBasedContainerScorer.java
@@ -1,0 +1,43 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.twitter.heron.packing.builder;
+
+/**
+ * Sorts containers ascending starting from container with id firstId and ending with id firstId - 1
+ */
+public class IdBasedContainerScorer implements Scorer<Container> {
+
+  private Integer firstId;
+  private Integer maxId;
+
+  public IdBasedContainerScorer(Integer firstId, Integer maxId) {
+    this.firstId = firstId;
+    this.maxId = maxId;
+  }
+
+  @Override
+  public boolean sortAscending() {
+    return true;
+  }
+
+  @Override
+  public double getScore(Container container) {
+    int containerId = container.getContainerId();
+    if (containerId >= firstId) {
+      return containerId - firstId;
+    } else {
+      return containerId + maxId;
+    }
+  }
+}

--- a/heron/packing/src/java/com/twitter/heron/packing/builder/PackingPlanBuilder.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/builder/PackingPlanBuilder.java
@@ -111,10 +111,11 @@ public class PackingPlanBuilder {
     return this;
   }
 
+  @SuppressWarnings("JavadocMethod")
   /**
    * Add an instance to the first container possible ranked by score.
    * @return containerId of the container the instance was added to
-   * @throws PackingException if the instance could not be added
+   * @throws com.twitter.heron.packing.ResourceExceededException if the instance could not be added
    */
   public int addInstance(Scorer<Container> scorer,
                          InstanceId instanceId) throws ResourceExceededException {
@@ -123,11 +124,12 @@ public class PackingPlanBuilder {
     return addInstance(scorers, instanceId);
   }
 
+  @SuppressWarnings("JavadocMethod")
   /**
    * Add an instance to the first container possible ranked by score. If a scoring tie exists,
    * uses the next scorer in the scorers list to break the tie.
    * @return containerId of the container the instance was added to
-   * @throws PackingException if the instance could not be added
+   * @throws com.twitter.heron.packing.ResourceExceededException if the instance could not be added
    */
   private int addInstance(List<Scorer<Container>> scorers, InstanceId instanceId)
       throws ResourceExceededException {
@@ -153,10 +155,11 @@ public class PackingPlanBuilder {
     return instancePlan.isPresent();
   }
 
+  @SuppressWarnings("JavadocMethod")
   /**
    * Remove an instance from the first container possible ranked by score.
    * @return containerId of the container the instance was removed from
-   * @throws PackingException if the instance could not be removed
+   * @throws com.twitter.heron.spi.packing.PackingException if the instance could not be removed
    */
   public int removeInstance(Scorer<Container> scorer, String componentName) {
     List<Scorer<Container>> scorers = new LinkedList<>();
@@ -164,11 +167,12 @@ public class PackingPlanBuilder {
     return removeInstance(scorers, componentName);
   }
 
+  @SuppressWarnings("JavadocMethod")
   /**
    * Remove an instance from the first container possible ranked by score. If a scoring tie exists,
    * uses the next scorer in the scorers list to break the tie.
    * @return containerId of the container the instance was removed from
-   * @throws PackingException if the instance could not be removed
+   * @throws com.twitter.heron.spi.packing.PackingException if the instance could not be removed
    */
   public int removeInstance(List<Scorer<Container>> scorers, String componentName) {
     initContainers();

--- a/heron/packing/src/java/com/twitter/heron/packing/builder/Scorer.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/builder/Scorer.java
@@ -1,0 +1,42 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.twitter.heron.packing.builder;
+
+import com.twitter.heron.classification.InterfaceAudience;
+import com.twitter.heron.classification.InterfaceStability;
+
+/**
+ * Scores an  object based on some heuristic. The ordering of the object by score could be used to
+ * drive algorithms that rely on preference of objects (e.g. containers) to be used for packing
+ * operations.
+ */
+@InterfaceAudience.LimitedPrivate
+@InterfaceStability.Unstable
+public interface Scorer<T> {
+
+  /**
+   * Whether or not scores produced by this scorer should sort ascending or descending
+   * @return true if the low scores should sort before higher scores
+   */
+  boolean sortAscending();
+
+  /**
+   * Return the score for a given component on a container
+   *
+   * @param object the object to be scored
+   * @return score for container
+   */
+  double getScore(T object);
+
+}

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
@@ -20,7 +20,7 @@ import java.util.logging.Logger;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.packing.ResourceExceededException;
-import com.twitter.heron.packing.builder.IdBasedContainerScorer;
+import com.twitter.heron.packing.builder.ContainerIdScorer;
 import com.twitter.heron.packing.builder.PackingPlanBuilder;
 import com.twitter.heron.packing.utils.PackingUtils;
 import com.twitter.heron.spi.common.Config;
@@ -318,10 +318,9 @@ public class ResourceCompliantRRPacking implements IPacking, IRepacking {
    */
   private void flexibleRRpolicy(PackingPlanBuilder planBuilder,
                                 InstanceId instanceId) throws ResourceExceededException {
-    //If there is not enough space on containerId look at other containers in a RR fashion
+    // If there is not enough space on containerId look at other containers in a RR fashion
     // starting from containerId.
-    IdBasedContainerScorer scorer =
-        new IdBasedContainerScorer(this.containerId, this.numContainers);
+    ContainerIdScorer scorer = new ContainerIdScorer(this.containerId, this.numContainers);
     this.containerId = nextContainerId(planBuilder.addInstance(scorer, instanceId));
   }
 
@@ -346,8 +345,7 @@ public class ResourceCompliantRRPacking implements IPacking, IRepacking {
    */
   private void removeRRInstance(PackingPlanBuilder packingPlanBuilder,
                                 String component) throws RuntimeException {
-    IdBasedContainerScorer scorer =
-        new IdBasedContainerScorer(this.containerId, this.numContainers);
+    ContainerIdScorer scorer = new ContainerIdScorer(this.containerId, this.numContainers);
     this.containerId = nextContainerId(packingPlanBuilder.removeInstance(scorer, component));
   }
 

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
@@ -173,15 +173,18 @@ public class ResourceCompliantRRPacking implements IPacking, IRepacking {
    *
    * @return new packing plan
    */
+  @Override
   public PackingPlan repack(PackingPlan currentPackingPlan, Map<String, Integer> componentChanges) {
     this.numContainers = currentPackingPlan.getContainers().size();
     resetToFirstContainer();
 
     int additionalContainers = computeNumAdditionalContainers(componentChanges, currentPackingPlan);
-    increaseNumContainers(additionalContainers);
-    LOG.info(String.format(
-        "Allocated %s additional containers for repack bring the number of containers to %s.",
-        additionalContainers, this.numContainers));
+    if (additionalContainers > 0) {
+      increaseNumContainers(additionalContainers);
+      LOG.info(String.format(
+          "Allocated %s additional containers for repack bring the number of containers to %s.",
+          additionalContainers, this.numContainers));
+    }
 
     while (true) {
       try {
@@ -197,8 +200,8 @@ public class ResourceCompliantRRPacking implements IPacking, IRepacking {
         increaseNumContainers(1);
         resetToFirstContainer();
         LOG.info(String.format(
-            "Increasing the number of containers to %s and attempting packing again.",
-            this.numContainers));
+            "%s Increasing the number of containers to %s and attempting packing again.",
+            e.getMessage(), this.numContainers));
       }
     }
   }


### PR DESCRIPTION
Instances are often added and removed to containers based on a ranking of all containers. This adds methods to the PackingPlanBuilder API to make it easy to do so without requiring the caller to rank, sort and iterate through containers. Instead, packing algorithms can now add/remove instances by passing a class that scores Components based on some heuristic. Multiple scorers can be passed for primary, secondary, tertiary, etc ranking.

This patch includes an common implementation that is used for round robin placement, but other custom implementations can be passed to score based on balance, resource utilization, etc.