### PR TITLE
Adding --help option to Heron client

### DIFF
--- a/heron/tools/cli/src/python/cli_helper.py
+++ b/heron/tools/cli/src/python/cli_helper.py
@@ -32,7 +32,7 @@ def create_parser(subparsers, action, help_arg):
       action,
       help=help_arg,
       usage="%(prog)s [options] cluster/[role]/[env] <topology-name>",
-      add_help=False)
+      add_help=True)
 
   args.add_titles(parser)
   args.add_cluster_role_env(parser)

--- a/heron/tools/cli/src/python/help.py
+++ b/heron/tools/cli/src/python/help.py
@@ -24,7 +24,7 @@ def create_parser(subparsers):
   parser = subparsers.add_parser(
       'help',
       help='Prints help for commands',
-      add_help=False)
+      add_help=True)
 
   # pylint: disable=protected-access
   parser._positionals.title = "Required arguments"

--- a/heron/tools/cli/src/python/main.py
+++ b/heron/tools/cli/src/python/main.py
@@ -73,7 +73,7 @@ def create_parser():
       prog='heron',
       epilog=HELP_EPILOG,
       formatter_class=config.SubcommandHelpFormatter,
-      add_help=False,
+      add_help=True,
       fromfile_prefix_chars='@')
 
   subparsers = parser.add_subparsers(

--- a/heron/tools/cli/src/python/restart.py
+++ b/heron/tools/cli/src/python/restart.py
@@ -25,7 +25,7 @@ def create_parser(subparsers):
       'restart',
       help='Restart a topology',
       usage="%(prog)s [options] cluster/[role]/[env] <topology-name> [container-id]",
-      add_help=False)
+      add_help=True)
 
   args.add_titles(parser)
   args.add_cluster_role_env(parser)

--- a/heron/tools/cli/src/python/submit.py
+++ b/heron/tools/cli/src/python/submit.py
@@ -42,7 +42,7 @@ def create_parser(subparsers):
       help='Submit a topology',
       usage="%(prog)s [options] cluster/[role]/[env] " + \
             "topology-file-name topology-class-name [topology-args]",
-      add_help=False
+      add_help=True
   )
 
   cli_args.add_titles(parser)

--- a/heron/tools/cli/src/python/update.py
+++ b/heron/tools/cli/src/python/update.py
@@ -26,7 +26,7 @@ def create_parser(subparsers):
       help='Update a topology',
       usage="%(prog)s [options] cluster/[role]/[env] <topology-name> "
       + "--component-parallelism <name:value>",
-      add_help=False)
+      add_help=True)
 
   args.add_titles(parser)
   args.add_cluster_role_env(parser)

--- a/heron/tools/cli/src/python/version.py
+++ b/heron/tools/cli/src/python/version.py
@@ -26,7 +26,7 @@ def create_parser(subparsers):
       'version',
       help='Print version of heron-cli',
       usage="%(prog)s",
-      add_help=False)
+      add_help=True)
 
   cli_args.add_titles(parser)
 


### PR DESCRIPTION
We already support the `heron help update` format, but it's also convenient to append `--help` at the end of a command line.