### PR TITLE
Remove duplicated code in SubmitterMain and SchedulerConfig

### DIFF
--- a/heron/common/src/java/com/twitter/heron/common/basics/FileUtils.java
+++ b/heron/common/src/java/com/twitter/heron/common/basics/FileUtils.java
@@ -123,4 +123,17 @@ public final class FileUtils {
   public static String getBaseName(String file) {
     return new File(file).getName();
   }
+
+  public static String getPkgType(String topologyBinaryFile) {
+    String pkgType;
+    String basename = FileUtils.getBaseName(topologyBinaryFile);
+    if (FileUtils.isOriginalPackagePex(basename)) {
+      pkgType = "pex";
+    } else if (FileUtils.isOriginalPackageJar(basename)) {
+      pkgType = "jar";
+    } else {
+      pkgType = "tar";
+    }
+    return pkgType;
+  }
 }

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
@@ -60,16 +60,7 @@ public class SubmitterMain {
   protected static Config topologyConfigs(
       String topologyPackage, String topologyBinaryFile, String topologyDefnFile,
       TopologyAPI.Topology topology) {
-
-    String pkgType;
-    String basename = FileUtils.getBaseName(topologyBinaryFile);
-    if (FileUtils.isOriginalPackagePex(basename)) {
-      pkgType = "pex";
-    } else if (FileUtils.isOriginalPackageJar(basename)) {
-      pkgType = "jar";
-    } else {
-      pkgType = "tar";
-    }
+    String pkgType = FileUtils.getPkgType(topologyBinaryFile);
 
     Config config = Config.newBuilder()
         .put(Keys.topologyId(), topology.getId())

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/SchedulerConfig.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/SchedulerConfig.java
@@ -43,15 +43,7 @@ public final class SchedulerConfig {
    */
   protected static Config topologyConfigs(String topologyBinaryFile,
                                           String topologyDefnFile, TopologyAPI.Topology topology) {
-    String basename = FileUtils.getBaseName(topologyBinaryFile);
-    String pkgType;
-    if (FileUtils.isOriginalPackagePex(basename)) {
-      pkgType = "pex";
-    } else if (FileUtils.isOriginalPackageJar(basename)) {
-      pkgType = "jar";
-    } else {
-      pkgType = "tar";
-    }
+    String pkgType = FileUtils.getPkgType(topologyBinaryFile);
 
     Config config = Config.newBuilder()
         .put(Keys.topologyId(), topology.getId())


### PR DESCRIPTION
As #1597 mentioned, the duplicated code is found in SubmitterMain and SchedulerConfig. 

This PR is trying to fix it and the changes are following:

* add an new method ` String getPkgType(String topologyBinaryFile)` in FileUtils
* invoke `getPkgType` method in SubmitterMain
* invoke `getPkgType` method in SchedulerConfig