### PR TITLE
Add number of packets to the per instance queue metrics

### DIFF
--- a/heron/common/src/cpp/network/connection.cpp
+++ b/heron/common/src/cpp/network/connection.cpp
@@ -44,7 +44,6 @@ Connection::Connection(ConnectionEndPoint* endpoint, ConnectionOptions* options,
   mOnNewPacket = NULL;
   mOnConnectionBufferEmpty = NULL;
   mOnConnectionBufferFull = NULL;
-  mOnConnectionBufferChange = NULL;
   mNumOutstandingPackets = 0;
   mNumOutstandingBytes = 0;
   mIOVectorSize = 1024;
@@ -84,10 +83,6 @@ sp_int32 Connection::sendPacket(OutgoingPacket* packet, VCallback<NetworkErrorCo
   mNumOutstandingPackets++;
   mNumOutstandingBytes += packet->GetTotalPacketSize();
 
-  if (mOnConnectionBufferChange) {
-    mOnConnectionBufferChange(this);
-  }
-
   if (!hasCausedBackPressure()) {
     // Are we above the threshold?
     if (mNumOutstandingBytes >= systemHWMOutstandingBytes) {
@@ -107,10 +102,6 @@ sp_int32 Connection::sendPacket(OutgoingPacket* packet, VCallback<NetworkErrorCo
 
 void Connection::registerForNewPacket(VCallback<IncomingPacket*> cb) {
   mOnNewPacket = std::move(cb);
-}
-
-void Connection::registerForBufferChange(VCallback<Connection*> cb) {
-  mOnConnectionBufferChange = std::move(cb);
 }
 
 sp_int32 Connection::registerForBackPressure(VCallback<Connection*> cbStarter,
@@ -145,11 +136,6 @@ sp_int32 Connection::writeIntoIOVector(sp_int32 maxWrite, sp_int32* toWrite) {
 
 void Connection::afterWriteIntoIOVector(sp_int32 simulWrites, ssize_t numWritten) {
   mNumOutstandingBytes -= numWritten;
-
-  if (mOnConnectionBufferChange) {
-    mOnConnectionBufferChange(this);
-  }
-
   for (sp_int32 i = 0; i < simulWrites; ++i) {
     auto pr = mOutstandingPackets.front();
     if (numWritten >= (ssize_t)mIOVector[i].iov_len) {

--- a/heron/common/src/cpp/network/connection.h
+++ b/heron/common/src/cpp/network/connection.h
@@ -104,10 +104,6 @@ class Connection : public BaseConnection {
    */
   sp_int32 registerForBackPressure(VCallback<Connection*> cbStarter,
                                    VCallback<Connection*> cbReliever);
-  /**
-   * Invoke this callback when the connection buffer size changes.
-   */
-  void registerForBufferChange(VCallback<Connection*> cb);
 
   sp_int32 getOutstandingPackets() const { return mNumOutstandingPackets; }
   sp_int32 getOutstandingBytes() const { return mNumOutstandingBytes; }
@@ -164,8 +160,6 @@ class Connection : public BaseConnection {
   // This call back gets registered from the Server and gets called once the conneciton pipe
   // becomes full (outstanding bytes exceed threshold)
   VCallback<Connection*> mOnConnectionBufferFull;
-
-  VCallback<Connection*> mOnConnectionBufferChange;
 
   sp_int32 mIOVectorSize;
   struct iovec* mIOVector;

--- a/heron/common/src/cpp/network/server.cpp
+++ b/heron/common/src/cpp/network/server.cpp
@@ -109,12 +109,6 @@ BaseConnection* Server::CreateConnection(ConnectionEndPoint* _endpoint, Connecti
 
   conn->registerForBackPressure(std::move(backpressure_starter_),
                                 std::move(backpressure_reliever_));
-
-  auto buffer_size_change_ = [this](Connection* conn) {
-    this->ConnectionBufferChangeCb(conn);
-  };
-
-  conn->registerForBufferChange(std::move(buffer_size_change_));
   return conn;
 }
 
@@ -260,8 +254,4 @@ void Server::StartBackPressureConnectionCb(Connection* conn) {
 
 void Server::StopBackPressureConnectionCb(Connection* conn) {
   // Nothing to be done here. Should be handled by inheritors if they care about backpressure
-}
-
-void Server::ConnectionBufferChangeCb(Connection* conn) {
-  // Nothing to be done here. Should be handled by inheritors if they care about buffer size change
 }

--- a/heron/common/src/cpp/network/server.h
+++ b/heron/common/src/cpp/network/server.h
@@ -176,9 +176,6 @@ class Server : public BaseServer {
   // Backpressure Reliever
   virtual void StopBackPressureConnectionCb(Connection* _connection);
 
-  // Connection buffer size monitor
-  virtual void ConnectionBufferChangeCb(Connection* _connection);
-
   // Return the underlying EventLoop.
   EventLoop* getEventLoop() { return eventLoop_; }
 

--- a/heron/stmgr/src/cpp/manager/stmgr-server.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-server.cpp
@@ -419,16 +419,11 @@ void StMgrServer::SendToInstance2(sp_int32 _task_id,
           ->incr_by(_message.control().fails_size());
     }
   } else {
-    if (_message.has_data()) {
-      instance_info_[_task_id]->data_tuples += _message.data().tuples_size();
-    }
     if (_message.has_control()) {
       stmgr_server_metrics_->scope(METRIC_ACK_TUPLES_TO_INSTANCES)
           ->incr_by(_message.control().acks_size());
       stmgr_server_metrics_->scope(METRIC_FAIL_TUPLES_TO_INSTANCES)
           ->incr_by(_message.control().fails_size());
-      instance_info_[_task_id]->ack_tuples += _message.control().acks_size();
-      instance_info_[_task_id]->fail_tuples += _message.control().fails_size();
     }
     SendMessage(iter->second->conn_, _message);
   }

--- a/heron/stmgr/src/cpp/manager/stmgr-server.h
+++ b/heron/stmgr/src/cpp/manager/stmgr-server.h
@@ -77,6 +77,7 @@ class StMgrServer : public Server {
   sp_string MakeBackPressureCompIdMetricName(const sp_string& instanceid);
   sp_string MakeQueueSizeCompIdMetricName(const sp_string& instanceid);
   sp_string GetInstanceName(Connection* _connection);
+  void UpdateQueueMetrics(EventLoop::Status);
 
   // Various handlers for different requests
 
@@ -103,9 +104,6 @@ class StMgrServer : public Server {
   void StartBackPressureConnectionCb(Connection* _connection);
   // Relieve back pressure
   void StopBackPressureConnectionCb(Connection* _connection);
-
-  // Connection buffer size metric
-  void ConnectionBufferChangeCb(Connection* _connection);
 
   // Can we free the back pressure on the spouts?
   void AttemptStopBackPressureFromSpouts();

--- a/heron/stmgr/src/cpp/manager/stmgr-server.h
+++ b/heron/stmgr/src/cpp/manager/stmgr-server.h
@@ -77,7 +77,6 @@ class StMgrServer : public Server {
  private:
   sp_string MakeBackPressureCompIdMetricName(const sp_string& instanceid);
   sp_string MakeQueueSizeCompIdMetricName(const sp_string& instanceid);
-  sp_string MakeInstanceTuplesMetricName(const sp_string& instanceid);
   sp_string GetInstanceName(Connection* _connection);
   void UpdateQueueMetrics(EventLoop::Status);
 

--- a/heron/stmgr/src/cpp/manager/stmgr-server.h
+++ b/heron/stmgr/src/cpp/manager/stmgr-server.h
@@ -79,7 +79,7 @@ class StMgrServer : public Server {
   sp_string MakeQueueSizeCompIdMetricName(const sp_string& instanceid);
   sp_string MakeInstanceTuplesMetricName(const sp_string& instanceid);
   sp_string GetInstanceName(Connection* _connection);
-  void UpdateStMgrServerMetrics(EventLoop::Status);
+  void UpdateQueueMetrics(EventLoop::Status);
 
   // Various handlers for different requests
 
@@ -155,11 +155,8 @@ class StMgrServer : public Server {
   InstanceMetricMap instance_metric_map_;
 
   // map of Instance_id/stmgrid to queue metric
-  typedef std::map<sp_string, heron::common::AssignableMetric*> QueueMetricMap;
+  typedef std::map<sp_string, heron::common::MultiAssignableMetric*> QueueMetricMap;
   QueueMetricMap queue_metric_map_;
-
-  typedef std::map<sp_string, heron::common::MultiAssignableMetric*> TuplesMetricMap;
-  TuplesMetricMap tuples_metrics_map_;
 
   // instances/stream mgrs causing back pressure
   std::set<sp_string> remote_ends_who_caused_back_pressure_;

--- a/heron/stmgr/src/cpp/manager/stmgr-server.h
+++ b/heron/stmgr/src/cpp/manager/stmgr-server.h
@@ -31,6 +31,7 @@ class MetricsMgrSt;
 class MultiCountMetric;
 class TimeSpentMetric;
 class AssignableMetric;
+class MultiAssignableMetric;
 }
 }
 
@@ -76,8 +77,9 @@ class StMgrServer : public Server {
  private:
   sp_string MakeBackPressureCompIdMetricName(const sp_string& instanceid);
   sp_string MakeQueueSizeCompIdMetricName(const sp_string& instanceid);
+  sp_string MakeInstanceTuplesMetricName(const sp_string& instanceid);
   sp_string GetInstanceName(Connection* _connection);
-  void UpdateQueueMetrics(EventLoop::Status);
+  void UpdateStMgrServerMetrics(EventLoop::Status);
 
   // Various handlers for different requests
 
@@ -116,7 +118,8 @@ class StMgrServer : public Server {
   class InstanceData {
    public:
     explicit InstanceData(proto::system::Instance* _instance)
-        : instance_(_instance), local_spout_(false), conn_(NULL) {}
+        : instance_(_instance), local_spout_(false), conn_(NULL), data_tuples(0), ack_tuples(0),
+          fail_tuples(0) {}
     ~InstanceData() { delete instance_; }
 
     void set_local_spout() { local_spout_ = true; }
@@ -125,6 +128,10 @@ class StMgrServer : public Server {
     proto::system::Instance* instance_;
     bool local_spout_;
     Connection* conn_;
+
+    sp_int64 data_tuples;
+    sp_int64 ack_tuples;
+    sp_int64 fail_tuples;
   };
 
   // map from stmgr_id to their connection
@@ -150,6 +157,9 @@ class StMgrServer : public Server {
   // map of Instance_id/stmgrid to queue metric
   typedef std::map<sp_string, heron::common::AssignableMetric*> QueueMetricMap;
   QueueMetricMap queue_metric_map_;
+
+  typedef std::map<sp_string, heron::common::MultiAssignableMetric*> TuplesMetricMap;
+  TuplesMetricMap tuples_metrics_map_;
 
   // instances/stream mgrs causing back pressure
   std::set<sp_string> remote_ends_who_caused_back_pressure_;

--- a/heron/stmgr/src/cpp/manager/stmgr-server.h
+++ b/heron/stmgr/src/cpp/manager/stmgr-server.h
@@ -118,8 +118,7 @@ class StMgrServer : public Server {
   class InstanceData {
    public:
     explicit InstanceData(proto::system::Instance* _instance)
-        : instance_(_instance), local_spout_(false), conn_(NULL), data_tuples(0), ack_tuples(0),
-          fail_tuples(0) {}
+        : instance_(_instance), local_spout_(false), conn_(NULL) {}
     ~InstanceData() { delete instance_; }
 
     void set_local_spout() { local_spout_ = true; }
@@ -128,10 +127,6 @@ class StMgrServer : public Server {
     proto::system::Instance* instance_;
     bool local_spout_;
     Connection* conn_;
-
-    sp_int64 data_tuples;
-    sp_int64 ack_tuples;
-    sp_int64 fail_tuples;
   };
 
   // map from stmgr_id to their connection


### PR DESCRIPTION
This PR first moves the metrics collecting code out of the hot path, then adds # packet to the per instance queue metrics as requested in issue #1671.

Sample output:
```
            "__queue_size_to_instance_by_compid/container_1_consumer_2/bytes": "86421995",
            "__queue_size_to_instance_by_compid/container_1_consumer_2/packets": "794",
            "__queue_size_to_instance_by_compid/container_1_word_1/bytes": "0",
            "__queue_size_to_instance_by_compid/container_1_word_1/packets": "0",
```