### PR TITLE
Fixing bug in WebSink metrics collector

### DIFF
--- a/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/WebSinkTest.java
+++ b/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/WebSinkTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -57,7 +58,7 @@ public class WebSinkTest {
 
   private Map<String, Object> defaultConf;
   private SinkContext context;
-  private Iterable<MetricsRecord> records;
+  private List<MetricsRecord> records;
 
 
   @Before
@@ -75,9 +76,11 @@ public class WebSinkTest {
 
     Iterable<MetricsInfo> infos = Arrays.asList(new MetricsInfo("metric_1", "1.0"),
         new MetricsInfo("metric_2", "2.0"));
+
     records = Arrays.asList(
         new MetricsRecord("machine/stuff/record_1", infos, Collections.<ExceptionInfo>emptyList()),
         new MetricsRecord("record_2", infos, Collections.<ExceptionInfo>emptyList()));
+
   }
 
   /**
@@ -168,6 +171,13 @@ public class WebSinkTest {
       sink.processRecord(r);
     }
 
+    //Update and override MetricsRecord 1
+    Iterable<MetricsInfo> infos2 = Arrays.asList(new MetricsInfo("metric_1", "3.0"),
+        new MetricsInfo("metric_3", "1.0"));
+    sink.processRecord(new MetricsRecord(records.get(0).getSource(),
+        infos2,
+        Collections.<ExceptionInfo>emptyList()));
+
     Map<String, Object> results = sink.getMetrics();
     Assert.assertEquals(2, results.size());
     @SuppressWarnings("unchecked")
@@ -175,11 +185,13 @@ public class WebSinkTest {
     @SuppressWarnings("unchecked")
     Map<String, Object> record2 = (Map<String, Object>) results.get("/record_2");
 
-    Assert.assertEquals(record1.get("metric_1"), 1.0d);
+    Assert.assertEquals(record1.get("metric_1"), 3.0d);
     Assert.assertEquals(record1.get("metric_2"), 2.0d);
+    Assert.assertEquals(record1.get("metric_3"), 1.0d);
     Assert.assertEquals(record2.get("metric_1"), 1.0d);
     Assert.assertEquals(record2.get("metric_2"), 2.0d);
   }
+
 
   /**
    * Testinging max metics size, and oldest keys get expired


### PR DESCRIPTION
I found a bug in the WebSink metrics collector, that I contributed a couple month ago.

If the metrics are getting exported in the hierarchical format, a new `MetricsRecord` would override and old `MetricsRecord` and the `MetricsInfo`s associated to it. Now a new `MetricsRecord` will merge the `MetricsInfo`s of an old `MetricsRecord`. A cache with expiration is used.