### PR TITLE
Follow symbolic links when searching status files.

### DIFF
--- a/scripts/packages/BUILD
+++ b/scripts/packages/BUILD
@@ -281,7 +281,7 @@ sh_binary(
 genrule(
     name = "generate-package-info",
     outs = generated_release_files,
-    cmd = "$(location :package-info-generator) $$(find . -name '*status*.txt') >$@",
+    cmd = "$(location :package-info-generator) $$(find -L . -name '*status*.txt') >$@",
     stamp = 1,
     tools = [":package-info-generator"],
 )


### PR DESCRIPTION
because in some OS X environment, `find` does not follow symlinks (`bazel-out/`), which means that Bazel will generate empty `release.yaml`, which means that `heron version` will output nothing.