### PR TITLE
Refactor ByteAmount checking args method

### DIFF
--- a/heron/common/src/java/com/twitter/heron/common/basics/ByteAmount.java
+++ b/heron/common/src/java/com/twitter/heron/common/basics/ByteAmount.java
@@ -13,6 +13,8 @@
 // limitations under the License.
 package com.twitter.heron.common.basics;
 
+import com.google.common.base.Preconditions;
+
 /**
  * Class that encapsulates number of bytes, with helpers to handle units properly.
  */
@@ -116,10 +118,8 @@ public final class ByteAmount implements Comparable<ByteAmount> {
    * @throws IllegalArgumentException if subtraction would overshoot Long.MIN_VALUE
    */
   public ByteAmount minus(ByteAmount other) {
-    if (Long.MIN_VALUE + other.asBytes() > asBytes()) {
-      throw new IllegalArgumentException(String.format(
-          "Subtracting %s from %s would overshoot Long.MIN_LONG", other, this));
-    }
+    Preconditions.checkArgument(Long.MIN_VALUE + other.asBytes() <= asBytes(), String.format(
+        "Subtracting %s from %s would overshoot Long.MIN_LONG", other, this));
     return ByteAmount.fromBytes(asBytes() - other.asBytes());
   }
 
@@ -130,10 +130,8 @@ public final class ByteAmount implements Comparable<ByteAmount> {
    * @throws IllegalArgumentException if addition would exceed Long.MAX_VALUE
    */
   public ByteAmount plus(ByteAmount other) {
-    if (Long.MAX_VALUE - asBytes() < other.asBytes()) {
-      throw new IllegalArgumentException(String.format(
-          "Adding %s to %s would exceed Long.MAX_LONG", other, this));
-    }
+    Preconditions.checkArgument(Long.MAX_VALUE - asBytes() >= other.asBytes(), String.format(
+        "Subtracting %s from %s would overshoot Long.MIN_LONG", other, this));
     return ByteAmount.fromBytes(asBytes() + other.asBytes());
   }
 
@@ -144,10 +142,8 @@ public final class ByteAmount implements Comparable<ByteAmount> {
    * @throws IllegalArgumentException if multiplication would exceed Long.MAX_VALUE
    */
   public ByteAmount multiply(int factor) {
-    if (asBytes() > Long.MAX_VALUE / factor) {
-      throw new IllegalArgumentException(String.format(
-          "Multiplying %s by %d would exceed Long.MAX_LONG", this, factor));
-    }
+    Preconditions.checkArgument(asBytes() <= Long.MAX_VALUE / factor, String.format(
+        "Subtracting %s from %s would overshoot Long.MIN_LONG", this, factor));
     return ByteAmount.fromBytes(asBytes() * factor);
   }
 
@@ -159,9 +155,7 @@ public final class ByteAmount implements Comparable<ByteAmount> {
    * @return a new ByteValue of this ByteValue divided by factor
    */
   public ByteAmount divide(int factor) {
-    if (factor == 0) {
-      throw new IllegalArgumentException(String.format("Can not divide %s by 0", this));
-    }
+    Preconditions.checkArgument(factor != 0, String.format("Can not divide %s by 0", this));
     return ByteAmount.fromBytes(Math.round((double) this.asBytes() / (double) factor));
   }
 
@@ -173,11 +167,8 @@ public final class ByteAmount implements Comparable<ByteAmount> {
    * @throws IllegalArgumentException if increase would exceed Long.MAX_VALUE
    */
   public ByteAmount increaseBy(int percentage) {
-    if (percentage < 0) {
-      throw new IllegalArgumentException(String.format(
-          "Increasing by negative percent (%d) not supported", percentage));
-    }
-
+    Preconditions.checkArgument(percentage >= 0, String.format(
+        "Increasing by negative percent (%d) not supported", percentage));
     double factor = 1.0 + ((double) percentage / 100);
     long max = Math.round(Long.MAX_VALUE / factor);
     if (asBytes() > max) {

--- a/heron/common/src/java/com/twitter/heron/common/basics/ByteAmount.java
+++ b/heron/common/src/java/com/twitter/heron/common/basics/ByteAmount.java
@@ -131,7 +131,7 @@ public final class ByteAmount implements Comparable<ByteAmount> {
    */
   public ByteAmount plus(ByteAmount other) {
     Preconditions.checkArgument(Long.MAX_VALUE - asBytes() >= other.asBytes(), String.format(
-        "Subtracting %s from %s would overshoot Long.MIN_LONG", other, this));
+        "Adding %s to %s would exceed Long.MAX_LONG", other, this));
     return ByteAmount.fromBytes(asBytes() + other.asBytes());
   }
 
@@ -143,7 +143,7 @@ public final class ByteAmount implements Comparable<ByteAmount> {
    */
   public ByteAmount multiply(int factor) {
     Preconditions.checkArgument(asBytes() <= Long.MAX_VALUE / factor, String.format(
-        "Subtracting %s from %s would overshoot Long.MIN_LONG", this, factor));
+        "Multiplying %s by %d would exceed Long.MAX_LONG", this, factor));
     return ByteAmount.fromBytes(asBytes() * factor);
   }
 
@@ -171,10 +171,8 @@ public final class ByteAmount implements Comparable<ByteAmount> {
         "Increasing by negative percent (%d) not supported", percentage));
     double factor = 1.0 + ((double) percentage / 100);
     long max = Math.round(Long.MAX_VALUE / factor);
-    if (asBytes() > max) {
-      throw new IllegalArgumentException(String.format(
-          "Increasing %s by %d percent would exceed Long.MAX_LONG", this, percentage));
-    }
+    Preconditions.checkArgument(asBytes() <= max, String.format(
+        "Increasing %s by %d percent would exceed Long.MAX_LONG", this, percentage));
     return ByteAmount.fromBytes(Math.round((double) asBytes() * factor));
   }
 


### PR DESCRIPTION
This PR related #1612 and #1613 is trying to use `Preconditions.checkArgument` to check arguments in `ByteAmount` 

The key changes are following:

* use `Preconditions.checkArgument` method
* modify the condition expression

cc @billonahill 