### PR TITLE
Drop corrupt packets to clients

### DIFF
--- a/heron/common/src/cpp/network/client.cpp
+++ b/heron/common/src/cpp/network/client.cpp
@@ -181,8 +181,10 @@ void Client::OnNewPacket(IncomingPacket* _ipkt) {
 
   if (_ipkt->UnPackString(&typname) != 0) {
     Connection* conn = static_cast<Connection*>(conn_);
-    LOG(FATAL) << "UnPackString failed from connection " << conn << " from hostport "
+    LOG(ERROR) << "UnPackString failed from connection " << conn << " from hostport "
                << conn->getIPAddress() << ":" << conn->getPort();
+    delete _ipkt;
+    return;
   }
 
   if (requestHandlers.count(typname) > 0) {


### PR DESCRIPTION
Instead of crashing stmgr, we can just ignore the corrupt packets.