### PR TITLE
command-line parser support for dry run.

### DIFF
--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
@@ -138,6 +138,11 @@ public class RuntimeManagerMain {
         .argName("container id")
         .build();
 
+    Option dryRun = Option.builder("u")
+        .desc("dry run")
+        .longOpt("dry_run")
+        .build();
+
     Option verbose = Option.builder("v")
         .desc("Enable debug logs")
         .longOpt("verbose")
@@ -154,6 +159,7 @@ public class RuntimeManagerMain {
     options.addOption(heronHome);
     options.addOption(containerId);
     options.addOption(componentParallelism);
+    options.addOption(dryRun);
     options.addOption(verbose);
 
     return options;
@@ -203,6 +209,12 @@ public class RuntimeManagerMain {
 
     // init log
     LoggingHelper.loggerInit(logLevel, false);
+
+    Boolean dryRun = false;
+    if (cmd.hasOption("u")) {
+      dryRun = true;
+      LOG.log(Level.FINE, "dry-run mode enabled");
+    }
 
     String cluster = cmd.getOptionValue("cluster");
     String role = cmd.getOptionValue("role");

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
@@ -219,6 +219,11 @@ public class SubmitterMain {
         .required()
         .build();
 
+    Option dryRun = Option.builder("u")
+        .desc("dry run")
+        .longOpt("dry_run")
+        .build();
+
     Option verbose = Option.builder("v")
         .desc("Enable debug logs")
         .longOpt("verbose")
@@ -234,6 +239,7 @@ public class SubmitterMain {
     options.addOption(topologyPackage);
     options.addOption(topologyDefn);
     options.addOption(topologyJar);
+    options.addOption(dryRun);
     options.addOption(verbose);
 
     return options;
@@ -271,6 +277,8 @@ public class SubmitterMain {
       throw new RuntimeException("Error parsing command line options: ", e);
     }
 
+
+
     Boolean verbose = false;
     Level logLevel = Level.INFO;
     if (cmd.hasOption("v")) {
@@ -280,6 +288,12 @@ public class SubmitterMain {
 
     // init log
     LoggingHelper.loggerInit(logLevel, false);
+
+    Boolean dryRun = false;
+    if (cmd.hasOption("u")) {
+      dryRun = true;
+      LOG.log(Level.FINE, "dry-run mode enabled");
+    }
 
     String cluster = cmd.getOptionValue("cluster");
     String role = cmd.getOptionValue("role");

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
@@ -277,8 +277,6 @@ public class SubmitterMain {
       throw new RuntimeException("Error parsing command line options: ", e);
     }
 
-
-
     Boolean verbose = false;
     Level logLevel = Level.INFO;
     if (cmd.hasOption("v")) {

--- a/heron/tools/cli/src/python/args.py
+++ b/heron/tools/cli/src/python/args.py
@@ -154,3 +154,13 @@ def add_extra_launch_classpath(parser):
       metavar='(a string; additional JVM class path for launching topology)',
       default="")
   return parser
+
+def add_dry_run(parser):
+  '''
+  :param parser:
+  :return:
+  '''
+  parser.add_argument(
+      '--dry-run',
+      action='store_true')
+  return parser

--- a/heron/tools/cli/src/python/submit.py
+++ b/heron/tools/cli/src/python/submit.py
@@ -53,6 +53,7 @@ def create_parser(subparsers):
   cli_args.add_deactive_deploy(parser)
   cli_args.add_extra_launch_classpath(parser)
   cli_args.add_system_property(parser)
+  cli_args.add_dry_run(parser)
   cli_args.add_verbose(parser)
 
   parser.set_defaults(subcommand='submit')
@@ -98,6 +99,9 @@ def launch_a_topology(cl_args, tmp_dir, topology_file, topology_defn_file, topol
 
   if Log.getEffectiveLevel() == logging.DEBUG:
     args.append("--verbose")
+
+  if cl_args["dry_run"]:
+    args.append("--dry_run")
 
   lib_jars = config.get_heron_libs(
       jars.scheduler_jars() + jars.uploader_jars() + jars.statemgr_jars() + jars.packing_jars()
@@ -319,4 +323,3 @@ def run(command, parser, cl_args, unknown_args):
 
   else:
     return submit_pex(cl_args, unknown_args, tmp_dir)
-

--- a/heron/tools/cli/src/python/update.py
+++ b/heron/tools/cli/src/python/update.py
@@ -48,6 +48,7 @@ def create_parser(subparsers):
       + 'colon-delimited: [component_name]:[parallelism]')
 
   args.add_config(parser)
+  args.add_dry_run(parser)
   args.add_verbose(parser)
 
   parser.set_defaults(subcommand='update')
@@ -58,6 +59,9 @@ def create_parser(subparsers):
 def run(command, parser, cl_args, unknown_args):
   """ run the update command """
   extra_args = ["--component_parallelism", ','.join(cl_args['component_parallelism'])]
+  if cl_args['dry_run']:
+    extra_args.append('--dry_run')
+
   extra_lib_jars = jars.packing_jars()
 
   return cli_helper.run(command, cl_args, "update topology", extra_args, extra_lib_jars)


### PR DESCRIPTION
Add command line parser support for dry run mode. User can pass `--dry-run` flag to `submit` and `update` subcommands.