### PR TITLE
[dry-run] use enum.name() instead of string for locale

### DIFF
--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
@@ -16,6 +16,7 @@ package com.twitter.heron.scheduler;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -320,7 +321,7 @@ public class RuntimeManagerMain {
     } catch (UpdateDryRunResponse response) {
       LOG.log(Level.FINE, "Sending out dry-run response");
       // Output may contain UTF-8 characters, so we should print using UTF-8 encoding
-      PrintStream out = new PrintStream(System.out, true, "UTF-8");
+      PrintStream out = new PrintStream(System.out, true, StandardCharsets.UTF_8.name());
       out.print(runtimeManagerMain.renderDryRunResponse(response));
       // SUPPRESS CHECKSTYLE RegexpSinglelineJava
       // Exit with status code 200 to indicate dry-run response is sent out

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
@@ -16,6 +16,7 @@ package com.twitter.heron.scheduler;
 
 import java.io.PrintStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -366,7 +367,7 @@ public class SubmitterMain {
     } catch (SubmitDryRunResponse response) {
       LOG.log(Level.FINE, "Sending out dry-run response");
       // Output may contain UTF-8 characters, so we should print using UTF-8 encoding
-      PrintStream out = new PrintStream(System.out, true, "UTF-8");
+      PrintStream out = new PrintStream(System.out, true, StandardCharsets.UTF_8.name());
       out.print(submitterMain.renderDryRunResponse(response));
       // Exit with status code 200 to indicate dry-run response is sent out
       // SUPPRESS CHECKSTYLE RegexpSinglelineJava


### PR DESCRIPTION
A tiny PR. Follow up of https://github.com/twitter/heron/pull/1675#discussion_r97236313