### PR TITLE
Change dryrun to not include format args if dry run is false

### DIFF
--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
@@ -252,7 +252,7 @@ public class RuntimeManagerMain {
 
     // Default dry-run output format type
     DryRunFormatType dryRunFormat = DryRunFormatType.TABLE;
-    if (cmd.hasOption("t")) {
+    if (dryRun && cmd.hasOption("t")) {
       String format = cmd.getOptionValue("dry_run_format");
       dryRunFormat = DryRunFormatType.getDryRunFormatType(format);
       LOG.fine(String.format("Running dry-run mode using format %s", format));

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
@@ -294,7 +294,7 @@ public class SubmitterMain {
 
     // Default dry-run output format type
     DryRunFormatType dryRunFormat = DryRunFormatType.TABLE;
-    if (cmd.hasOption("f")) {
+    if (dryRun && cmd.hasOption("t")) {
       String format = cmd.getOptionValue("dry_run_format");
       dryRunFormat = DryRunFormatType.getDryRunFormatType(format);
       LOG.fine(String.format("Running dry-run mode using format %s", format));

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/ReflectionUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/ReflectionUtils.java
@@ -28,6 +28,9 @@ public final class ReflectionUtils {
   @SuppressWarnings("unchecked") // we don't know what T is until runtime
   public static <T> T newInstance(ClassLoader classLoader, String className)
       throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+    if (className == null) {
+      throw new ClassNotFoundException("Can not instantiate class. className must not be null");
+    }
     return (T) classLoader.loadClass(className).newInstance();
   }
 }

--- a/heron/tools/cli/src/python/submit.py
+++ b/heron/tools/cli/src/python/submit.py
@@ -102,9 +102,8 @@ def launch_a_topology(cl_args, tmp_dir, topology_file, topology_defn_file, topol
 
   if cl_args["dry_run"]:
     args.append("--dry_run")
-
-  if "dry_run_format" in cl_args:
-    args += ["--dry_run_format", cl_args["dry_run_format"]]
+    if "dry_run_format" in cl_args:
+      args += ["--dry_run_format", cl_args["dry_run_format"]]
 
   lib_jars = config.get_heron_libs(
       jars.scheduler_jars() + jars.uploader_jars() + jars.statemgr_jars() + jars.packing_jars()

--- a/heron/tools/cli/src/python/update.py
+++ b/heron/tools/cli/src/python/update.py
@@ -62,7 +62,7 @@ def run(command, parser, cl_args, unknown_args):
   extra_lib_jars = jars.packing_jars()
   if cl_args["dry_run"]:
     extra_args.append('--dry_run')
-  if "dry_run_format" in cl_args:
-    extra_args += ["--dry_run_format", cl_args["dry_run_format"]]
+    if "dry_run_format" in cl_args:
+      extra_args += ["--dry_run_format", cl_args["dry_run_format"]]
 
   return cli_helper.run(command, cl_args, "update topology", extra_args, extra_lib_jars)


### PR DESCRIPTION
I noticed when testing that dry run format args were being passed with empty values even when dry-run was not enabled. Change to not pass format if dry run is not passed.

Also SubmitterMain was using the wrong option char for dry run format.