### PR TITLE
patching heron for missing api/constants

### DIFF
--- a/heron/instance/src/java/shade.conf
+++ b/heron/instance/src/java/shade.conf
@@ -1,3 +1,3 @@
 rule com.google.protobuf** com.twitter.heron.shaded.@0
 rule org.yaml.snakeyaml** com.twitter.heron.shaded.@0
-
+rule com.esotericsoftware.kryo** com.twitter.heron.shaded.@0

--- a/heron/storm/src/java/backtype/storm/Constants.java
+++ b/heron/storm/src/java/backtype/storm/Constants.java
@@ -16,21 +16,13 @@
  * limitations under the License.
  */
 
-package org.apache.storm.generated;
+package backtype.storm;
 
-import com.twitter.heron.api.HeronTopology;
+public final class Constants {
 
-public class StormTopology {
-  private HeronTopology topology;
-
-  public StormTopology() {
+  private Constants() {
   }
 
-  public StormTopology(HeronTopology topology) {
-    this.topology = topology;
-  }
-
-  public HeronTopology getStormTopology() {
-    return topology;
-  }
+  public static final String SYSTEM_COMPONENT_ID = "__system";
+  public static final String SYSTEM_TICK_STREAM_ID = "__tick";
 }

--- a/heron/storm/src/java/backtype/storm/generated/StormTopology.java
+++ b/heron/storm/src/java/backtype/storm/generated/StormTopology.java
@@ -23,6 +23,9 @@ import com.twitter.heron.api.HeronTopology;
 public class StormTopology {
   private HeronTopology topology;
 
+  public StormTopology() {
+  }
+
   public StormTopology(HeronTopology topology) {
     this.topology = topology;
   }

--- a/heron/storm/src/java/org/apache/storm/spout/MultiScheme.java
+++ b/heron/storm/src/java/org/apache/storm/spout/MultiScheme.java
@@ -19,12 +19,13 @@
 package org.apache.storm.spout;
 
 import java.io.Serializable;
+import java.nio.ByteBuffer;
 import java.util.List;
 
 import org.apache.storm.tuple.Fields;
 
 public interface MultiScheme extends Serializable {
-  Iterable<List<Object>> deserialize(byte[] ser);
+  Iterable<List<Object>> deserialize(ByteBuffer ser);
 
   Fields getOutputFields();
 }

--- a/heron/storm/src/java/org/apache/storm/spout/RawMultiScheme.java
+++ b/heron/storm/src/java/org/apache/storm/spout/RawMultiScheme.java
@@ -18,6 +18,7 @@
 
 package org.apache.storm.spout;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 import org.apache.storm.tuple.Fields;
@@ -29,7 +30,7 @@ public class RawMultiScheme implements MultiScheme {
   private static final long serialVersionUID = 4272415692741188347L;
 
   @Override
-  public Iterable<List<Object>> deserialize(byte[] ser) {
+  public Iterable<List<Object>> deserialize(ByteBuffer ser) {
     return asList(tuple(ser));
   }
 

--- a/heron/storm/src/java/org/apache/storm/spout/RawScheme.java
+++ b/heron/storm/src/java/org/apache/storm/spout/RawScheme.java
@@ -18,6 +18,7 @@
 
 package org.apache.storm.spout;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 import org.apache.storm.tuple.Fields;
@@ -27,7 +28,7 @@ import static org.apache.storm.utils.Utils.tuple;
 public class RawScheme implements Scheme {
   private static final long serialVersionUID = 6098042939916415521L;
 
-  public List<Object> deserialize(byte[] ser) {
+  public List<Object> deserialize(ByteBuffer ser) {
     return tuple(ser);
   }
 

--- a/heron/storm/src/java/org/apache/storm/spout/Scheme.java
+++ b/heron/storm/src/java/org/apache/storm/spout/Scheme.java
@@ -19,12 +19,13 @@
 package org.apache.storm.spout;
 
 import java.io.Serializable;
+import java.nio.ByteBuffer;
 import java.util.List;
 
 import org.apache.storm.tuple.Fields;
 
 public interface Scheme extends Serializable {
-  List<Object> deserialize(byte[] ser);
+  List<Object> deserialize(ByteBuffer ser);
 
   Fields getOutputFields();
 }

--- a/heron/storm/src/java/org/apache/storm/spout/SchemeAsMultiScheme.java
+++ b/heron/storm/src/java/org/apache/storm/spout/SchemeAsMultiScheme.java
@@ -18,6 +18,7 @@
 
 package org.apache.storm.spout;
 
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 
@@ -32,7 +33,7 @@ public class SchemeAsMultiScheme implements MultiScheme {
   }
 
   @Override
-  public Iterable<List<Object>> deserialize(final byte[] ser) {
+  public Iterable<List<Object>> deserialize(final ByteBuffer ser) {
     List<Object> o = scheme.deserialize(ser);
     if (o == null) {
       return null;


### PR DESCRIPTION
1. shading the Kryo used by internal heron system
2. update `deserialize(byte[])` to `deserialize(ByteBuffer)` in storm 1.0 api to comply with the storm api
3. add necessary constants and constructors