### PR TITLE
upgrade yarn scheduler driver memory to ByteAmount

### DIFF
--- a/heron/common/src/java/com/twitter/heron/common/basics/TypeUtils.java
+++ b/heron/common/src/java/com/twitter/heron/common/basics/TypeUtils.java
@@ -87,6 +87,17 @@ public final class TypeUtils {
     }
   }
 
+  public static ByteAmount getByteAmountMB(Object o) {
+    if (o != null && o instanceof ByteAmount) {
+      return (ByteAmount) o;
+    }
+    try {
+      return ByteAmount.fromMegabytes(getLong(o));
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Don't know how to convert " + o + " to ByteAmount", e);
+    }
+  }
+
   public static Boolean getBoolean(Object o) {
     if (o instanceof Boolean) {
       return (Boolean) o;

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/HeronMasterDriver.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/HeronMasterDriver.java
@@ -99,9 +99,7 @@ import com.twitter.heron.spi.packing.Resource;
  */
 @Unit
 public class HeronMasterDriver {
-  static final int TM_MEM_SIZE_MB = 1024;
   static final int TMASTER_CONTAINER_ID = 0;
-  static final int MB = 1024 * 1024;
   private static final Logger LOG = Logger.getLogger(HeronMasterDriver.class.getName());
   private final String topologyPackageName;
   private final String heronCorePackageName;

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/YarnContext.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/YarnContext.java
@@ -14,6 +14,8 @@
 
 package com.twitter.heron.scheduler.yarn;
 
+import com.twitter.heron.common.basics.ByteAmount;
+import com.twitter.heron.common.basics.TypeUtils;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Context;
 
@@ -27,8 +29,8 @@ public final class YarnContext extends Context {
         YarnKey.HERON_SCHEDULER_YARN_QUEUE.getDefaultString());
   }
 
-  public static int heronDriverMemoryMb(Config cfg) {
-    return cfg.getIntegerValue(YarnKey.YARN_SCHEDULER_DRIVER_MEMORY_MB.value(),
-        YarnKey.YARN_SCHEDULER_DRIVER_MEMORY_MB.getDefaultInt());
+  public static ByteAmount heronDriverMemoryMb(Config cfg) {
+    return cfg.getByteAmountValueMB(YarnKey.YARN_SCHEDULER_DRIVER_MEMORY_MB.value(),
+        (ByteAmount) YarnKey.YARN_SCHEDULER_DRIVER_MEMORY_MB.getDefault());
   }
 }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/YarnKey.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/YarnKey.java
@@ -14,6 +14,7 @@
 
 package com.twitter.heron.scheduler.yarn;
 
+import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.spi.common.Key;
 
 /**
@@ -23,7 +24,7 @@ public enum YarnKey {
   // yarn queue for submitting and launching the topology
   HERON_SCHEDULER_YARN_QUEUE("heron.scheduler.yarn.queue", "default"),
   // the amount of memory topology's driver (yarn application master) needs
-  YARN_SCHEDULER_DRIVER_MEMORY_MB("heron.scheduler.yarn.driver.memory.mb", 2048);
+  YARN_SCHEDULER_DRIVER_MEMORY_MB("heron.scheduler.yarn.driver.memory.mb", ByteAmount.fromMegabytes(2048));
 
   private final String value;
   private final Key.Type type;
@@ -35,9 +36,9 @@ public enum YarnKey {
     this.defaultValue = defaultValue;
   }
 
-  YarnKey(String value, Integer defaultValue) {
+  YarnKey(String value, ByteAmount defaultValue) {
     this.value = value;
-    this.type = Key.Type.INTEGER;
+    this.type = Key.Type.BYTE_AMOUNT;
     this.defaultValue = defaultValue;
   }
 
@@ -55,13 +56,5 @@ public enum YarnKey {
           "Config Key %s is type %s, getDefaultString() not supported", this.name(), this.type));
     }
     return (String) this.defaultValue;
-  }
-
-  public int getDefaultInt() {
-    if (type != Key.Type.INTEGER) {
-      throw new IllegalAccessError(String.format(
-          "Config Key %s is type %s, getDefaultInt() not supported", this.name(), this.type));
-    }
-    return (Integer) this.defaultValue;
   }
 }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/YarnLauncher.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/YarnLauncher.java
@@ -34,6 +34,7 @@ import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.annotations.Unit;
 import org.apache.reef.tang.exceptions.InjectionException;
 
+import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.scheduler.yarn.HeronMasterDriver.ContainerAllocationHandler;
 import com.twitter.heron.scheduler.yarn.HeronMasterDriver.FailedContainerHandler;
 import com.twitter.heron.scheduler.yarn.HeronMasterDriver.HeronSchedulerLauncher;
@@ -63,7 +64,7 @@ public class YarnLauncher implements ILauncher {
   private String role;
   private String env;
   private String queue;
-  private int driverMemory;
+  private ByteAmount driverMemory;
   private ArrayList<String> libJars = new ArrayList<>();
 
   @Override
@@ -161,7 +162,7 @@ public class YarnLauncher implements ILauncher {
         .set(HeronDriverConfiguration.HTTP_PORT, 0)
         .set(HeronDriverConfiguration.VERBOSE, false)
         .set(YarnDriverConfiguration.QUEUE, queue)
-        .set(DriverConfiguration.DRIVER_MEMORY, driverMemory)
+        .set(DriverConfiguration.DRIVER_MEMORY, driverMemory.asMegabytes())
         .build();
   }
 

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Config.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Config.java
@@ -240,6 +240,14 @@ public class Config {
     return TypeUtils.getByteAmount(value);
   }
 
+  public ByteAmount getByteAmountValueMB(String key, ByteAmount defaultValue) {
+    Object value = get(key);
+    if (value != null) {
+      return TypeUtils.getByteAmountMB(value);
+    }
+    return defaultValue;
+  }
+
   DryRunFormatType getDryRunFormatType(Key key) {
     return (DryRunFormatType) get(key);
   }


### PR DESCRIPTION
As #1727 mentioned and #1707 refactored, this PR upgraded driver memory to use ByteAmount.

The key changes are following:

* add getByteAmountValueMB() in Config class
* change `driverMemory` from int to ByteAmount
* refactor YarnKey class

cc: @billonahill @ashvina 