### PR TITLE
[dry-run] print with UTF-8 encoding and consume stream with UTF-8 decoding

### DIFF
--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
@@ -15,6 +15,7 @@
 package com.twitter.heron.scheduler;
 
 import java.io.IOException;
+import java.io.PrintStream;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -318,7 +319,9 @@ public class RuntimeManagerMain {
       // SUPPRESS CHECKSTYLE IllegalCatch
     } catch (UpdateDryRunResponse response) {
       LOG.log(Level.FINE, "Sending out dry-run response");
-      System.out.print(runtimeManagerMain.renderDryRunResponse(response));
+      // Output may contain UTF-8 characters, so we should print using UTF-8 encoding
+      PrintStream out = new PrintStream(System.out, true, "UTF-8");
+      out.print(runtimeManagerMain.renderDryRunResponse(response));
       // SUPPRESS CHECKSTYLE RegexpSinglelineJava
       // Exit with status code 200 to indicate dry-run response is sent out
       System.exit(200);

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
@@ -15,6 +15,7 @@
 package com.twitter.heron.scheduler;
 
 import java.net.URI;
+import java.io.PrintStream;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -364,7 +365,9 @@ public class SubmitterMain {
       submitterMain.submitTopology();
     } catch (SubmitDryRunResponse response) {
       LOG.log(Level.FINE, "Sending out dry-run response");
-      System.out.print(submitterMain.renderDryRunResponse(response));
+      // Output may contain UTF-8 characters, so we should print using UTF-8 encoding
+      PrintStream out = new PrintStream(System.out, true, "UTF-8");
+      out.print(submitterMain.renderDryRunResponse(response));
       // Exit with status code 200 to indicate dry-run response is sent out
       // SUPPRESS CHECKSTYLE RegexpSinglelineJava
       System.exit(200);

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
@@ -14,8 +14,8 @@
 
 package com.twitter.heron.scheduler;
 
-import java.net.URI;
 import java.io.PrintStream;
+import java.net.URI;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/dryrun/SubmitDryRunRenderTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/dryrun/SubmitDryRunRenderTest.java
@@ -15,6 +15,7 @@ package com.twitter.heron.scheduler.dryrun;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -68,7 +69,8 @@ public class SubmitDryRunRenderTest {
     if (stream == null) {
       throw new RuntimeException("Sample output file not found");
     }
-    String exampleTable = IOUtils.toString(stream);
+    // Input might contain UTF-8 character, so we read stream with UTF-8 decoding
+    String exampleTable = IOUtils.toString(stream, StandardCharsets.UTF_8);
     TopologyAPI.Topology topology = PowerMockito.mock(TopologyAPI.Topology.class);
     Config config = Config.newBuilder().put(ConfigKeys.get("PACKING_CLASS"),
         "com.twitter.heron.packing.roundrobin.RoundRobinPacking").build();

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/dryrun/UpdateDryRunRenderTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/dryrun/UpdateDryRunRenderTest.java
@@ -15,6 +15,7 @@ package com.twitter.heron.scheduler.dryrun;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
@@ -94,7 +95,8 @@ public class UpdateDryRunRenderTest {
     if (stream == null) {
       throw new RuntimeException("Sample output file not found");
     }
-    String exampleTable = IOUtils.toString(stream);
+    // Input might contain UTF-8 character, so we read stream with UTF-8 decoding
+    String exampleTable = IOUtils.toString(stream, StandardCharsets.UTF_8);
     TopologyAPI.Topology topology = PowerMockito.mock(TopologyAPI.Topology.class);
     Config config = Config.newBuilder().put(ConfigKeys.get("REPACKING_CLASS"),
         "com.twitter.heron.packing.binpacking.FirstFitDecreasingPacking").build();
@@ -111,7 +113,8 @@ public class UpdateDryRunRenderTest {
     if (stream == null) {
       throw new RuntimeException("Sample output file not found");
     }
-    String exampleTable = IOUtils.toString(stream);
+    // Input might contain UTF-8 character, so we read stream with UTF-8 decoding
+    String exampleTable = IOUtils.toString(stream, StandardCharsets.UTF_8);
     TopologyAPI.Topology topology = PowerMockito.mock(TopologyAPI.Topology.class);
     Config config = Config.newBuilder().put(ConfigKeys.get("REPACKING_CLASS"),
         "com.twitter.heron.packing.binpacking.FirstFitDecreasingPacking").build();


### PR DESCRIPTION
Since we are using UTF-8 character when rendering dry-run response, we need to take care of some UTF-8 locale issue. For example, in CI Ubuntu environment, the Java program does not print with UTF-8 encoding or consume input stream with UTF-8 decoding, which could cause at least two problems:
1. CLI outputs question marks instead of proper UTF-8 character
2. Unit test fails because input stream of sample output file is not decoded with UTF-8

Test has also been done in internal Linux environment.