### PR TITLE
Adding metrics sink: WebSink

### DIFF
--- a/heron/config/src/yaml/conf/examples/metrics_sinks.yaml
+++ b/heron/config/src/yaml/conf/examples/metrics_sinks.yaml
@@ -79,3 +79,16 @@ tmaster-sink:
 #   graphite_port: 2004 # The port of graphite to be exported metrics to
 #   metrics_prefix: "heron" # The prefix of every metrics
 #   server_max_reconnect-attempts: 20 # The max reconnect attempts when failing to connect to graphite server
+
+### Config for web-sink
+### The web-sink publishes metrics as json on http://host:port/path
+# web-sink:
+#   class: "com.twitter.heron.metricsmgr.sink.WebSink"
+#   port: 8080 # The port on which to run (either port or port-file are mandatory)
+#   # port-file: metrics.port # Alternatively supply a file which contains the port (text file containing single integer)
+#   path: /metrics.json # The path on which to publish the metrics (mandatory)
+#   flat-metrics: true # By default the web-sink will publish a flat "name -> value" json map
+#   # setting flat-metrics to "false" will group metrics by metric source (default ture)
+#   include-topology-name: false # Include topology name in metric name (default false)
+#   metrics-cache-max-size: 1000000 # Max number of metrics cached and published (default 1000000)
+#   metrics-cache-ttl-sec: 600 # Time in seconds after which a metric that was collected will stopped being published (default 600)

--- a/heron/metricsmgr/src/java/BUILD
+++ b/heron/metricsmgr/src/java/BUILD
@@ -16,11 +16,12 @@ java_library(
         "//heron/proto:proto_metrics_java",
         "//heron/proto:proto_tmaster_java",
         "//heron/metricsmgr/src/thrift:thrift_scribe_java",
+        "//third_party/java:guava",
         "//third_party/java:jackson",
+        "//third_party/java:logging", # slf4j is only used for thrift in scribe-sink
         "@org_yaml_snakeyaml//jar",
         "@com_google_protobuf_protobuf_java//jar",
         "@org_apache_thrift_libthrift//jar",
-        "//third_party/java:logging", # slf4j is only used for thrift in scribe-sink
     ],
 )
 

--- a/heron/metricsmgr/src/java/BUILD
+++ b/heron/metricsmgr/src/java/BUILD
@@ -19,9 +19,9 @@ java_library(
         "//third_party/java:guava", # only used in WebSink
         "//third_party/java:jackson",
         "//third_party/java:logging", # slf4j is only used for thrift in scribe-sink
-        "@org_yaml_snakeyaml//jar",
         "@com_google_protobuf_protobuf_java//jar",
         "@org_apache_thrift_libthrift//jar",
+        "@org_yaml_snakeyaml//jar",
     ],
 )
 

--- a/heron/metricsmgr/src/java/BUILD
+++ b/heron/metricsmgr/src/java/BUILD
@@ -16,7 +16,7 @@ java_library(
         "//heron/proto:proto_metrics_java",
         "//heron/proto:proto_tmaster_java",
         "//heron/metricsmgr/src/thrift:thrift_scribe_java",
-        "//third_party/java:guava",
+        "//third_party/java:guava", # only used in WebSink
         "//third_party/java:jackson",
         "//third_party/java:logging", # slf4j is only used for thrift in scribe-sink
         "@org_yaml_snakeyaml//jar",

--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/WebSink.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/WebSink.java
@@ -149,7 +149,6 @@ public class WebSink implements IMetricsSink {
       });
       httpServer.start();
     } catch (IOException e) {
-      LOG.log(Level.SEVERE, "Could not create HttpServer on port " + port, e);
       throw new RuntimeException("Failed to create Http server on port " + port, e);
     }
   }

