### PR TITLE
Separate config params for SCP/SSH options and target host

### DIFF
--- a/heron/uploaders/src/java/com/twitter/heron/uploader/scp/ScpContext.java
+++ b/heron/uploaders/src/java/com/twitter/heron/uploader/scp/ScpContext.java
@@ -18,18 +18,30 @@ import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Context;
 
 public class ScpContext extends Context {
-  public static final String HERON_UPLOADER_SCP_COMMAND = "heron.uploader.scp.command.options";
-  public static final String HERON_UPLOADER_SSH_COMMAND = "heron.uploader.ssh.command.options";
+  public static final String HERON_UPLOADER_SCP_OPTIONS = "heron.uploader.scp.command.options";
+  public static final String HERON_UPLOADER_SCP_CONNECTION =
+      "heron.uploader.scp.command.connection";
+  public static final String HERON_UPLOADER_SSH_OPTIONS = "heron.uploader.ssh.command.options";
+  public static final String HERON_UPLOADER_SSH_CONNECTION =
+      "heron.uploader.ssh.command.connection";
   public static final String HERON_UPLOADER_SCP_DIR_PATH = "heron.uploader.scp.dir.path";
   public static final String HERON_UPLOADER_SCP_DIR_PATH_DEFAULT =
       "${HOME}/heron/repository/${CLUSTER}/${ROLE}/${TOPOLOGY}";
 
-  public static String scpCommand(Config config) {
-    return config.getStringValue(HERON_UPLOADER_SCP_COMMAND);
+  public static String scpOptions(Config config) {
+    return config.getStringValue(HERON_UPLOADER_SCP_OPTIONS);
   }
 
-  public static String sshCommand(Config config) {
-    return config.getStringValue(HERON_UPLOADER_SSH_COMMAND);
+  public static String scpConnection(Config config) {
+    return config.getStringValue(HERON_UPLOADER_SCP_CONNECTION);
+  }
+
+  public static String sshOptions(Config config) {
+    return config.getStringValue(HERON_UPLOADER_SSH_OPTIONS);
+  }
+
+  public static String sshConnection(Config config) {
+    return config.getStringValue(HERON_UPLOADER_SSH_CONNECTION);
   }
 
   public static String uploadDirPath(Config config) {

--- a/heron/uploaders/src/java/com/twitter/heron/uploader/scp/ScpController.java
+++ b/heron/uploaders/src/java/com/twitter/heron/uploader/scp/ScpController.java
@@ -20,28 +20,40 @@ import com.twitter.heron.spi.utils.ShellUtils;
 
 public class ScpController {
   private static final Logger LOG = Logger.getLogger(ScpController.class.getName());
-  private String scpCommand;
-  private String sshCommand;
+  private String scpOptions;
+  private String scpConnection;
+  private String sshOptions;
+  private String sshConnection;
   private boolean isVerbose;
 
-  public ScpController(String scpCommand, String sshCommand, boolean isVerbose) {
-    this.scpCommand = scpCommand;
-    this.sshCommand = sshCommand;
+  public ScpController(String scpOptions, String scpConnection, String sshOptions,
+                       String sshConnection, boolean isVerbose) {
+    this.scpOptions = scpOptions;
+    this.scpConnection = scpConnection;
+
+    this.sshOptions = sshOptions;
+    this.sshConnection = sshConnection;
+
     this.isVerbose = isVerbose;
   }
 
   public boolean mkdirsIfNotExists(String dir) {
-    String command = String.format("ssh %s mkdir -p %s", sshCommand,  dir);
+    // an example ssh command created by the format looks like this:
+    // ssh -i ~/.ssh/id_rsa -p 23 user@example.com mkdir -p /heron/repository/...
+    String command = String.format("ssh %s %s mkdir -p %s", sshOptions, sshConnection, dir);
     return 0 == ShellUtils.runProcess(isVerbose, command, null, null);
   }
 
   public boolean copyFromLocalFile(String source, String destination) {
-    String command = String.format("scp %s %s:%s", source, scpCommand, destination);
+    // an example scp command created by the format looks like this:
+    // scp -i ~/.ssh/id_rsa -p 23 ./foo.tar.gz user@example.com:/heron/foo.tar.gz
+    String command =
+        String.format("scp %s %s %s:%s", scpOptions, source, scpConnection, destination);
     return 0 == ShellUtils.runProcess(isVerbose, command, null, null);
   }
 
   public boolean delete(String filePath) {
-    String command = String.format("ssh %s rm -rf %s", sshCommand, filePath);
+    String command = String.format("ssh %s %s rm -rf %s", sshOptions, sshConnection, filePath);
     return 0 == ShellUtils.runProcess(isVerbose, command, null, null);
   }
 }

--- a/heron/uploaders/src/java/com/twitter/heron/uploader/scp/ScpUploader.java
+++ b/heron/uploaders/src/java/com/twitter/heron/uploader/scp/ScpUploader.java
@@ -58,18 +58,31 @@ public class ScpUploader implements IUploader {
 
   // Utils method
   protected ScpController getScpController() {
-    String scpCommand = ScpContext.scpCommand(config);
-    String sshCommand = ScpContext.sshCommand(config);
-    if (scpCommand == null) {
-      throw new RuntimeException("Missing heron.uploader.scp.command.options config value");
+    String scpOptions = ScpContext.scpOptions(config);
+    String scpConnection = ScpContext.scpConnection(config);
+    String sshOptions = ScpContext.sshOptions(config);
+    String sshConnection = ScpContext.sshConnection(config);
+
+    if (scpOptions == null) {
+      throw new RuntimeException("Missing "
+          + ScpContext.HERON_UPLOADER_SCP_OPTIONS + " config value");
+    }
+    if (scpConnection == null) {
+      throw new RuntimeException("Missing "
+          + ScpContext.HERON_UPLOADER_SCP_CONNECTION + " config value");
     }
 
-    if (sshCommand == null) {
-      throw new RuntimeException("Missing heron.uploader.ssh.command.options config value");
+    if (sshOptions == null) {
+      throw new RuntimeException("Missing "
+          + ScpContext.HERON_UPLOADER_SSH_OPTIONS + " config value");
+    }
+    if (sshConnection == null) {
+      throw new RuntimeException("Missing "
+          + ScpContext.HERON_UPLOADER_SSH_CONNECTION + " config value");
     }
 
     return new ScpController(
-        scpCommand, sshCommand, Context.verbose(config));
+        scpOptions, scpConnection, sshOptions, sshConnection, Context.verbose(config));
   }
 
   @Override

--- a/heron/uploaders/src/java/com/twitter/heron/uploader/scp/sample.yaml
+++ b/heron/uploaders/src/java/com/twitter/heron/uploader/scp/sample.yaml
@@ -1,13 +1,17 @@
 # uploader class for transferring the topology jar/tar files to storage
 heron.class.uploader:         com.twitter.heron.uploader.scp.ScpUploader
-# This is the scp command options that will be used by the uploader, this has to be customized to
-# reflect the user name, hostname and ssh keys if required. It is recommended to have
+# This is the scp command options that will be used by the uploader, this can be used to
+# specify custom options such as the location of ssh keys. It is recommended to have
 # passwordless ssh between machines
-heron.uploader.scp.command.options:   "user@host"
-# The ssh command options that will be used to connect to the uploading host to execute
-# command such as delete files, make directories. It is recommended to have passwordless ssh between
-#  machines
-heron.uploader.ssh.command.options:   "user@host"
+heron.uploader.scp.command.options:   "-i ~/.ssh/id_rsa"
+# The scp connection string sets the remote user name and host used by the uploader.
+heron.uploader.scp.command.connection:   "user@host"
+# The ssh command options that will be used when connecting to the uploading host to execute
+# command such as delete files, make directories. It is recommended to have
+# passwordless ssh between machines
+heron.uploader.ssh.command.options:   "-i ~/.ssh/id_rsa"
+# The ssh connection string sets the remote user name and host used by the uploader.
+heron.uploader.ssh.command.connection:   "user@host"
 # the directory where the file will be uploaded, make sure the user has the necessary permissions
 # to upload the file here.
 heron.uploader.scp.dir.path:   ${HOME}/heron/repository/${CLUSTER}/${ROLE}/${TOPOLOGY}

--- a/heron/uploaders/tests/java/com/twitter/heron/uploader/scp/ScpUploaderTest.java
+++ b/heron/uploaders/tests/java/com/twitter/heron/uploader/scp/ScpUploaderTest.java
@@ -41,22 +41,34 @@ public class ScpUploaderTest {
 
   @Test
   public void testConfiguration() throws Exception {
-    // Insert mock HdfsController
+    // Insert mock ScpUploader
     ScpUploader uploader = Mockito.spy(new ScpUploader());
     // exception
-    Mockito.doReturn(null).when(config).getStringValue(ScpContext.HERON_UPLOADER_SCP_COMMAND);
+    Mockito.doReturn(null).when(config).getStringValue(ScpContext.HERON_UPLOADER_SCP_OPTIONS);
     exception.expect(RuntimeException.class);
     uploader.getScpController();
     // exception
-    Mockito.doReturn(null).when(config).getStringValue(ScpContext.HERON_UPLOADER_SSH_COMMAND);
+    Mockito.doReturn(null).when(config).getStringValue(ScpContext.HERON_UPLOADER_SSH_OPTIONS);
+    exception.expect(RuntimeException.class);
+    uploader.getScpController();
+    // exception
+    Mockito.doReturn(null).when(config).getStringValue(ScpContext.HERON_UPLOADER_SCP_CONNECTION);
+    exception.expect(RuntimeException.class);
+    uploader.getScpController();
+    // exception
+    Mockito.doReturn(null).when(config).getStringValue(ScpContext.HERON_UPLOADER_SSH_CONNECTION);
     exception.expect(RuntimeException.class);
     uploader.getScpController();
 
     // happy path
     Mockito.doReturn(Mockito.anyString()).when(config).getStringValue(
-        ScpContext.HERON_UPLOADER_SCP_COMMAND);
+        ScpContext.HERON_UPLOADER_SCP_OPTIONS);
     Mockito.doReturn(Mockito.anyString()).when(config).getStringValue(
-        ScpContext.HERON_UPLOADER_SSH_COMMAND);
+        ScpContext.HERON_UPLOADER_SCP_CONNECTION);
+    Mockito.doReturn(Mockito.anyString()).when(config).getStringValue(
+        ScpContext.HERON_UPLOADER_SSH_OPTIONS);
+    Mockito.doReturn(Mockito.anyString()).when(config).getStringValue(
+        ScpContext.HERON_UPLOADER_SSH_CONNECTION);
     Assert.assertNotNull(uploader.getScpController());
   }
 

--- a/website/content/docs/operators/deployment/uploaders/scp.md
+++ b/website/content/docs/operators/deployment/uploaders/scp.md
@@ -19,10 +19,14 @@ for the Heron cluster. You'll need to specify the following for each cluster:
 
 * `heron.class.uploader` --- Indicate the uploader class to be loaded. You should set this to
 com.twitter.heron.uploader.scp.ScpUploader
-* `heron.uploader.scp.command.options` --- Part of the SCP command where you specify the username,
-host and key options. i.e "-i ~/.ssh/id_rsa user@localhost"
-* `heron.uploader.ssh.command.options` --- Part of the SCP command where you specify the username,
-host and key options. i.e "-i ~/.ssh/id_rsa user@localhost"
+* `heron.uploader.scp.command.options` --- Part of the SCP command where you specify custom options.
+i.e "-i ~/.ssh/id_rsa"
+* `heron.uploader.scp.command.connection` --- The user name and host pair to be used by the SCP command.
+i.e "user@host"
+* `heron.uploader.ssh.command.options` --- Part of the SSH command where you specify custom options.
+i.e "-i ~/.ssh/id_rsa"
+* `heron.uploader.ssh.command.connection` --- The user name and host pair to be used by the SSH command.
+i.e "user@host"
 * `heron.uploader.scp.dir.path` --- The directory to be used to uploading the package.
 
 ### Example SCP Uploader Configuration
@@ -32,18 +36,29 @@ Below is an example configuration (in `uploader.yaml`) for a SCP uploader:
 ```yaml
 # uploader class for transferring the topology jar/tar files to storage
 heron.class.uploader:         com.twitter.heron.uploader.scp.ScpUploader
-# This is the scp command options that will be used by the uploader, this has to be customized to
-# reflect the user name, hostname and ssh keys if required.
-heron.uploader.scp.command.options:   "-i ~/.ssh/id_rsa user@host"
-# The ssh command options that will be used to connect to the uploading host to execute
+# This is the scp command options that will be used by the uploader, this can be used to
+# specify custom options such as the location of ssh keys.
+heron.uploader.scp.command.options:   "-i ~/.ssh/id_rsa"
+# The scp connection string sets the remote user name and host used by the uploader.
+heron.uploader.scp.command.connection:   "user@host"
+
+# The ssh command options that will be used when connecting to the uploading host to execute
 # command such as delete files, make directories.
-heron.uploader.ssh.command.options:   "-i ~/.ssh/id_rsa user@host"
+heron.uploader.ssh.command.options:   "-i ~/.ssh/id_rsa"
+# The ssh connection string sets the remote user name and host used by the uploader.
+heron.uploader.ssh.command.connection:   "user@host"
+
 # the directory where the file will be uploaded, make sure the user has the necessary permissions
 # to upload the file here.
 heron.uploader.scp.dir.path:   ${HOME}/heron/repository/${CLUSTER}/${ROLE}/${TOPOLOGY}
 ```
 
-Below is an example `scp` command configuration in the `heron.aurora` file.
+The uploader will use SSH to create the entire directory structure specified in `heron.uploader.scp.dir.path` 
+by running `mkdir -p` before using SCP to upload the topology package.
+
+
+Below is an example `scp` command configuration in the `heron.aurora` file. The cmdline is run by every node
+in the cluster to **download** the topology package.
 
 ```bash
 fetch_user_package = Process(


### PR DESCRIPTION
Currently, the `heron.uploader.scp.command.options` config value is incorrectly used to build and execute a SCP command, which causes the topology package upload to fail when using the ScpUploader. 

A correct scp invocation looks like this: `scp <options> <src> <user@host>:<dest>`
The current implementation of ScpController formats the command line like this: `scp <src> <heron.uploader.scp.command.options>:<dest>`

Because scp expects options to be set before specifying the source file, the upload fails if `heron.uploader.scp.command.options` contains both options and a user@host pair. Note that [the documentation](http://twitter.github.io/heron/docs/operators/deployment/uploaders/scp/) gives an incorrect example.

This PR aims to fix this issue by separating the SCP options and user@host pair into two distinct configuration parameters which are then used by the ScpController to format a correct command line.

I'm still unsure whether or not the name `connection` for the user@host pair is appropriate...