### PR TITLE
Slightly increase delta.

### DIFF
--- a/heron/common/tests/python/basics/gateway_looper_unittest.py
+++ b/heron/common/tests/python/basics/gateway_looper_unittest.py
@@ -34,7 +34,7 @@ class GatewayLooperTest(unittest.TestCase):
     sleep_times = [0.1, 0.3, 0.5, 1.0, 3.0, 5.0]
     for sleep in sleep_times:
       start, end = self.prepare_wakeup_test(sleep)
-      self.assertAlmostEqual(start + sleep, end, delta=0.01)
+      self.assertAlmostEqual(start + sleep, end, delta=0.02)
 
   def prepare_wakeup_test(self, sleep, poll_timeout=30.0):
     looper = GatewayLooper(socket_map={})


### PR DESCRIPTION
resolves #1730 

recent internal unit test fails because delta is at range of `(0.01, 0.02)`.