--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/WebSink.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/WebSink.java
@@ -23,11 +23,15 @@ import java.nio.file.Paths;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.google.common.base.Strings;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
@@ -49,16 +53,36 @@ public class WebSink implements IMetricsSink {
 
   private static final int HTTP_STATUS_OK = 200;
 
+  // Metrics will be published on http://host:port/path, the port
   private static final String KEY_PORT = "port";
+
+  // If you want to specify a file from which to read the port instead of
+  // supplying it directly
   private static final String KEY_PORT_FILE = "port-file";
+
+  // The path
   private static final String KEY_PATH = "path";
+
+  // If flat-metrics is false, the metrics will be grouped by the metrics
+  // source source,
+  // if flat-metrics is true, the metric names will be prefixed by the source
   private static final String KEY_FLAT_METRICS = "flat-metrics";
+
+  // Include the topology name in the metric name
   private static final String KEY_INCLUDE_TOPOLOGY_NAME = "include-topology-name";
 
-  protected ConcurrentHashMap<String, Object> metrics = new ConcurrentHashMap<>();
+  // Maximum number of metrics getting served
+  private static final String KEY_METRICS_CACHE_MAX_SIZE = "metrics-cache-max-size";
+
+  // Time To Live before a metric gets evicted from the cache
+  private static final String KEY_METRICS_CACHE_TTL_SEC = "metrics-cache-ttl-sec";
+
+  // This is the cache that is used to serve the metrics
+  protected Cache<String, Object> metricsCache;
+
   private HttpServer httpServer;
   private boolean isFlatMetrics = true;
-  private boolean includeServiceNamespace = true;
+  private boolean includeTopologyName = true;
   private String topologyName;
 
   @Override
@@ -66,19 +90,31 @@ public class WebSink implements IMetricsSink {
     String path = (String) conf.get(KEY_PATH);
     String portFile = (String) conf.get(KEY_PORT_FILE);
     isFlatMetrics = TypeUtils.getBoolean(conf.getOrDefault(KEY_FLAT_METRICS, true));
-    includeServiceNamespace = TypeUtils.getBoolean(
-        conf.getOrDefault(KEY_INCLUDE_TOPOLOGY_NAME, false));
+    includeTopologyName = TypeUtils.getBoolean(
+            conf.getOrDefault(KEY_INCLUDE_TOPOLOGY_NAME, false));
+    long cacheMaxSize = TypeUtils.getLong(conf.getOrDefault(KEY_METRICS_CACHE_MAX_SIZE, 1000000));
+    long cacheTtlSec = TypeUtils.getLong(conf.getOrDefault(KEY_METRICS_CACHE_TTL_SEC, 600));
+
+    metricsCache = CacheBuilder.newBuilder()
+            .maximumSize(cacheMaxSize)
+            .expireAfterWrite(cacheTtlSec, TimeUnit.SECONDS)
+            .build();
+
     topologyName = context.getTopologyName();
+
+
 
     int port = TypeUtils.getInteger(conf.getOrDefault(KEY_PORT, 0));
     if (port == 0) {
-      if (portFile != null) {
+      if (!Strings.isNullOrEmpty(portFile)) {
         try {
-          port = TypeUtils.getInteger(Files.lines(Paths.get(portFile)).findFirst().get().trim());
-        } catch (IOException e) {
+          port = TypeUtils.getInteger(Files.lines(Paths.get(portFile)).findFirst()
+                  .get().trim());
+        } catch (IOException | SecurityException | IllegalArgumentException e) {
           throw new IllegalArgumentException("Could not parse " + KEY_PORT_FILE + " " + portFile
-              + " Make sure the file only contains the port on which the service should run"
-              + " and is UTF8 encoded", e);
+                  + " Make sure the file is readable,"
+                  + " only contains the port on which the service should run"
+                  + " and is UTF8 encoded", e);
         }
       } else {
         throw new IllegalArgumentException("Neither 'port' nor 'port_file' "
@@ -101,7 +137,9 @@ public class WebSink implements IMetricsSink {
       httpServer.createContext(path, new HttpHandler() {
         @Override
         public void handle(HttpExchange httpExchange) throws IOException {
-          byte[] response = MAPPER.writeValueAsString(metrics).getBytes();
+          metricsCache.cleanUp();
+          byte[] response = MAPPER.writeValueAsString(metricsCache.asMap())
+                  .getBytes();
           httpExchange.sendResponseHeaders(HTTP_STATUS_OK, response.length);
           OutputStream os = httpExchange.getResponseBody();
           os.write(response);
@@ -112,20 +150,29 @@ public class WebSink implements IMetricsSink {
       httpServer.start();
     } catch (IOException e) {
       LOG.log(Level.SEVERE, "Could not create HttpServer on port " + port, e);
+      throw new RuntimeException("Failed to create Http server on port " + port, e);
     }
   }
 
-  private static void processMetrics(String prefix, Iterable<MetricsInfo> metrics,
-                                     Map<String, Object> out) {
+  /**
+   * Helper to prefix metric names, convert metric value to double and return as map
+   *
+   * @param prefix
+   * @param metrics
+   * @return Map of metric name to metric value
+   */
+  private Map<String, Double> processMetrics(String prefix, Iterable<MetricsInfo> metrics) {
+    Map<String, Double> map = new HashMap<>();
     for (MetricsInfo r : metrics) {
       try {
-        out.put(prefix + r.getName(), Double.valueOf(r.getValue()));
+        map.put(prefix + r.getName(), Double.valueOf(r.getValue()));
       } catch (NumberFormatException ne) {
-        LOG.log(Level.SEVERE, "Could not parse metric, Name: " + r.getName()
-            + " Value: " + r.getValue(), ne);
+        LOG.log(Level.SEVERE, "Could not parse metric, Name: "
+                + r.getName() + " Value: " + r.getValue(), ne);
         continue;
       }
     }
+    return map;
   }
 
   @Override
@@ -134,21 +181,20 @@ public class WebSink implements IMetricsSink {
     String source;
 
     if (sources.length > 2) {
-      source = includeServiceNamespace
+      source = includeTopologyName
           ? String.format("%s/%s/%s", topologyName, sources[1], sources[2])
           : String.format("/%s/%s", sources[1], sources[2]);
     } else {
-      source = includeServiceNamespace
+      source = includeTopologyName
           ? String.format("%s/%s", topologyName, record.getSource())
           : String.format("/%s", record.getSource());
     }
 
     if (isFlatMetrics) {
-      processMetrics(source + "/", record.getMetrics(), metrics);
+      metricsCache.putAll(processMetrics(source + "/", record.getMetrics()));
     } else {
-      Map<String, Object> sourceMap = new HashMap<>();
-      processMetrics("", record.getMetrics(), sourceMap);
-      metrics.put(source, sourceMap);
+      Map<String, Double> sourceMap = processMetrics("", record.getMetrics());
+      metricsCache.put(source, sourceMap);
     }
   }
 

--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/WebSink.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/WebSink.java
@@ -1,0 +1,162 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.twitter.heron.metricsmgr.sink;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import com.twitter.heron.common.basics.TypeUtils;
+import com.twitter.heron.spi.metricsmgr.metrics.MetricsInfo;
+import com.twitter.heron.spi.metricsmgr.metrics.MetricsRecord;
+import com.twitter.heron.spi.metricsmgr.sink.IMetricsSink;
+import com.twitter.heron.spi.metricsmgr.sink.SinkContext;
+
+
+/**
+ * A metrics sink that publishes metrics on a http endpoint
+ */
+public class WebSink implements IMetricsSink {
+  private static final Logger LOG = Logger.getLogger(WebSink.class.getName());
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private static final int HTTP_STATUS_OK = 200;
+
+  private static final String KEY_PORT = "port";
+  private static final String KEY_PORT_FILE = "port-file";
+  private static final String KEY_PATH = "path";
+  private static final String KEY_FLAT_METRICS = "flat-metrics";
+  private static final String KEY_INCLUDE_TOPOLOGY_NAME = "include-topology-name";
+
+  protected ConcurrentHashMap<String, Object> metrics = new ConcurrentHashMap<>();
+  private HttpServer httpServer;
+  private boolean isFlatMetrics = true;
+  private boolean includeServiceNamespace = true;
+  private String topologyName;
+
+  @Override
+  public void init(Map<String, Object> conf, SinkContext context) {
+    String path = (String) conf.get(KEY_PATH);
+    String portFile = (String) conf.get(KEY_PORT_FILE);
+    isFlatMetrics = TypeUtils.getBoolean(conf.getOrDefault(KEY_FLAT_METRICS, true));
+    includeServiceNamespace = TypeUtils.getBoolean(
+        conf.getOrDefault(KEY_INCLUDE_TOPOLOGY_NAME, false));
+    topologyName = context.getTopologyName();
+
+    int port = TypeUtils.getInteger(conf.getOrDefault(KEY_PORT, 0));
+    if (port == 0) {
+      if (portFile != null) {
+        try {
+          port = TypeUtils.getInteger(Files.lines(Paths.get(portFile)).findFirst().get().trim());
+        } catch (IOException e) {
+          throw new IllegalArgumentException("Could not parse " + KEY_PORT_FILE + " " + portFile
+              + " Make sure the file only contains the port on which the service should run"
+              + " and is UTF8 encoded", e);
+        }
+      } else {
+        throw new IllegalArgumentException("Neither 'port' nor 'port_file' "
+            + "were specified in config for metrics sink " + context.getSinkId());
+      }
+    }
+    startHttpServer(path, port);
+  }
+
+  /**
+   * Start a http server on supplied port that will serve the metrics, as json,
+   * on the specified path.
+   *
+   * @param path
+   * @param port
+   */
+  protected void startHttpServer(String path, int port) {
+    try {
+      httpServer = HttpServer.create(new InetSocketAddress(port), 0);
+      httpServer.createContext(path, new HttpHandler() {
+        @Override
+        public void handle(HttpExchange httpExchange) throws IOException {
+          byte[] response = MAPPER.writeValueAsString(metrics).getBytes();
+          httpExchange.sendResponseHeaders(HTTP_STATUS_OK, response.length);
+          OutputStream os = httpExchange.getResponseBody();
+          os.write(response);
+          os.close();
+          LOG.log(Level.INFO, "Received metrics request.");
+        }
+      });
+      httpServer.start();
+    } catch (IOException e) {
+      LOG.log(Level.SEVERE, "Could not create HttpServer on port " + port, e);
+    }
+  }
+
+  private static void processMetrics(String prefix, Iterable<MetricsInfo> metrics,
+                                     Map<String, Object> out) {
+    for (MetricsInfo r : metrics) {
+      try {
+        out.put(prefix + r.getName(), Double.valueOf(r.getValue()));
+      } catch (NumberFormatException ne) {
+        LOG.log(Level.SEVERE, "Could not parse metric, Name: " + r.getName()
+            + " Value: " + r.getValue(), ne);
+        continue;
+      }
+    }
+  }
+
+  @Override
+  public void processRecord(MetricsRecord record) {
+    String[] sources = record.getSource().split("/");
+    String source;
+
+    if (sources.length > 2) {
+      source = includeServiceNamespace
+          ? String.format("%s/%s/%s", topologyName, sources[1], sources[2])
+          : String.format("/%s/%s", sources[1], sources[2]);
+    } else {
+      source = includeServiceNamespace
+          ? String.format("%s/%s", topologyName, record.getSource())
+          : String.format("/%s", record.getSource());
+    }
+
+    if (isFlatMetrics) {
+      processMetrics(source + "/", record.getMetrics(), metrics);
+    } else {
+      Map<String, Object> sourceMap = new HashMap<>();
+      processMetrics("", record.getMetrics(), sourceMap);
+      metrics.put(source, sourceMap);
+    }
+  }
+
+  @Override
+  public void flush() { }
+
+  @Override
+  public void close() {
+    httpServer.stop(0);
+  }
+}

--- a/heron/metricsmgr/tests/java/BUILD
+++ b/heron/metricsmgr/tests/java/BUILD
@@ -24,6 +24,7 @@ java_tests(
         "com.twitter.heron.metricsmgr.executor.SinkExecutorTest",
         "com.twitter.heron.metricsmgr.sink.tmaster.TMasterSinkTest",
         "com.twitter.heron.metricsmgr.sink.FileSinkTest",
+        "com.twitter.heron.metricsmgr.sink.WebSinkTest",
     ],
     runtime_deps = [
         ":metricsmgr-tests",

--- a/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/WebSinkTest.java
+++ b/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/WebSinkTest.java
@@ -1,0 +1,178 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.twitter.heron.metricsmgr.sink;
+
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.twitter.heron.spi.metricsmgr.metrics.ExceptionInfo;
+import com.twitter.heron.spi.metricsmgr.metrics.MetricsInfo;
+import com.twitter.heron.spi.metricsmgr.metrics.MetricsRecord;
+import com.twitter.heron.spi.metricsmgr.sink.SinkContext;
+
+/**
+ * WebSink Tester.
+ */
+public class WebSinkTest {
+
+  private class WebTestSink extends WebSink {
+    public String servicePath;
+    public int servicePort;
+
+    @Override
+    protected void startHttpServer(String path, int port) {
+      this.servicePath = path;
+      this.servicePort = port;
+    }
+
+    public Map<String, Object> getMetrics() {
+      return super.metrics;
+    }
+  }
+
+  private Map<String, Object> defaultConf;
+  private SinkContext context;
+  private Iterable<MetricsRecord> records;
+
+
+  @Before
+  public void before() throws IOException {
+
+    defaultConf = new HashMap<>();
+    defaultConf.put("port", "9999");
+    defaultConf.put("path", "test");
+    defaultConf.put("flat-metrics", "true");
+    defaultConf.put("include-topology-name", "false");
+
+    context = Mockito.mock(SinkContext.class);
+    Mockito.when(context.getTopologyName()).thenReturn("testTopology");
+    Mockito.when(context.getSinkId()).thenReturn("testId");
+
+    Iterable<MetricsInfo> infos = Arrays.asList(new MetricsInfo("metric_1", "1.0"),
+        new MetricsInfo("metric_2", "2.0"));
+    records = Arrays.asList(
+        new MetricsRecord("machine/stuff/record_1", infos, Collections.<ExceptionInfo>emptyList()),
+        new MetricsRecord("record_2", infos, Collections.<ExceptionInfo>emptyList()));
+  }
+
+  /**
+   * Testing exception when illegal port is specified
+   */
+  @Test(expected = IllegalArgumentException.class)
+  public void testIllegalPort() throws IOException {
+    Map<String, Object> conf = new HashMap<>(defaultConf);
+    conf.put("port", "fdfsaf");
+    WebTestSink sink = new WebTestSink();
+    sink.init(conf, context);
+  }
+
+  /**
+   * Testing exception when no port is specified
+   */
+  @Test(expected = IllegalArgumentException.class)
+  public void testNoPort() throws IOException {
+    Map<String, Object> conf = new HashMap<>(defaultConf);
+    conf.remove("port");
+    WebTestSink sink = new WebTestSink();
+    sink.init(conf, context);
+  }
+
+  /**
+   * Testing port and path setting
+   */
+  public void testPortAndPath() throws IOException {
+    Map<String, Object> conf = new HashMap<>(defaultConf);
+    WebTestSink sink = new WebTestSink();
+    sink.init(conf, context);
+    Assert.assertEquals(sink.servicePort, 9999);
+    Assert.assertEquals(sink.servicePath, "test");
+  }
+
+  /**
+   * Testing flat map with metrics
+   */
+  @Test
+  public void testFlatMetrics() throws IOException {
+    Map<String, Object> conf = new HashMap<>(defaultConf);
+    WebTestSink sink = new WebTestSink();
+    sink.init(conf, context);
+    for (MetricsRecord r : records) {
+      sink.processRecord(r);
+    }
+
+    Map<String, Object> results = sink.getMetrics();
+    Assert.assertTrue(results.size() == 4);
+    Assert.assertEquals(results.get("/stuff/record_1/metric_1"), 1.0d);
+    Assert.assertEquals(results.get("/stuff/record_1/metric_2"), 2.0d);
+    Assert.assertEquals(results.get("/record_2/metric_1"), 1.0d);
+    Assert.assertEquals(results.get("/record_2/metric_2"), 2.0d);
+  }
+
+  /**
+   * Testing flat map with metrics, prefixed with topology name
+   */
+  @Test
+  public void testIncludeTopologyName() throws IOException {
+    Map<String, Object> conf = new HashMap<>(defaultConf);
+    conf.put("include-topology-name", "true");
+    WebTestSink sink = new WebTestSink();
+    sink.init(conf, context);
+    for (MetricsRecord r : records) {
+      sink.processRecord(r);
+    }
+
+    Map<String, Object> results = sink.getMetrics();
+    Assert.assertTrue(results.size() == 4);
+    Assert.assertEquals(results.get("testTopology/stuff/record_1/metric_1"), 1.0d);
+    Assert.assertEquals(results.get("testTopology/stuff/record_1/metric_2"), 2.0d);
+    Assert.assertEquals(results.get("testTopology/record_2/metric_1"), 1.0d);
+    Assert.assertEquals(results.get("testTopology/record_2/metric_2"), 2.0d);
+  }
+
+  /**
+   * Testing grouped map with metrics
+   */
+  @Test
+  public void testGroupedMetrics() throws IOException {
+    Map<String, Object> conf = new HashMap<>(defaultConf);
+    conf.put("flat-metrics", "false");
+    WebTestSink sink = new WebTestSink();
+    sink.init(conf, context);
+    for (MetricsRecord r : records) {
+      sink.processRecord(r);
+    }
+
+    Map<String, Object> results = sink.getMetrics();
+    Assert.assertTrue(results.size() == 2);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> record1 = (Map<String, Object>) results.get("/stuff/record_1");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> record2 = (Map<String, Object>) results.get("/record_2");
+
+    Assert.assertEquals(record1.get("metric_1"), 1.0d);
+    Assert.assertEquals(record1.get("metric_2"), 2.0d);
+    Assert.assertEquals(record2.get("metric_1"), 1.0d);
+    Assert.assertEquals(record2.get("metric_2"), 2.0d);
+  }
+}


### PR DESCRIPTION
Adding a new metrics sink, WebSink, that publishes metrics on a http endpoint. 

Background:
In our environment processes publish metrics on an configureable http endpoint. We are running a metrics collector that hits these endpoints to collect metrics in specific intervals.