### PR TITLE
Standardize Java formatter string.

### DIFF
--- a/heron/spi/src/java/com/twitter/heron/spi/utils/TMasterUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/TMasterUtils.java
@@ -137,7 +137,7 @@ public final class TMasterUtils {
 
     if (state == expectedState) {
       throw new TMasterException(String.format(
-          "Topology {0} command received topology {1} but already in {2} state",
+          "Topology %s command received topology '%s' but already in state %s",
           topologyStateControlCommand, topologyName, state));
     }
 


### PR DESCRIPTION
#### Problem
The current argument index is invalid, which will be rejected by some Java compiler (`jdk1.8.0_77` in internal OS X CI environment). See: http://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html#syntax. Even though some compilers do not reject this syntax, it is not valid according to language spec anyway.

#### Solution
Switch to ``%s``.