### PR TITLE
Support connection buffer metrics between stmgr and instances

### DIFF
--- a/heron/common/src/cpp/network/connection.cpp
+++ b/heron/common/src/cpp/network/connection.cpp
@@ -44,7 +44,6 @@ Connection::Connection(ConnectionEndPoint* endpoint, ConnectionOptions* options,
   mOnNewPacket = NULL;
   mOnConnectionBufferEmpty = NULL;
   mOnConnectionBufferFull = NULL;
-  mOnConnectionBufferChange = NULL;
   mNumOutstandingPackets = 0;
   mNumOutstandingBytes = 0;
   mIOVectorSize = 1024;
@@ -84,10 +83,6 @@ sp_int32 Connection::sendPacket(OutgoingPacket* packet, VCallback<NetworkErrorCo
   mNumOutstandingPackets++;
   mNumOutstandingBytes += packet->GetTotalPacketSize();
 
-  if (mOnConnectionBufferChange) {
-    mOnConnectionBufferChange(this);
-  }
-
   if (!hasCausedBackPressure()) {
     // Are we above the threshold?
     if (mNumOutstandingBytes >= systemHWMOutstandingBytes) {
@@ -107,10 +102,6 @@ sp_int32 Connection::sendPacket(OutgoingPacket* packet, VCallback<NetworkErrorCo
 
 void Connection::registerForNewPacket(VCallback<IncomingPacket*> cb) {
   mOnNewPacket = std::move(cb);
-}
-
-void Connection::registerForBufferChange(VCallback<Connection*> cb) {
-  mOnConnectionBufferChange = std::move(cb);
 }
 
 sp_int32 Connection::registerForBackPressure(VCallback<Connection*> cbStarter,
@@ -145,10 +136,6 @@ sp_int32 Connection::writeIntoIOVector(sp_int32 maxWrite, sp_int32* toWrite) {
 
 void Connection::afterWriteIntoIOVector(sp_int32 simulWrites, ssize_t numWritten) {
   mNumOutstandingBytes -= numWritten;
-
-  if (mOnConnectionBufferChange) {
-    mOnConnectionBufferChange(this);
-  }
 
   for (sp_int32 i = 0; i < simulWrites; ++i) {
     auto pr = mOutstandingPackets.front();

--- a/heron/common/src/cpp/network/connection.h
+++ b/heron/common/src/cpp/network/connection.h
@@ -104,10 +104,6 @@ class Connection : public BaseConnection {
    */
   sp_int32 registerForBackPressure(VCallback<Connection*> cbStarter,
                                    VCallback<Connection*> cbReliever);
-  /**
-   * Invoke this callback when the connection buffer size changes.
-   */
-  void registerForBufferChange(VCallback<Connection*> cb);
 
   sp_int32 getOutstandingPackets() const { return mNumOutstandingPackets; }
   sp_int32 getOutstandingBytes() const { return mNumOutstandingBytes; }
@@ -164,8 +160,6 @@ class Connection : public BaseConnection {
   // This call back gets registered from the Server and gets called once the conneciton pipe
   // becomes full (outstanding bytes exceed threshold)
   VCallback<Connection*> mOnConnectionBufferFull;
-
-  VCallback<Connection*> mOnConnectionBufferChange;
 
   sp_int32 mIOVectorSize;
   struct iovec* mIOVector;

--- a/heron/common/src/cpp/network/server.cpp
+++ b/heron/common/src/cpp/network/server.cpp
@@ -110,11 +110,6 @@ BaseConnection* Server::CreateConnection(ConnectionEndPoint* _endpoint, Connecti
   conn->registerForBackPressure(std::move(backpressure_starter_),
                                 std::move(backpressure_reliever_));
 
-  auto buffer_size_change_ = [this](Connection* conn) {
-    this->ConnectionBufferChangeCb(conn);
-  };
-
-  conn->registerForBufferChange(std::move(buffer_size_change_));
   return conn;
 }
 
@@ -260,8 +255,4 @@ void Server::StartBackPressureConnectionCb(Connection* conn) {
 
 void Server::StopBackPressureConnectionCb(Connection* conn) {
   // Nothing to be done here. Should be handled by inheritors if they care about backpressure
-}
-
-void Server::ConnectionBufferChangeCb(Connection* conn) {
-  // Nothing to be done here. Should be handled by inheritors if they care about buffer size change
 }

--- a/heron/common/src/cpp/network/server.h
+++ b/heron/common/src/cpp/network/server.h
@@ -176,9 +176,6 @@ class Server : public BaseServer {
   // Backpressure Reliever
   virtual void StopBackPressureConnectionCb(Connection* _connection);
 
-  // Connection buffer size monitor
-  virtual void ConnectionBufferChangeCb(Connection* _connection);
-
   // Return the underlying EventLoop.
   EventLoop* getEventLoop() { return eventLoop_; }
 

--- a/heron/stmgr/src/cpp/manager/stmgr-server.h
+++ b/heron/stmgr/src/cpp/manager/stmgr-server.h
@@ -31,6 +31,7 @@ class MetricsMgrSt;
 class MultiCountMetric;
 class TimeSpentMetric;
 class AssignableMetric;
+class MultiMeanMetric;
 }
 }
 
@@ -77,6 +78,7 @@ class StMgrServer : public Server {
   sp_string MakeBackPressureCompIdMetricName(const sp_string& instanceid);
   sp_string MakeQueueSizeCompIdMetricName(const sp_string& instanceid);
   sp_string GetInstanceName(Connection* _connection);
+  void UpdateQueueMetrics(EventLoop::Status);
 
   // Various handlers for different requests
 
@@ -103,9 +105,6 @@ class StMgrServer : public Server {
   void StartBackPressureConnectionCb(Connection* _connection);
   // Relieve back pressure
   void StopBackPressureConnectionCb(Connection* _connection);
-
-  // Connection buffer size metric
-  void ConnectionBufferChangeCb(Connection* _connection);
 
   // Can we free the back pressure on the spouts?
   void AttemptStopBackPressureFromSpouts();
@@ -150,8 +149,8 @@ class StMgrServer : public Server {
   InstanceMetricMap instance_metric_map_;
 
   // map of Instance_id/stmgrid to queue metric
-  typedef std::map<sp_string, heron::common::AssignableMetric*> QueueMetricMap;
-  QueueMetricMap queue_metric_map_;
+  typedef std::map<sp_string, heron::common::MultiMeanMetric*> ConnectionBufferMetricMap;
+  ConnectionBufferMetricMap connection_buffer_metric_map_;
 
   // instances/stream mgrs causing back pressure
   std::set<sp_string> remote_ends_who_caused_back_pressure_;


### PR DESCRIPTION
The patch supports connection buffer metrics between stmgr and instances.
It exports the connection buffer metrics in both # of packets and # of bytes.
It will sample the metrics at an interval and then export the average value during every metrics-collection-interval.

Metric name format:
1. packets count
``__connection_buffer_by_intanceid/{instance-id}/packets``
2. bytes
``__connection_buffer_by_intanceid/{instance-id}/bytes``

Examples:
``__connection_buffer_by_intanceid/container_2_word_6/bytes``
``__connection_buffer_by_intanceid/container_2_word_6/packets``

This bases on @congwang : #1686 