### PR TITLE
Uses consistent scale-down algorithm for both IRepacking classes

### DIFF
--- a/heron/packing/src/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPacking.java
@@ -25,8 +25,12 @@ import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.packing.RamRequirement;
 import com.twitter.heron.packing.ResourceExceededException;
+import com.twitter.heron.packing.builder.Container;
 import com.twitter.heron.packing.builder.ContainerIdScorer;
+import com.twitter.heron.packing.builder.HomogeneityScorer;
+import com.twitter.heron.packing.builder.InstanceCountScorer;
 import com.twitter.heron.packing.builder.PackingPlanBuilder;
+import com.twitter.heron.packing.builder.Scorer;
 import com.twitter.heron.packing.utils.PackingUtils;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Context;
@@ -275,13 +279,21 @@ public class FirstFitDecreasingPacking implements IPacking, IRepacking {
     ArrayList<RamRequirement> ramRequirements =
         getSortedRAMInstances(componentsToScaleDown.keySet());
 
-    ContainerIdScorer scorer = new ContainerIdScorer();
+    InstanceCountScorer instanceCountScorer = new InstanceCountScorer();
+    ContainerIdScorer containerIdScorer = new ContainerIdScorer(false);
 
     for (RamRequirement ramRequirement : ramRequirements) {
-      String component = ramRequirement.getComponentName();
-      int numInstancesToRemove = -componentsToScaleDown.get(component);
+      String componentName = ramRequirement.getComponentName();
+      int numInstancesToRemove = -componentsToScaleDown.get(componentName);
+      List<Scorer<Container>> scorers = new ArrayList<>();
+
+      scorers.add(new HomogeneityScorer(componentName, true));  // all-same-component containers
+      scorers.add(instanceCountScorer);                         // then fewest instances
+      scorers.add(new HomogeneityScorer(componentName, false)); // then most homogeneous
+      scorers.add(containerIdScorer);                           // then highest container id
+
       for (int j = 0; j < numInstancesToRemove; j++) {
-        packingPlanBuilder.removeInstance(scorer, component);
+        packingPlanBuilder.removeInstance(scorers, componentName);
       }
     }
   }

