### PR TITLE
Add a configurable memory cap for mempool

### DIFF
--- a/heron/common/src/cpp/config/heron-internals-config-reader.cpp
+++ b/heron/common/src/cpp/config/heron-internals-config-reader.cpp
@@ -200,8 +200,8 @@ sp_int32 HeronInternalsConfigReader::GetHeronStreammgrCacheDrainSizeMb() {
   return config_[HeronInternalsConfigVars::HERON_STREAMMGR_CACHE_DRAIN_SIZE_MB].as<int>();
 }
 
-sp_int32 HeronInternalsConfigReader::GetHeronStreammgrMempoolSize() {
-  return config_[HeronInternalsConfigVars::HERON_STREAMMGR_MEMPOOL_SIZE].as<int>();
+sp_int32 HeronInternalsConfigReader::GetHeronStreammgrMempoolSizeMb() {
+  return config_[HeronInternalsConfigVars::HERON_STREAMMGR_MEMPOOL_SIZE_MB].as<int>();
 }
 
 sp_int32 HeronInternalsConfigReader::GetHeronStreammgrXormgrRotatingmapNbuckets() {

--- a/heron/common/src/cpp/config/heron-internals-config-reader.cpp
+++ b/heron/common/src/cpp/config/heron-internals-config-reader.cpp
@@ -200,6 +200,10 @@ sp_int32 HeronInternalsConfigReader::GetHeronStreammgrCacheDrainSizeMb() {
   return config_[HeronInternalsConfigVars::HERON_STREAMMGR_CACHE_DRAIN_SIZE_MB].as<int>();
 }
 
+sp_int32 HeronInternalsConfigReader::GetHeronStreammgrMempoolSize() {
+  return config_[HeronInternalsConfigVars::HERON_STREAMMGR_MEMPOOL_SIZE].as<int>();
+}
+
 sp_int32 HeronInternalsConfigReader::GetHeronStreammgrXormgrRotatingmapNbuckets() {
   return config_[HeronInternalsConfigVars::HERON_STREAMMGR_XORMGR_ROTATINGMAP_NBUCKETS].as<int>();
 }

--- a/heron/common/src/cpp/config/heron-internals-config-reader.h
+++ b/heron/common/src/cpp/config/heron-internals-config-reader.h
@@ -152,6 +152,9 @@ class HeronInternalsConfigReader : public YamlFileReader {
   // The sized based threshold in MB for draining the tuple cache
   sp_int32 GetHeronStreammgrCacheDrainSizeMb();
 
+  // For the size of the memory pool for each type of messages
+  sp_int32 GetHeronStreammgrMempoolSize();
+
   // Get the Nbucket value, for efficient acknowledgement
   sp_int32 GetHeronStreammgrXormgrRotatingmapNbuckets();
 

--- a/heron/common/src/cpp/config/heron-internals-config-reader.h
+++ b/heron/common/src/cpp/config/heron-internals-config-reader.h
@@ -153,7 +153,7 @@ class HeronInternalsConfigReader : public YamlFileReader {
   sp_int32 GetHeronStreammgrCacheDrainSizeMb();
 
   // For the size of the memory pool for each type of messages
-  sp_int32 GetHeronStreammgrMempoolSize();
+  sp_int32 GetHeronStreammgrMempoolSizeMb();
 
   // Get the Nbucket value, for efficient acknowledgement
   sp_int32 GetHeronStreammgrXormgrRotatingmapNbuckets();

--- a/heron/common/src/cpp/config/heron-internals-config-reader.h
+++ b/heron/common/src/cpp/config/heron-internals-config-reader.h
@@ -152,7 +152,7 @@ class HeronInternalsConfigReader : public YamlFileReader {
   // The sized based threshold in MB for draining the tuple cache
   sp_int32 GetHeronStreammgrCacheDrainSizeMb();
 
-  // The max size of the memory pool for each type of messages
+  // The max size of the memory pool for all types of messages
   sp_int32 GetHeronStreammgrMempoolSizeMb();
 
   // Get the Nbucket value, for efficient acknowledgement

--- a/heron/common/src/cpp/config/heron-internals-config-reader.h
+++ b/heron/common/src/cpp/config/heron-internals-config-reader.h
@@ -152,7 +152,7 @@ class HeronInternalsConfigReader : public YamlFileReader {
   // The sized based threshold in MB for draining the tuple cache
   sp_int32 GetHeronStreammgrCacheDrainSizeMb();
 
-  // For the size of the memory pool for each type of messages
+  // The max size of the memory pool for each type of messages
   sp_int32 GetHeronStreammgrMempoolSizeMb();
 
   // Get the Nbucket value, for efficient acknowledgement

--- a/heron/common/src/cpp/config/heron-internals-config-vars.cpp
+++ b/heron/common/src/cpp/config/heron-internals-config-vars.cpp
@@ -88,6 +88,8 @@ const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_CACHE_DRAIN_FREQUENCY_
     "heron.streammgr.cache.drain.frequency.ms";
 const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_CACHE_DRAIN_SIZE_MB =
     "heron.streammgr.cache.drain.size.mb";
+const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_MEMPOOL_SIZE =
+    "heron.streammgr.mempool.size";
 const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_XORMGR_ROTATINGMAP_NBUCKETS =
     "heron.streammgr.xormgr.rotatingmap.nbuckets";
 const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_CLIENT_RECONNECT_INTERVAL_SEC =

--- a/heron/common/src/cpp/config/heron-internals-config-vars.cpp
+++ b/heron/common/src/cpp/config/heron-internals-config-vars.cpp
@@ -88,8 +88,8 @@ const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_CACHE_DRAIN_FREQUENCY_
     "heron.streammgr.cache.drain.frequency.ms";
 const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_CACHE_DRAIN_SIZE_MB =
     "heron.streammgr.cache.drain.size.mb";
-const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_MEMPOOL_SIZE =
-    "heron.streammgr.mempool.size";
+const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_MEMPOOL_SIZE_MB =
+    "heron.streammgr.mempool.size.mb";
 const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_XORMGR_ROTATINGMAP_NBUCKETS =
     "heron.streammgr.xormgr.rotatingmap.nbuckets";
 const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_CLIENT_RECONNECT_INTERVAL_SEC =

--- a/heron/common/src/cpp/config/heron-internals-config-vars.h
+++ b/heron/common/src/cpp/config/heron-internals-config-vars.h
@@ -140,7 +140,7 @@ class HeronInternalsConfigVars {
   // The sized based threshold in MB for draining the tuple cache
   static const sp_string HERON_STREAMMGR_CACHE_DRAIN_SIZE_MB;
 
-  // The max size of the memory pool for each type of messages
+  // The max size of the memory pool for all types of messages
   static const sp_string HERON_STREAMMGR_MEMPOOL_SIZE_MB;
 
   // For efficient acknowledgement

--- a/heron/common/src/cpp/config/heron-internals-config-vars.h
+++ b/heron/common/src/cpp/config/heron-internals-config-vars.h
@@ -140,7 +140,7 @@ class HeronInternalsConfigVars {
   // The sized based threshold in MB for draining the tuple cache
   static const sp_string HERON_STREAMMGR_CACHE_DRAIN_SIZE_MB;
 
-  // For the size of the memory pool for each type of messages
+  // The max size of the memory pool for each type of messages
   static const sp_string HERON_STREAMMGR_MEMPOOL_SIZE_MB;
 
   // For efficient acknowledgement

--- a/heron/common/src/cpp/config/heron-internals-config-vars.h
+++ b/heron/common/src/cpp/config/heron-internals-config-vars.h
@@ -141,7 +141,7 @@ class HeronInternalsConfigVars {
   static const sp_string HERON_STREAMMGR_CACHE_DRAIN_SIZE_MB;
 
   // For the size of the memory pool for each type of messages
-  static const sp_string HERON_STREAMMGR_MEMPOOL_SIZE;
+  static const sp_string HERON_STREAMMGR_MEMPOOL_SIZE_MB;
 
   // For efficient acknowledgement
   static const sp_string HERON_STREAMMGR_XORMGR_ROTATINGMAP_NBUCKETS;

--- a/heron/common/src/cpp/config/heron-internals-config-vars.h
+++ b/heron/common/src/cpp/config/heron-internals-config-vars.h
@@ -140,6 +140,9 @@ class HeronInternalsConfigVars {
   // The sized based threshold in MB for draining the tuple cache
   static const sp_string HERON_STREAMMGR_CACHE_DRAIN_SIZE_MB;
 
+  // For the size of the memory pool for each type of messages
+  static const sp_string HERON_STREAMMGR_MEMPOOL_SIZE;
+
   // For efficient acknowledgement
   static const sp_string HERON_STREAMMGR_XORMGR_ROTATINGMAP_NBUCKETS;
 

--- a/heron/common/src/cpp/network/client.h
+++ b/heron/common/src/cpp/network/client.h
@@ -174,8 +174,8 @@ class Client : public BaseClient {
   // Return the underlying EventLoop.
   EventLoop* getEventLoop() { return eventLoop_; }
 
-  void set_pool_size(sp_int32 size) {
-    _heron_message_pool.set_size(size);
+  void set_pool_limit(sp_int32 limit) {
+    _heron_message_pool.set_limit(limit);
   }
 
   template<typename M>

--- a/heron/common/src/cpp/network/client.h
+++ b/heron/common/src/cpp/network/client.h
@@ -174,8 +174,9 @@ class Client : public BaseClient {
   // Return the underlying EventLoop.
   EventLoop* getEventLoop() { return eventLoop_; }
 
-  // TODO(mfu):
-  MemPool<google::protobuf::Message> _heron_message_pool;
+  void set_pool_size(sp_int32 size) {
+    _heron_message_pool.set_size(size);
+  }
 
   template<typename M>
   void release(M* m) {
@@ -214,6 +215,8 @@ class Client : public BaseClient {
   virtual void StopBackPressureConnectionCb(Connection* _connection);
 
  private:
+  MemPool<google::protobuf::Message> _heron_message_pool;
+
   //! Imlement methods of BaseClient
   virtual BaseConnection* CreateConnection(ConnectionEndPoint* endpoint, ConnectionOptions* options,
                                            EventLoop* eventLoop);

--- a/heron/common/src/cpp/network/mempool.h
+++ b/heron/common/src/cpp/network/mempool.h
@@ -52,7 +52,7 @@ class BaseMemPool {
 template<typename B>
 class MemPool {
  public:
-  MemPool() {
+  MemPool() : size_(0) {
   }
 
   // TODO(cwang): we have a memory leak here.
@@ -64,6 +64,10 @@ class MemPool {
       m.second.clear();
     }
     map_.clear();
+  }
+
+  void set_size(sp_int32 size) {
+    size_ = size;
   }
 
   template<typename M>
@@ -83,8 +87,7 @@ class MemPool {
   void release(M* ptr) {
     std::type_index type = typeid(M);
     auto& pool = map_[type];
-    // TODO(cwang): expose this limit via config?
-    if (pool.size() > 2048) {
+    if (pool.size() > size_) {
       auto first = pool.front();
       pool.pop_front();
       delete first;
@@ -93,6 +96,7 @@ class MemPool {
   }
 
  private:
+  sp_int32 size_;
   std::unordered_map<std::type_index, std::list<B*>> map_;
 };
 

--- a/heron/common/src/cpp/network/mempool.h
+++ b/heron/common/src/cpp/network/mempool.h
@@ -96,7 +96,7 @@ class MemPool {
     if (size_ > size_limit_) {
       auto first = pool.front();
       pool.pop_front();
-      size_ -= sizeof(*first);
+      size_ -= sizeof(M);
       delete first;
     }
     pool.push_back(static_cast<B*>(ptr));

--- a/heron/common/src/cpp/network/mempool.h
+++ b/heron/common/src/cpp/network/mempool.h
@@ -16,7 +16,7 @@
 #ifndef MEM_POOL_H
 #define MEM_POOL_H
 
-#include <list>
+#include <deque>
 #include <vector>
 #include <unordered_map>
 #include <typeindex>
@@ -106,7 +106,7 @@ class MemPool {
  private:
   sp_int32 size_;
   sp_int32 size_limit_;
-  std::unordered_map<std::type_index, std::list<B*>> map_;
+  std::unordered_map<std::type_index, std::deque<B*>> map_;
 };
 
 #endif

--- a/heron/common/src/cpp/network/server.h
+++ b/heron/common/src/cpp/network/server.h
@@ -208,8 +208,8 @@ class Server : public BaseServer {
   // Called when the connection is closed
   virtual void HandleConnectionClose_Base(BaseConnection* connection, NetworkErrorCode _status);
 
-  void set_pool_size(sp_int32 size) {
-    _heron_message_pool.set_size(size);
+  void set_pool_limit(sp_int32 limit) {
+    _heron_message_pool.set_limit(limit);
   }
 
   template<typename M>

--- a/heron/common/src/cpp/network/server.h
+++ b/heron/common/src/cpp/network/server.h
@@ -208,7 +208,9 @@ class Server : public BaseServer {
   // Called when the connection is closed
   virtual void HandleConnectionClose_Base(BaseConnection* connection, NetworkErrorCode _status);
 
-  MemPool<google::protobuf::Message> _heron_message_pool;
+  void set_pool_size(sp_int32 size) {
+    _heron_message_pool.set_size(size);
+  }
 
   template<typename M>
   void release(M* m) {
@@ -221,6 +223,8 @@ class Server : public BaseServer {
   }
 
  private:
+  MemPool<google::protobuf::Message> _heron_message_pool;
+
   // When a new packet arrives on the connection, this is invoked by the Connection
   void OnNewPacket(Connection* connection, IncomingPacket* packet);
 

--- a/heron/config/src/yaml/conf/aurora/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/aurora/heron_internals.yaml
@@ -61,7 +61,7 @@ heron.streammgr.cache.drain.size.mb: 100
 # For efficient acknowledgements
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
-# For the size of the memory pool for each type of messages
+# The max size of the memory pool for all types of messages
 heron.streammgr.mempool.size.mb: 100
 
 # The reconnect interval to other stream managers in secs for stream manager client

--- a/heron/config/src/yaml/conf/aurora/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/aurora/heron_internals.yaml
@@ -62,7 +62,7 @@ heron.streammgr.cache.drain.size.mb: 100
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
 # For the size of the memory pool for each type of messages
-heron.streammgr.mempool.size: 3072
+heron.streammgr.mempool.size.mb: 100
 
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1

--- a/heron/config/src/yaml/conf/aurora/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/aurora/heron_internals.yaml
@@ -61,6 +61,9 @@ heron.streammgr.cache.drain.size.mb: 100
 # For efficient acknowledgements
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
+# For the size of the memory pool for each type of messages
+heron.streammgr.mempool.size: 3072
+
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 

--- a/heron/config/src/yaml/conf/examples/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/examples/heron_internals.yaml
@@ -61,7 +61,7 @@ heron.streammgr.cache.drain.size.mb: 100
 # For efficient acknowledgements
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
-# For the size of the memory pool for each type of messages
+# The max size of the memory pool for all types of messages
 heron.streammgr.mempool.size.mb: 100
 
 # The reconnect interval to other stream managers in secs for stream manager client

--- a/heron/config/src/yaml/conf/examples/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/examples/heron_internals.yaml
@@ -62,7 +62,7 @@ heron.streammgr.cache.drain.size.mb: 100
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
 # For the size of the memory pool for each type of messages
-heron.streammgr.mempool.size: 3072
+heron.streammgr.mempool.size.mb: 100
 
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1

--- a/heron/config/src/yaml/conf/examples/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/examples/heron_internals.yaml
@@ -61,6 +61,9 @@ heron.streammgr.cache.drain.size.mb: 100
 # For efficient acknowledgements
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
+# For the size of the memory pool for each type of messages
+heron.streammgr.mempool.size: 3072
+
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 

--- a/heron/config/src/yaml/conf/local/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/local/heron_internals.yaml
@@ -61,7 +61,7 @@ heron.streammgr.cache.drain.size.mb: 100
 # For efficient acknowledgements
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
-# For the size of the memory pool for each type of messages
+# The max size of the memory pool for all types of messages
 heron.streammgr.mempool.size.mb: 100
 
 # The reconnect interval to other stream managers in secs for stream manager client

--- a/heron/config/src/yaml/conf/local/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/local/heron_internals.yaml
@@ -62,7 +62,7 @@ heron.streammgr.cache.drain.size.mb: 100
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
 # For the size of the memory pool for each type of messages
-heron.streammgr.mempool.size: 3072
+heron.streammgr.mempool.size.mb: 100
 
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1

--- a/heron/config/src/yaml/conf/local/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/local/heron_internals.yaml
@@ -61,6 +61,9 @@ heron.streammgr.cache.drain.size.mb: 100
 # For efficient acknowledgements
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
+# For the size of the memory pool for each type of messages
+heron.streammgr.mempool.size: 3072
+
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 

--- a/heron/config/src/yaml/conf/localzk/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/localzk/heron_internals.yaml
@@ -61,7 +61,7 @@ heron.streammgr.cache.drain.size.mb: 100
 # For efficient acknowledgements
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
-# For the size of the memory pool for each type of messages
+# The max size of the memory pool for all types of messages
 heron.streammgr.mempool.size.mb: 100
 
 # The reconnect interval to other stream managers in secs for stream manager client

--- a/heron/config/src/yaml/conf/localzk/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/localzk/heron_internals.yaml
@@ -62,7 +62,7 @@ heron.streammgr.cache.drain.size.mb: 100
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
 # For the size of the memory pool for each type of messages
-heron.streammgr.mempool.size: 3072
+heron.streammgr.mempool.size.mb: 100
 
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1

--- a/heron/config/src/yaml/conf/localzk/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/localzk/heron_internals.yaml
@@ -61,6 +61,9 @@ heron.streammgr.cache.drain.size.mb: 100
 # For efficient acknowledgements
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
+# For the size of the memory pool for each type of messages
+heron.streammgr.mempool.size: 3072
+
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 

--- a/heron/config/src/yaml/conf/marathon/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/marathon/heron_internals.yaml
@@ -61,7 +61,7 @@ heron.streammgr.cache.drain.size.mb: 100
 # For efficient acknowledgements
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
-# For the size of the memory pool for each type of messages
+# The max size of the memory pool for all types of messages
 heron.streammgr.mempool.size.mb: 100
 
 # The reconnect interval to other stream managers in secs for stream manager client

--- a/heron/config/src/yaml/conf/marathon/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/marathon/heron_internals.yaml
@@ -62,7 +62,7 @@ heron.streammgr.cache.drain.size.mb: 100
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
 # For the size of the memory pool for each type of messages
-heron.streammgr.mempool.size: 3072
+heron.streammgr.mempool.size.mb: 100
 
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1

--- a/heron/config/src/yaml/conf/marathon/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/marathon/heron_internals.yaml
@@ -61,6 +61,9 @@ heron.streammgr.cache.drain.size.mb: 100
 # For efficient acknowledgements
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
+# For the size of the memory pool for each type of messages
+heron.streammgr.mempool.size: 3072
+
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 

--- a/heron/config/src/yaml/conf/mesos/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/mesos/heron_internals.yaml
@@ -61,7 +61,7 @@ heron.streammgr.cache.drain.size.mb: 100
 # For efficient acknowledgements
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
-# For the size of the memory pool for each type of messages
+# The max size of the memory pool for all types of messages
 heron.streammgr.mempool.size.mb: 100
 
 # The reconnect interval to other stream managers in secs for stream manager client

--- a/heron/config/src/yaml/conf/mesos/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/mesos/heron_internals.yaml
@@ -62,7 +62,7 @@ heron.streammgr.cache.drain.size.mb: 100
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
 # For the size of the memory pool for each type of messages
-heron.streammgr.mempool.size: 3072
+heron.streammgr.mempool.size.mb: 100
 
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1

--- a/heron/config/src/yaml/conf/mesos/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/mesos/heron_internals.yaml
@@ -61,6 +61,9 @@ heron.streammgr.cache.drain.size.mb: 100
 # For efficient acknowledgements
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
+# For the size of the memory pool for each type of messages
+heron.streammgr.mempool.size: 3072
+
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 

--- a/heron/config/src/yaml/conf/slurm/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/slurm/heron_internals.yaml
@@ -62,7 +62,7 @@ heron.streammgr.cache.drain.size.mb: 100
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3 
 
 # For the size of the memory pool for each type of messages
-heron.streammgr.mempool.size: 3072
+heron.streammgr.mempool.size.mb: 100
 
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1 

--- a/heron/config/src/yaml/conf/slurm/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/slurm/heron_internals.yaml
@@ -61,6 +61,9 @@ heron.streammgr.cache.drain.size.mb: 100
 # For efficient acknowledgements
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3 
 
+# For the size of the memory pool for each type of messages
+heron.streammgr.mempool.size: 3072
+
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1 
 

--- a/heron/config/src/yaml/conf/slurm/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/slurm/heron_internals.yaml
@@ -61,7 +61,7 @@ heron.streammgr.cache.drain.size.mb: 100
 # For efficient acknowledgements
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3 
 
-# For the size of the memory pool for each type of messages
+# The max size of the memory pool for all types of messages
 heron.streammgr.mempool.size.mb: 100
 
 # The reconnect interval to other stream managers in secs for stream manager client

--- a/heron/config/src/yaml/conf/test/test_heron_internals.yaml
+++ b/heron/config/src/yaml/conf/test/test_heron_internals.yaml
@@ -49,7 +49,7 @@ heron.streammgr.cache.drain.size.mb: 100
 # For efficient acknowledgement
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
-# For the size of the memory pool for each type of messages
+# The max size of the memory pool for all types of messages
 heron.streammgr.mempool.size.mb: 100
 
 # The reconnect interval to other stream managers in second for stream manager client

--- a/heron/config/src/yaml/conf/test/test_heron_internals.yaml
+++ b/heron/config/src/yaml/conf/test/test_heron_internals.yaml
@@ -50,7 +50,7 @@ heron.streammgr.cache.drain.size.mb: 100
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
 # For the size of the memory pool for each type of messages
-heron.streammgr.mempool.size: 3072
+heron.streammgr.mempool.size.mb: 100
 
 # The reconnect interval to other stream managers in second for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1

--- a/heron/config/src/yaml/conf/test/test_heron_internals.yaml
+++ b/heron/config/src/yaml/conf/test/test_heron_internals.yaml
@@ -49,6 +49,9 @@ heron.streammgr.cache.drain.size.mb: 100
 # For efficient acknowledgement
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
+# For the size of the memory pool for each type of messages
+heron.streammgr.mempool.size: 3072
+
 # The reconnect interval to other stream managers in second for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 

--- a/heron/config/src/yaml/conf/yarn/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/yarn/heron_internals.yaml
@@ -61,7 +61,7 @@ heron.streammgr.cache.drain.size.mb: 100
 # For efficient acknowledgements
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
-# For the size of the memory pool for each type of messages
+# The max size of the memory pool for all types of messages
 heron.streammgr.mempool.size.mb: 100
 
 # The reconnect interval to other stream managers in secs for stream manager client

--- a/heron/config/src/yaml/conf/yarn/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/yarn/heron_internals.yaml
@@ -62,7 +62,7 @@ heron.streammgr.cache.drain.size.mb: 100
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
 # For the size of the memory pool for each type of messages
-heron.streammgr.mempool.size: 3072
+heron.streammgr.mempool.size.mb: 100
 
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1

--- a/heron/config/src/yaml/conf/yarn/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/yarn/heron_internals.yaml
@@ -61,6 +61,9 @@ heron.streammgr.cache.drain.size.mb: 100
 # For efficient acknowledgements
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
+# For the size of the memory pool for each type of messages
+heron.streammgr.mempool.size: 3072
+
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 

--- a/heron/stmgr/src/cpp/manager/stmgr-client.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-client.cpp
@@ -72,6 +72,10 @@ StMgrClient::StMgrClient(EventLoop* eventLoop, const NetworkOptions& _options,
 
   stmgr_client_metrics_ = new heron::common::MultiCountMetric();
   metrics_manager_client_->register_metric("__client_" + other_stmgr_id_, stmgr_client_metrics_);
+
+  sp_int32 pool_size =
+    config::HeronInternalsConfigReader::Instance()->GetHeronStreammgrMempoolSize();
+  set_pool_size(pool_size);
 }
 
 StMgrClient::~StMgrClient() {

--- a/heron/stmgr/src/cpp/manager/stmgr-client.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-client.cpp
@@ -73,9 +73,9 @@ StMgrClient::StMgrClient(EventLoop* eventLoop, const NetworkOptions& _options,
   stmgr_client_metrics_ = new heron::common::MultiCountMetric();
   metrics_manager_client_->register_metric("__client_" + other_stmgr_id_, stmgr_client_metrics_);
 
-  sp_int32 pool_size =
-    config::HeronInternalsConfigReader::Instance()->GetHeronStreammgrMempoolSize();
-  set_pool_size(pool_size);
+  sp_int32 pool_limit =
+    config::HeronInternalsConfigReader::Instance()->GetHeronStreammgrMempoolSizeMb();
+  set_pool_limit(pool_limit * 1024 * 1024);
 }
 
 StMgrClient::~StMgrClient() {

--- a/heron/stmgr/src/cpp/manager/stmgr-server.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-server.cpp
@@ -109,9 +109,9 @@ StMgrServer::StMgrServer(EventLoop* eventLoop, const NetworkOptions& _options,
                                            back_pressure_metric_initiated_);
   spouts_under_back_pressure_ = false;
 
-  sp_int32 pool_size =
-    config::HeronInternalsConfigReader::Instance()->GetHeronStreammgrMempoolSize();
-  set_pool_size(pool_size);
+  sp_int32 pool_limit =
+    config::HeronInternalsConfigReader::Instance()->GetHeronStreammgrMempoolSizeMb();
+  set_pool_limit(pool_limit * 1024 * 1024);
 }
 
 StMgrServer::~StMgrServer() {

--- a/heron/stmgr/src/cpp/manager/stmgr-server.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-server.cpp
@@ -26,6 +26,7 @@
 #include "network/network.h"
 #include "config/helper.h"
 #include "metrics/metrics.h"
+#include "config/heron-internals-config-reader.h"
 
 namespace heron {
 namespace stmgr {
@@ -107,6 +108,10 @@ StMgrServer::StMgrServer(EventLoop* eventLoop, const NetworkOptions& _options,
   metrics_manager_client_->register_metric(METRIC_TIME_SPENT_BACK_PRESSURE_INIT,
                                            back_pressure_metric_initiated_);
   spouts_under_back_pressure_ = false;
+
+  sp_int32 pool_size =
+    config::HeronInternalsConfigReader::Instance()->GetHeronStreammgrMempoolSize();
+  set_pool_size(pool_size);
 }
 
 StMgrServer::~StMgrServer() {


### PR DESCRIPTION
Currently mempool is unbounded and memory in mempool grows and settles on steady state. This causes stream manager could use a lot of memory in production. We need a mechanism to add a cap there, the heap usage of stmgr is reduced down to 10% and meanwhile performance is almost not affected at all.

This should resolve https://github.com/twitter/heron/issues/1567
