### PR TITLE
Modifying configs at submit if numContainers is off

### DIFF
--- a/heron/packing/src/java/com/twitter/heron/packing/builder/PackingPlanBuilder.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/builder/PackingPlanBuilder.java
@@ -124,7 +124,7 @@ public class PackingPlanBuilder {
           instanceId, instanceResource, containerId), e);
     }
 
-    LOG.fine(String.format("Added to container %d instance %s", containerId, instanceId));
+    LOG.finest(String.format("Added to container %d instance %s", containerId, instanceId));
     return this;
   }
 

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
@@ -163,7 +163,7 @@ public class ResourceCompliantRRPacking implements IPacking, IRepacking {
 
       } catch (ResourceExceededException e) {
         //Not enough containers. Adjust the number of containers.
-        LOG.info(String.format(
+        LOG.finest(String.format(
             "%s Increasing the number of containers to %s and attempting to place again.",
             e.getMessage(), this.numContainers + 1));
         increaseNumContainers(1);

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/LaunchRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/LaunchRunner.java
@@ -30,7 +30,6 @@ import com.twitter.heron.spi.packing.PackingPlanProtoSerializer;
 import com.twitter.heron.spi.scheduler.ILauncher;
 import com.twitter.heron.spi.scheduler.LauncherException;
 import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
-import com.twitter.heron.spi.utils.TopologyUtils;
 
 /**
  * Runs Launcher and launch topology. Also Uploads launch state to state manager.
@@ -134,25 +133,14 @@ public class LaunchRunner {
       throw new SubmitDryRunResponse(topology, config, packedPlan);
     }
 
-    int numContainers = TopologyUtils.getNumContainers(topology);
-    int numContainerPlans = packedPlan.getContainers().size();
-    if (numContainers != packedPlan.getContainers().size()) {
-      int instanceCount = packedPlan.getInstanceCount();
-      throw new LauncherException(String.format("Can not launch topology. The configured number of "
-          + "containers (%d) differs from the number of container plans (%d) for topology of %d "
-          + "instances", numContainers, numContainerPlans, instanceCount));
-    }
-
     // initialize the launcher
     launcher.initialize(config, runtime);
-
-    Boolean result;
 
     // Set topology def first since we determine whether a topology is running
     // by checking the existence of topology def
     // store the trimmed topology definition into the state manager
     // TODO(rli): log-and-false anti-pattern is too nested on this path. will not refactor
-    result = statemgr.setTopology(trimTopology(topology), topologyName);
+    Boolean result = statemgr.setTopology(trimTopology(topology), topologyName);
     if (result == null || !result) {
       throw new LauncherException(String.format(
           "Failed to set topology definition for topology '%s'", topologyName));

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
@@ -442,13 +442,13 @@ public class SubmitterMain {
           .put(Key.LAUNCHER_CLASS_INSTANCE, launcher)
           .build();
 
-      PackingPlan packedPlan = LauncherUtils.getInstance()
+      PackingPlan packingPlan = LauncherUtils.getInstance()
           .createPackingPlan(config, runtimeWithoutPackageURI);
 
       // The packing plan might call for a number of containers different than the config
       // settings. If that's the case we need to modify the configs to match.
       runtimeWithoutPackageURI =
-          updateNumContainersIfNeeded(runtimeWithoutPackageURI, topology, packedPlan);
+          updateNumContainersIfNeeded(runtimeWithoutPackageURI, topology, packingPlan);
 
       // If the packing plan is valid we will upload necessary packages
       URI packageURI = uploadPackage(uploader);

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
@@ -44,6 +44,7 @@ import com.twitter.heron.spi.common.ConfigLoader;
 import com.twitter.heron.spi.common.Context;
 import com.twitter.heron.spi.common.Key;
 import com.twitter.heron.spi.packing.PackingException;
+import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.scheduler.ILauncher;
 import com.twitter.heron.spi.scheduler.LauncherException;
 import com.twitter.heron.spi.statemgr.IStateManager;
@@ -360,9 +361,7 @@ public class SubmitterMain {
   // topology definition
   private final TopologyAPI.Topology topology;
 
-  public SubmitterMain(
-      Config config,
-      TopologyAPI.Topology topology) {
+  public SubmitterMain(Config config, TopologyAPI.Topology topology) {
     // initialize the options
     this.config = config;
     this.topology = topology;
@@ -422,32 +421,46 @@ public class SubmitterMain {
       // Bypass validation and upload if in dry-run mode
       if (Context.dryRun(config)) {
         callLauncherRunner(primaryRuntime);
-      } else {
-        // initialize the state manager
-        statemgr.initialize(config);
-
-        // TODO(mfu): timeout should read from config
-        SchedulerStateManagerAdaptor adaptor = new SchedulerStateManagerAdaptor(statemgr, 5000);
-
-        // Check if topology is already running
-        validateSubmit(adaptor, topology.getName());
-
-        LOG.log(Level.FINE, "Topology {0} to be submitted", topology.getName());
-
-        // Try to submit topology if valid
-        // Firstly, try to upload necessary packages
-        URI packageURI = uploadPackage(uploader);
-
-        // Secondly, try to submit the topology
-        // build the complete runtime config
-        Config runtimeAll = Config.newBuilder()
-            .putAll(primaryRuntime)
-            .putAll(LauncherUtils.getInstance().createAdaptorRuntime(adaptor))
-            .put(Key.TOPOLOGY_PACKAGE_URI, packageURI)
-            .put(Key.LAUNCHER_CLASS_INSTANCE, launcher)
-            .build();
-        callLauncherRunner(runtimeAll);
+        return;
       }
+
+      // initialize the state manager
+      statemgr.initialize(config);
+
+      // TODO(mfu): timeout should read from config
+      SchedulerStateManagerAdaptor adaptor = new SchedulerStateManagerAdaptor(statemgr, 5000);
+
+      // Check if topology is already running
+      validateSubmit(adaptor, topology.getName());
+
+      LOG.log(Level.FINE, "Topology {0} to be submitted", topology.getName());
+
+      // First, create the basic runtime config to generate the packing plan
+      Config runtimeWithoutPackageURI = Config.newBuilder()
+          .putAll(primaryRuntime)
+          .putAll(LauncherUtils.getInstance().createAdaptorRuntime(adaptor))
+          .put(Key.LAUNCHER_CLASS_INSTANCE, launcher)
+          .build();
+
+      PackingPlan packedPlan = LauncherUtils.getInstance()
+          .createPackingPlan(config, runtimeWithoutPackageURI);
+
+      // The packing plan might call for a number of containers different than the config
+      // settings. If that's the case we need to modify the configs to match.
+      runtimeWithoutPackageURI =
+          updateNumContainersIfNeeded(runtimeWithoutPackageURI, topology, packedPlan);
+
+      // If the packing plan is valid we will upload necessary packages
+      URI packageURI = uploadPackage(uploader);
+
+      // Update the runtime config with the packageURI
+      Config runtimeAll = Config.newBuilder()
+          .putAll(runtimeWithoutPackageURI)
+          .put(Key.TOPOLOGY_PACKAGE_URI, packageURI)
+          .build();
+
+      callLauncherRunner(runtimeAll);
+
     } catch (LauncherException | PackingException e) {
       // we undo uploading of topology package only if launcher fails to
       // launch topology, which will throw LauncherException or PackingException
@@ -458,6 +471,67 @@ public class SubmitterMain {
       SysUtils.closeIgnoringExceptions(launcher);
       SysUtils.closeIgnoringExceptions(statemgr);
     }
+  }
+
+  /**
+   * Checks that the number of containers specified in the topology matches the number of containers
+   * called for in the packing plan. If they are different, returns a new config with settings
+   * updated to align with the packing plan. The new config will include an updated
+   * Key.TOPOLOGY_DEFINITION containing a cloned Topology with it's settings also updated.
+   *
+   * @param initialConfig initial config to clone and update (if necessary)
+   * @param initialTopology topology to check and clone/update (if necessary)
+   * @param packingPlan packing plan to compare settings with
+   * @return a new Config cloned from initialConfig and modified as needed to align with packedPlan
+   */
+  @VisibleForTesting
+  Config updateNumContainersIfNeeded(Config initialConfig,
+                                     TopologyAPI.Topology initialTopology,
+                                     PackingPlan packingPlan) {
+
+    int configNumStreamManagers = TopologyUtils.getNumContainers(initialTopology);
+    int packingNumStreamManagers = packingPlan.getContainers().size();
+
+    if (configNumStreamManagers == packingNumStreamManagers) {
+      return initialConfig;
+    }
+
+    Config.Builder newConfigBuilder = Config.newBuilder()
+        .putAll(initialConfig)
+        .put(Key.NUM_CONTAINERS, packingNumStreamManagers + 1)
+        .put(Key.TOPOLOGY_DEFINITION,
+            cloneWithNewNumContainers(initialTopology, packingNumStreamManagers));
+
+    String packingClass = Context.packingClass(initialConfig);
+    LOG.warning(String.format("The packing plan (generated by %s) calls for a different number of "
+            + "containers (%d) than what was explicitly set in the topology configs (%d). "
+            + "Overriding the configs to specify %d containers. When using %s do not explicitly "
+            + "call config.setNumStmgrs(..) or config.setNumWorkers(..).",
+        packingClass, packingNumStreamManagers, configNumStreamManagers,
+        packingNumStreamManagers, packingClass));
+
+    return newConfigBuilder.build();
+  }
+
+  private TopologyAPI.Topology cloneWithNewNumContainers(TopologyAPI.Topology initialTopology,
+                                                         int numStreamManagers) {
+    TopologyAPI.Topology.Builder topologyBuilder = TopologyAPI.Topology.newBuilder(initialTopology);
+    TopologyAPI.Config.Builder configBuilder = TopologyAPI.Config.newBuilder();
+
+    for (TopologyAPI.Config.KeyValue keyValue : initialTopology.getTopologyConfig().getKvsList()) {
+
+      // override TOPOLOGY_STMGRS value once we find it
+      if (com.twitter.heron.api.Config.TOPOLOGY_STMGRS.equals(keyValue.getKey())) {
+        TopologyAPI.Config.KeyValue.Builder kvBuilder = TopologyAPI.Config.KeyValue.newBuilder();
+        kvBuilder.setKey(keyValue.getKey());
+        kvBuilder.setValue(Integer.toString(numStreamManagers));
+        configBuilder.addKvs(kvBuilder.build());
+      } else {
+        configBuilder.addKvs(keyValue);
+      }
+    }
+
+    return topologyBuilder.setTopologyConfig(configBuilder).build();
   }
 
   protected void validateSubmit(SchedulerStateManagerAdaptor adaptor, String topologyName)

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/LaunchRunnerTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/LaunchRunnerTest.java
@@ -281,10 +281,10 @@ public class LaunchRunnerTest {
     doTestLaunch(new com.twitter.heron.api.Config());
   }
 
-  @Test(expected = LauncherException.class)
-  public void testFailureNumContainers() throws Exception {
+  @Test
+  public void testCallSuccessWithDifferentNumContainers() throws Exception {
     com.twitter.heron.api.Config topologyConfig = new com.twitter.heron.api.Config();
-    topologyConfig.setNumStmgrs(2); // fails because packing plan has only 1 container plan
+    topologyConfig.setNumStmgrs(2); // packing plan has only 1 container plan but numStmgrs is 2
 
     doTestLaunch(topologyConfig);
   }

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/SubmitterMainTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/SubmitterMainTest.java
@@ -25,7 +25,9 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.twitter.heron.api.generated.TopologyAPI;
+import com.twitter.heron.packing.roundrobin.RoundRobinPacking;
 import com.twitter.heron.scheduler.dryrun.SubmitDryRunResponse;
+import com.twitter.heron.scheduler.utils.LauncherUtils;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Key;
 import com.twitter.heron.spi.packing.IPacking;
@@ -35,6 +37,7 @@ import com.twitter.heron.spi.statemgr.IStateManager;
 import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
 import com.twitter.heron.spi.uploader.IUploader;
 import com.twitter.heron.spi.uploader.UploaderException;
+import com.twitter.heron.spi.utils.PackingTestUtils;
 import com.twitter.heron.spi.utils.ReflectionUtils;
 
 import static org.mockito.Mockito.any;
@@ -51,7 +54,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(ReflectionUtils.class)
+@PrepareForTest({LauncherUtils.class, ReflectionUtils.class})
 public class SubmitterMainTest {
   private static final String TOPOLOGY_NAME = "topologyName";
 
@@ -62,7 +65,6 @@ public class SubmitterMainTest {
 
   private IStateManager statemgr;
   private ILauncher launcher;
-  private IPacking packing;
   private IUploader uploader;
 
   private Config config;
@@ -72,9 +74,9 @@ public class SubmitterMainTest {
   @Before
   public void setUp() throws Exception {
     // Mock objects to be verified
+    IPacking packing = mock(IPacking.class);
     statemgr = mock(IStateManager.class);
     launcher = mock(ILauncher.class);
-    packing = mock(IPacking.class);
     uploader = mock(IUploader.class);
 
     // Mock ReflectionUtils stuff
@@ -97,6 +99,9 @@ public class SubmitterMainTest {
         .thenReturn(PACKING_CLASS);
     when(config.getStringValue(Key.UPLOADER_CLASS))
         .thenReturn(UPLOADER_CLASS);
+
+    when(packing.pack())
+        .thenReturn(PackingTestUtils.testPackingPlan(TOPOLOGY_NAME, new RoundRobinPacking()));
 
     topology = TopologyAPI.Topology.getDefaultInstance();
   }

--- a/heron/spi/src/java/com/twitter/heron/spi/packing/IPacking.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/packing/IPacking.java
@@ -21,7 +21,10 @@ import com.twitter.heron.spi.common.Config;
 
 /**
  * Packing algorithm to use for packing multiple instances into containers. Packing hints like
- * number of container may be passed through scheduler config.
+ * number of containers may be passed through scheduler config. Configs might contain settings for
+ * the number of containers requested or the amount of instance or container resources to allocate.
+ * Implementations may choose to ignore some or all of these settings as needed, since they could be
+ * contradictory, or not all possible to be achieved based on the algorithm.
  */
 @InterfaceAudience.LimitedPrivate
 @InterfaceStability.Unstable

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/TopologyUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/TopologyUtils.java
@@ -220,6 +220,7 @@ public final class TopologyUtils {
     return ramMap;
   }
 
+  // TODO: in a PR of it's own rename this to getNumStreamManagers to be correct
   public static int getNumContainers(TopologyAPI.Topology topology) {
     List<TopologyAPI.Config.KeyValue> topologyConfig = topology.getTopologyConfig().getKvsList();
     return Integer.parseInt(TopologyUtils.getConfigWithDefault(


### PR DESCRIPTION
Fixes #1742 by updating configs and the topology to match the number of containers specified by the packing plan. The key parts to look at is the `SubmitterMain.updateNumContainersIfNeeded` method.

Also moves this validation into `SubmitterMain` so it can happen before uploading the package. @ashvina I know we refactored to not build the packing plan in both `SubmitterMain` and `LaunchRunner`, but I think it makes sense to do this logic as early as possible, since we're mutating the user-provided topology and configs.