### PR TITLE
Remove scheduler state manager adaptor requirement for submission dry-run

### DIFF
--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SchedulerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SchedulerMain.java
@@ -367,7 +367,8 @@ public class SchedulerMain {
       // build the runtime config
       LauncherUtils launcherUtils = LauncherUtils.getInstance();
       Config runtime = Config.newBuilder()
-          .putAll(launcherUtils.getPrimaryRuntime(topology, adaptor))
+          .putAll(launcherUtils.createPrimaryRuntime(topology))
+          .putAll(launcherUtils.createAdaptorRuntime(adaptor))
           .put(Key.SCHEDULER_SHUTDOWN, getShutdown())
           .put(Key.SCHEDULER_PROPERTIES, properties)
           .build();

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/dryrun/FormatterUtils.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/dryrun/FormatterUtils.java
@@ -381,7 +381,7 @@ public final class FormatterUtils {
     }
   }
 
-  private static final List<String> titleNames = Arrays.asList(
+  private static final List<String> TITLE_NAMES = Arrays.asList(
         "component", "task ID", "CPU", "RAM (GB)", "disk (GB)");
 
 
@@ -431,7 +431,7 @@ public final class FormatterUtils {
   }
 
   public static String renderOneContainer(List<Row> rows) {
-    Row title = new Row(titleNames);
+    Row title = new Row(TITLE_NAMES);
     title.setStyle(TextStyle.BOLD);
     return new Table(title, rows).createTable();
   }

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/dryrun/FormatterUtils.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/dryrun/FormatterUtils.java
@@ -341,7 +341,7 @@ public final class FormatterUtils {
      *
      * @return
      */
-    private int caculateFrameLength() {
+    private int calculateFrameLength() {
       int total = 0;
       for (Integer width: calculateColumnsMax()) {
         total += width + 3;
@@ -362,7 +362,7 @@ public final class FormatterUtils {
         row.setFormatters(formatters);
       }
       // Calculate length for frames
-      int frameLength = caculateFrameLength();
+      int frameLength = calculateFrameLength();
       // Start building table
       StringBuilder builder = new StringBuilder();
       // Add upper frame
@@ -380,6 +380,9 @@ public final class FormatterUtils {
       return builder.toString();
     }
   }
+
+  private static final List<String> titleNames = Arrays.asList(
+        "component", "task ID", "CPU", "RAM (GB)", "disk (GB)");
 
 
   /******************************** Auxiliary functions ********************************/
@@ -428,8 +431,6 @@ public final class FormatterUtils {
   }
 
   public static String renderOneContainer(List<Row> rows) {
-    List<String> titleNames = Arrays.asList(
-        "component", "task ID", "CPU", "RAM (GB)", "disk (GB)");
     Row title = new Row(titleNames);
     title.setStyle(TextStyle.BOLD);
     return new Table(title, rows).createTable();

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/LauncherUtils.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/LauncherUtils.java
@@ -126,31 +126,39 @@ public class LauncherUtils {
   }
 
   /**
-   * Builds initial runtime config instance using topology information.
+   * Creates initial runtime config instance using topology information.
    *
    * @return initial runtime config instance
    */
-  public Config getPrimaryRuntime(TopologyAPI.Topology topology,
-                                  SchedulerStateManagerAdaptor adaptor) {
+  public Config createPrimaryRuntime(TopologyAPI.Topology topology) {
     return Config.newBuilder()
         .put(Key.TOPOLOGY_ID, topology.getId())
         .put(Key.TOPOLOGY_NAME, topology.getName())
         .put(Key.TOPOLOGY_DEFINITION, topology)
-        .put(Key.SCHEDULER_STATE_MANAGER_ADAPTOR, adaptor)
         .put(Key.NUM_CONTAINERS, 1 + TopologyUtils.getNumContainers(topology))
         .build();
   }
 
   /**
+   * Creates initial runtime config of scheduler state manager adaptor
+   *
+   * @return adaptor config
+   */
+  public Config createAdaptorRuntime(SchedulerStateManagerAdaptor adaptor) {
+    return Config.newBuilder()
+        .put(Key.SCHEDULER_STATE_MANAGER_ADAPTOR, adaptor).build();
+  }
+
+  /**
    * Creates a config instance with packing plan info added to runtime config
+   *
+   * @return packing details config
    */
   public Config createConfigWithPackingDetails(Config runtime, PackingPlan packing) {
-    Config ytruntime;
-    ytruntime = Config.newBuilder()
+    return Config.newBuilder()
         .putAll(runtime)
         .put(Key.COMPONENT_RAMMAP, packing.getComponentRamDistribution())
         .put(Key.NUM_CONTAINERS, 1 + packing.getContainers().size())
         .build();
-    return ytruntime;
   }
 }

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/SubmitterMainTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/SubmitterMainTest.java
@@ -183,9 +183,6 @@ public class SubmitterMainTest {
 
   @Test(expected = SubmitDryRunResponse.class)
   public void testSubmitTopologyDryRun() throws Exception {
-    SchedulerStateManagerAdaptor adaptor = mock(SchedulerStateManagerAdaptor.class);
-    PowerMockito.whenNew(SchedulerStateManagerAdaptor.class).withAnyArguments().
-        thenReturn(adaptor);
     SubmitterMain submitterMain = spy(new SubmitterMain(config, topology));
     when(config.getBooleanValue(Key.DRY_RUN, false)).thenReturn(true);
     try {
@@ -196,7 +193,7 @@ public class SubmitterMainTest {
          2. validate that topology is not running
        */
       verify(uploader, never()).uploadPackage();
-      verify(adaptor, never()).isTopologyRunning(anyString());
+      verify(statemgr, never()).initialize(any(Config.class));
     }
   }
 

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/utils/LauncherUtilsTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/utils/LauncherUtilsTest.java
@@ -96,7 +96,9 @@ public class LauncherUtilsTest {
     PowerMockito.doReturn(456).when(TopologyUtils.class, "getNumContainers", mockTopology);
 
     Config runtime = Config.newBuilder()
-        .putAll(LauncherUtils.getInstance().getPrimaryRuntime(mockTopology, mockStMgr)).build();
+        .putAll(LauncherUtils.getInstance().createPrimaryRuntime(mockTopology))
+        .putAll(LauncherUtils.getInstance().createAdaptorRuntime(mockStMgr))
+            .build();
     Assert.assertEquals("testTopologyId", Runtime.topologyId(runtime));
     Assert.assertEquals("testTopologyName", Runtime.topologyName(runtime));
     Assert.assertEquals(mockTopology, Runtime.topology(runtime));


### PR DESCRIPTION
Dry-run submission does not need to use adaptor to scheduler state manager. With this PR, state manager initialization will not happen, which reduces dry-run of submission to Aurora from 10 seconds to 1.7 seconds.

resolves #1692 