### PR TITLE
use startsWith to filter prefix of metric name

### DIFF
--- a/heron/spi/src/java/com/twitter/heron/spi/metricsmgr/metrics/MetricsFilter.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/metricsmgr/metrics/MetricsFilter.java
@@ -40,7 +40,7 @@ public class MetricsFilter {
 
   public boolean contains(String metricName) {
     for (String prefix : prefixToType.keySet()) {
-      if (metricName.contains(prefix)) {
+      if (metricName.startsWith(prefix)) {
         return true;
       }
     }


### PR DESCRIPTION
MetricsFilter Specifies the metric-prefix or metric-name we need to keep, so startsWith is more suitable than contains to check  prefix of metricName.  