### PR TITLE
Use BaseMemPool for tuple cache

### DIFF
--- a/heron/stmgr/src/cpp/util/tuple-cache.cpp
+++ b/heron/stmgr/src/cpp/util/tuple-cache.cpp
@@ -105,11 +105,6 @@ TupleCache::TupleList::TupleList() {
 
 TupleCache::TupleList::~TupleList() {
   CHECK(tuples_.empty());
-
-  for (auto& n : heron_tuple_set_pool_) {
-    delete n;
-  }
-  heron_tuple_set_pool_.clear();
 }
 
 sp_int64 TupleCache::TupleList::add_data_tuple(const proto::api::StreamId& _streamid,


### PR DESCRIPTION
Use BaseMemPool directly instead of implementing it again. No functional change.