### PR TITLE
Fix response of ``help'' and ``version'' subcommands

### DIFF
--- a/heron/tools/cli/src/python/help.py
+++ b/heron/tools/cli/src/python/help.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 ''' help.py '''
 from heron.common.src.python.utils.log import Log
+from heron.tools.cli.src.python.response import Response, Status
 import heron.tools.common.src.python.utils.config as config
 
 def create_parser(subparsers):
@@ -54,13 +55,13 @@ def run(command, parser, args, unknown_args):
   # if no command is provided, just print main help
   if command_help == 'help':
     parser.print_help()
-    return True
+    return Response(Status.Ok)
 
   # get the subparser for the specific command
   subparser = config.get_subparser(parser, command_help)
   if subparser:
     print subparser.format_help()
-    return True
+    return Response(Status.Ok)
   else:
-    Log.error("Unknown subcommand \'%s\'" % command_help)
-    return False
+    Log.error("Unknown subcommand \'%s\'", command_help)
+    return Response(Status.InvocationError)

--- a/heron/tools/cli/src/python/version.py
+++ b/heron/tools/cli/src/python/version.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ''' version.py '''
+from heron.tools.cli.src.python.response import Response, Status
 import heron.tools.cli.src.python.args as cli_args
 import heron.tools.common.src.python.utils.config as config
-
 
 def create_parser(subparsers):
   '''
@@ -43,4 +43,4 @@ def run(command, parser, args, unknown_args):
   :return:
   '''
   config.print_build_info()
-  return True
+  return Response(Status.Ok)

--- a/heron/tools/cli/src/python/version.py
+++ b/heron/tools/cli/src/python/version.py
@@ -16,6 +16,7 @@ from heron.tools.cli.src.python.response import Response, Status
 import heron.tools.cli.src.python.args as cli_args
 import heron.tools.common.src.python.utils.config as config
 
+
 def create_parser(subparsers):
   '''
   :param subparsers:


### PR DESCRIPTION
The boolean type response is invalid. We should use `Response` object instead.