### PR TITLE
using constant instead of utf8 string in heron package

### DIFF
--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
@@ -14,7 +14,7 @@
 
 package com.twitter.heron.scheduler.aurora;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -154,7 +154,7 @@ public class AuroraScheduler implements IScheduler, IScalable {
    */
   protected String formatJavaOpts(String javaOpts) {
     String javaOptsBase64 = DatatypeConverter.printBase64Binary(
-        javaOpts.getBytes(Charset.forName("UTF-8")));
+        javaOpts.getBytes(StandardCharsets.UTF_8));
 
     return String.format("\"%s\"", javaOptsBase64.replace("=", "&equals;"));
   }

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/SchedulerUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/SchedulerUtils.java
@@ -14,7 +14,7 @@
 
 package com.twitter.heron.spi.utils;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -321,7 +321,7 @@ public final class SchedulerUtils {
    */
   public static String encodeJavaOpts(String javaOpts) {
     String javaOptsBase64 = DatatypeConverter.printBase64Binary(
-        javaOpts.getBytes(Charset.forName("UTF-8")));
+        javaOpts.getBytes(StandardCharsets.UTF_8));
 
     return String.format("\"%s\"", javaOptsBase64.replace("=", "&equals;"));
   }
@@ -342,7 +342,7 @@ public final class SchedulerUtils {
             replace("&equals;", "=");
 
     return new String(
-        DatatypeConverter.parseBase64Binary(javaOptsBase64), Charset.forName("UTF-8"));
+        DatatypeConverter.parseBase64Binary(javaOptsBase64), StandardCharsets.UTF_8);
   }
 
   /**

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/ShellUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/ShellUtils.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -44,7 +45,7 @@ public final class ShellUtils {
   static String inputstreamToString(InputStream is) {
     char[] buffer = new char[2048];
     StringBuilder builder = new StringBuilder();
-    try (Reader reader = new InputStreamReader(is, "UTF-8")) {
+    try (Reader reader = new InputStreamReader(is, StandardCharsets.UTF_8)) {
       while (true) {
         int readSize = reader.read(buffer, 0, buffer.length);
         if (0 > readSize) {

--- a/integration-test/src/java/com/twitter/heron/integration_test/common/HdfsHelper.java
+++ b/integration-test/src/java/com/twitter/heron/integration_test/common/HdfsHelper.java
@@ -15,6 +15,7 @@ package com.twitter.heron.integration_test.common;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -40,6 +41,6 @@ public final class HdfsHelper {
     Path pt = new Path(path);
     Configuration conf = new Configuration();
     FileSystem fileSystem = FileSystem.get(conf);
-    return new InputStreamReader(fileSystem.open(pt), "UTF-8");
+    return new InputStreamReader(fileSystem.open(pt), StandardCharsets.UTF_8);
   }
 }


### PR DESCRIPTION
As #1598 mentioned, this PR is trying to use constant instead of `UTF-8` string on Java side in heron package. I've just modify the code in heron package, the contrib package is not included. If so, I can modify them as well. I'm not sure if I've found all the `UTF-8` strings in heron package. Please let me know if I have any omissions.

The key changes are following:

* remove `import java.nio.charset.Charset` and add `java.nio.charset.StandardCharsets`
* replace `Charset.forName("UTF-8")` to `StandardCharsets.UTF_8`

There are four classes included:

* heron/spi/utils/SchedulerUtils.java
* heron/scheduler/aurora/AuroraScheduler.java
* heron/spi/utils/ShellUtils.java
* heron/integration_test/common/HdfsHelper.java