### PR TITLE
Avoid notifying when no one is waiting on proceedLock

### DIFF
--- a/heron/common/src/java/com/twitter/heron/common/basics/SlaveLooper.java
+++ b/heron/common/src/java/com/twitter/heron/common/basics/SlaveLooper.java
@@ -63,7 +63,6 @@ public class SlaveLooper extends WakeableLooper {
     if (!lock.isToProceed) {
       synchronized (lock.proceedLock) {
         lock.isToProceed = true;
-        lock.proceedLock.notify();
       }
     }
   }

--- a/heron/common/src/java/com/twitter/heron/common/basics/SlaveLooper.java
+++ b/heron/common/src/java/com/twitter/heron/common/basics/SlaveLooper.java
@@ -43,13 +43,13 @@ public class SlaveLooper extends WakeableLooper {
         // or no wakeUp() is called during the thread's run, will the thread wait().
         if (nextTimeoutIntervalMs > 0) {
           try {
-            lock.waiting = true;
+            lock.isWaiting = true;
             // The wait will take the timeout in unit of milli-seconds
             lock.proceedLock.wait(nextTimeoutIntervalMs);
           } catch (InterruptedException e) {
             e.printStackTrace();
           } finally {
-            lock.waiting = false;
+            lock.isWaiting = false;
           }
         } else {
           // break the loop if timeout happens
@@ -66,7 +66,7 @@ public class SlaveLooper extends WakeableLooper {
     if (!lock.isToProceed) {
       synchronized (lock.proceedLock) {
         lock.isToProceed = true;
-        if (lock.waiting) {
+        if (lock.isWaiting) {
           lock.proceedLock.notify();
         }
       }
@@ -79,12 +79,12 @@ public class SlaveLooper extends WakeableLooper {
     private volatile boolean isToProceed;
 
     // Is anyone waiting on proceedLock
-    private volatile boolean waiting;
+    private volatile boolean isWaiting;
 
     RunnableLock() {
       this.proceedLock = new Object();
       isToProceed = false;
-      waiting = false;
+      isWaiting = false;
     }
   }
 }

--- a/heron/common/src/java/com/twitter/heron/common/basics/SlaveLooper.java
+++ b/heron/common/src/java/com/twitter/heron/common/basics/SlaveLooper.java
@@ -78,7 +78,7 @@ public class SlaveLooper extends WakeableLooper {
     private Object proceedLock;
     private volatile boolean isToProceed;
 
-    // Is anyone waiting on proceedLock
+    // Are we doing a wait() on proceedLock.
     private volatile boolean isWaiting;
 
     RunnableLock() {


### PR DESCRIPTION
In one of our Heron jobs we found that the spout is spending 20-30% time in just calling notify in SlaveLooper. Notify happens to be an expensive call and in this case it seems that the invocation of notify is almost always redundant since SpoutInstance calls SlaveLooper from a single thread. Optimizing that here. The cost of optimization is two extra volatile writes while waiting and one extra volatile read in wakeUp. volatile reads are pretty fast so wouldn't add much overhead to wakeUp. volatile writes are slower but waits are less common and cost of volatile writes is much lower compared to wait.