### PR TITLE
Wait for a new pplan properly

### DIFF
--- a/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
@@ -1521,7 +1521,8 @@ TEST(StMgr, test_tmaster_restart_on_same_address) {
   // Note: Here we sleep longer compared to the previous test as we need
   // to tmasterClient could take upto 1 second (specified in test_heron_internals.yaml)
   // to retry connecting to tmaster.
-  sleep(3);
+  while (regular_stmgr->GetPhysicalPlan()->stmgrs(1).data_port() == common.stmgr_baseport_ + 1)
+    sleep(1);
 
   // Ensure that Stmgr connected to the new tmaster and has received new physical plan
   CHECK_EQ(regular_stmgr->GetPhysicalPlan()->stmgrs(1).data_port(), common.stmgr_baseport_ + 2);

--- a/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
@@ -1521,7 +1521,9 @@ TEST(StMgr, test_tmaster_restart_on_same_address) {
   // Note: Here we sleep longer compared to the previous test as we need
   // to tmasterClient could take upto 1 second (specified in test_heron_internals.yaml)
   // to retry connecting to tmaster.
-  while (regular_stmgr->GetPhysicalPlan()->stmgrs(1).data_port() == common.stmgr_baseport_ + 1)
+  int retries = 30;
+  while (regular_stmgr->GetPhysicalPlan()->stmgrs(1).data_port() == common.stmgr_baseport_ + 1
+         && retries--)
     sleep(1);
 
   // Ensure that Stmgr connected to the new tmaster and has received new physical plan


### PR DESCRIPTION
In test case StMgr.test_tmaster_restart_on_same_address, currently we wait for 3 seconds for a new pplan to come in and then check for the new pplan. This is broken if we don't receive the new pplan within 3 seconds. So, just wait for the change of the pplan.

This should resolve #1592.