### PR TITLE
Consolidate more common failure tests in CommonPackingTests

### DIFF
--- a/heron/api/src/java/com/twitter/heron/api/HeronTopology.java
+++ b/heron/api/src/java/com/twitter/heron/api/HeronTopology.java
@@ -40,15 +40,16 @@ public class HeronTopology {
   private static TopologyAPI.Config.Builder getConfigBuilder(Config config) {
     TopologyAPI.Config.Builder cBldr = TopologyAPI.Config.newBuilder();
     Set<String> apiVars = config.getApiVars();
-    for (Map.Entry<String, Object> entry : config.entrySet()) {
+    for (String key : config.keySet()) {
+      Object value = config.get(key);
       TopologyAPI.Config.KeyValue.Builder b = TopologyAPI.Config.KeyValue.newBuilder();
-      b.setKey(entry.getKey());
-      if (apiVars.contains(entry.getKey())) {
+      b.setKey(key);
+      if (apiVars.contains(key)) {
         b.setType(TopologyAPI.ConfigValueType.STRING_VALUE);
-        b.setValue(entry.getValue().toString());
+        b.setValue(value.toString());
       } else {
         b.setType(TopologyAPI.ConfigValueType.JAVA_SERIALIZED_VALUE);
-        b.setSerializedValue(ByteString.copyFrom(Utils.serialize(entry.getValue())));
+        b.setSerializedValue(ByteString.copyFrom(Utils.serialize(value)));
       }
       cBldr.addKvs(b);
     }

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
@@ -33,7 +33,6 @@ import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Context;
 import com.twitter.heron.spi.packing.IPacking;
 import com.twitter.heron.spi.packing.IRepacking;
-import com.twitter.heron.spi.packing.PackingException;
 import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.packing.Resource;
 import com.twitter.heron.spi.utils.TopologyUtils;
@@ -236,11 +235,14 @@ public class ResourceCompliantRRPacking implements IPacking, IRepacking {
       PackingPlanBuilder planBuilder) throws ResourceExceededException {
 
     Map<String, Integer> parallelismMap = TopologyUtils.getComponentParallelism(topology);
-    int totalInstance = TopologyUtils.getTotalInstance(topology);
+    int totalInstances = TopologyUtils.getTotalInstance(topology);
 
-    if (numContainers > totalInstance) {
-      throw new PackingException("More containers allocated than instances. " + numContainers
-          + " containers allocated to host " + totalInstance + " instances.");
+    if (numContainers > totalInstances) {
+      LOG.warning(String.format(
+          "More containers requested (%s) than total instances (%s). Reducing containers to %s",
+          numContainers, totalInstances, totalInstances));
+      numContainers = totalInstances;
+      planBuilder.updateNumContainers(numContainers);
     }
 
     assignInstancesToContainers(planBuilder, parallelismMap, PolicyType.STRICT);

--- a/heron/packing/tests/java/com/twitter/heron/packing/CommonPackingTests.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/CommonPackingTests.java
@@ -60,10 +60,12 @@ public abstract class CommonPackingTests {
     this.spoutParallelism = 4;
     this.boltParallelism = 3;
     this.totalInstances = this.spoutParallelism + this.boltParallelism;
-    int numContainers = 2;
-    // Set up the topology and its config
+
+    // Set up the topology and its config. Tests can safely modify the config by reference after the
+    // topology is created, but those changes will not be reflected in the underlying protobuf
+    // object Config and Topology objects. This is typically fine for packing tests since they don't
+    // access the protobuf values.
     this.topologyConfig = new com.twitter.heron.api.Config();
-    topologyConfig.put(com.twitter.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
     this.topology = getTopology(spoutParallelism, boltParallelism, topologyConfig);
 
     Config config = Config.newBuilder()

--- a/heron/packing/tests/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPackingTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPackingTest.java
@@ -29,6 +29,7 @@ import com.twitter.heron.packing.CommonPackingTests;
 import com.twitter.heron.packing.utils.PackingUtils;
 import com.twitter.heron.spi.packing.IPacking;
 import com.twitter.heron.spi.packing.IRepacking;
+import com.twitter.heron.spi.packing.PackingException;
 import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.packing.Resource;
 
@@ -44,16 +45,9 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
     return new FirstFitDecreasingPacking();
   }
 
-  @Test(expected = RuntimeException.class)
-  public void testCheckFailure() throws Exception {
-    int numContainers = 2;
-
-    // Explicit set insufficient ram for container
-    ByteAmount containerRam = ByteAmount.fromGigabytes(0);
-
-    topologyConfig.put(com.twitter.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
-    topologyConfig.setContainerMaxRamHint(containerRam);
-
+  @Test (expected = PackingException.class)
+  public void testFailureInsufficientContainerRamHint() throws Exception {
+    topologyConfig.setContainerMaxRamHint(ByteAmount.ZERO);
     pack(getTopology(spoutParallelism, boltParallelism, topologyConfig));
   }
 
@@ -276,30 +270,6 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
   }
 
   /**
-   * Test invalid ram for instance
-   */
-  @Test(expected = RuntimeException.class)
-  public void testInvalidRamInstance() throws Exception {
-    ByteAmount maxContainerRam = ByteAmount.fromGigabytes(10);
-    int defaultNumInstancesperContainer = 4;
-
-    // Explicit set component ram map
-    ByteAmount boltRam = ByteAmount.ZERO;
-
-    topologyConfig.setContainerMaxRamHint(maxContainerRam);
-    topologyConfig.setComponentRam(BOLT_NAME, boltRam);
-
-    TopologyAPI.Topology topologyExplicitRamMap =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitRamMap = pack(topologyExplicitRamMap);
-    Assert.assertEquals(totalInstances, packingPlanExplicitRamMap.getInstanceCount());
-    AssertPacking.assertNumInstances(packingPlanExplicitRamMap.getContainers(), BOLT_NAME, 3);
-    AssertPacking.assertNumInstances(packingPlanExplicitRamMap.getContainers(), SPOUT_NAME, 4);
-    AssertPacking.assertContainerRam(packingPlanExplicitRamMap.getContainers(),
-        instanceDefaultResources.getRam().multiply(defaultNumInstancesperContainer));
-  }
-
-  /**
    * Test the scenario where the max container size is the default
    * and scaling is requested.
    */
@@ -409,14 +379,6 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
         newPackingPlan.getInstanceCount());
     AssertPacking.assertContainers(newPackingPlan.getContainers(),
         BOLT_NAME, SPOUT_NAME, boltRam, instanceDefaultResources.getRam(), null);
-  }
-
-  @Test(expected = RuntimeException.class)
-  public void testScaleDownInvalidComponent() throws Exception {
-    Map<String, Integer> componentChanges = new HashMap<>();
-    componentChanges.put("SPOUT_FAKE", -10); //try to remove a component that does not exist
-    int numContainersBeforeRepack = 2;
-    doDefaultScalingTest(componentChanges, numContainersBeforeRepack);
   }
 
   /**

--- a/heron/packing/tests/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPackingTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPackingTest.java
@@ -269,6 +269,11 @@ public class FirstFitDecreasingPackingTest extends CommonPackingTests {
         maxContainerRam);
   }
 
+  @Test
+  public void testContainersRequestedExceedsInstanceCount() throws Exception {
+    doTestContainerCountRequested(8, 2); // instances will fit into 2 containers
+  }
+
   /**
    * Test the scenario where the max container size is the default
    * and scaling is requested.

--- a/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPackingTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPackingTest.java
@@ -154,6 +154,7 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
     ByteAmount containerDisk = ByteAmount.fromGigabytes(20);
     float containerCpu = 30;
 
+    topologyConfig.put(com.twitter.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
     topologyConfig.setContainerRamRequested(containerRam);
     topologyConfig.setContainerDiskRequested(containerDisk);
     topologyConfig.setContainerCpuRequested(containerCpu);

--- a/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPackingTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPackingTest.java
@@ -142,36 +142,9 @@ public class ResourceCompliantRRPackingTest extends CommonPackingTests {
     }
   }
 
-  /**
-   * Test the scenario where container level resource config are set
-   */
   @Test
-  public void testContainerRequestedResourcesTwoContainers() throws Exception {
-    int numContainers = 2;
-
-    // Explicit set resources for container
-    ByteAmount containerRam = ByteAmount.fromGigabytes(10);
-    ByteAmount containerDisk = ByteAmount.fromGigabytes(20);
-    float containerCpu = 30;
-
-    topologyConfig.put(com.twitter.heron.api.Config.TOPOLOGY_STMGRS, numContainers);
-    topologyConfig.setContainerRamRequested(containerRam);
-    topologyConfig.setContainerDiskRequested(containerDisk);
-    topologyConfig.setContainerCpuRequested(containerCpu);
-    TopologyAPI.Topology topologyExplicitResourcesConfig =
-        getTopology(spoutParallelism, boltParallelism, topologyConfig);
-    PackingPlan packingPlanExplicitResourcesConfig = pack(topologyExplicitResourcesConfig);
-
-    Assert.assertEquals(numContainers, packingPlanExplicitResourcesConfig.getContainers().size());
-    Assert.assertEquals(totalInstances, packingPlanExplicitResourcesConfig.getInstanceCount());
-
-    // Ram for bolt/spout should be the value in component ram map
-    for (PackingPlan.ContainerPlan containerPlan
-        : packingPlanExplicitResourcesConfig.getContainers()) {
-      for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
-        Assert.assertEquals(instanceDefaultResources.getRam(), instancePlan.getResource().getRam());
-      }
-    }
+  public void testContainersRequestedExceedsInstanceCount() throws Exception {
+    doTestContainerCountRequested(8, 7); // each of the 7 instances will get their own container
   }
 
   /**


### PR DESCRIPTION
Pull some failure scenario tests up to `CommonPackingTests` since they should apply to both packing impls. Also, expecting `PackingException` instead of `RuntimeException`.