### PR TITLE
Extending S3 updater

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,7 +1,7 @@
 # versions shared across artifacts that should be upgraded together
-aws_version = "1.11.14"
+aws_version = "1.11.58"
 curator_version = "2.9.0"
-jackson_version = "2.6.3"
+jackson_version = "2.6.6"
 powermock_version = "1.6.2"
 reef_version = "0.14.0"
 slf4j_version = "1.7.7"
@@ -49,6 +49,11 @@ maven_jar(
 maven_jar(
   name = "commons_beanutils_commons_beanutils",
   artifact = "commons-beanutils:commons-beanutils:1.9.2",
+)
+
+maven_jar(
+  name = "commons_codec",
+  artifact = "commons-codec:commons-codec:1.9",
 )
 
 maven_jar(

--- a/heron/uploaders/src/java/BUILD
+++ b/heron/uploaders/src/java/BUILD
@@ -11,6 +11,7 @@ uploader_spi_files = [
 s3_deps_files = \
     uploader_spi_files + [
         "//third_party/java:aws-java-sdk",
+        "//third_party/java:guava",
     ]
 
 java_library(

--- a/heron/uploaders/src/java/com/twitter/heron/uploader/s3/S3Context.java
+++ b/heron/uploaders/src/java/com/twitter/heron/uploader/s3/S3Context.java
@@ -14,16 +14,22 @@
 
 package com.twitter.heron.uploader.s3;
 
+import com.amazonaws.regions.Regions;
+
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Context;
 
 public class S3Context extends Context {
+  public static final String HERON_UPLOADER_S3_AWS_PROFILE = "heron.uploader.s3.aws_profile";
   public static final String HERON_UPLOADER_S3_ACCESS_KEY = "heron.uploader.s3.access_key";
   public static final String HERON_UPLOADER_S3_SECRET_KEY = "heron.uploader.s3.secret_key";
   public static final String HERON_UPLOADER_S3_BUCKET = "heron.uploader.s3.bucket";
   public static final String HERON_UPLOADER_S3_PATH_PREFIX = "heron.uploader.s3.path_prefix";
+  public static final String HERON_UPLOADER_S3_PROXY_URI = "heron.uploader.s3.proxy_uri";
   public static final String HERON_UPLOADER_S3_URI = "heron.uploader.s3.uri";
   public static final String HERON_UPLOADER_S3_REGION = "heron.uploader.s3.region";
+
+
 
   public static String pathPrefix(Config config) {
     return config.getStringValue(HERON_UPLOADER_S3_PATH_PREFIX, "/");
@@ -31,6 +37,10 @@ public class S3Context extends Context {
 
   public static String bucket(Config config) {
     return config.getStringValue(HERON_UPLOADER_S3_BUCKET);
+  }
+
+  public static String awsProfile(Config config) {
+    return config.getStringValue(HERON_UPLOADER_S3_AWS_PROFILE);
   }
 
   public static String accessKey(Config config) {
@@ -42,10 +52,16 @@ public class S3Context extends Context {
   }
 
   public static String region(Config config) {
-    return config.getStringValue(HERON_UPLOADER_S3_REGION);
+    return config.getStringValue(HERON_UPLOADER_S3_REGION, Regions.DEFAULT_REGION.getName());
   }
 
   public static String uri(Config config) {
     return config.getStringValue(HERON_UPLOADER_S3_URI);
   }
+
+  public static String proxyUri(Config config) {
+    return config.getStringValue(HERON_UPLOADER_S3_PROXY_URI);
+  }
+
 }
+

--- a/heron/uploaders/src/java/com/twitter/heron/uploader/s3/S3Uploader.java
+++ b/heron/uploaders/src/java/com/twitter/heron/uploader/s3/S3Uploader.java
@@ -100,6 +100,12 @@ public class S3Uploader implements IUploader {
     // is specified. If neither was set just use the DefaultAWSCredentialsProviderChain
     // by not specifying a CredentialsProvider.
     if (!Strings.isNullOrEmpty(accessKey) || !Strings.isNullOrEmpty(accessSecret)) {
+
+      if (!Strings.isNullOrEmpty(awsProfile)) {
+        throw new RuntimeException("Please provide access_key/secret_key "
+            + "or aws_profile, not both.");
+      }
+
       if (Strings.isNullOrEmpty(accessKey)) {
         throw new RuntimeException("Missing heron.uploader.s3.access_key config value");
       }
@@ -120,7 +126,7 @@ public class S3Uploader implements IUploader {
       try  {
         proxyUri = new URI(proxy);
       } catch (URISyntaxException e) {
-        throw new RuntimeException("Invalid heron.uploader.s3.proxy_uri config value");
+        throw new RuntimeException("Invalid heron.uploader.s3.proxy_uri config value: " + proxy, e);
       }
 
       ClientConfiguration clientCfg = new ClientConfiguration();
@@ -223,7 +229,7 @@ public class S3Uploader implements IUploader {
         // Restore the previous version of the topology
         s3Client.copyObject(bucket, previousVersionFilePath, bucket, remoteFilePath);
       } catch (SdkClientException e) {
-        LOG.log(Level.SEVERE, "Error undoing deploying", e);
+        LOG.log(Level.SEVERE, "Reverting to previous topology version failed", e);
         return false;
       }
     }

--- a/heron/uploaders/src/java/com/twitter/heron/uploader/s3/sample.yaml
+++ b/heron/uploaders/src/java/com/twitter/heron/uploader/s3/sample.yaml
@@ -25,8 +25,8 @@ heron.uploader.s3.bucket:     heron-topologies-company-com
 # However you have the option to directly specify aws credentials:
 # heron.uploader.s3.access_key: access_key
 # heron.uploader.s3.secret_key: secret_access_key
-# If you have multiple AWS profiles in your credentials file (~/.aws/credentials)
-# you can also specify the aws profile:
+# Alternatively to directly specifying aws credentials, you can specify the aws profile
+# in case you have multiple AWS profiles in your credentials file (~/.aws/credentials):
 # heron.uploader.s3.aws_profile: profile_name
 
 

--- a/heron/uploaders/src/java/com/twitter/heron/uploader/s3/sample.yaml
+++ b/heron/uploaders/src/java/com/twitter/heron/uploader/s3/sample.yaml
@@ -9,13 +9,24 @@ heron.uploader.s3.bucket:     heron-topologies-company-com
 # s3://#{bucket}/#{prefix}/#{topology_name}/topology.tar.gz
 # heron.uploader.s3.path_prefix: path/prefix
 
-# By default, assume AWS S3. However, you can specify custom url if you are using proxy or a
-# S3 compatible storage layer.
-# heron.uploader.s3.uri : localhost:9000
+# By default, assume AWS S3. However, you can specify a custom url if you are using a
+# S3 compatible storage layer (or using a reverse proxy for accessing S3).
+# heron.uploader.s3.uri: hostname:port
+# If you want to access S3 through a http proxy, use
+# heron.upload.s3.proxy_uri: http://username:password@hostname:port
+# username and password are optional
+
 # Specifies a custom region - see http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/regions/Regions.html#US_EAST_1
 # heron.uploader.s3.region : meh
 
-# Credentials that have write access to the bucket specified above
-heron.uploader.s3.access_key: access_key
-heron.uploader.s3.secret_key: secret_access_key
+# AWS Credentials
+# By default the S3 Uploader will use the Default Credential Provider Chain for accessing the S3 bucket -
+# see http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#using-the-default-credential-provider-chain
+# However you have the option to directly specify aws credentials:
+# heron.uploader.s3.access_key: access_key
+# heron.uploader.s3.secret_key: secret_access_key
+# If you have multiple AWS profiles in your credentials file (~/.aws/credentials)
+# you can also specify the aws profile:
+# heron.uploader.s3.aws_profile: profile_name
+
 

--- a/heron/uploaders/tests/java/com/twitter/heron/uploader/s3/S3UploaderTest.java
+++ b/heron/uploaders/tests/java/com/twitter/heron/uploader/s3/S3UploaderTest.java
@@ -16,10 +16,11 @@ package com.twitter.heron.uploader.s3;
 
 import java.io.File;
 import java.net.URI;
+import java.net.URL;
 import java.util.Map;
 
-import com.amazonaws.AmazonClientException;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.s3.AmazonS3;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -36,21 +37,19 @@ import static org.mockito.Mockito.when;
 
 public class S3UploaderTest {
   private S3Uploader uploader;
-  private AmazonS3Client mockS3Client;
+  private AmazonS3 mockS3Client;
   private Config.Builder configBuilder;
   private File tempFile;
 
   @Before
   public void setUp() throws Exception {
-    mockS3Client = mock(AmazonS3Client.class);
+    mockS3Client = mock(AmazonS3.class);
 
     tempFile = File.createTempFile("temp-file-name", ".tmp");
     tempFile.deleteOnExit();
 
     configBuilder = Config.newBuilder()
         .put(S3Context.HERON_UPLOADER_S3_BUCKET, "bucket")
-        .put(S3Context.HERON_UPLOADER_S3_ACCESS_KEY, "access_key")
-        .put(S3Context.HERON_UPLOADER_S3_SECRET_KEY, "secret_key")
         .put(ConfigKeys.get("TOPOLOGY_NAME"), "test-topology")
         .put(ConfigKeys.get("TOPOLOGY_PACKAGE_FILE"), "topology.tar.gz");
 
@@ -93,14 +92,14 @@ public class S3UploaderTest {
     String expectedBucket = "bucket";
 
     when(mockS3Client.doesObjectExist(expectedBucket, expectedRemotePath)).thenReturn(false);
-    when(mockS3Client.getResourceUrl(expectedBucket, expectedRemotePath)).thenReturn("http://url");
+    when(mockS3Client.getUrl(expectedBucket, expectedRemotePath)).thenReturn(new URL("http://url"));
 
     URI uri = uploader.uploadPackage();
 
     verify(mockS3Client).putObject(Mockito.eq(expectedBucket),
         Mockito.eq(expectedRemotePath), Mockito.any(File.class));
 
-    verify(mockS3Client).getResourceUrl(expectedBucket, expectedRemotePath);
+    verify(mockS3Client).getUrl(expectedBucket, expectedRemotePath);
 
     assertEquals(new URI("http://url"), uri);
   }
@@ -112,7 +111,7 @@ public class S3UploaderTest {
     String expectedBucket = "bucket";
 
     when(mockS3Client.doesObjectExist(expectedBucket, expectedRemotePath)).thenReturn(true);
-    when(mockS3Client.getResourceUrl(expectedBucket, expectedRemotePath)).thenReturn("http://url");
+    when(mockS3Client.getUrl(expectedBucket, expectedRemotePath)).thenReturn(new URL("http://url"));
 
     URI uri = uploader.uploadPackage();
 
@@ -122,7 +121,7 @@ public class S3UploaderTest {
     verify(mockS3Client).putObject(Mockito.eq(expectedBucket), Mockito.eq(expectedRemotePath),
         Mockito.any(File.class));
 
-    verify(mockS3Client).getResourceUrl(expectedBucket, expectedRemotePath);
+    verify(mockS3Client).getUrl(expectedBucket, expectedRemotePath);
 
     assertEquals(new URI("http://url"), uri);
   }
@@ -135,7 +134,7 @@ public class S3UploaderTest {
 
     when(mockS3Client.doesObjectExist(expectedBucket, expectedRemotePath)).thenReturn(true);
     when(mockS3Client.putObject(Mockito.eq(expectedBucket), Mockito.eq(expectedRemotePath),
-        Mockito.any(File.class))).thenThrow(AmazonClientException.class);
+        Mockito.any(File.class))).thenThrow(SdkClientException.class);
 
     URI uri = uploader.uploadPackage();
     assertEquals(null, uri);
@@ -189,7 +188,7 @@ public class S3UploaderTest {
     String expectedRemotePath = "path/prefix/test-topology/topology.tar.gz";
     String expectedBucket = "bucket";
 
-    when(mockS3Client.getResourceUrl(expectedBucket, expectedRemotePath)).thenReturn("http://url");
+    when(mockS3Client.getUrl(expectedBucket, expectedRemotePath)).thenReturn(new URL("http://url"));
 
     uploader.uploadPackage();
 

--- a/third_party/java/BUILD
+++ b/third_party/java/BUILD
@@ -13,6 +13,7 @@ java_library(
         "@com_amazonaws_aws_java_sdk_core//jar",
         "@com_amazonaws_aws_java_sdk_s3//jar",
         "//third_party/java:joda_time",
+        "@commons_codec//jar",
         "@commons_logging_commons_logging//jar",
         "@org_apache_httpcomponents_http_client//jar",
         "@org_apache_httpcomponents_http_core//jar",

--- a/third_party/java/BUILD
+++ b/third_party/java/BUILD
@@ -39,6 +39,13 @@ java_library(
 )
 
 java_library(
+    name = "guava",
+    srcs = [ "Empty.java" ],
+    exports = [ "@com_google_guava_guava//jar" ],
+    deps = [ "@com_google_guava_guava//jar" ],
+)
+
+java_library(
     name = "jackson",
     srcs = [ "Empty.java" ],
     exports = [


### PR DESCRIPTION
Changes:
Upgrading AWS library
Upgrading and extending the S3 updater
Fixing proxy code
Adding commons-codec dependency for AWS

All changes should be compatible with existing configurations.

The current S3 updater requires hard coded credentials. These changes allow to the S3 updater to just use the AWS [Default Credential Provider Chain](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html). In addition it allows the configuration of an AWS Profile to signal which credentials to use from an AWS credentials file.

The Proxy code of the current version only supported reverse proxies, now reverse proxies and authenticated http proxies are supported.

`commons-codec` is required by the AWS library for authenticated proxies.
I upgraded to the latest AWS library version, which simplified usage of `CredentialsProvider`s.