--- a/heron/packing/tests/java/BUILD
+++ b/heron/packing/tests/java/BUILD
@@ -46,9 +46,10 @@ java_library(
     ),
     deps = [
         "//heron/common/src/java:basics-java",
+        "//heron/packing/src/java:binpacking-packing",
         "//heron/packing/src/java:builder",
         "//heron/packing/src/java:roundrobin-packing",
-        "//heron/packing/src/java:binpacking-packing",
+        "//heron/packing/src/java:utils",
         "//heron/spi/src/java:packing-spi-java",
         "//third_party/java:junit4",
         "//heron/api/src/java:api-java",

--- a/heron/packing/tests/java/com/twitter/heron/packing/CommonPackingTests.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/CommonPackingTests.java
@@ -1,0 +1,294 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.twitter.heron.packing;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.twitter.heron.api.generated.TopologyAPI;
+import com.twitter.heron.common.basics.ByteAmount;
+import com.twitter.heron.common.basics.Pair;
+import com.twitter.heron.spi.common.ClusterDefaults;
+import com.twitter.heron.spi.common.Config;
+import com.twitter.heron.spi.common.Context;
+import com.twitter.heron.spi.common.Keys;
+import com.twitter.heron.spi.packing.IPacking;
+import com.twitter.heron.spi.packing.IRepacking;
+import com.twitter.heron.spi.packing.InstanceId;
+import com.twitter.heron.spi.packing.PackingPlan;
+import com.twitter.heron.spi.packing.Resource;
+import com.twitter.heron.spi.utils.TopologyTests;
+
+/**
+ * There is some common functionality in multiple packing plans. This class contains common tests.
+ */
+public abstract class CommonPackingTests {
+  private static final String A  = "A";
+  private static final String B = "B";
+
+  protected static final String BOLT_NAME = "bolt";
+  protected static final String SPOUT_NAME = "spout";
+  protected static final int DEFAULT_CONTAINER_PADDING = 10;
+  protected int spoutParallelism;
+  protected int boltParallelism;
+  protected Integer totalInstances;
+  protected com.twitter.heron.api.Config topologyConfig;
+  protected TopologyAPI.Topology topology;
+  protected Resource instanceDefaultResources;
+
+  protected abstract IPacking getPackingImpl();
+  protected abstract IRepacking getRepackingImpl();
+
+  @Before
+  public void setUp() {
+    this.spoutParallelism = 4;
+    this.boltParallelism = 3;
+    this.totalInstances = this.spoutParallelism + this.boltParallelism;
+    int numContainers = 2;
+    // Set up the topology and its config
+    this.topologyConfig = new com.twitter.heron.api.Config();
+    topologyConfig.put(com.twitter.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
+    this.topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
+
+    Config config = Config.newBuilder()
+        .put(Keys.topologyId(), topology.getId())
+        .put(Keys.topologyName(), topology.getName())
+        .putAll(ClusterDefaults.getDefaults())
+        .build();
+    this.instanceDefaultResources = new Resource(
+        Context.instanceCpu(config), Context.instanceRam(config), Context.instanceDisk(config));
+  }
+
+  protected static TopologyAPI.Topology getTopology(
+      int spoutParallelism, int boltParallelism,
+      com.twitter.heron.api.Config topologyConfig) {
+    return TopologyTests.createTopology("testTopology", topologyConfig, SPOUT_NAME, BOLT_NAME,
+        spoutParallelism, boltParallelism);
+  }
+
+  private static Config newTestConfig(TopologyAPI.Topology topology) {
+    return Config.newBuilder()
+            .put(Keys.topologyId(), topology.getId())
+            .put(Keys.topologyName(), topology.getName())
+            .putAll(ClusterDefaults.getDefaults())
+            .build();
+  }
+
+  protected PackingPlan pack(TopologyAPI.Topology testTopology) {
+    IPacking packing = getPackingImpl();
+    packing.initialize(newTestConfig(testTopology), testTopology);
+    return packing.pack();
+  }
+
+  private PackingPlan repack(TopologyAPI.Topology testTopology,
+                               PackingPlan initialPackingPlan,
+                               Map<String, Integer> componentChanges) {
+    IRepacking repacking = getRepackingImpl();
+    repacking.initialize(newTestConfig(testTopology), testTopology);
+    return repacking.repack(initialPackingPlan, componentChanges);
+  }
+
+  protected PackingPlan doDefaultScalingTest(Map<String, Integer> componentChanges,
+                                             int numContainersBeforeRepack) {
+    return doScalingTest(topology, componentChanges,
+        instanceDefaultResources.getRam(), boltParallelism,
+        instanceDefaultResources.getRam(), spoutParallelism,
+        numContainersBeforeRepack, totalInstances);
+  }
+
+  /**
+   * Performs a scaling test for a specific topology. It first
+   * computes an initial packing plan as a basis for scaling.
+   * Given specific component parallelism changes, a new packing plan is produced.
+   *
+   * @param testTopology Input topology
+   * @param componentChanges parallelism changes for scale up/down
+   * @param boltRam ram allocated to bolts
+   * @param testBoltParallelism bolt parallelism
+   * @param spoutRam ram allocated to spouts
+   * @param testSpoutParallelism spout parallelism
+   * @param numContainersBeforeRepack number of containers that the initial packing plan should use
+   * @param totalInstancesExpected number of instances expected before scaling
+   * @return the new packing plan
+   */
+  protected PackingPlan doScalingTest(TopologyAPI.Topology testTopology,
+                                      Map<String, Integer> componentChanges,
+                                      ByteAmount boltRam,
+                                      int testBoltParallelism, ByteAmount spoutRam,
+                                      int testSpoutParallelism,
+                                      int numContainersBeforeRepack,
+                                      int totalInstancesExpected) {
+    PackingPlan packingPlan = pack(testTopology);
+
+    Assert.assertEquals(numContainersBeforeRepack, packingPlan.getContainers().size());
+    Assert.assertEquals(totalInstancesExpected, (int) packingPlan.getInstanceCount());
+    AssertPacking.assertContainers(packingPlan.getContainers(),
+        BOLT_NAME, SPOUT_NAME, boltRam, spoutRam, null);
+    AssertPacking.assertNumInstances(packingPlan.getContainers(), BOLT_NAME, testBoltParallelism);
+    AssertPacking.assertNumInstances(packingPlan.getContainers(), SPOUT_NAME, testSpoutParallelism);
+
+    PackingPlan newPackingPlan =
+        repack(testTopology, packingPlan, componentChanges);
+    AssertPacking.assertContainerRam(newPackingPlan.getContainers(),
+        packingPlan.getMaxContainerResources().getRam());
+
+    return newPackingPlan;
+  }
+
+  private void doScaleDownTest(Pair<Integer, InstanceId>[] initialComponentInstances,
+                               Map<String, Integer> componentChanges,
+                               Pair<Integer, InstanceId>[] expectedComponentInstances)
+      throws ResourceExceededException {
+    String topologyId = this.topology.getId();
+
+    // The padding percentage used in repack() must be <= one as used in pack(), otherwise we can't
+    // reconstruct the PackingPlan, see https://github.com/twitter/heron/issues/1577
+    PackingPlan initialPackingPlan = PackingTestHelper.addToTestPackingPlan(
+        topologyId, null, PackingTestHelper.toContainerIdComponentNames(initialComponentInstances),
+        DEFAULT_CONTAINER_PADDING);
+    AssertPacking.assertPackingPlan(topologyId, initialComponentInstances, initialPackingPlan);
+
+    PackingPlan newPackingPlan = repack(this.topology, initialPackingPlan, componentChanges);
+
+    AssertPacking.assertPackingPlan(topologyId, expectedComponentInstances, newPackingPlan);
+  }
+
+  /**
+   * Test the scenario where scaling down removes instances from containers that are most imbalanced
+   * (i.e., tending towards homogeneity) first. If there is a tie (e.g. AABB, AB), chooses from the
+   * container with the fewest instances, to favor ultimately removing  containers. If there is
+   * still a tie, favor removing from higher numbered containers
+   */
+  @Test
+  public void testScaleDownOneComponentRemoveContainer() throws Exception {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<Integer, InstanceId>[] initialComponentInstances = new Pair[] {
+        new Pair<>(1, new InstanceId(A, 1, 0)),
+        new Pair<>(1, new InstanceId(A, 2, 1)),
+        new Pair<>(1, new InstanceId(B, 3, 0)),
+        new Pair<>(3, new InstanceId(B, 4, 1)),
+        new Pair<>(3, new InstanceId(B, 5, 2)),
+        new Pair<>(4, new InstanceId(B, 6, 3)),
+        new Pair<>(4, new InstanceId(B, 7, 4))
+    };
+
+    Map<String, Integer> componentChanges = new HashMap<>();
+    componentChanges.put(B, -2);
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<Integer, InstanceId>[] expectedComponentInstances = new Pair[] {
+        new Pair<>(1, new InstanceId(A, 1, 0)),
+        new Pair<>(1, new InstanceId(A, 2, 1)),
+        new Pair<>(1, new InstanceId(B, 3, 0)),
+        new Pair<>(3, new InstanceId(B, 4, 1)),
+        new Pair<>(3, new InstanceId(B, 5, 2)),
+    };
+
+    doScaleDownTest(initialComponentInstances, componentChanges, expectedComponentInstances);
+  }
+
+  @Test
+  public void testScaleDownTwoComponentsRemoveContainer() throws Exception {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<Integer, InstanceId>[] initialComponentInstances = new Pair[] {
+        new Pair<>(1, new InstanceId(A, 1, 0)),
+        new Pair<>(1, new InstanceId(A, 2, 1)),
+        new Pair<>(1, new InstanceId(B, 3, 0)),
+        new Pair<>(1, new InstanceId(B, 4, 1)),
+        new Pair<>(3, new InstanceId(A, 5, 2)),
+        new Pair<>(3, new InstanceId(A, 6, 3)),
+        new Pair<>(3, new InstanceId(B, 7, 2)),
+        new Pair<>(3, new InstanceId(B, 8, 3))
+    };
+
+    Map<String, Integer> componentChanges = new HashMap<>();
+    componentChanges.put(A, -2);
+    componentChanges.put(B, -2);
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<Integer, InstanceId>[] expectedComponentInstances = new Pair[] {
+        new Pair<>(1, new InstanceId(A, 1, 0)),
+        new Pair<>(1, new InstanceId(A, 2, 1)),
+        new Pair<>(1, new InstanceId(B, 3, 0)),
+        new Pair<>(1, new InstanceId(B, 4, 1)),
+    };
+
+    doScaleDownTest(initialComponentInstances, componentChanges, expectedComponentInstances);
+  }
+
+  @Test
+  public void testScaleDownHomogenousFirst() throws Exception {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<Integer, InstanceId>[] initialComponentInstances = new Pair[] {
+        new Pair<>(1, new InstanceId(A, 1, 0)),
+        new Pair<>(1, new InstanceId(A, 2, 1)),
+        new Pair<>(1, new InstanceId(B, 3, 0)),
+        new Pair<>(3, new InstanceId(B, 4, 1)),
+        new Pair<>(3, new InstanceId(B, 5, 2)),
+        new Pair<>(3, new InstanceId(B, 6, 3)),
+        new Pair<>(3, new InstanceId(B, 7, 4))
+    };
+
+    Map<String, Integer> componentChanges = new HashMap<>();
+    componentChanges.put(B, -4);
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<Integer, InstanceId>[] expectedComponentInstances = new Pair[] {
+        new Pair<>(1, new InstanceId(A, 1, 0)),
+        new Pair<>(1, new InstanceId(A, 2, 1)),
+        new Pair<>(1, new InstanceId(B, 3, 0))
+    };
+
+    doScaleDownTest(initialComponentInstances, componentChanges, expectedComponentInstances);
+  }
+
+  /**
+   * Test the scenario where scaling down and up is simultaneously requested
+   */
+  @Test
+  public void scaleDownAndUp() throws Exception {
+    int spoutScalingDown = -4;
+    int boltScalingUp = 6;
+
+    Map<String, Integer> componentChanges = new HashMap<>();
+    componentChanges.put(SPOUT_NAME, spoutScalingDown); // 0 spouts
+    componentChanges.put(BOLT_NAME, boltScalingUp); // 9 bolts
+    int numContainersBeforeRepack = 2;
+    PackingPlan newPackingPlan = doDefaultScalingTest(componentChanges, numContainersBeforeRepack);
+
+    Assert.assertEquals(3, newPackingPlan.getContainers().size());
+    Assert.assertEquals((Integer) (totalInstances + spoutScalingDown + boltScalingUp),
+        newPackingPlan.getInstanceCount());
+    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
+        BOLT_NAME, 9);
+    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
+        SPOUT_NAME, 0);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testScaleDownInvalidScaleFactor() throws Exception {
+
+    //try to remove more spout instances than possible
+    int spoutScalingDown = -5;
+    Map<String, Integer> componentChanges = new HashMap<>();
+    componentChanges.put(SPOUT_NAME, spoutScalingDown);
+
+    int numContainersBeforeRepack = 2;
+    doDefaultScalingTest(componentChanges, numContainersBeforeRepack);
+  }
+}

--- a/heron/packing/tests/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPackingTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPackingTest.java
@@ -20,132 +20,28 @@ import java.util.Map;
 import java.util.Set;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.packing.AssertPacking;
+import com.twitter.heron.packing.CommonPackingTests;
 import com.twitter.heron.packing.utils.PackingUtils;
-import com.twitter.heron.spi.common.ClusterDefaults;
-import com.twitter.heron.spi.common.Config;
-import com.twitter.heron.spi.common.Context;
-import com.twitter.heron.spi.common.Keys;
+import com.twitter.heron.spi.packing.IPacking;
+import com.twitter.heron.spi.packing.IRepacking;
 import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.packing.Resource;
-import com.twitter.heron.spi.utils.TopologyTests;
 
-public class FirstFitDecreasingPackingTest {
-  private static final String BOLT_NAME = "bolt";
-  private static final String SPOUT_NAME = "spout";
-  private static final int DEFAULT_CONTAINER_PADDING = 10;
+public class FirstFitDecreasingPackingTest extends CommonPackingTests {
 
-  private int spoutParallelism;
-  private int boltParallelism;
-  private Integer totalInstances;
-  private com.twitter.heron.api.Config topologyConfig;
-  private TopologyAPI.Topology topology;
-  private Resource instanceDefaultResources;
-
-  private static TopologyAPI.Topology getTopology(
-      int spoutParallelism, int boltParallelism,
-      com.twitter.heron.api.Config topologyConfig) {
-    return TopologyTests.createTopology("testTopology", topologyConfig, SPOUT_NAME, BOLT_NAME,
-        spoutParallelism, boltParallelism);
+  @Override
+  protected IPacking getPackingImpl() {
+    return new FirstFitDecreasingPacking();
   }
 
-  private static PackingPlan getFirstFitDecreasingPackingPlan(TopologyAPI.Topology topology) {
-    Config config = Config.newBuilder()
-        .put(Keys.topologyId(), topology.getId())
-        .put(Keys.topologyName(), topology.getName())
-        .putAll(ClusterDefaults.getDefaults())
-        .build();
-
-    FirstFitDecreasingPacking packing = new FirstFitDecreasingPacking();
-
-    packing.initialize(config, topology);
-    return packing.pack();
-  }
-
-  private static PackingPlan getFirstFitDecreasingPackingPlanRepack(
-      TopologyAPI.Topology topology,
-      PackingPlan currentPackingPlan,
-      Map<String, Integer> componentChanges) {
-    Config config = Config.newBuilder()
-        .put(Keys.topologyId(), topology.getId())
-        .put(Keys.topologyName(), topology.getName())
-        .putAll(ClusterDefaults.getDefaults())
-        .build();
-
-    FirstFitDecreasingPacking packing = new FirstFitDecreasingPacking();
-    packing.initialize(config, topology);
-    return packing.repack(currentPackingPlan, componentChanges);
-  }
-
-  /**
-   * Performs a scaling test for a specific topology. It first
-   * computes an initial packing plan as a basis for scaling.
-   * Given specific component parallelism changes, a new packing plan is produced.
-   *
-   * @param topology Input topology
-   * @param componentChanges parallelism changes for scale up/down
-   * @param boltRam ram allocated to bolts
-   * @param boltParallelism bolt parallelism
-   * @param spoutRam ram allocated to spouts
-   * @param spoutParallelism spout parallelism
-   * @param numContainersBeforeRepack number of containers that the initial packing plan should use
-   * @param totalInstancesExpected number of instances expected before scaling
-   * @return the new packing plan
-   */
-  private static PackingPlan doScalingTest(TopologyAPI.Topology topology,
-                                           Map<String, Integer> componentChanges,
-                                           ByteAmount boltRam,
-                                           int boltParallelism, ByteAmount spoutRam,
-                                           int spoutParallelism,
-                                           int numContainersBeforeRepack,
-                                           int totalInstancesExpected) {
-    PackingPlan packingPlan = getFirstFitDecreasingPackingPlan(topology);
-
-    Assert.assertEquals(numContainersBeforeRepack, packingPlan.getContainers().size());
-    Assert.assertEquals(totalInstancesExpected, (int) packingPlan.getInstanceCount());
-    AssertPacking.assertContainers(packingPlan.getContainers(),
-        BOLT_NAME, SPOUT_NAME, boltRam, spoutRam, null);
-    AssertPacking.assertNumInstances(packingPlan.getContainers(), BOLT_NAME, boltParallelism);
-    AssertPacking.assertNumInstances(packingPlan.getContainers(), SPOUT_NAME, spoutParallelism);
-
-    PackingPlan newPackingPlan =
-        getFirstFitDecreasingPackingPlanRepack(topology, packingPlan, componentChanges);
-    AssertPacking.assertContainerRam(newPackingPlan.getContainers(),
-        packingPlan.getMaxContainerResources().getRam());
-
-    return newPackingPlan;
-  }
-
-  private PackingPlan doDefaultScalingTest(Map<String, Integer> componentChanges,
-                                           int numContainersBeforeRepack) {
-    return doScalingTest(topology, componentChanges,
-        instanceDefaultResources.getRam(), boltParallelism,
-        instanceDefaultResources.getRam(), spoutParallelism,
-        numContainersBeforeRepack, totalInstances);
-  }
-
-  @Before
-  public void setUp() {
-    this.spoutParallelism = 4;
-    this.boltParallelism = 3;
-    this.totalInstances = this.spoutParallelism + this.boltParallelism;
-
-    // Set up the topology and its config
-    this.topologyConfig = new com.twitter.heron.api.Config();
-    this.topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
-
-    Config config = Config.newBuilder()
-        .put(Keys.topologyId(), topology.getId())
-        .put(Keys.topologyName(), topology.getName())
-        .putAll(ClusterDefaults.getDefaults())
-        .build();
-    this.instanceDefaultResources = new Resource(
-        Context.instanceCpu(config), Context.instanceRam(config), Context.instanceDisk(config));
+  @Override
+  protected IRepacking getRepackingImpl() {
+    return new FirstFitDecreasingPacking();
   }
 
   @Test(expected = RuntimeException.class)
@@ -158,8 +54,7 @@ public class FirstFitDecreasingPackingTest {
     topologyConfig.put(com.twitter.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
     topologyConfig.setContainerMaxRamHint(containerRam);
 
-    getFirstFitDecreasingPackingPlan(
-        getTopology(spoutParallelism, boltParallelism, topologyConfig));
+    pack(getTopology(spoutParallelism, boltParallelism, topologyConfig));
   }
 
   /**
@@ -168,7 +63,7 @@ public class FirstFitDecreasingPackingTest {
   @Test
   public void testDefaultContainerSize() throws Exception {
     int defaultNumInstancesperContainer = 4;
-    PackingPlan packingPlan = getFirstFitDecreasingPackingPlan(topology);
+    PackingPlan packingPlan = pack(topology);
 
     Assert.assertEquals(2, packingPlan.getContainers().size());
     Assert.assertEquals(totalInstances, packingPlan.getInstanceCount());
@@ -191,7 +86,7 @@ public class FirstFitDecreasingPackingTest {
     topologyConfig.setContainerPaddingPercentage(padding);
     TopologyAPI.Topology newTopology =
         getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlan = getFirstFitDecreasingPackingPlan(newTopology);
+    PackingPlan packingPlan = pack(newTopology);
 
     Assert.assertEquals(2, packingPlan.getContainers().size());
     Assert.assertEquals(totalInstances, packingPlan.getInstanceCount());
@@ -219,8 +114,7 @@ public class FirstFitDecreasingPackingTest {
 
     TopologyAPI.Topology topologyExplicitResourcesConfig =
         getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitResourcesConfig =
-        getFirstFitDecreasingPackingPlan(topologyExplicitResourcesConfig);
+    PackingPlan packingPlanExplicitResourcesConfig = pack(topologyExplicitResourcesConfig);
 
     Assert.assertEquals(1, packingPlanExplicitResourcesConfig.getContainers().size());
     Assert.assertEquals(totalInstances, packingPlanExplicitResourcesConfig.getInstanceCount());
@@ -281,7 +175,7 @@ public class FirstFitDecreasingPackingTest {
     TopologyAPI.Topology topologyExplicitRamMap =
         getTopology(spoutParallelism, boltParallelism, topologyConfig);
     PackingPlan packingPlanExplicitRamMap =
-        getFirstFitDecreasingPackingPlan(topologyExplicitRamMap);
+        pack(topologyExplicitRamMap);
 
     Assert.assertEquals(1, packingPlanExplicitRamMap.getContainers().size());
     Assert.assertEquals(totalInstances, packingPlanExplicitRamMap.getInstanceCount());
@@ -311,7 +205,7 @@ public class FirstFitDecreasingPackingTest {
     TopologyAPI.Topology topologyExplicitRamMap =
         getTopology(spoutParallelism, boltParallelism, topologyConfig);
     PackingPlan packingPlanExplicitRamMap =
-        getFirstFitDecreasingPackingPlan(topologyExplicitRamMap);
+        pack(topologyExplicitRamMap);
 
     Assert.assertEquals(2, packingPlanExplicitRamMap.getContainers().size());
     Assert.assertEquals(totalInstances, packingPlanExplicitRamMap.getInstanceCount());
@@ -340,8 +234,7 @@ public class FirstFitDecreasingPackingTest {
 
     TopologyAPI.Topology topologyExplicitRamMap =
         getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitRamMap =
-        getFirstFitDecreasingPackingPlan(topologyExplicitRamMap);
+    PackingPlan packingPlanExplicitRamMap = pack(topologyExplicitRamMap);
 
     Assert.assertEquals(2, packingPlanExplicitRamMap.getContainers().size());
     Assert.assertEquals(totalInstances, packingPlanExplicitRamMap.getInstanceCount());
@@ -371,8 +264,7 @@ public class FirstFitDecreasingPackingTest {
 
     TopologyAPI.Topology topologyExplicitRamMap =
         getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitRamMap =
-        getFirstFitDecreasingPackingPlan(topologyExplicitRamMap);
+    PackingPlan packingPlanExplicitRamMap = pack(topologyExplicitRamMap);
 
     Assert.assertEquals(2, packingPlanExplicitRamMap.getContainers().size());
     Assert.assertEquals(totalInstances, packingPlanExplicitRamMap.getInstanceCount());
@@ -401,8 +293,7 @@ public class FirstFitDecreasingPackingTest {
 
     TopologyAPI.Topology topologyExplicitRamMap =
         getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitRamMap =
-        getFirstFitDecreasingPackingPlan(topologyExplicitRamMap);
+    PackingPlan packingPlanExplicitRamMap = pack(topologyExplicitRamMap);
     Assert.assertEquals(totalInstances, packingPlanExplicitRamMap.getInstanceCount());
     AssertPacking.assertNumInstances(packingPlanExplicitRamMap.getContainers(), BOLT_NAME, 3);
     AssertPacking.assertNumInstances(packingPlanExplicitRamMap.getContainers(), SPOUT_NAME, 4);
@@ -530,19 +421,6 @@ public class FirstFitDecreasingPackingTest {
     doDefaultScalingTest(componentChanges, numContainersBeforeRepack);
   }
 
-  @Test(expected = RuntimeException.class)
-  public void testScaleDownInvalidScaleFactor() throws Exception {
-
-    //try to remove more spout instances than possible
-    int spoutScalingDown = -5;
-    Map<String, Integer> componentChanges = new HashMap<>();
-    componentChanges.put(SPOUT_NAME, spoutScalingDown);
-
-    int numContainersBeforeRepack = 2;
-    doDefaultScalingTest(componentChanges, numContainersBeforeRepack);
-  }
-
-
   /**
    * Test the scenario where the scaling down is requested
    */
@@ -586,29 +464,6 @@ public class FirstFitDecreasingPackingTest {
         newPackingPlan.getInstanceCount());
     AssertPacking.assertNumInstances(newPackingPlan.getContainers(), BOLT_NAME, 3);
     AssertPacking.assertNumInstances(newPackingPlan.getContainers(), SPOUT_NAME, 0);
-  }
-
-  /**
-   * Test the scenario where scaling down and up is simultaneously requested
-   */
-  @Test
-  public void scaleDownAndUp() throws Exception {
-    int spoutScalingDown = -4;
-    int boltScalingUp = 6;
-
-    Map<String, Integer> componentChanges = new HashMap<>();
-    componentChanges.put(SPOUT_NAME, spoutScalingDown); // 0 spouts
-    componentChanges.put(BOLT_NAME, boltScalingUp); // 9 bolts
-    int numContainersBeforeRepack = 2;
-    PackingPlan newPackingPlan = doDefaultScalingTest(componentChanges, numContainersBeforeRepack);
-
-    Assert.assertEquals(3, newPackingPlan.getContainers().size());
-    Assert.assertEquals((Integer) (totalInstances + spoutScalingDown + boltScalingUp),
-        newPackingPlan.getInstanceCount());
-    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
-        BOLT_NAME, 9);
-    AssertPacking.assertNumInstances(newPackingPlan.getContainers(),
-        SPOUT_NAME, 0);
   }
 
   /**

--- a/heron/packing/tests/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPackingTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPackingTest.java
@@ -174,8 +174,7 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
 
     TopologyAPI.Topology topologyExplicitRamMap =
         getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitRamMap =
-        pack(topologyExplicitRamMap);
+    PackingPlan packingPlanExplicitRamMap = pack(topologyExplicitRamMap);
 
     Assert.assertEquals(1, packingPlanExplicitRamMap.getContainers().size());
     Assert.assertEquals(totalInstances, packingPlanExplicitRamMap.getInstanceCount());
@@ -204,8 +203,7 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
 
     TopologyAPI.Topology topologyExplicitRamMap =
         getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitRamMap =
-        pack(topologyExplicitRamMap);
+    PackingPlan packingPlanExplicitRamMap = pack(topologyExplicitRamMap);
 
     Assert.assertEquals(2, packingPlanExplicitRamMap.getContainers().size());
     Assert.assertEquals(totalInstances, packingPlanExplicitRamMap.getInstanceCount());


### PR DESCRIPTION
Update `FirstFitDecreasingPacking` to use the same scale down approach as we've added to RCRRP.

In doing this I wanted to share scale-down unit tests across the two so I created CommonPackingTests. This had the added benefit of sharing a lot of other duplicate test code that already existed in both sets of tests.