### PR TITLE
Change Misc pattern substitution logic to match any Key value

### DIFF
--- a/heron/spi/src/java/com/twitter/heron/spi/common/Misc.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Misc.java
@@ -76,7 +76,7 @@ public final class Misc {
         if (m.matches()) {
           String token = m.group(1);
           try {
-            // For backwards compatibility the ${TOPOLOGY} token will match Key.TOPOLOGY
+            // For backwards compatibility the ${TOPOLOGY} token will match Key.TOPOLOGY_NAME
             if ("TOPOLOGY".equals(token)) {
               token = "TOPOLOGY_NAME";
             }

--- a/heron/spi/tests/java/com/twitter/heron/spi/common/MiscTest.java
+++ b/heron/spi/tests/java/com/twitter/heron/spi/common/MiscTest.java
@@ -14,16 +14,20 @@
 
 package com.twitter.heron.spi.common;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class MiscTest {
 
-  private static String substitute(String heronHome, String pathString) {
+  private static String substitute(String pathString) {
     Config config = Config.newBuilder()
-        .put(Key.HERON_HOME, heronHome)
+        .put(Key.BUILD_HOST, "build_host")
+        .put(Key.HERON_LIB, "/some/lib/dir")
+        .put(Key.HERON_HOME, "/usr/local/heron")
+        .put(Key.TOPOLOGY_NAME, "topology_name")
         .build();
     return Misc.substitute(config, pathString);
   }
@@ -34,60 +38,51 @@ public class MiscTest {
   @Test
   public void testHeronHome() {
     // check no occurrence
-    assertEquals(
-        "./bin", substitute("/usr/local/heron", "./bin")
-    );
+    assertEquals("./bin", substitute("./bin"));
 
     // check a single substitution at the beginning
-    assertEquals(
-        "/usr/local/heron/bin",
-        substitute("/usr/local/heron", "${HERON_HOME}/bin")
-    );
+    assertEquals("/usr/local/heron/bin", substitute("${HERON_HOME}/bin"));
 
     // check a single substitution at the beginning with relative path
-    assertEquals(
-        "./usr/local/heron/bin",
-        substitute("/usr/local/heron", "./${HERON_HOME}/bin")
-    );
+    assertEquals("./usr/local/heron/bin", substitute("./${HERON_HOME}/bin"));
 
     // check a single substitution at the end
-    assertEquals(
-        "/bin/usr/local/heron",
-        substitute("/usr/local/heron", "/bin/${HERON_HOME}")
-    );
+    assertEquals("/bin/usr/local/heron", substitute("/bin/${HERON_HOME}"));
 
     // check a single substitution at the end with relative path
-    assertEquals(
-        "./bin/usr/local/heron",
-        substitute("/usr/local/heron", "./bin/${HERON_HOME}")
-    );
+    assertEquals("./bin/usr/local/heron", substitute("./bin/${HERON_HOME}"));
 
     // check a single substitution in the middle
-    assertEquals(
-        "/bin/usr/local/heron/etc",
-        substitute("/usr/local/heron", "/bin/${HERON_HOME}/etc")
-    );
+    assertEquals("/bin/usr/local/heron/etc", substitute("/bin/${HERON_HOME}/etc"));
 
     // check a single substitution in the middle with relative path
-    assertEquals(
-        "./bin/usr/local/heron/etc",
-        substitute("/usr/local/heron", "./bin/${HERON_HOME}/etc")
-    );
+    assertEquals("./bin/usr/local/heron/etc", substitute("./bin/${HERON_HOME}/etc"));
   }
 
   @Test
   public void testURL() {
-    Assert.assertTrue(
-        Misc.isURL("file:///users/john/afile.txt")
-    );
-    Assert.assertFalse(
-        Misc.isURL("/users/john/afile.txt")
-    );
-    Assert.assertTrue(
-        Misc.isURL("https://gotoanywebsite.net/afile.html")
-    );
-    Assert.assertFalse(
-        Misc.isURL("https//gotoanywebsite.net//afile.html")
-    );
+    assertTrue(Misc.isURL("file:///users/john/afile.txt"));
+    assertFalse(Misc.isURL("/users/john/afile.txt"));
+    assertTrue(Misc.isURL("https://gotoanywebsite.net/afile.html"));
+    assertFalse(Misc.isURL("https//gotoanywebsite.net//afile.html"));
+  }
+
+  @Test
+  public void testToken() {
+    assertTrue(Misc.isToken("${FOO_BAR}"));
+    assertTrue(Misc.isToken("${FOO}"));
+    assertFalse(Misc.isToken("x${FOO}"));
+    assertFalse(Misc.isToken("${FOO}x"));
+    assertFalse(Misc.isToken("${}"));
+    assertFalse(Misc.isToken("$FOO"));
+    assertFalse(Misc.isToken("foo"));
+  }
+
+  @Test
+  public void testArbitraryToken() {
+    assertEquals("/some/lib/dir/some/path", substitute("${HERON_LIB}/some/path"));
+    assertEquals("./bin/build_host/etc", substitute("./bin/${BUILD_HOST}/etc"));
+    assertEquals("./bin/topology_name/etc", substitute("./bin/${TOPOLOGY}/etc"));
+    assertEquals("./bin/topology_name/etc", substitute("./bin/${TOPOLOGY_NAME}/etc"));
   }
 }


### PR DESCRIPTION
Clean up the token substitution logic to match on any Key enum, without the need to whitelist supported tokens. Also cleaning up the class and the tests a bit by reordering some methods.

Next up I plan to rename the `Misc` class to `ValueSubstitution` or something like that. Suggestions welcome.