### PR TITLE
Read back pressure configs from config file

### DIFF
--- a/heron/common/src/cpp/network/baseclient.cpp
+++ b/heron/common/src/cpp/network/baseclient.cpp
@@ -31,6 +31,8 @@ void BaseClient::Init(EventLoop* eventLoop, const NetworkOptions& _options) {
   options_ = _options;
   conn_ = NULL;
   connection_options_.max_packet_size_ = options_.get_max_packet_size();
+  connection_options_.high_watermark_ = options_.get_high_watermark();
+  connection_options_.low_watermark_ = options_.get_low_watermark();
   state_ = DISCONNECTED;
 }
 

--- a/heron/common/src/cpp/network/baseconnection.h
+++ b/heron/common/src/cpp/network/baseconnection.h
@@ -71,6 +71,8 @@ class ConnectionEndPoint {
  */
 struct ConnectionOptions {
   sp_uint32 max_packet_size_;
+  sp_int64 high_watermark_;
+  sp_int64 low_watermark_;
 };
 
 /*

--- a/heron/common/src/cpp/network/baseserver.cpp
+++ b/heron/common/src/cpp/network/baseserver.cpp
@@ -37,6 +37,8 @@ void BaseServer::Init(EventLoop* eventLoop, const NetworkOptions& _options) {
   options_ = _options;
   listen_fd_ = -1;
   connection_options_.max_packet_size_ = options_.get_max_packet_size();
+  connection_options_.high_watermark_ = options_.get_high_watermark();
+  connection_options_.low_watermark_ = options_.get_low_watermark();
   on_new_connection_callback_ = [this](EventLoop::Status status) { this->OnNewConnection(status); };
 }
 

--- a/heron/common/src/cpp/network/connection.h
+++ b/heron/common/src/cpp/network/connection.h
@@ -117,12 +117,6 @@ class Connection : public BaseConnection {
   sp_int32 putBackPressure();
   sp_int32 removeBackPressure();
 
- public:
-  // This is the high water mark on the num of bytes that can be left outstanding on a connection
-  static sp_int64 systemHWMOutstandingBytes;
-  // This is the low water mark on the num of bytes that can be left outstanding on a connection
-  static sp_int64 systemLWMOutstandingBytes;
-
  private:
   virtual sp_int32 writeIntoEndPoint(sp_int32 fd);
 

--- a/heron/common/src/cpp/network/networkoptions.cpp
+++ b/heron/common/src/cpp/network/networkoptions.cpp
@@ -18,12 +18,19 @@
 #include <arpa/inet.h>
 #include <string>
 
+// This is the high water mark on the num of bytes that can be left outstanding on a connection
+const sp_int64 systemHWMOutstandingBytes = 1024 * 1024 * 100;  // 100M
+// This is the low water mark on the num of bytes that can be left outstanding on a connection
+const sp_int64 systemLWMOutstandingBytes = 1024 * 1024 * 50;  // 50M
+
 NetworkOptions::NetworkOptions() {
   host_ = "localhost";
   port_ = 8080;
   max_packet_size_ = 1024;
   socket_family_ = PF_INET;
   sin_path_ = "";
+  high_watermark_ = systemHWMOutstandingBytes;
+  low_watermark_ = systemLWMOutstandingBytes;
 }
 
 NetworkOptions::NetworkOptions(const NetworkOptions& _copyFrom) {
@@ -31,6 +38,8 @@ NetworkOptions::NetworkOptions(const NetworkOptions& _copyFrom) {
   port_ = _copyFrom.get_port();
   max_packet_size_ = _copyFrom.get_max_packet_size();
   socket_family_ = _copyFrom.get_socket_family();
+  high_watermark_ = _copyFrom.get_high_watermark();
+  low_watermark_ = _copyFrom.get_low_watermark();
   sin_path_ = _copyFrom.get_sin_path();
 }
 
@@ -49,6 +58,18 @@ void NetworkOptions::set_max_packet_size(sp_uint32 _max_packet_size) {
 }
 
 sp_uint32 NetworkOptions::get_max_packet_size() const { return max_packet_size_; }
+
+void NetworkOptions::set_high_watermark(sp_int64 _high_watermark) {
+  high_watermark_ = _high_watermark;
+}
+
+sp_int64 NetworkOptions::get_high_watermark() const { return high_watermark_; }
+
+void NetworkOptions::set_low_watermark(sp_int64 _low_watermark) {
+  low_watermark_ = _low_watermark;
+}
+
+sp_int64 NetworkOptions::get_low_watermark() const { return low_watermark_; }
 
 void NetworkOptions::set_socket_family(sp_int32 _socket_family) { socket_family_ = _socket_family; }
 

--- a/heron/common/src/cpp/network/networkoptions.cpp
+++ b/heron/common/src/cpp/network/networkoptions.cpp
@@ -18,9 +18,11 @@
 #include <arpa/inet.h>
 #include <string>
 
-// This is the high water mark on the num of bytes that can be left outstanding on a connection
+// This is the default high water mark on the num of bytes that can be left outstanding on
+// a connection
 const sp_int64 systemHWMOutstandingBytes = 1024 * 1024 * 100;  // 100M
-// This is the low water mark on the num of bytes that can be left outstanding on a connection
+// This is the default low water mark on the num of bytes that can be left outstanding on
+// a connection
 const sp_int64 systemLWMOutstandingBytes = 1024 * 1024 * 50;  // 50M
 
 NetworkOptions::NetworkOptions() {

--- a/heron/common/src/cpp/network/networkoptions.h
+++ b/heron/common/src/cpp/network/networkoptions.h
@@ -40,6 +40,12 @@ class NetworkOptions {
   // set the socket family
   void set_socket_family(sp_int32 socket_family);
 
+  // set high water mark for back pressure
+  void set_high_watermark(sp_int64 _high_watermark);
+
+  // set low water mark for back pressure
+  void set_low_watermark(sp_int64 _low_watermark);
+
   // set the sin path
   // applicable only for unix sockets
   void set_sin_path(const std::string& socket_path);
@@ -50,6 +56,12 @@ class NetworkOptions {
 
   // get functions for unix address family
   sp_uint32 get_max_packet_size() const;
+
+  // get high water mark for back pressure
+  sp_int64 get_high_watermark() const;
+
+  // get low water mark for back pressure
+  sp_int64 get_low_watermark() const;
 
   // get the family type
   sp_int32 get_socket_family() const;
@@ -76,6 +88,9 @@ class NetworkOptions {
   // Whats the socket path
   // applicable only for UNIX sockets
   std::string sin_path_;
+
+  sp_int64 high_watermark_;
+  sp_int64 low_watermark_;
 };
 
 #endif  // NETWORKOPTIONS_H_

--- a/heron/stmgr/src/cpp/manager/stmgr-clientmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-clientmgr.cpp
@@ -37,13 +37,16 @@ const sp_string METRIC_STMGR_NEW_CONNECTIONS = "__stmgr_new_connections";
 StMgrClientMgr::StMgrClientMgr(EventLoop* eventLoop, const sp_string& _topology_name,
                                const sp_string& _topology_id, const sp_string& _stmgr_id,
                                StMgr* _stream_manager,
-                               heron::common::MetricsMgrSt* _metrics_manager_client)
+                               heron::common::MetricsMgrSt* _metrics_manager_client,
+                               sp_int64 _high_watermark, sp_int64 _low_watermark)
     : topology_name_(_topology_name),
       topology_id_(_topology_id),
       stmgr_id_(_stmgr_id),
       eventLoop_(eventLoop),
       stream_manager_(_stream_manager),
-      metrics_manager_client_(_metrics_manager_client) {
+      metrics_manager_client_(_metrics_manager_client),
+      high_watermark_(_high_watermark),
+      low_watermark_(_low_watermark) {
   stmgr_clientmgr_metrics_ = new heron::common::MultiCountMetric();
   metrics_manager_client_->register_metric("__clientmgr", stmgr_clientmgr_metrics_);
 }
@@ -114,12 +117,8 @@ StMgrClient* StMgrClientMgr::CreateClient(const sp_string& _other_stmgr_id,
   options.set_max_packet_size(config::HeronInternalsConfigReader::Instance()
                                   ->GetHeronStreammgrNetworkOptionsMaximumPacketMb() *
                               1024 * 1024);
-  options.set_high_watermark(config::HeronInternalsConfigReader::Instance()
-                                    ->GetHeronStreammgrNetworkBackpressureHighwatermarkMb() *
-                              1024 * 1024);
-  options.set_low_watermark(config::HeronInternalsConfigReader::Instance()
-                                    ->GetHeronStreammgrNetworkBackpressureLowwatermarkMb() *
-                              1024 * 1024);
+  options.set_high_watermark(high_watermark_);
+  options.set_low_watermark(low_watermark_);
   options.set_socket_family(PF_INET);
   StMgrClient* client = new StMgrClient(eventLoop_, options, topology_name_, topology_id_,
                                         stmgr_id_, _other_stmgr_id, this, metrics_manager_client_);

--- a/heron/stmgr/src/cpp/manager/stmgr-clientmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-clientmgr.cpp
@@ -114,6 +114,12 @@ StMgrClient* StMgrClientMgr::CreateClient(const sp_string& _other_stmgr_id,
   options.set_max_packet_size(config::HeronInternalsConfigReader::Instance()
                                   ->GetHeronStreammgrNetworkOptionsMaximumPacketMb() *
                               1024 * 1024);
+  options.set_high_watermark(config::HeronInternalsConfigReader::Instance()
+                                    ->GetHeronStreammgrNetworkBackpressureHighwatermarkMb() *
+                              1024 * 1024);
+  options.set_low_watermark(config::HeronInternalsConfigReader::Instance()
+                                    ->GetHeronStreammgrNetworkBackpressureLowwatermarkMb() *
+                              1024 * 1024);
   options.set_socket_family(PF_INET);
   StMgrClient* client = new StMgrClient(eventLoop_, options, topology_name_, topology_id_,
                                         stmgr_id_, _other_stmgr_id, this, metrics_manager_client_);

--- a/heron/stmgr/src/cpp/manager/stmgr-clientmgr.h
+++ b/heron/stmgr/src/cpp/manager/stmgr-clientmgr.h
@@ -38,7 +38,8 @@ class StMgrClientMgr {
  public:
   StMgrClientMgr(EventLoop* eventLoop, const sp_string& _topology_name,
                  const sp_string& _topology_id, const sp_string& _stmgr_id, StMgr* _stream_manager,
-                 heron::common::MetricsMgrSt* _metrics_manager_client);
+                 heron::common::MetricsMgrSt* _metrics_manager_client, sp_int64 _high_watermark,
+                 sp_int64 _low_watermark);
   virtual ~StMgrClientMgr();
 
   void NewPhysicalPlan(const proto::system::PhysicalPlan* _pplan);
@@ -72,6 +73,9 @@ class StMgrClientMgr {
   // Metrics
   heron::common::MetricsMgrSt* metrics_manager_client_;
   heron::common::MultiCountMetric* stmgr_clientmgr_metrics_;
+
+  sp_int64 high_watermark_;
+  sp_int64 low_watermark_;
 };
 
 }  // namespace stmgr

--- a/heron/stmgr/src/cpp/manager/stmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr.cpp
@@ -190,6 +190,12 @@ void StMgr::StartStmgrServer() {
   sops.set_port(stmgr_port_);
   sops.set_socket_family(PF_INET);
   sops.set_max_packet_size(std::numeric_limits<sp_uint32>::max() - 1);
+  sops.set_high_watermark(config::HeronInternalsConfigReader::Instance()
+                              ->GetHeronStreammgrNetworkBackpressureHighwatermarkMb() *
+                              1024 * 1024);
+  sops.set_low_watermark(config::HeronInternalsConfigReader::Instance()
+                              ->GetHeronStreammgrNetworkBackpressureLowwatermarkMb() *
+                              1024 * 1024);
   server_ = new StMgrServer(eventLoop_, sops, topology_name_, topology_id_, stmgr_id_, instances_,
                             this, metrics_manager_client_);
 
@@ -206,6 +212,12 @@ void StMgr::CreateTMasterClient(proto::tmaster::TMasterLocation* tmasterLocation
   master_options.set_port(tmasterLocation->master_port());
   master_options.set_socket_family(PF_INET);
   master_options.set_max_packet_size(std::numeric_limits<sp_uint32>::max() - 1);
+  master_options.set_high_watermark(config::HeronInternalsConfigReader::Instance()
+                                        ->GetHeronStreammgrNetworkBackpressureHighwatermarkMb() *
+                                    1024 * 1024);
+  master_options.set_low_watermark(config::HeronInternalsConfigReader::Instance()
+                                        ->GetHeronStreammgrNetworkBackpressureLowwatermarkMb() *
+                                    1024 * 1024);
   auto pplan_watch = [this](proto::system::PhysicalPlan* pplan) { this->NewPhysicalPlan(pplan); };
 
   tmaster_client_ = new TMasterClient(eventLoop_, master_options, stmgr_id_, stmgr_port_,

--- a/heron/stmgr/src/cpp/manager/stmgr.h
+++ b/heron/stmgr/src/cpp/manager/stmgr.h
@@ -51,7 +51,8 @@ class StMgr {
   StMgr(EventLoop* eventLoop, sp_int32 _myport, const sp_string& _topology_name,
         const sp_string& _topology_id, proto::api::Topology* _topology, const sp_string& _stmgr_id,
         const std::vector<sp_string>& _instances, const sp_string& _zkhostport,
-        const sp_string& _zkroot, sp_int32 _metricsmgr_port, sp_int32 _shell_port);
+        const sp_string& _zkroot, sp_int32 _metricsmgr_port, sp_int32 _shell_port,
+        sp_int64 _high_watermark, sp_int64 _low_watermark);
   virtual ~StMgr();
 
   // All kinds of initialization like starting servers and clients
@@ -161,6 +162,9 @@ class StMgr {
   proto::system::HeronTupleSet2* tuple_set_from_other_stmgr_;
 
   sp_string heron_tuple_set_2_ = "heron.proto.system.HeronTupleSet2";
+
+  sp_int64 high_watermark_;
+  sp_int64 low_watermark_;
 };
 
 }  // namespace stmgr

--- a/heron/stmgr/src/cpp/server/stmgr-main.cpp
+++ b/heron/stmgr/src/cpp/server/stmgr-main.cpp
@@ -70,8 +70,15 @@ int main(int argc, char* argv[]) {
     LOG(FATAL) << "Corrupt topology defn file" << std::endl;
   }
 
+  sp_int64 high_watermark = heron::config::HeronInternalsConfigReader::Instance()
+                              ->GetHeronStreammgrNetworkBackpressureHighwatermarkMb() *
+                                1024 * 1024;
+  sp_int64 low_watermark = heron::config::HeronInternalsConfigReader::Instance()
+                              ->GetHeronStreammgrNetworkBackpressureLowwatermarkMb() *
+                                1024 * 1024;
   heron::stmgr::StMgr mgr(&ss, myport, topology_name, topology_id, topology, myid, instances,
-                          zkhostportlist, topdir, metricsmgr_port, shell_port);
+                          zkhostportlist, topdir, metricsmgr_port, shell_port, high_watermark,
+                          low_watermark);
   mgr.Init();
   ss.loop();
   return 0;

--- a/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
@@ -362,6 +362,10 @@ struct CommonResources {
     snprintf(dpath, sizeof(dpath), "%s", "/tmp/XXXXXX");
     mkdtemp(dpath);
     dpath_ = sp_string(dpath);
+    // Lets change the Connection buffer HWM and LWN for back pressure to get the
+    // test case done faster
+    high_watermark_ = 10 * 1024 * 1024;
+    low_watermark_ = 5 * 1024 * 1024;
   }
 };
 
@@ -840,10 +844,6 @@ TEST(StMgr, test_back_pressure_instance) {
   // Empty so that we don't attempt to connect to the zk
   // but instead connect to the local filesytem
   common.zkhostportlist_ = "";
-  // Lets change the Connection buffer HWM and LWN for back pressure to get the
-  // test case done faster
-  common.high_watermark_ = 10 * 1024 * 1024;
-  common.low_watermark_ = 5 * 1024 * 1024;
 
   int num_msgs_sent_by_spout_instance = 100 * 1000 * 1000;  // 100M
 
@@ -952,10 +952,6 @@ TEST(StMgr, test_spout_death_under_backpressure) {
   // Empty so that we don't attempt to connect to the zk
   // but instead connect to the local filesytem
   common.zkhostportlist_ = "";
-  // Lets change the Connection buffer HWM and LWN for back pressure to get the
-  // test case done faster
-  common.high_watermark_ = 10 * 1024 * 1024;
-  common.low_watermark_ = 5 * 1024 * 1024;
 
   int num_msgs_sent_by_spout_instance = 100 * 1000 * 1000;  // 100M
 
@@ -1089,8 +1085,7 @@ TEST(StMgr, test_back_pressure_stmgr) {
   // Empty so that we don't attempt to connect to the zk
   // but instead connect to the local filesytem
   common.zkhostportlist_ = "";
-  // Lets change the Connection buffer HWM and LWN for back pressure to get the
-  // test case done faster
+  // Overwrite the default values for back pressure
   common.high_watermark_ = 1 * 1024 * 1024;
   common.low_watermark_ = 500 * 1024;
 
@@ -1204,10 +1199,6 @@ TEST(StMgr, test_back_pressure_stmgr_reconnect) {
   // Empty so that we don't attempt to connect to the zk
   // but instead connect to the local filesytem
   common.zkhostportlist_ = "";
-  // Lets change the Connection buffer HWM and LWN for back pressure to get the
-  // test case done faster
-  common.high_watermark_ = 10 * 1024 * 1024;
-  common.low_watermark_ = 5 * 1024 * 1024;
 
   int num_msgs_sent_by_spout_instance = 100 * 1000 * 1000;  // 100M
 
@@ -1319,11 +1310,6 @@ TEST(StMgr, test_tmaster_restart_on_new_address) {
   // Empty so that we don't attempt to connect to the zk
   // but instead connect to the local filesytem
   common.zkhostportlist_ = "";
-
-  // Lets change the Connection buffer HWM and LWN for back pressure to get the
-  // test case done faster
-  common.high_watermark_ = 10 * 1024 * 1024;
-  common.low_watermark_ = 5 * 1024 * 1024;
 
   int num_msgs_sent_by_spout_instance = 100 * 1000 * 1000;  // 100M
 
@@ -1451,11 +1437,6 @@ TEST(StMgr, test_tmaster_restart_on_same_address) {
   // Empty so that we don't attempt to connect to the zk
   // but instead connect to the local filesytem
   common.zkhostportlist_ = "";
-
-  // Lets change the Connection buffer HWM and LWN for back pressure to get the
-  // test case done faster
-  common.high_watermark_ = 10 * 1024 * 1024;
-  common.low_watermark_ = 5 * 1024 * 1024;
 
   int num_msgs_sent_by_spout_instance = 100 * 1000 * 1000;  // 100M
 
@@ -1587,10 +1568,6 @@ TEST(StMgr, test_metricsmgr_reconnect) {
   // Empty so that we don't attempt to connect to the zk
   // but instead connect to the local filesytem
   common.zkhostportlist_ = "";
-  // Lets change the Connection buffer HWM and LWN for back pressure to get the
-  // test case done faster
-  common.high_watermark_ = 10 * 1024 * 1024;
-  common.low_watermark_ = 5 * 1024 * 1024;
 
   int num_msgs_sent_by_spout_instance = 100 * 1000 * 1000;  // 100M
 


### PR DESCRIPTION
heron.streammgr.network.backpressure.highwatermark.mb and heron.streammgr.network.backpressure.lowwatermark.mb are already available in heron_internals.yaml, but we never actually read them from it. This PR makes stream manager reading these configs from heron_internals.yaml. Note, other non-stmgr connections still use the default values in the original code.

This resolves #1750.