### PR TITLE
use raw Map in storm api

### DIFF
--- a/heron/examples/src/java/com/twitter/heron/examples/AckingTopology.java
+++ b/heron/examples/src/java/com/twitter/heron/examples/AckingTopology.java
@@ -75,8 +75,9 @@ public final class AckingTopology {
     public AckingTestWordSpout() {
     }
 
+    @SuppressWarnings("rawtypes")
     public void open(
-        Map<String, Object> conf,
+        Map conf,
         TopologyContext context,
         SpoutOutputCollector acollector) {
       collector = acollector;

--- a/heron/examples/src/java/com/twitter/heron/examples/MultiStageAckingTopology.java
+++ b/heron/examples/src/java/com/twitter/heron/examples/MultiStageAckingTopology.java
@@ -75,8 +75,9 @@ public final class MultiStageAckingTopology {
     public AckingTestWordSpout() {
     }
 
+    @SuppressWarnings("rawtypes")
     public void open(
-        Map<String, Object> conf,
+        Map conf,
         TopologyContext context,
         SpoutOutputCollector acollector) {
       collector = acollector;

--- a/heron/examples/src/java/com/twitter/heron/examples/TaskHookTopology.java
+++ b/heron/examples/src/java/com/twitter/heron/examples/TaskHookTopology.java
@@ -94,7 +94,8 @@ public final class TaskHookTopology {
     }
 
     @Override
-    public void prepare(Map<String, Object> conf, TopologyContext context) {
+    @SuppressWarnings("rawtypes")
+    public void prepare(Map conf, TopologyContext context) {
       GlobalMetrics.incr("hook_prepare");
       System.out.println(constructString);
       System.out.println("prepare() is invoked in hook");
@@ -191,8 +192,9 @@ public final class TaskHookTopology {
     public AckingTestWordSpout() {
     }
 
+    @SuppressWarnings("rawtypes")
     public void open(
-        Map<String, Object> conf,
+        Map conf,
         TopologyContext context,
         SpoutOutputCollector acollector) {
       collector = acollector;

--- a/heron/examples/src/java/com/twitter/heron/examples/TestWordSpout.java
+++ b/heron/examples/src/java/com/twitter/heron/examples/TestWordSpout.java
@@ -31,8 +31,9 @@ public class TestWordSpout extends BaseRichSpout {
   private String[] words;
   private Random rand;
 
+  @SuppressWarnings("rawtypes")
   public void open(
-      Map<String, Object> conf,
+      Map conf,
       TopologyContext context,
       SpoutOutputCollector acollector) {
     collector = acollector;

--- a/heron/storm/src/java/backtype/storm/Config.java
+++ b/heron/storm/src/java/backtype/storm/Config.java
@@ -319,81 +319,81 @@ public class Config extends com.twitter.heron.api.Config {
   public static final String STORMCOMPAT_TOPOLOGY_AUTO_TASK_HOOKS =
       "stormcompat.topology.auto.task.hooks";
 
-  public static void setDebug(Map<String, Object> conf, boolean isOn) {
+  public static void setDebug(Map conf, boolean isOn) {
     conf.put(Config.TOPOLOGY_DEBUG, isOn);
   }
 
-  public static void setTeamName(Map<String, Object> conf, String teamName) {
+  public static void setTeamName(Map conf, String teamName) {
     conf.put(Config.TOPOLOGY_TEAM_NAME, teamName);
   }
 
-  public static void setTeamEmail(Map<String, Object> conf, String teamEmail) {
+  public static void setTeamEmail(Map conf, String teamEmail) {
     conf.put(Config.TOPOLOGY_TEAM_EMAIL, teamEmail);
   }
 
-  public static void setTopologyCapTicket(Map<String, Object> conf, String ticket) {
+  public static void setTopologyCapTicket(Map conf, String ticket) {
     conf.put(Config.TOPOLOGY_CAP_TICKET, ticket);
   }
 
-  public static void setTopologyProjectName(Map<String, Object> conf, String project) {
+  public static void setTopologyProjectName(Map conf, String project) {
     conf.put(Config.TOPOLOGY_PROJECT_NAME, project);
   }
 
-  public static void setNumWorkers(Map<String, Object> conf, int workers) {
+  public static void setNumWorkers(Map conf, int workers) {
     conf.put(Config.TOPOLOGY_WORKERS, workers);
   }
 
-  public static void setNumAckers(Map<String, Object> conf, int numExecutors) {
+  public static void setNumAckers(Map conf, int numExecutors) {
     conf.put(Config.TOPOLOGY_ACKER_EXECUTORS, numExecutors);
   }
 
-  public static void setMessageTimeoutSecs(Map<String, Object> conf, int secs) {
+  public static void setMessageTimeoutSecs(Map conf, int secs) {
     conf.put(Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS, secs);
   }
 
-  public static void registerSerialization(Map<String, Object> conf, Class klass) {
+  public static void registerSerialization(Map conf, Class klass) {
     getRegisteredSerializations(conf).add(klass.getName());
   }
 
   public static void registerSerialization(
-      Map<String, Object> conf, Class klass, Class<? extends Serializer> serializerClass) {
+      Map conf, Class klass, Class<? extends Serializer> serializerClass) {
     Map<String, String> register = new HashMap<>();
     register.put(klass.getName(), serializerClass.getName());
     getRegisteredSerializations(conf).add(register);
   }
 
   public static void registerDecorator(
-      Map<String, Object> conf,
+      Map conf,
       Class<? extends IKryoDecorator> klass) {
     getRegisteredDecorators(conf).add(klass.getName());
   }
 
-  public static void setKryoFactory(Map<String, Object> conf, Class<? extends IKryoFactory> klass) {
+  public static void setKryoFactory(Map conf, Class<? extends IKryoFactory> klass) {
     conf.put(Config.TOPOLOGY_KRYO_FACTORY, klass.getName());
   }
 
-  public static void setSkipMissingKryoRegistrations(Map<String, Object> conf, boolean skip) {
+  public static void setSkipMissingKryoRegistrations(Map conf, boolean skip) {
     conf.put(Config.TOPOLOGY_SKIP_MISSING_KRYO_REGISTRATIONS, skip);
   }
 
-  public static void setMaxTaskParallelism(Map<String, Object> conf, int max) {
+  public static void setMaxTaskParallelism(Map conf, int max) {
     conf.put(Config.TOPOLOGY_MAX_TASK_PARALLELISM, max);
   }
 
-  public static void setMaxSpoutPending(Map<String, Object> conf, int max) {
+  public static void setMaxSpoutPending(Map conf, int max) {
     conf.put(Config.TOPOLOGY_MAX_SPOUT_PENDING, max);
   }
 
-  public static void setStatsSampleRate(Map<String, Object> conf, double rate) {
+  public static void setStatsSampleRate(Map conf, double rate) {
     conf.put(Config.TOPOLOGY_STATS_SAMPLE_RATE, rate);
   }
 
-  public static void setFallBackOnJavaSerialization(Map<String, Object> conf, boolean fallback) {
+  public static void setFallBackOnJavaSerialization(Map conf, boolean fallback) {
     conf.put(Config.TOPOLOGY_FALL_BACK_ON_JAVA_SERIALIZATION, fallback);
   }
 
   @SuppressWarnings("rawtypes") // List can contain strings or maps
-  private static List getRegisteredSerializations(Map<String, Object> conf) {
+  private static List getRegisteredSerializations(Map conf) {
     List ret;
     if (!conf.containsKey(Config.TOPOLOGY_KRYO_REGISTER)) {
       ret = new ArrayList();
@@ -404,7 +404,7 @@ public class Config extends com.twitter.heron.api.Config {
     return ret;
   }
 
-  private static List<String> getRegisteredDecorators(Map<String, Object> conf) {
+  private static List<String> getRegisteredDecorators(Map conf) {
     List<String> ret;
     if (!conf.containsKey(Config.TOPOLOGY_KRYO_DECORATORS)) {
       ret = new ArrayList<>();
@@ -466,13 +466,13 @@ public class Config extends com.twitter.heron.api.Config {
   }
 
   public void registerMetricsConsumer(Class klass, Object argument, long parallelismHint) {
-    HashMap<String, Object> m = new HashMap<>();
+    HashMap m = new HashMap<>();
     m.put("class", klass.getCanonicalName());
     m.put("parallelism.hint", parallelismHint);
     m.put("argument", argument);
 
-    List<Map<String, Object>> l =
-        (List<Map<String, Object>>) this.get(TOPOLOGY_METRICS_CONSUMER_REGISTER);
+    List l =
+        (List) this.get(TOPOLOGY_METRICS_CONSUMER_REGISTER);
     if (l == null) {
       l = new ArrayList<>();
     }

--- a/heron/storm/src/java/backtype/storm/LocalCluster.java
+++ b/heron/storm/src/java/backtype/storm/LocalCluster.java
@@ -28,10 +28,11 @@ import backtype.storm.generated.NotAliveException;
 import backtype.storm.generated.StormTopology;
 import backtype.storm.utils.ConfigUtils;
 
+@SuppressWarnings("rawtypes")
 public class LocalCluster implements ILocalCluster {
   private final Simulator simulator;
   private String topologyName;
-  private Map<String, Object> conf;
+  private Map conf;
   private StormTopology topology;
 
   public LocalCluster() {

--- a/heron/storm/src/java/backtype/storm/StormSubmitter.java
+++ b/heron/storm/src/java/backtype/storm/StormSubmitter.java
@@ -47,9 +47,10 @@ public final class StormSubmitter {
    * @throws AlreadyAliveException if a topology with this name is already running
    * @throws InvalidTopologyException if an invalid topology was submitted
    */
+  @SuppressWarnings("rawtypes")
   public static void submitTopology(
       String name,
-      Map<String, Object> stormConfig,
+      Map stormConfig,
       StormTopology topology) throws AlreadyAliveException, InvalidTopologyException {
 
     // First do config translation

--- a/heron/storm/src/java/backtype/storm/hooks/BaseTaskHook.java
+++ b/heron/storm/src/java/backtype/storm/hooks/BaseTaskHook.java
@@ -30,7 +30,8 @@ import backtype.storm.task.TopologyContext;
 
 public class BaseTaskHook implements ITaskHook {
   @Override
-  public void prepare(Map<String, Object> conf, TopologyContext context) {
+  @SuppressWarnings("rawtypes")
+  public void prepare(Map conf, TopologyContext context) {
   }
 
   @Override

--- a/heron/storm/src/java/backtype/storm/hooks/ITaskHook.java
+++ b/heron/storm/src/java/backtype/storm/hooks/ITaskHook.java
@@ -29,7 +29,8 @@ import backtype.storm.hooks.info.SpoutFailInfo;
 import backtype.storm.task.TopologyContext;
 
 public interface ITaskHook {
-  void prepare(Map<String, Object> conf, TopologyContext context);
+  @SuppressWarnings("rawtypes")
+  void prepare(Map conf, TopologyContext context);
 
   void cleanup();
 

--- a/heron/storm/src/java/backtype/storm/hooks/ITaskHookDelegate.java
+++ b/heron/storm/src/java/backtype/storm/hooks/ITaskHookDelegate.java
@@ -42,9 +42,10 @@ import backtype.storm.task.TopologyContext;
  * is invoked.
  * 2. task hook added dynamically by invoking addHook(ITaskHook)
  */
+@SuppressWarnings("rawtypes")
 public class ITaskHookDelegate implements com.twitter.heron.api.hooks.ITaskHook {
   private List<ITaskHook> hooks;
-  private Map<String, Object> conf;
+  private Map conf;
 
   // zero arg constructor
   public ITaskHookDelegate() {
@@ -59,7 +60,7 @@ public class ITaskHookDelegate implements com.twitter.heron.api.hooks.ITaskHook 
     return hooks;
   }
 
-  public Map<String, Object> getConf() {
+  public Map getConf() {
     return conf;
   }
 

--- a/heron/storm/src/java/backtype/storm/serialization/DefaultKryoFactory.java
+++ b/heron/storm/src/java/backtype/storm/serialization/DefaultKryoFactory.java
@@ -29,7 +29,8 @@ import backtype.storm.Config;
 public class DefaultKryoFactory implements IKryoFactory {
 
   @Override
-  public Kryo getKryo(Map<String, Object> conf) {
+  @SuppressWarnings("rawtypes")
+  public Kryo getKryo(Map conf) {
     KryoSerializableDefault k = new KryoSerializableDefault();
     k.setRegistrationRequired(
         !((Boolean) conf.get(Config.TOPOLOGY_FALL_BACK_ON_JAVA_SERIALIZATION)));
@@ -38,15 +39,18 @@ public class DefaultKryoFactory implements IKryoFactory {
   }
 
   @Override
-  public void preRegister(Kryo k, Map<String, Object> conf) {
+  @SuppressWarnings("rawtypes")
+  public void preRegister(Kryo k, Map conf) {
   }
 
-  public void postRegister(Kryo k, Map<String, Object> conf) {
+  @SuppressWarnings("rawtypes")
+  public void postRegister(Kryo k, Map conf) {
     ((KryoSerializableDefault) k).overrideDefault(true);
   }
 
   @Override
-  public void postDecorate(Kryo k, Map<String, Object> conf) {
+  @SuppressWarnings("rawtypes")
+  public void postDecorate(Kryo k, Map conf) {
   }
 
   public static class KryoSerializableDefault extends Kryo {

--- a/heron/storm/src/java/backtype/storm/serialization/HeronPluggableSerializerDelegate.java
+++ b/heron/storm/src/java/backtype/storm/serialization/HeronPluggableSerializerDelegate.java
@@ -34,7 +34,8 @@ public class HeronPluggableSerializerDelegate implements
   }
 
   @Override
-  public void initialize(Map<String, Object> config) {
+  @SuppressWarnings("rawtypes")
+  public void initialize(Map config) {
     kryo = SerializationFactory.getKryo(config);
     kryoOut = new Output(2000, 2000000000);
     kryoIn = new Input(1);

--- a/heron/storm/src/java/backtype/storm/serialization/IKryoFactory.java
+++ b/heron/storm/src/java/backtype/storm/serialization/IKryoFactory.java
@@ -34,12 +34,13 @@ import com.esotericsoftware.kryo.Kryo;
  * 6. Storm calls all user-defined decorators through topology.kryo.decorators
  * 7. Storm calls postDecorate hook
  */
+@SuppressWarnings("rawtypes")
 public interface IKryoFactory {
-  Kryo getKryo(Map<String, Object> conf);
+  Kryo getKryo(Map conf);
 
-  void preRegister(Kryo k, Map<String, Object> conf);
+  void preRegister(Kryo k, Map conf);
 
-  void postRegister(Kryo k, Map<String, Object> conf);
+  void postRegister(Kryo k, Map conf);
 
-  void postDecorate(Kryo k, Map<String, Object> conf);
+  void postDecorate(Kryo k, Map conf);
 }

--- a/heron/storm/src/java/backtype/storm/serialization/SerializationFactory.java
+++ b/heron/storm/src/java/backtype/storm/serialization/SerializationFactory.java
@@ -53,7 +53,7 @@ public final class SerializationFactory {
    * @return Kryo
    */
   @SuppressWarnings({"rawtypes", "unchecked"})
-  public static Kryo getKryo(Map<String, Object> conf) {
+  public static Kryo getKryo(Map conf) {
     IKryoFactory kryoFactory =
         (IKryoFactory) Utils.newInstance((String) conf.get(Config.TOPOLOGY_KRYO_FACTORY));
     Kryo k = kryoFactory.getKryo(conf);
@@ -175,7 +175,7 @@ public final class SerializationFactory {
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})
-  private static Map<String, String> normalizeKryoRegister(Map<String, Object> conf) {
+  private static Map<String, String> normalizeKryoRegister(Map conf) {
     // TODO: de-duplicate this logic with the code in nimbus
     Object res = conf.get(Config.TOPOLOGY_KRYO_REGISTER);
     if (res == null) {

--- a/heron/storm/src/java/backtype/storm/spout/ISpout.java
+++ b/heron/storm/src/java/backtype/storm/spout/ISpout.java
@@ -56,7 +56,8 @@ public interface ISpout extends Serializable {
    * @param context This object can be used to get information about this task's place within the topology, including the task id and component id of this task, input and output information, etc.
    * @param collector The collector is used to emit tuples from this spout. Tuples can be emitted at any time, including the open and close methods. The collector is thread-safe and should be saved as an instance variable of this spout object.
    */
-  void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector);
+  @SuppressWarnings("rawtypes")
+  void open(Map conf, TopologyContext context, SpoutOutputCollector collector);
 
   /**
    * Called when an ISpout is going to be shutdown. There is no guarentee that close

--- a/heron/storm/src/java/backtype/storm/spout/ISpoutWaitStrategy.java
+++ b/heron/storm/src/java/backtype/storm/spout/ISpoutWaitStrategy.java
@@ -30,7 +30,8 @@ import java.util.Map;
  * The default strategy sleeps for one millisecond.
  */
 public interface ISpoutWaitStrategy {
-  void prepare(Map<String, Object> conf);
+  @SuppressWarnings("rawtypes")
+  void prepare(Map conf);
 
   void emptyEmit(long streak);
 }

--- a/heron/storm/src/java/backtype/storm/spout/NothingEmptyEmitStrategy.java
+++ b/heron/storm/src/java/backtype/storm/spout/NothingEmptyEmitStrategy.java
@@ -26,7 +26,8 @@ public class NothingEmptyEmitStrategy implements ISpoutWaitStrategy {
   }
 
   @Override
-  public void prepare(Map<String, Object> conf) {
+  @SuppressWarnings("rawtypes")
+  public void prepare(Map conf) {
     throw new UnsupportedOperationException("Not supported yet.");
   }
 }

--- a/heron/storm/src/java/backtype/storm/spout/SleepSpoutWaitStrategy.java
+++ b/heron/storm/src/java/backtype/storm/spout/SleepSpoutWaitStrategy.java
@@ -27,7 +27,8 @@ public class SleepSpoutWaitStrategy implements ISpoutWaitStrategy {
   private long sleepMillis;
 
   @Override
-  public void prepare(Map<String, Object> conf) {
+  @SuppressWarnings("rawtypes")
+  public void prepare(Map conf) {
     sleepMillis =
         ((Number) conf.get(Config.TOPOLOGY_SLEEP_SPOUT_WAIT_STRATEGY_TIME_MS)).longValue();
   }

--- a/heron/storm/src/java/backtype/storm/task/GeneralTopologyContext.java
+++ b/heron/storm/src/java/backtype/storm/task/GeneralTopologyContext.java
@@ -35,7 +35,8 @@ import backtype.storm.tuple.Fields;
 public class GeneralTopologyContext implements JSONAware {
   private com.twitter.heron.api.topology.GeneralTopologyContext delegate;
 
-  public GeneralTopologyContext(StormTopology topology, Map<String, Object> stormConf,
+  @SuppressWarnings("rawtypes")
+  public GeneralTopologyContext(StormTopology topology, Map stormConf,
                                 Map<Integer, String> taskToComponent,
                                 Map<String, List<Integer>> componentToSortedTasks,
                                 Map<String, Map<String, Fields>> componentToStreamToFields,

--- a/heron/storm/src/java/backtype/storm/task/TopologyContext.java
+++ b/heron/storm/src/java/backtype/storm/task/TopologyContext.java
@@ -56,7 +56,8 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
   // Constructor to match the signature of the storm's TopologyContext
   // Note that here, we fake the clojure.lang.Atom by creating our own class
   // This is real hacking a hack!
-  public TopologyContext(StormTopology topology, Map<String, Object> stormConf,
+  @SuppressWarnings("rawtypes")
+  public TopologyContext(StormTopology topology, Map stormConf,
                          Map<Integer, String> taskToComponent,
                          Map<String, List<Integer>> componentToSortedTasks,
                          Map<String, Map<String, Fields>> componentToStreamToFields,

--- a/heron/storm/src/java/backtype/storm/task/WorkerTopologyContext.java
+++ b/heron/storm/src/java/backtype/storm/task/WorkerTopologyContext.java
@@ -29,9 +29,10 @@ import backtype.storm.tuple.Fields;
 public class WorkerTopologyContext extends GeneralTopologyContext {
   private com.twitter.heron.api.topology.TopologyContext delegate;
 
+  @SuppressWarnings("rawtypes")
   public WorkerTopologyContext(
       StormTopology topology,
-      Map<String, Object> stormConf,
+      Map stormConf,
       Map<Integer, String> taskToComponent,
       Map<String, List<Integer>> componentToSortedTasks,
       Map<String, Map<String, Fields>> componentToStreamToFields,

--- a/heron/storm/src/java/backtype/storm/testing/TestWordSpout.java
+++ b/heron/storm/src/java/backtype/storm/testing/TestWordSpout.java
@@ -35,8 +35,9 @@ public class TestWordSpout extends BaseRichSpout {
   private String[] words;
   private Random rand;
 
+  @SuppressWarnings("rawtypes")
   public void open(
-      Map<String, Object> conf,
+      Map conf,
       TopologyContext context,
       SpoutOutputCollector aCollector) {
     collector = aCollector;

--- a/heron/storm/src/java/backtype/storm/topology/BoltDeclarerImpl.java
+++ b/heron/storm/src/java/backtype/storm/topology/BoltDeclarerImpl.java
@@ -33,8 +33,9 @@ public class BoltDeclarerImpl implements BoltDeclarer {
   }
 
   @Override
-  public BoltDeclarer addConfigurations(Map<String, Object> conf) {
-    delegate.addConfigurations(conf);
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public BoltDeclarer addConfigurations(Map conf) {
+    delegate.addConfigurations((Map<String, Object>) conf);
     return this;
   }
 

--- a/heron/storm/src/java/backtype/storm/topology/ComponentConfigurationDeclarer.java
+++ b/heron/storm/src/java/backtype/storm/topology/ComponentConfigurationDeclarer.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 @SuppressWarnings("rawtypes")
 public interface ComponentConfigurationDeclarer<T extends ComponentConfigurationDeclarer> {
-  T addConfigurations(Map<String, Object> conf);
+  T addConfigurations(Map conf);
 
   T addConfiguration(String config, Object value);
 

--- a/heron/storm/src/java/backtype/storm/topology/IRichBoltDelegate.java
+++ b/heron/storm/src/java/backtype/storm/topology/IRichBoltDelegate.java
@@ -39,8 +39,9 @@ public class IRichBoltDelegate implements com.twitter.heron.api.bolt.IRichBolt {
   }
 
   @Override
+  @SuppressWarnings("rawtypes")
   public void prepare(
-       Map<String, Object> conf,
+      Map conf,
       com.twitter.heron.api.topology.TopologyContext context,
       com.twitter.heron.api.bolt.OutputCollector collector) {
     topologyContextImpl = new TopologyContext(context);

--- a/heron/storm/src/java/backtype/storm/topology/IRichSpoutDelegate.java
+++ b/heron/storm/src/java/backtype/storm/topology/IRichSpoutDelegate.java
@@ -40,7 +40,8 @@ public class IRichSpoutDelegate implements com.twitter.heron.api.spout.IRichSpou
   }
 
   @Override
-  public void open(Map<String, Object> conf, com.twitter.heron.api.topology.TopologyContext context,
+  @SuppressWarnings("rawtypes")
+  public void open(Map conf, com.twitter.heron.api.topology.TopologyContext context,
                    SpoutOutputCollector collector) {
     topologyContextImpl = new TopologyContext(context);
     spoutOutputCollectorImpl = new SpoutOutputCollectorImpl(collector);

--- a/heron/storm/src/java/backtype/storm/topology/SpoutDeclarerImpl.java
+++ b/heron/storm/src/java/backtype/storm/topology/SpoutDeclarerImpl.java
@@ -28,8 +28,9 @@ public class SpoutDeclarerImpl implements SpoutDeclarer {
   }
 
   @Override
-  public SpoutDeclarer addConfigurations(Map<String, Object> conf) {
-    delegate.addConfigurations(conf);
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public SpoutDeclarer addConfigurations(Map conf) {
+    delegate.addConfigurations((Map<String, Object>) conf);
     return this;
   }
 

--- a/heron/storm/src/java/backtype/storm/utils/ConfigUtils.java
+++ b/heron/storm/src/java/backtype/storm/utils/ConfigUtils.java
@@ -36,8 +36,9 @@ public final class ConfigUtils {
    * @param stormConfig the storm config
    * @return a heron config
    */
-  public static Config translateConfig(Map<String, Object> stormConfig) {
-    Config heronConfig = new Config(stormConfig);
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public static Config translateConfig(Map stormConfig) {
+    Config heronConfig = new Config((Map<String, Object>) stormConfig);
     // Look at serialization stuff first
     doSerializationTranslation(heronConfig);
 

--- a/heron/storm/src/java/org/apache/storm/Config.java
+++ b/heron/storm/src/java/org/apache/storm/Config.java
@@ -315,81 +315,82 @@ public class Config extends com.twitter.heron.api.Config {
   public static final String STORMCOMPAT_TOPOLOGY_AUTO_TASK_HOOKS =
       "stormcompat.topology.auto.task.hooks";
 
-  public static void setDebug(Map<String, Object> conf, boolean isOn) {
+  public static void setDebug(Map conf, boolean isOn) {
     conf.put(Config.TOPOLOGY_DEBUG, isOn);
   }
 
-  public static void setTeamName(Map<String, Object> conf, String teamName) {
+  public static void setTeamName(Map conf, String teamName) {
     conf.put(Config.TOPOLOGY_TEAM_NAME, teamName);
   }
 
-  public static void setTeamEmail(Map<String, Object> conf, String teamEmail) {
+  public static void setTeamEmail(Map conf, String teamEmail) {
     conf.put(Config.TOPOLOGY_TEAM_EMAIL, teamEmail);
   }
 
-  public static void setTopologyCapTicket(Map<String, Object> conf, String ticket) {
+  public static void setTopologyCapTicket(Map conf, String ticket) {
     conf.put(Config.TOPOLOGY_CAP_TICKET, ticket);
   }
 
-  public static void setTopologyProjectName(Map<String, Object> conf, String project) {
+  public static void setTopologyProjectName(Map conf, String project) {
     conf.put(Config.TOPOLOGY_PROJECT_NAME, project);
   }
 
-  public static void setNumWorkers(Map<String, Object> conf, int workers) {
+  public static void setNumWorkers(Map conf, int workers) {
     conf.put(Config.TOPOLOGY_WORKERS, workers);
   }
 
-  public static void setNumAckers(Map<String, Object> conf, int numExecutors) {
+  public static void setNumAckers(Map conf, int numExecutors) {
     conf.put(Config.TOPOLOGY_ACKER_EXECUTORS, numExecutors);
   }
 
-  public static void setMessageTimeoutSecs(Map<String, Object> conf, int secs) {
+  public static void setMessageTimeoutSecs(Map conf, int secs) {
     conf.put(Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS, secs);
   }
 
-  public static void registerSerialization(Map<String, Object> conf, Class klass) {
+  public static void registerSerialization(Map conf, Class klass) {
     getRegisteredSerializations(conf).add(klass.getName());
   }
 
   public static void registerSerialization(
-      Map<String, Object> conf, Class klass, Class<? extends Serializer> serializerClass) {
+      Map conf, Class klass, Class<? extends Serializer> serializerClass) {
     Map<String, String> register = new HashMap<>();
     register.put(klass.getName(), serializerClass.getName());
     getRegisteredSerializations(conf).add(register);
   }
 
+  @SuppressWarnings("rawtypes")
   public static void registerDecorator(
-      Map<String, Object> conf,
+      Map conf,
       Class<? extends IKryoDecorator> klass) {
     getRegisteredDecorators(conf).add(klass.getName());
   }
 
-  public static void setKryoFactory(Map<String, Object> conf, Class<? extends IKryoFactory> klass) {
+  public static void setKryoFactory(Map conf, Class<? extends IKryoFactory> klass) {
     conf.put(Config.TOPOLOGY_KRYO_FACTORY, klass.getName());
   }
 
-  public static void setSkipMissingKryoRegistrations(Map<String, Object> conf, boolean skip) {
+  public static void setSkipMissingKryoRegistrations(Map conf, boolean skip) {
     conf.put(Config.TOPOLOGY_SKIP_MISSING_KRYO_REGISTRATIONS, skip);
   }
 
-  public static void setMaxTaskParallelism(Map<String, Object> conf, int max) {
+  public static void setMaxTaskParallelism(Map conf, int max) {
     conf.put(Config.TOPOLOGY_MAX_TASK_PARALLELISM, max);
   }
 
-  public static void setMaxSpoutPending(Map<String, Object> conf, int max) {
+  public static void setMaxSpoutPending(Map conf, int max) {
     conf.put(Config.TOPOLOGY_MAX_SPOUT_PENDING, max);
   }
 
-  public static void setStatsSampleRate(Map<String, Object> conf, double rate) {
+  public static void setStatsSampleRate(Map conf, double rate) {
     conf.put(Config.TOPOLOGY_STATS_SAMPLE_RATE, rate);
   }
 
-  public static void setFallBackOnJavaSerialization(Map<String, Object> conf, boolean fallback) {
+  public static void setFallBackOnJavaSerialization(Map conf, boolean fallback) {
     conf.put(Config.TOPOLOGY_FALL_BACK_ON_JAVA_SERIALIZATION, fallback);
   }
 
   @SuppressWarnings("rawtypes") // List can contain strings or maps
-  private static List getRegisteredSerializations(Map<String, Object> conf) {
+  private static List getRegisteredSerializations(Map conf) {
     List ret;
     if (!conf.containsKey(Config.TOPOLOGY_KRYO_REGISTER)) {
       ret = new ArrayList();
@@ -400,7 +401,8 @@ public class Config extends com.twitter.heron.api.Config {
     return ret;
   }
 
-  private static List<String> getRegisteredDecorators(Map<String, Object> conf) {
+  @SuppressWarnings("rawtypes")
+  private static List<String> getRegisteredDecorators(Map conf) {
     List<String> ret;
     if (!conf.containsKey(Config.TOPOLOGY_KRYO_DECORATORS)) {
       ret = new ArrayList<>();
@@ -462,13 +464,12 @@ public class Config extends com.twitter.heron.api.Config {
   }
 
   public void registerMetricsConsumer(Class klass, Object argument, long parallelismHint) {
-    HashMap<String, Object> m = new HashMap<>();
+    HashMap m = new HashMap<>();
     m.put("class", klass.getCanonicalName());
     m.put("parallelism.hint", parallelismHint);
     m.put("argument", argument);
 
-    List<Map<String, Object>> l =
-        (List<Map<String, Object>>) this.get(TOPOLOGY_METRICS_CONSUMER_REGISTER);
+    List l = (List) this.get(TOPOLOGY_METRICS_CONSUMER_REGISTER);
     if (l == null) {
       l = new ArrayList<>();
     }

--- a/heron/storm/src/java/org/apache/storm/LocalCluster.java
+++ b/heron/storm/src/java/org/apache/storm/LocalCluster.java
@@ -28,10 +28,11 @@ import org.apache.storm.utils.ConfigUtils;
 
 import com.twitter.heron.simulator.Simulator;
 
+@SuppressWarnings("rawtypes")
 public class LocalCluster implements ILocalCluster {
   private final Simulator simulator;
   private String topologyName;
-  private Map<String, Object> conf;
+  private Map conf;
   private StormTopology topology;
 
   public LocalCluster() {

--- a/heron/storm/src/java/org/apache/storm/StormSubmitter.java
+++ b/heron/storm/src/java/org/apache/storm/StormSubmitter.java
@@ -47,9 +47,10 @@ public final class StormSubmitter {
    * @throws AlreadyAliveException if a topology with this name is already running
    * @throws InvalidTopologyException if an invalid topology was submitted
    */
+  @SuppressWarnings("rawtypes")
   public static void submitTopology(
       String name,
-      Map<String, Object> stormConfig,
+      Map stormConfig,
       StormTopology topology) throws AlreadyAliveException, InvalidTopologyException {
 
     // First do config translation

--- a/heron/storm/src/java/org/apache/storm/hooks/BaseTaskHook.java
+++ b/heron/storm/src/java/org/apache/storm/hooks/BaseTaskHook.java
@@ -30,7 +30,8 @@ import org.apache.storm.task.TopologyContext;
 
 public class BaseTaskHook implements ITaskHook {
   @Override
-  public void prepare(Map<String, Object> conf, TopologyContext context) {
+  @SuppressWarnings("rawtypes")
+  public void prepare(Map conf, TopologyContext context) {
   }
 
   @Override

--- a/heron/storm/src/java/org/apache/storm/hooks/ITaskHook.java
+++ b/heron/storm/src/java/org/apache/storm/hooks/ITaskHook.java
@@ -29,7 +29,8 @@ import org.apache.storm.hooks.info.SpoutFailInfo;
 import org.apache.storm.task.TopologyContext;
 
 public interface ITaskHook {
-  void prepare(Map<String, Object> conf, TopologyContext context);
+  @SuppressWarnings("rawtypes")
+  void prepare(Map conf, TopologyContext context);
 
   void cleanup();
 

--- a/heron/storm/src/java/org/apache/storm/hooks/ITaskHookDelegate.java
+++ b/heron/storm/src/java/org/apache/storm/hooks/ITaskHookDelegate.java
@@ -42,9 +42,10 @@ import com.twitter.heron.common.basics.TypeUtils;
  * is invoked.
  * 2. task hook added dynamically by invoking addHook(ITaskHook)
  */
+@SuppressWarnings("rawtypes")
 public class ITaskHookDelegate implements com.twitter.heron.api.hooks.ITaskHook {
   private List<ITaskHook> hooks;
-  private Map<String, Object> conf;
+  private Map conf;
 
   // zero arg constructor
   public ITaskHookDelegate() {
@@ -59,7 +60,7 @@ public class ITaskHookDelegate implements com.twitter.heron.api.hooks.ITaskHook 
     return hooks;
   }
 
-  public Map<String, Object> getConf() {
+  public Map getConf() {
     return conf;
   }
 

--- a/heron/storm/src/java/org/apache/storm/serialization/DefaultKryoFactory.java
+++ b/heron/storm/src/java/org/apache/storm/serialization/DefaultKryoFactory.java
@@ -29,7 +29,8 @@ import org.apache.storm.Config;
 public class DefaultKryoFactory implements IKryoFactory {
 
   @Override
-  public Kryo getKryo(Map<String, Object> conf) {
+  @SuppressWarnings("rawtypes")
+  public Kryo getKryo(Map conf) {
     KryoSerializableDefault k = new KryoSerializableDefault();
     k.setRegistrationRequired(
         !((Boolean) conf.get(Config.TOPOLOGY_FALL_BACK_ON_JAVA_SERIALIZATION)));
@@ -38,15 +39,18 @@ public class DefaultKryoFactory implements IKryoFactory {
   }
 
   @Override
-  public void preRegister(Kryo k, Map<String, Object> conf) {
+  @SuppressWarnings("rawtypes")
+  public void preRegister(Kryo k, Map conf) {
   }
 
-  public void postRegister(Kryo k, Map<String, Object> conf) {
+  @SuppressWarnings("rawtypes")
+  public void postRegister(Kryo k, Map conf) {
     ((KryoSerializableDefault) k).overrideDefault(true);
   }
 
   @Override
-  public void postDecorate(Kryo k, Map<String, Object> conf) {
+  @SuppressWarnings("rawtypes")
+  public void postDecorate(Kryo k, Map conf) {
   }
 
   public static class KryoSerializableDefault extends Kryo {

--- a/heron/storm/src/java/org/apache/storm/serialization/HeronPluggableSerializerDelegate.java
+++ b/heron/storm/src/java/org/apache/storm/serialization/HeronPluggableSerializerDelegate.java
@@ -34,7 +34,8 @@ public class HeronPluggableSerializerDelegate implements
   }
 
   @Override
-  public void initialize(Map<String, Object> config) {
+  @SuppressWarnings("rawtypes")
+  public void initialize(Map config) {
     kryo = SerializationFactory.getKryo(config);
     kryoOut = new Output(2000, 2000000000);
     kryoIn = new Input(1);

--- a/heron/storm/src/java/org/apache/storm/serialization/IKryoFactory.java
+++ b/heron/storm/src/java/org/apache/storm/serialization/IKryoFactory.java
@@ -34,12 +34,13 @@ import com.esotericsoftware.kryo.Kryo;
  * 6. Storm calls all user-defined decorators through topology.kryo.decorators
  * 7. Storm calls postDecorate hook
  */
+@SuppressWarnings("rawtypes")
 public interface IKryoFactory {
-  Kryo getKryo(Map<String, Object> conf);
+  Kryo getKryo(Map conf);
 
-  void preRegister(Kryo k, Map<String, Object> conf);
+  void preRegister(Kryo k, Map conf);
 
-  void postRegister(Kryo k, Map<String, Object> conf);
+  void postRegister(Kryo k, Map conf);
 
-  void postDecorate(Kryo k, Map<String, Object> conf);
+  void postDecorate(Kryo k, Map conf);
 }

--- a/heron/storm/src/java/org/apache/storm/serialization/SerializationFactory.java
+++ b/heron/storm/src/java/org/apache/storm/serialization/SerializationFactory.java
@@ -54,7 +54,7 @@ public final class SerializationFactory {
    * @return Kryo
    */
   @SuppressWarnings({"rawtypes", "unchecked"})
-  public static Kryo getKryo(Map<String, Object> conf) {
+  public static Kryo getKryo(Map conf) {
     IKryoFactory kryoFactory =
         (IKryoFactory) Utils.newInstance((String) conf.get(Config.TOPOLOGY_KRYO_FACTORY));
     Kryo k = kryoFactory.getKryo(conf);
@@ -175,8 +175,8 @@ public final class SerializationFactory {
             serializerClass.getName(), superClass.getName()));
   }
 
-  @SuppressWarnings("unchecked")
-  private static Map<String, String> normalizeKryoRegister(Map<String, Object> conf) {
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private static Map<String, String> normalizeKryoRegister(Map conf) {
     // TODO: de-duplicate this logic with the code in nimbus
     Object res = conf.get(Config.TOPOLOGY_KRYO_REGISTER);
     if (res == null) {

--- a/heron/storm/src/java/org/apache/storm/spout/ISpout.java
+++ b/heron/storm/src/java/org/apache/storm/spout/ISpout.java
@@ -56,7 +56,8 @@ public interface ISpout extends Serializable {
    * @param context This object can be used to get information about this task's place within the topology, including the task id and component id of this task, input and output information, etc.
    * @param collector The collector is used to emit tuples from this spout. Tuples can be emitted at any time, including the open and close methods. The collector is thread-safe and should be saved as an instance variable of this spout object.
    */
-  void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector);
+  @SuppressWarnings("rawtypes")
+  void open(Map conf, TopologyContext context, SpoutOutputCollector collector);
 
   /**
    * Called when an ISpout is going to be shutdown. There is no guarentee that close

--- a/heron/storm/src/java/org/apache/storm/spout/ISpoutWaitStrategy.java
+++ b/heron/storm/src/java/org/apache/storm/spout/ISpoutWaitStrategy.java
@@ -30,7 +30,8 @@ import java.util.Map;
  * The default strategy sleeps for one millisecond.
  */
 public interface ISpoutWaitStrategy {
-  void prepare(Map<String, Object> conf);
+  @SuppressWarnings("rawtypes")
+  void prepare(Map conf);
 
   void emptyEmit(long streak);
 }

--- a/heron/storm/src/java/org/apache/storm/spout/NothingEmptyEmitStrategy.java
+++ b/heron/storm/src/java/org/apache/storm/spout/NothingEmptyEmitStrategy.java
@@ -26,7 +26,8 @@ public class NothingEmptyEmitStrategy implements ISpoutWaitStrategy {
   }
 
   @Override
-  public void prepare(Map<String, Object> conf) {
+  @SuppressWarnings("rawtypes")
+  public void prepare(Map conf) {
     throw new UnsupportedOperationException("Not supported yet.");
   }
 }

--- a/heron/storm/src/java/org/apache/storm/spout/SleepSpoutWaitStrategy.java
+++ b/heron/storm/src/java/org/apache/storm/spout/SleepSpoutWaitStrategy.java
@@ -27,7 +27,8 @@ public class SleepSpoutWaitStrategy implements ISpoutWaitStrategy {
   private long sleepMillis;
 
   @Override
-    public void prepare(Map<String, Object> conf) {
+  @SuppressWarnings("rawtypes")
+  public void prepare(Map conf) {
     sleepMillis =
         ((Number) conf.get(Config.TOPOLOGY_SLEEP_SPOUT_WAIT_STRATEGY_TIME_MS)).longValue();
   }

--- a/heron/storm/src/java/org/apache/storm/task/GeneralTopologyContext.java
+++ b/heron/storm/src/java/org/apache/storm/task/GeneralTopologyContext.java
@@ -34,7 +34,8 @@ import org.json.simple.JSONAware;
 public class GeneralTopologyContext implements JSONAware {
   private com.twitter.heron.api.topology.GeneralTopologyContext delegate;
 
-  public GeneralTopologyContext(StormTopology topology, Map<String, Object> stormConf,
+  @SuppressWarnings("rawtypes")
+  public GeneralTopologyContext(StormTopology topology, Map stormConf,
                                 Map<Integer, String> taskToComponent,
                                 Map<String, List<Integer>> componentToSortedTasks,
                                 Map<String, Map<String, Fields>> componentToStreamToFields,

--- a/heron/storm/src/java/org/apache/storm/task/TopologyContext.java
+++ b/heron/storm/src/java/org/apache/storm/task/TopologyContext.java
@@ -55,7 +55,8 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
   // Constructor to match the signature of the storm's TopologyContext
   // Note that here, we fake the clojure.lang.Atom by creating our own class
   // This is real hacking a hack!
-  public TopologyContext(StormTopology topology, Map<String, Object> stormConf,
+  @SuppressWarnings("rawtypes")
+  public TopologyContext(StormTopology topology, Map stormConf,
                          Map<Integer, String> taskToComponent,
                          Map<String, List<Integer>> componentToSortedTasks,
                          Map<String, Map<String, Fields>> componentToStreamToFields,

--- a/heron/storm/src/java/org/apache/storm/task/WorkerTopologyContext.java
+++ b/heron/storm/src/java/org/apache/storm/task/WorkerTopologyContext.java
@@ -29,9 +29,10 @@ import org.apache.storm.tuple.Fields;
 public class WorkerTopologyContext extends GeneralTopologyContext {
   private com.twitter.heron.api.topology.TopologyContext delegate;
 
+  @SuppressWarnings("rawtypes")
   public WorkerTopologyContext(
       StormTopology topology,
-      Map<String, Object> stormConf,
+      Map stormConf,
       Map<Integer, String> taskToComponent,
       Map<String, List<Integer>> componentToSortedTasks,
       Map<String, Map<String, Fields>> componentToStreamToFields,

--- a/heron/storm/src/java/org/apache/storm/testing/TestWordSpout.java
+++ b/heron/storm/src/java/org/apache/storm/testing/TestWordSpout.java
@@ -34,8 +34,9 @@ public class TestWordSpout extends BaseRichSpout {
   private String[] words;
   private Random rand;
 
+  @SuppressWarnings("rawtypes")
   public void open(
-      Map<String, Object> conf,
+      Map conf,
       TopologyContext context,
       SpoutOutputCollector aCollector) {
     collector = aCollector;

--- a/heron/storm/src/java/org/apache/storm/topology/BoltDeclarerImpl.java
+++ b/heron/storm/src/java/org/apache/storm/topology/BoltDeclarerImpl.java
@@ -33,8 +33,9 @@ public class BoltDeclarerImpl implements BoltDeclarer {
   }
 
   @Override
-  public BoltDeclarer addConfigurations(Map<String, Object> conf) {
-    delegate.addConfigurations(conf);
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public BoltDeclarer addConfigurations(Map conf) {
+    delegate.addConfigurations((Map<String, Object>) conf);
     return this;
   }
 

--- a/heron/storm/src/java/org/apache/storm/topology/ComponentConfigurationDeclarer.java
+++ b/heron/storm/src/java/org/apache/storm/topology/ComponentConfigurationDeclarer.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 @SuppressWarnings("rawtypes")
 public interface ComponentConfigurationDeclarer<T extends ComponentConfigurationDeclarer> {
-  T addConfigurations(Map<String, Object> conf);
+  T addConfigurations(Map conf);
 
   T addConfiguration(String config, Object value);
 

--- a/heron/storm/src/java/org/apache/storm/topology/IRichBoltDelegate.java
+++ b/heron/storm/src/java/org/apache/storm/topology/IRichBoltDelegate.java
@@ -39,8 +39,9 @@ public class IRichBoltDelegate implements com.twitter.heron.api.bolt.IRichBolt {
   }
 
   @Override
+  @SuppressWarnings("rawtypes")
   public void prepare(
-      Map<String, Object> conf,
+      Map conf,
       com.twitter.heron.api.topology.TopologyContext context,
       com.twitter.heron.api.bolt.OutputCollector collector) {
     topologyContextImpl = new TopologyContext(context);

--- a/heron/storm/src/java/org/apache/storm/topology/IRichSpoutDelegate.java
+++ b/heron/storm/src/java/org/apache/storm/topology/IRichSpoutDelegate.java
@@ -40,7 +40,8 @@ public class IRichSpoutDelegate implements com.twitter.heron.api.spout.IRichSpou
   }
 
   @Override
-  public void open(Map<String, Object> conf, com.twitter.heron.api.topology.TopologyContext context,
+  @SuppressWarnings("rawtypes")
+  public void open(Map conf, com.twitter.heron.api.topology.TopologyContext context,
                    SpoutOutputCollector collector) {
     topologyContextImpl = new TopologyContext(context);
     spoutOutputCollectorImpl = new SpoutOutputCollectorImpl(collector);

--- a/heron/storm/src/java/org/apache/storm/topology/SpoutDeclarerImpl.java
+++ b/heron/storm/src/java/org/apache/storm/topology/SpoutDeclarerImpl.java
@@ -28,8 +28,9 @@ public class SpoutDeclarerImpl implements SpoutDeclarer {
   }
 
   @Override
-  public SpoutDeclarer addConfigurations(Map<String, Object> conf) {
-    delegate.addConfigurations(conf);
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public SpoutDeclarer addConfigurations(Map conf) {
+    delegate.addConfigurations((Map<String, Object>) conf);
     return this;
   }
 

--- a/heron/storm/src/java/org/apache/storm/utils/ConfigUtils.java
+++ b/heron/storm/src/java/org/apache/storm/utils/ConfigUtils.java
@@ -36,8 +36,9 @@ public final class ConfigUtils {
    * @param stormConfig the storm config
    * @return a heron config
    */
-  public static Config translateConfig(Map<String, Object> stormConfig) {
-    Config heronConfig = new Config(stormConfig);
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public static Config translateConfig(Map stormConfig) {
+    Config heronConfig = new Config((Map<String, Object>) stormConfig);
     // Look at serialization stuff first
     doSerializationTranslation(heronConfig);
 


### PR DESCRIPTION
As part of coding style improvement, we previously changed the config type from raw Map to Map<String, Object> in storm directory. 

This causes incompatibility with the existing storm api and caused compilation failures in certain cases (e.g. topology written in scala).

In this PR, the raw Map is used again and all the warnings for it is suppressed. This change only happens in heron/storm directory.