### PR TITLE
Change AuroraController to an interface

### DIFF
--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraCLIController.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraCLIController.java
@@ -1,0 +1,158 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.twitter.heron.scheduler.aurora;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import com.twitter.heron.spi.packing.PackingPlan;
+import com.twitter.heron.spi.utils.ShellUtils;
+
+/**
+ * This file defines Utils methods used by Aurora
+ */
+class AuroraCLIController implements AuroraController {
+  private static final Logger LOG = Logger.getLogger(AuroraCLIController.class.getName());
+
+  private final String jobSpec;
+  private final boolean isVerbose;
+
+  AuroraCLIController(
+      String jobName,
+      String cluster,
+      String role,
+      String env,
+      boolean isVerbose) {
+    this.isVerbose = isVerbose;
+    this.jobSpec = String.format("%s/%s/%s/%s", cluster, role, env, jobName);
+  }
+
+  @Override
+  public boolean createJob(String auroraFilename, Map<String, String> bindings) {
+    List<String> auroraCmd =
+        new ArrayList<>(Arrays.asList("aurora", "job", "create", "--wait-until", "RUNNING"));
+
+    for (Map.Entry<String, String> binding : bindings.entrySet()) {
+      auroraCmd.add("--bind");
+      auroraCmd.add(String.format("%s=%s", binding.getKey(), binding.getValue()));
+    }
+
+    auroraCmd.add(jobSpec);
+    auroraCmd.add(auroraFilename);
+
+    if (isVerbose) {
+      auroraCmd.add("--verbose");
+    }
+
+    return runProcess(auroraCmd);
+  }
+
+  // Kill an aurora job
+  @Override
+  public boolean killJob() {
+    List<String> auroraCmd = new ArrayList<>(Arrays.asList("aurora", "job", "killall"));
+    auroraCmd.add(jobSpec);
+
+    appendAuroraCommandOptions(auroraCmd, isVerbose);
+
+    return runProcess(auroraCmd);
+  }
+
+  // Restart an aurora job
+  @Override
+  public boolean restartJob(int containerId) {
+    List<String> auroraCmd = new ArrayList<>(Arrays.asList("aurora", "job", "restart"));
+    if (containerId != -1) {
+      auroraCmd.add(String.format("%s/%s", jobSpec, Integer.toString(containerId)));
+    } else {
+      auroraCmd.add(jobSpec);
+    }
+
+    appendAuroraCommandOptions(auroraCmd, isVerbose);
+
+    return runProcess(auroraCmd);
+  }
+
+  @Override
+  public void removeContainers(Set<PackingPlan.ContainerPlan> containersToRemove) {
+    String instancesToKill = getInstancesIdsToKill(containersToRemove);
+    //aurora job kill <cluster>/<role>/<env>/<name>/<instance_ids>
+    List<String> auroraCmd = new ArrayList<>(Arrays.asList(
+        "aurora", "job", "kill", jobSpec + "/" + instancesToKill));
+    LOG.info(String.format(
+        "Killing %s aurora containers: %s", containersToRemove.size(), auroraCmd));
+    if (!runProcess(auroraCmd)) {
+      throw new RuntimeException("Failed to kill freed aurora instances: " + instancesToKill);
+    }
+  }
+
+  @Override
+  public void addContainers(Integer count) {
+    //aurora job add <cluster>/<role>/<env>/<name>/<instance_id> <count>
+    //clone instance 0
+    List<String> auroraCmd = new ArrayList<>(Arrays.asList(
+        "aurora", "job", "add", "--wait-until", "RUNNING", jobSpec + "/0", count.toString()));
+    LOG.info(String.format("Requesting %s new aurora containers %s", count, auroraCmd));
+    if (!runProcess(auroraCmd)) {
+      throw new RuntimeException("Failed to create " + count + " new aurora instances");
+    }
+  }
+
+  // Utils method for unit tests
+  @VisibleForTesting
+  boolean runProcess(List<String> auroraCmd) {
+    StringBuilder stdout = new StringBuilder();
+    StringBuilder stderr = new StringBuilder();
+    int status =
+        ShellUtils.runProcess(auroraCmd.toArray(new String[auroraCmd.size()]), stdout, stderr);
+
+    if (status != 0) {
+      LOG.severe(String.format(
+          "Failed to run process. Command=%s, STDOUT=%s, STDERR=%s", auroraCmd, stdout, stderr));
+    }
+    return status == 0;
+  }
+
+  private static String getInstancesIdsToKill(Set<PackingPlan.ContainerPlan> containersToRemove) {
+    StringBuilder ids = new StringBuilder();
+    for (PackingPlan.ContainerPlan containerPlan : containersToRemove) {
+      if (ids.length() > 0) {
+        ids.append(",");
+      }
+      ids.append(containerPlan.getId());
+    }
+    return ids.toString();
+  }
+
+  // Static method to append verbose and batching options if needed
+  private static void appendAuroraCommandOptions(List<String> auroraCmd, boolean isVerbose) {
+    // Append verbose if needed
+    if (isVerbose) {
+      auroraCmd.add("--verbose");
+    }
+
+    // Append batch size.
+    // Note that we can not use "--no-batching" since "restart" command does not accept it.
+    // So we play a small trick here by setting batch size Integer.MAX_VALUE.
+    auroraCmd.add("--batch-size");
+    auroraCmd.add(Integer.toString(Integer.MAX_VALUE));
+  }
+}

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraCLIController.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraCLIController.java
@@ -84,8 +84,8 @@ class AuroraCLIController implements AuroraController {
   @Override
   public boolean restart(Integer containerId) {
     List<String> auroraCmd = new ArrayList<>(Arrays.asList("aurora", "job", "restart"));
-    if (containerId != null && containerId != -1) {
-      auroraCmd.add(String.format("%s/%s", jobSpec, Integer.toString(containerId)));
+    if (containerId != null) {
+      auroraCmd.add(String.format("%s/%d", jobSpec, containerId));
     } else {
       auroraCmd.add(jobSpec);
     }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraCLIController.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraCLIController.java
@@ -35,19 +35,22 @@ class AuroraCLIController implements AuroraController {
 
   private final String jobSpec;
   private final boolean isVerbose;
+  private final String auroraFilename;
 
   AuroraCLIController(
       String jobName,
       String cluster,
       String role,
       String env,
+      String auroraFilename,
       boolean isVerbose) {
+    this.auroraFilename = auroraFilename;
     this.isVerbose = isVerbose;
     this.jobSpec = String.format("%s/%s/%s/%s", cluster, role, env, jobName);
   }
 
   @Override
-  public boolean createJob(String auroraFilename, Map<String, String> bindings) {
+  public boolean createJob(Map<String, String> bindings) {
     List<String> auroraCmd =
         new ArrayList<>(Arrays.asList("aurora", "job", "create", "--wait-until", "RUNNING"));
 

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraCLIController.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraCLIController.java
@@ -50,13 +50,13 @@ class AuroraCLIController implements AuroraController {
   }
 
   @Override
-  public boolean createJob(Map<String, String> bindings) {
+  public boolean createJob(Map<AuroraField, String> bindings) {
     List<String> auroraCmd =
         new ArrayList<>(Arrays.asList("aurora", "job", "create", "--wait-until", "RUNNING"));
 
-    for (Map.Entry<String, String> binding : bindings.entrySet()) {
+    for (AuroraField field : bindings.keySet()) {
       auroraCmd.add("--bind");
-      auroraCmd.add(String.format("%s=%s", binding.getKey(), binding.getValue()));
+      auroraCmd.add(String.format("%s=%s", field, bindings.get(field)));
     }
 
     auroraCmd.add(jobSpec);
@@ -82,9 +82,9 @@ class AuroraCLIController implements AuroraController {
 
   // Restart an aurora job
   @Override
-  public boolean restartJob(int containerId) {
+  public boolean restart(Integer containerId) {
     List<String> auroraCmd = new ArrayList<>(Arrays.asList("aurora", "job", "restart"));
-    if (containerId != -1) {
+    if (containerId != null && containerId != -1) {
       auroraCmd.add(String.format("%s/%s", jobSpec, Integer.toString(containerId)));
     } else {
       auroraCmd.add(jobSpec);

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraCLIController.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraCLIController.java
@@ -27,7 +27,8 @@ import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.utils.ShellUtils;
 
 /**
- * This file defines Utils methods used by Aurora
+ * Implementation of AuroraController that shells out to the Aurora CLI to control the Aurora
+ * scheduler workflow of a topology.
  */
 class AuroraCLIController implements AuroraController {
   private static final Logger LOG = Logger.getLogger(AuroraCLIController.class.getName());

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraController.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraController.java
@@ -23,9 +23,15 @@ import com.twitter.heron.spi.packing.PackingPlan;
  */
 public interface AuroraController {
 
-  boolean createJob(Map<String, String> auroraProperties);
+  boolean createJob(Map<AuroraField, String> auroraProperties);
   boolean killJob();
-  boolean restartJob(int containerId);
+
+  /**
+   * Restarts a given container, or the entire job if containerId is null
+   * @param containerId ID of container to restart, or entire job if null
+   */
+  boolean restart(Integer containerId);
+
   void removeContainers(Set<PackingPlan.ContainerPlan> containersToRemove);
   void addContainers(Integer count);
 }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraController.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraController.java
@@ -23,7 +23,7 @@ import com.twitter.heron.spi.packing.PackingPlan;
  */
 public interface AuroraController {
 
-  boolean createJob(String auroraFilename, Map<String, String> bindings);
+  boolean createJob(Map<String, String> auroraProperties);
   boolean killJob();
   boolean restartJob(int containerId);
   void removeContainers(Set<PackingPlan.ContainerPlan> containersToRemove);

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraController.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraController.java
@@ -11,144 +11,21 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package com.twitter.heron.scheduler.aurora;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Logger;
-
-import com.google.common.annotations.VisibleForTesting;
 
 import com.twitter.heron.spi.packing.PackingPlan;
-import com.twitter.heron.spi.utils.ShellUtils;
 
 /**
- * This file defines Utils methods used by Aurora
+ * Interface that defines how a client interacts with aurora to control the job lifecycle
  */
-class AuroraController {
-  private static final Logger LOG = Logger.getLogger(AuroraController.class.getName());
+public interface AuroraController {
 
-  private final String jobSpec;
-  private final boolean isVerbose;
-
-  AuroraController(
-      String jobName,
-      String cluster,
-      String role,
-      String env,
-      boolean isVerbose) {
-    this.isVerbose = isVerbose;
-    this.jobSpec = String.format("%s/%s/%s/%s", cluster, role, env, jobName);
-  }
-
-  // Create an aurora job
-  boolean createJob(String auroraFilename, Map<String, String> bindings) {
-    List<String> auroraCmd =
-        new ArrayList<>(Arrays.asList("aurora", "job", "create", "--wait-until", "RUNNING"));
-
-    for (Map.Entry<String, String> binding : bindings.entrySet()) {
-      auroraCmd.add("--bind");
-      auroraCmd.add(String.format("%s=%s", binding.getKey(), binding.getValue()));
-    }
-
-    auroraCmd.add(jobSpec);
-    auroraCmd.add(auroraFilename);
-
-    if (isVerbose) {
-      auroraCmd.add("--verbose");
-    }
-
-    return runProcess(auroraCmd);
-  }
-
-  // Kill an aurora job
-  boolean killJob() {
-    List<String> auroraCmd = new ArrayList<>(Arrays.asList("aurora", "job", "killall"));
-    auroraCmd.add(jobSpec);
-
-    appendAuroraCommandOptions(auroraCmd, isVerbose);
-
-    return runProcess(auroraCmd);
-  }
-
-  // Restart an aurora job
-  boolean restartJob(int containerId) {
-    List<String> auroraCmd = new ArrayList<>(Arrays.asList("aurora", "job", "restart"));
-    if (containerId != -1) {
-      auroraCmd.add(String.format("%s/%s", jobSpec, Integer.toString(containerId)));
-    } else {
-      auroraCmd.add(jobSpec);
-    }
-
-    appendAuroraCommandOptions(auroraCmd, isVerbose);
-
-    return runProcess(auroraCmd);
-  }
-
-  void removeContainers(Set<PackingPlan.ContainerPlan> containersToRemove) {
-    String instancesToKill = getInstancesIdsToKill(containersToRemove);
-    //aurora job kill <cluster>/<role>/<env>/<name>/<instance_ids>
-    List<String> auroraCmd = new ArrayList<>(Arrays.asList(
-        "aurora", "job", "kill", jobSpec + "/" + instancesToKill));
-    LOG.info(String.format(
-        "Killing %s aurora containers: %s", containersToRemove.size(), auroraCmd));
-    if (!runProcess(auroraCmd)) {
-      throw new RuntimeException("Failed to kill freed aurora instances: " + instancesToKill);
-    }
-  }
-
-  void addContainers(Integer count) {
-    //aurora job add <cluster>/<role>/<env>/<name>/<instance_id> <count>
-    //clone instance 0
-    List<String> auroraCmd = new ArrayList<>(Arrays.asList(
-        "aurora", "job", "add", "--wait-until", "RUNNING", jobSpec + "/0", count.toString()));
-    LOG.info(String.format("Requesting %s new aurora containers %s", count, auroraCmd));
-    if (!runProcess(auroraCmd)) {
-      throw new RuntimeException("Failed to create " + count + " new aurora instances");
-    }
-  }
-
-  // Utils method for unit tests
-  @VisibleForTesting
-  boolean runProcess(List<String> auroraCmd) {
-    StringBuilder stdout = new StringBuilder();
-    StringBuilder stderr = new StringBuilder();
-    int status =
-        ShellUtils.runProcess(auroraCmd.toArray(new String[auroraCmd.size()]), stdout, stderr);
-
-    if (status != 0) {
-      LOG.severe(String.format(
-          "Failed to run process. Command=%s, STDOUT=%s, STDERR=%s", auroraCmd, stdout, stderr));
-    }
-    return status == 0;
-  }
-
-  private static String getInstancesIdsToKill(Set<PackingPlan.ContainerPlan> containersToRemove) {
-    StringBuilder ids = new StringBuilder();
-    for (PackingPlan.ContainerPlan containerPlan : containersToRemove) {
-      if (ids.length() > 0) {
-        ids.append(",");
-      }
-      ids.append(containerPlan.getId());
-    }
-    return ids.toString();
-  }
-
-  // Static method to append verbose and batching options if needed
-  private static void appendAuroraCommandOptions(List<String> auroraCmd, boolean isVerbose) {
-    // Append verbose if needed
-    if (isVerbose) {
-      auroraCmd.add("--verbose");
-    }
-
-    // Append batch size.
-    // Note that we can not use "--no-batching" since "restart" command does not accept it.
-    // So we play a small trick here by setting batch size Integer.MAX_VALUE.
-    auroraCmd.add("--batch-size");
-    auroraCmd.add(Integer.toString(Integer.MAX_VALUE));
-  }
+  boolean createJob(String auroraFilename, Map<String, String> bindings);
+  boolean killJob();
+  boolean restartJob(int containerId);
+  void removeContainers(Set<PackingPlan.ContainerPlan> containersToRemove);
+  void addContainers(Integer count);
 }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraField.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraField.java
@@ -1,0 +1,58 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.twitter.heron.scheduler.aurora;
+
+/**
+ * Field names passed to aurora controllers during job creation
+ */
+public enum AuroraField {
+  CLUSTER,
+  COMPONENT_JVM_OPTS_IN_BASE64,
+  COMPONENT_RAMMAP,
+  CORE_PACKAGE_URI,
+  CPUS_PER_CONTAINER,
+  DISK_PER_CONTAINER,
+  ENVIRON,
+  HERON_SANDBOX_JAVA_HOME,
+  INSTANCE_JVM_OPTS_IN_BASE64,
+  /**
+   * Previous flag updated to use IS_PRODUCTION instead
+   * @deprecated remove in future release once config/src/yaml/heron.aurora is updated
+   */
+  @Deprecated
+  ISPRODUCTION,
+  IS_PRODUCTION,
+  NUM_CONTAINERS,
+  RAM_PER_CONTAINER,
+  ROLE,
+  SANDBOX_EXECUTOR_BINARY,
+  SANDBOX_INSTANCE_CLASSPATH,
+  SANDBOX_METRICSMGR_CLASSPATH,
+  SANDBOX_METRICS_YAML,
+  SANDBOX_PYTHON_INSTANCE_BINARY,
+  SANDBOX_SCHEDULER_CLASSPATH,
+  SANDBOX_SHELL_BINARY,
+  SANDBOX_STMGR_BINARY,
+  SANDBOX_SYSTEM_YAML,
+  SANDBOX_TMASTER_BINARY,
+  STATEMGR_CONNECTION_STRING,
+  STATEMGR_ROOT_PATH,
+  TOPOLOGY_BINARY_FILE,
+  TOPOLOGY_CLASSPATH,
+  TOPOLOGY_DEFINITION_FILE,
+  TOPOLOGY_ID,
+  TOPOLOGY_NAME,
+  TOPOLOGY_PACKAGE_TYPE,
+  TOPOLOGY_PACKAGE_URI
+}

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
@@ -71,6 +71,7 @@ public class AuroraScheduler implements IScheduler, IScalable {
         Context.cluster(config),
         Context.role(config),
         Context.environ(config),
+        AuroraContext.getHeronAuroraPath(config),
         Context.verbose(config));
   }
 
@@ -97,7 +98,7 @@ public class AuroraScheduler implements IScheduler, IScalable {
 
     Map<String, String> auroraProperties = createAuroraProperties(updatedPackingPlan);
 
-    return controller.createJob(AuroraContext.getHeronAuroraPath(config), auroraProperties);
+    return controller.createJob(auroraProperties);
   }
 
   @Override

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
@@ -96,7 +96,7 @@ public class AuroraScheduler implements IScheduler, IScalable {
     SchedulerUtils.persistUpdatedPackingPlan(Runtime.topologyName(runtime), updatedPackingPlan,
         Runtime.schedulerStateManagerAdaptor(runtime));
 
-    Map<String, String> auroraProperties = createAuroraProperties(updatedPackingPlan);
+    Map<AuroraField, String> auroraProperties = createAuroraProperties(updatedPackingPlan);
 
     return controller.createJob(auroraProperties);
   }
@@ -122,8 +122,11 @@ public class AuroraScheduler implements IScheduler, IScalable {
 
   @Override
   public boolean onRestart(Scheduler.RestartTopologyRequest request) {
-    int containerId = request.getContainerIndex();
-    return controller.restartJob(containerId);
+    Integer containerId = null;
+    if (request.getContainerIndex() != -1) {
+      containerId = request.getContainerIndex();
+    }
+    return controller.restart(containerId);
   }
 
   @Override
@@ -160,77 +163,82 @@ public class AuroraScheduler implements IScheduler, IScalable {
     return String.format("\"%s\"", javaOptsBase64.replace("=", "&equals;"));
   }
 
-  protected Map<String, String> createAuroraProperties(PackingPlan packing) {
-    Map<String, String> auroraProperties = new HashMap<>();
+  @SuppressWarnings("deprecation") // remove once we remove ISPRODUCTION usage below
+  protected Map<AuroraField, String> createAuroraProperties(PackingPlan packing) {
+    Map<AuroraField, String> auroraProperties = new HashMap<>();
 
     TopologyAPI.Topology topology = Runtime.topology(runtime);
     Resource containerResource = packing.getContainers().iterator().next().getRequiredResource();
 
-    auroraProperties.put("SANDBOX_EXECUTOR_BINARY", Context.executorSandboxBinary(config));
-    auroraProperties.put("TOPOLOGY_NAME", topology.getName());
-    auroraProperties.put("TOPOLOGY_ID", topology.getId());
-    auroraProperties.put("TOPOLOGY_DEFINITION_FILE",
+    auroraProperties.put(AuroraField.SANDBOX_EXECUTOR_BINARY,
+        Context.executorSandboxBinary(config));
+    auroraProperties.put(AuroraField.TOPOLOGY_NAME, topology.getName());
+    auroraProperties.put(AuroraField.TOPOLOGY_ID, topology.getId());
+    auroraProperties.put(AuroraField.TOPOLOGY_DEFINITION_FILE,
         FileUtils.getBaseName(Context.topologyDefinitionFile(config)));
-    auroraProperties.put("STATEMGR_CONNECTION_STRING",
+    auroraProperties.put(AuroraField.STATEMGR_CONNECTION_STRING,
         Context.stateManagerConnectionString(config));
-    auroraProperties.put("STATEMGR_ROOT_PATH", Context.stateManagerRootPath(config));
-    auroraProperties.put("SANDBOX_TMASTER_BINARY", Context.tmasterSandboxBinary(config));
-    auroraProperties.put("SANDBOX_STMGR_BINARY", Context.stmgrSandboxBinary(config));
-    auroraProperties.put("SANDBOX_METRICSMGR_CLASSPATH",
+    auroraProperties.put(AuroraField.STATEMGR_ROOT_PATH, Context.stateManagerRootPath(config));
+    auroraProperties.put(AuroraField.SANDBOX_TMASTER_BINARY, Context.tmasterSandboxBinary(config));
+    auroraProperties.put(AuroraField.SANDBOX_STMGR_BINARY, Context.stmgrSandboxBinary(config));
+    auroraProperties.put(AuroraField.SANDBOX_METRICSMGR_CLASSPATH,
         Context.metricsManagerSandboxClassPath(config));
-    auroraProperties.put("INSTANCE_JVM_OPTS_IN_BASE64",
+    auroraProperties.put(AuroraField.INSTANCE_JVM_OPTS_IN_BASE64,
         formatJavaOpts(TopologyUtils.getInstanceJvmOptions(topology)));
-    auroraProperties.put("TOPOLOGY_CLASSPATH",
+    auroraProperties.put(AuroraField.TOPOLOGY_CLASSPATH,
         TopologyUtils.makeClassPath(topology, Context.topologyBinaryFile(config)));
 
-    auroraProperties.put("SANDBOX_SYSTEM_YAML", Context.systemConfigSandboxFile(config));
-    auroraProperties.put("COMPONENT_RAMMAP", Runtime.componentRamMap(runtime));
-    auroraProperties.put("COMPONENT_JVM_OPTS_IN_BASE64",
+    auroraProperties.put(AuroraField.SANDBOX_SYSTEM_YAML, Context.systemConfigSandboxFile(config));
+    auroraProperties.put(AuroraField.COMPONENT_RAMMAP, Runtime.componentRamMap(runtime));
+    auroraProperties.put(AuroraField.COMPONENT_JVM_OPTS_IN_BASE64,
         formatJavaOpts(TopologyUtils.getComponentJvmOptions(topology)));
-    auroraProperties.put("TOPOLOGY_PACKAGE_TYPE",
+    auroraProperties.put(AuroraField.TOPOLOGY_PACKAGE_TYPE,
         Context.topologyPackageType(config).name().toLowerCase());
-    auroraProperties.put("TOPOLOGY_BINARY_FILE",
+    auroraProperties.put(AuroraField.TOPOLOGY_BINARY_FILE,
         FileUtils.getBaseName(Context.topologyBinaryFile(config)));
-    auroraProperties.put("HERON_SANDBOX_JAVA_HOME", Context.javaSandboxHome(config));
+    auroraProperties.put(AuroraField.HERON_SANDBOX_JAVA_HOME, Context.javaSandboxHome(config));
 
-    auroraProperties.put("SANDBOX_SHELL_BINARY", Context.shellSandboxBinary(config));
-    auroraProperties.put("SANDBOX_PYTHON_INSTANCE_BINARY",
+    auroraProperties.put(AuroraField.SANDBOX_SHELL_BINARY, Context.shellSandboxBinary(config));
+    auroraProperties.put(AuroraField.SANDBOX_PYTHON_INSTANCE_BINARY,
         Context.pythonInstanceSandboxBinary(config));
 
-    auroraProperties.put("CPUS_PER_CONTAINER", Double.toString(containerResource.getCpu()));
-    auroraProperties.put("DISK_PER_CONTAINER",
+    auroraProperties.put(AuroraField.CPUS_PER_CONTAINER,
+        Double.toString(containerResource.getCpu()));
+    auroraProperties.put(AuroraField.DISK_PER_CONTAINER,
         Long.toString(containerResource.getDisk().asBytes()));
-    auroraProperties.put("RAM_PER_CONTAINER",
+    auroraProperties.put(AuroraField.RAM_PER_CONTAINER,
         Long.toString(containerResource.getRam().asBytes()));
 
-    auroraProperties.put("NUM_CONTAINERS", (1 + TopologyUtils.getNumContainers(topology)) + "");
+    auroraProperties.put(AuroraField.NUM_CONTAINERS,
+        Integer.toString(1 + TopologyUtils.getNumContainers(topology)));
 
-    auroraProperties.put("CLUSTER", Context.cluster(config));
-    auroraProperties.put("ENVIRON", Context.environ(config));
-    auroraProperties.put("ROLE", Context.role(config));
-    auroraProperties.put("ISPRODUCTION", isProduction() + "");
+    auroraProperties.put(AuroraField.CLUSTER, Context.cluster(config));
+    auroraProperties.put(AuroraField.ENVIRON, Context.environ(config));
+    auroraProperties.put(AuroraField.ROLE, Context.role(config));
 
-    auroraProperties.put("SANDBOX_INSTANCE_CLASSPATH", Context.instanceSandboxClassPath(config));
-    auroraProperties.put("SANDBOX_METRICS_YAML", Context.metricsSinksSandboxFile(config));
+    // TODO (nlu): currently enforce environment to be "prod" for a Production job
+    String isProduction = Boolean.toString("prod".equals(Context.environ(config)));
+    // TODO: remove this and suppress above once we cut a release and update the aurora config file
+    auroraProperties.put(AuroraField.ISPRODUCTION, isProduction);
+    auroraProperties.put(AuroraField.IS_PRODUCTION, isProduction);
+
+    auroraProperties.put(AuroraField.SANDBOX_INSTANCE_CLASSPATH,
+        Context.instanceSandboxClassPath(config));
+    auroraProperties.put(AuroraField.SANDBOX_METRICS_YAML, Context.metricsSinksSandboxFile(config));
 
     String completeSchedulerClassPath = new StringBuilder()
         .append(Context.schedulerSandboxClassPath(config)).append(":")
         .append(Context.packingSandboxClassPath(config)).append(":")
         .append(Context.stateManagerSandboxClassPath(config))
         .toString();
-    auroraProperties.put("SANDBOX_SCHEDULER_CLASSPATH", completeSchedulerClassPath);
+    auroraProperties.put(AuroraField.SANDBOX_SCHEDULER_CLASSPATH, completeSchedulerClassPath);
 
     String heronCoreReleasePkgURI = Context.corePackageUri(config);
     String topologyPkgURI = Runtime.topologyPackageUri(runtime).toString();
 
-    auroraProperties.put("CORE_PACKAGE_URI", heronCoreReleasePkgURI);
-    auroraProperties.put("TOPOLOGY_PACKAGE_URI", topologyPkgURI);
+    auroraProperties.put(AuroraField.CORE_PACKAGE_URI, heronCoreReleasePkgURI);
+    auroraProperties.put(AuroraField.TOPOLOGY_PACKAGE_URI, topologyPkgURI);
 
     return auroraProperties;
-  }
-
-  protected boolean isProduction() {
-    // TODO (nlu): currently enforce environment to be "prod" for a Production job
-    return "prod".equals(Context.environ(config));
   }
 }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
@@ -61,12 +61,12 @@ public class AuroraScheduler implements IScheduler, IScalable {
   }
 
   /**
-   * Get an AuroraControl basing on the config and runtime
+   * Get an AuroraController based on the config and runtime
    *
-   * @return AuroraControl
+   * @return AuroraController
    */
   protected AuroraController getController() {
-    return new AuroraController(
+    return new AuroraCLIController(
         Runtime.topologyName(runtime),
         Context.cluster(config),
         Context.role(config),

--- a/heron/schedulers/tests/java/BUILD
+++ b/heron/schedulers/tests/java/BUILD
@@ -72,7 +72,7 @@ java_tests(
   test_classes = [
     "com.twitter.heron.scheduler.aurora.AuroraSchedulerTest",
     "com.twitter.heron.scheduler.aurora.AuroraLauncherTest",
-    "com.twitter.heron.scheduler.aurora.AuroraControllerTest",
+    "com.twitter.heron.scheduler.aurora.AuroraCLIControllerTest",
     "com.twitter.heron.scheduler.aurora.AuroraContextTest",
   ],
   runtime_deps = [ ":aurora-tests" ],

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraCLIControllerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraCLIControllerTest.java
@@ -40,6 +40,7 @@ public class AuroraCLIControllerTest {
   private static final String CLUSTER = "cluster";
   private static final String ROLE = "role";
   private static final String ENV = "gz";
+  private static final String AURORA_FILENAME = "file.aurora";
   private static final String VERBOSE_CONFIG = "--verbose";
   private static final String BATCH_CONFIG = "--batch-size";
   private static final String JOB_SPEC = String.format("%s/%s/%s/%s", CLUSTER, ROLE, ENV, JOB_NAME);
@@ -58,7 +59,8 @@ public class AuroraCLIControllerTest {
 
   @Before
   public void setUp() throws Exception {
-    controller = Mockito.spy(new AuroraCLIController(JOB_NAME, CLUSTER, ROLE, ENV, IS_VERBOSE));
+    controller = Mockito.spy(
+        new AuroraCLIController(JOB_NAME, CLUSTER, ROLE, ENV, AURORA_FILENAME, IS_VERBOSE));
   }
 
   @After
@@ -67,19 +69,18 @@ public class AuroraCLIControllerTest {
 
   @Test
   public void testCreateJob() throws Exception {
-    String auroraFilename = "file.aurora";
     Map<String, String> bindings = new HashMap<>();
     List<String> expectedCommand = asList("aurora job create --wait-until RUNNING %s %s %s",
-            JOB_SPEC, auroraFilename, VERBOSE_CONFIG);
+            JOB_SPEC, AURORA_FILENAME, VERBOSE_CONFIG);
 
     // Failed
     Mockito.doReturn(false).when(controller).runProcess(Matchers.anyListOf(String.class));
-    Assert.assertFalse(controller.createJob(auroraFilename, bindings));
+    Assert.assertFalse(controller.createJob(bindings));
     Mockito.verify(controller).runProcess(Mockito.eq(expectedCommand));
 
     // Happy path
     Mockito.doReturn(true).when(controller).runProcess(Matchers.anyListOf(String.class));
-    Assert.assertTrue(controller.createJob(auroraFilename, bindings));
+    Assert.assertTrue(controller.createJob(bindings));
     Mockito.verify(controller, Mockito.times(2)).runProcess(expectedCommand);
   }
 

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraCLIControllerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraCLIControllerTest.java
@@ -35,7 +35,7 @@ import org.mockito.Mockito;
 import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.utils.PackingTestUtils;
 
-public class AuroraControllerTest {
+public class AuroraCLIControllerTest {
   private static final String JOB_NAME = "jobName";
   private static final String CLUSTER = "cluster";
   private static final String ROLE = "role";
@@ -45,7 +45,7 @@ public class AuroraControllerTest {
   private static final String JOB_SPEC = String.format("%s/%s/%s/%s", CLUSTER, ROLE, ENV, JOB_NAME);
   private static final boolean IS_VERBOSE = true;
 
-  private AuroraController controller;
+  private AuroraCLIController controller;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
@@ -58,7 +58,7 @@ public class AuroraControllerTest {
 
   @Before
   public void setUp() throws Exception {
-    controller = Mockito.spy(new AuroraController(JOB_NAME, CLUSTER, ROLE, ENV, IS_VERBOSE));
+    controller = Mockito.spy(new AuroraCLIController(JOB_NAME, CLUSTER, ROLE, ENV, IS_VERBOSE));
   }
 
   @After

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraCLIControllerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraCLIControllerTest.java
@@ -69,7 +69,7 @@ public class AuroraCLIControllerTest {
 
   @Test
   public void testCreateJob() throws Exception {
-    Map<String, String> bindings = new HashMap<>();
+    Map<AuroraField, String> bindings = new HashMap<>();
     List<String> expectedCommand = asList("aurora job create --wait-until RUNNING %s %s %s",
             JOB_SPEC, AURORA_FILENAME, VERBOSE_CONFIG);
 
@@ -108,12 +108,12 @@ public class AuroraCLIControllerTest {
 
     // Failed
     Mockito.doReturn(false).when(controller).runProcess(Matchers.anyListOf(String.class));
-    Assert.assertFalse(controller.restartJob(containerId));
+    Assert.assertFalse(controller.restart(containerId));
     Mockito.verify(controller).runProcess(Mockito.eq(expectedCommand));
 
     // Happy path
     Mockito.doReturn(true).when(controller).runProcess(Matchers.anyListOf(String.class));
-    Assert.assertTrue(controller.restartJob(containerId));
+    Assert.assertTrue(controller.restart(containerId));
     Mockito.verify(controller, Mockito.times(2)).runProcess(expectedCommand);
   }
 

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraSchedulerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraSchedulerTest.java
@@ -112,24 +112,24 @@ public class AuroraSchedulerTest {
 
     // Failed to create job via controller
     Mockito.doReturn(false).when(controller)
-        .createJob(Matchers.anyMapOf(String.class, String.class));
+        .createJob(Matchers.anyMapOf(AuroraField.class, String.class));
     Mockito.doReturn(true).when(stateManager)
         .updatePackingPlan(any(PackingPlans.PackingPlan.class), eq(TOPOLOGY_NAME));
 
     Assert.assertFalse(scheduler.onSchedule(validPlan));
 
     Mockito.verify(controller)
-        .createJob(Matchers.anyMapOf(String.class, String.class));
+        .createJob(Matchers.anyMapOf(AuroraField.class, String.class));
     Mockito.verify(stateManager)
         .updatePackingPlan(any(PackingPlans.PackingPlan.class), eq(TOPOLOGY_NAME));
 
     // Happy path
     Mockito.doReturn(true).when(controller)
-        .createJob(Matchers.anyMapOf(String.class, String.class));
+        .createJob(Matchers.anyMapOf(AuroraField.class, String.class));
     Assert.assertTrue(scheduler.onSchedule(validPlan));
 
     Mockito.verify(controller, Mockito.times(2))
-        .createJob(Matchers.anyMapOf(String.class, String.class));
+        .createJob(Matchers.anyMapOf(AuroraField.class, String.class));
     Mockito.verify(stateManager, Mockito.times(2))
         .updatePackingPlan(any(PackingPlans.PackingPlan.class), eq(TOPOLOGY_NAME));
   }
@@ -166,15 +166,15 @@ public class AuroraSchedulerTest {
 
     // Failed to kill job via controller
     Mockito.doReturn(false).when(
-        controller).restartJob(containerToRestart);
+        controller).restart(containerToRestart);
     Assert.assertFalse(scheduler.onRestart(restartTopologyRequest));
-    Mockito.verify(controller).restartJob(containerToRestart);
+    Mockito.verify(controller).restart(containerToRestart);
 
     // Happy path
     Mockito.doReturn(true).when(
-        controller).restartJob(containerToRestart);
+        controller).restart(containerToRestart);
     Assert.assertTrue(scheduler.onRestart(restartTopologyRequest));
-    Mockito.verify(controller, Mockito.times(2)).restartJob(containerToRestart);
+    Mockito.verify(controller, Mockito.times(2)).restart(containerToRestart);
   }
 
   @Test

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraSchedulerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraSchedulerTest.java
@@ -112,24 +112,24 @@ public class AuroraSchedulerTest {
 
     // Failed to create job via controller
     Mockito.doReturn(false).when(controller)
-        .createJob(Mockito.anyString(), Matchers.anyMapOf(String.class, String.class));
+        .createJob(Matchers.anyMapOf(String.class, String.class));
     Mockito.doReturn(true).when(stateManager)
         .updatePackingPlan(any(PackingPlans.PackingPlan.class), eq(TOPOLOGY_NAME));
 
     Assert.assertFalse(scheduler.onSchedule(validPlan));
 
     Mockito.verify(controller)
-        .createJob(Mockito.eq(AURORA_PATH), Matchers.anyMapOf(String.class, String.class));
+        .createJob(Matchers.anyMapOf(String.class, String.class));
     Mockito.verify(stateManager)
         .updatePackingPlan(any(PackingPlans.PackingPlan.class), eq(TOPOLOGY_NAME));
 
     // Happy path
     Mockito.doReturn(true).when(controller)
-        .createJob(Mockito.anyString(), Matchers.anyMapOf(String.class, String.class));
+        .createJob(Matchers.anyMapOf(String.class, String.class));
     Assert.assertTrue(scheduler.onSchedule(validPlan));
 
     Mockito.verify(controller, Mockito.times(2))
-        .createJob(eq(AURORA_PATH), Matchers.anyMapOf(String.class, String.class));
+        .createJob(Matchers.anyMapOf(String.class, String.class));
     Mockito.verify(stateManager, Mockito.times(2))
         .updatePackingPlan(any(PackingPlans.PackingPlan.class), eq(TOPOLOGY_NAME));
   }


### PR DESCRIPTION
The current implementation of `AuroraController` shells out to the aurora cli and is intended to be run locally by a developer. Other implementations might call the aurora scheduler service directly. Changing `AuroraController` to be an interface allows other implementations to be used by `AuroraScheduler`.

The diff makes things appear messier than they are but basically `AuroraController` was renamed to `AuroraCLIController` and a new `AuroraController` interface was added.