### PR TITLE
Define suffix for KB, MB, s, ms

### DIFF
--- a/heron/common/src/cpp/basics/spconsts.h
+++ b/heron/common/src/cpp/basics/spconsts.h
@@ -23,6 +23,8 @@
 #if !defined(HERON_CONSTS_H_)
 #define HERON_CONSTS_H_
 
+#include "basics/sptypes.h"
+
 // constants related to logs
 constexpr auto constMaxNumLogFiles = 5;
 constexpr auto constLogsDirectory = "log-files";
@@ -37,5 +39,21 @@ constexpr auto constPathSeparator = "/";
 constexpr auto constTcpKeepAliveSecs = 300;          // 5 min
 constexpr auto constTcpKeepAliveProbeInterval = 10;  // 10 seconds
 constexpr auto constTcpKeepAliveProbes = 5;
+
+constexpr sp_int64 operator"" _KB(unsigned long long bytes) { // NOLINT
+    return (sp_int64)bytes * 1024;
+}
+
+constexpr sp_int64 operator"" _MB(unsigned long long bytes) { // NOLINT
+    return (sp_int64)bytes * 1024 * 1024;
+}
+
+constexpr sp_int64 operator"" _s(unsigned long long us) { // NOLINT
+    return (sp_int64)us * 1000000;
+}
+
+constexpr sp_int64 operator"" _ms(unsigned long long us) { // NOLINT
+    return (sp_int64)us * 1000;
+}
 
 #endif

--- a/heron/common/src/cpp/basics/spconsts.h
+++ b/heron/common/src/cpp/basics/spconsts.h
@@ -40,20 +40,20 @@ constexpr auto constTcpKeepAliveSecs = 300;          // 5 min
 constexpr auto constTcpKeepAliveProbeInterval = 10;  // 10 seconds
 constexpr auto constTcpKeepAliveProbes = 5;
 
-constexpr sp_int64 operator"" _KB(unsigned long long bytes) { // NOLINT
-    return (sp_int64)bytes * 1024;
+constexpr sp_int64 operator"" _KB(unsigned long long kilobytes) { // NOLINT
+    return (sp_int64)kilobytes * 1024;
 }
 
-constexpr sp_int64 operator"" _MB(unsigned long long bytes) { // NOLINT
-    return (sp_int64)bytes * 1024 * 1024;
+constexpr sp_int64 operator"" _MB(unsigned long long megabytes) { // NOLINT
+    return (sp_int64)megabytes * 1024 * 1024;
 }
 
-constexpr sp_int64 operator"" _s(unsigned long long us) { // NOLINT
-    return (sp_int64)us * 1000000;
+constexpr sp_int64 operator"" _s(unsigned long long sec) { // NOLINT
+    return (sp_int64)sec * 1000000;
 }
 
-constexpr sp_int64 operator"" _ms(unsigned long long us) { // NOLINT
-    return (sp_int64)us * 1000;
+constexpr sp_int64 operator"" _ms(unsigned long long ms) { // NOLINT
+    return (sp_int64)ms * 1000;
 }
 
 #endif

--- a/heron/common/src/cpp/network/networkoptions.cpp
+++ b/heron/common/src/cpp/network/networkoptions.cpp
@@ -17,18 +17,19 @@
 #include "network/networkoptions.h"
 #include <arpa/inet.h>
 #include <string>
+#include "basics/spconsts.h"
 
 // This is the default high water mark on the num of bytes that can be left outstanding on
 // a connection
-const sp_int64 systemHWMOutstandingBytes = 1024 * 1024 * 100;  // 100M
+const sp_int64 systemHWMOutstandingBytes = 100_MB;
 // This is the default low water mark on the num of bytes that can be left outstanding on
 // a connection
-const sp_int64 systemLWMOutstandingBytes = 1024 * 1024 * 50;  // 50M
+const sp_int64 systemLWMOutstandingBytes = 50_MB;
 
 NetworkOptions::NetworkOptions() {
   host_ = "localhost";
   port_ = 8080;
-  max_packet_size_ = 1024;
+  max_packet_size_ = 1_KB;
   socket_family_ = PF_INET;
   sin_path_ = "";
   high_watermark_ = systemHWMOutstandingBytes;

--- a/heron/stmgr/src/cpp/dummy/dummytmaster-main.cpp
+++ b/heron/stmgr/src/cpp/dummy/dummytmaster-main.cpp
@@ -48,7 +48,7 @@ int main(int argc, char* argv[]) {
   NetworkOptions options;
   options.set_host(myhost);
   options.set_port(master_port);
-  options.set_max_packet_size(1024 * 1024);
+  options.set_max_packet_size(1_MB);
   options.set_socket_family(PF_INET);
   heron::tmaster::TMasterServer tmaster(&ss, options, topology_name, zkhostportlist, topdir,
                                         stmgrs);

--- a/heron/stmgr/src/cpp/manager/stmgr-clientmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-clientmgr.cpp
@@ -115,8 +115,7 @@ StMgrClient* StMgrClientMgr::CreateClient(const sp_string& _other_stmgr_id,
   options.set_host(_hostname);
   options.set_port(_port);
   options.set_max_packet_size(config::HeronInternalsConfigReader::Instance()
-                                  ->GetHeronStreammgrNetworkOptionsMaximumPacketMb() *
-                              1024 * 1024);
+                                  ->GetHeronStreammgrNetworkOptionsMaximumPacketMb() * 1_MB);
   options.set_high_watermark(high_watermark_);
   options.set_low_watermark(low_watermark_);
   options.set_socket_family(PF_INET);

--- a/heron/stmgr/src/cpp/manager/stmgr-server.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-server.cpp
@@ -77,7 +77,7 @@ const sp_string METRIC_TIME_SPENT_BACK_PRESSURE_COMPID = "__time_spent_back_pres
 const sp_string CONNECTION_BUFFER_BY_INSTANCEID = "__connection_buffer_by_instanceid/";
 
 // TODO(mfu): Read this value from config
-const sp_int64 SYSTEM_METRICS_SAMPLE_INTERVAL_MICROSECOND = 10 * 1000 * 1000;
+const sp_int64 SYSTEM_METRICS_SAMPLE_INTERVAL_MICROSECOND = 10_s;
 
 
 StMgrServer::StMgrServer(EventLoop* eventLoop, const NetworkOptions& _options,

--- a/heron/stmgr/src/cpp/server/stmgr-main.cpp
+++ b/heron/stmgr/src/cpp/server/stmgr-main.cpp
@@ -72,10 +72,10 @@ int main(int argc, char* argv[]) {
 
   sp_int64 high_watermark = heron::config::HeronInternalsConfigReader::Instance()
                               ->GetHeronStreammgrNetworkBackpressureHighwatermarkMb() *
-                                1024 * 1024;
+                                1_MB;
   sp_int64 low_watermark = heron::config::HeronInternalsConfigReader::Instance()
                               ->GetHeronStreammgrNetworkBackpressureLowwatermarkMb() *
-                                1024 * 1024;
+                                1_MB;
   heron::stmgr::StMgr mgr(&ss, myport, topology_name, topology_id, topology, myid, instances,
                           zkhostportlist, topdir, metricsmgr_port, shell_port, high_watermark,
                           low_watermark);

--- a/heron/stmgr/tests/cpp/server/dummy_stmgr.cpp
+++ b/heron/stmgr/tests/cpp/server/dummy_stmgr.cpp
@@ -85,7 +85,7 @@ DummyStMgr::DummyStMgr(EventLoopImpl* ss, const NetworkOptions& options, const s
   NetworkOptions tmaster_options;
   tmaster_options.set_host(tmaster_host);
   tmaster_options.set_port(tmaster_port);
-  tmaster_options.set_max_packet_size(1024 * 1024);
+  tmaster_options.set_max_packet_size(1_MB);
   tmaster_options.set_socket_family(PF_INET);
 
   tmaster_client_ = new DummyTMasterClient(ss, tmaster_options, stmgr_id, stmgr_host, stmgr_port,

--- a/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
@@ -223,7 +223,7 @@ void StartDummyStMgr(EventLoopImpl*& ss, DummyStMgr*& mgr, std::thread*& stmgr_t
   NetworkOptions options;
   options.set_host(LOCALHOST);
   options.set_port(stmgr_port);
-  options.set_max_packet_size(1024 * 1024);
+  options.set_max_packet_size(1_MB);
   options.set_socket_family(PF_INET);
 
   mgr = new DummyStMgr(ss, options, stmgr_id, LOCALHOST, stmgr_port, LOCALHOST, tmaster_port,
@@ -241,7 +241,7 @@ void StartDummyMtrMgr(EventLoopImpl*& ss, DummyMtrMgr*& mgr, std::thread*& mtmgr
   NetworkOptions options;
   options.set_host(LOCALHOST);
   options.set_port(mtmgr_port);
-  options.set_max_packet_size(1024 * 1024);
+  options.set_max_packet_size(1_MB);
   options.set_socket_family(PF_INET);
 
   mgr = new DummyMtrMgr(ss, options, stmgr_id, tmasterLatch, connectionCloseLatch);
@@ -262,7 +262,7 @@ void StartDummySpoutInstance(EventLoopImpl*& ss, DummySpoutInstance*& worker,
   NetworkOptions options;
   options.set_host(LOCALHOST);
   options.set_port(stmgr_port);
-  options.set_max_packet_size(1024 * 1024);
+  options.set_max_packet_size(1_MB);
   options.set_socket_family(PF_INET);
 
   worker = new DummySpoutInstance(ss, options, topology_name, topology_id, instance_id,
@@ -284,7 +284,7 @@ void StartDummyBoltInstance(EventLoopImpl*& ss, DummyBoltInstance*& worker,
   NetworkOptions options;
   options.set_host(LOCALHOST);
   options.set_port(stmgr_port);
-  options.set_max_packet_size(1024 * 1024);
+  options.set_max_packet_size(1_MB);
   options.set_socket_family(PF_INET);
 
   worker =
@@ -364,8 +364,8 @@ struct CommonResources {
     dpath_ = sp_string(dpath);
     // Lets change the Connection buffer HWM and LWN for back pressure to get the
     // test case done faster
-    high_watermark_ = 10 * 1024 * 1024;
-    low_watermark_ = 5 * 1024 * 1024;
+    high_watermark_ = 10_MB;
+    low_watermark_ = 5_MB;
   }
 };
 
@@ -1086,8 +1086,8 @@ TEST(StMgr, test_back_pressure_stmgr) {
   // but instead connect to the local filesytem
   common.zkhostportlist_ = "";
   // Overwrite the default values for back pressure
-  common.high_watermark_ = 1 * 1024 * 1024;
-  common.low_watermark_ = 500 * 1024;
+  common.high_watermark_ = 1_MB;
+  common.low_watermark_ = 500_KB;
 
   int num_msgs_sent_by_spout_instance = 500 * 1000 * 1000;  // 100M
 

--- a/heron/stmgr/tests/cpp/util/tuple-cache_unittest.cpp
+++ b/heron/stmgr/tests/cpp/util/tuple-cache_unittest.cpp
@@ -116,7 +116,7 @@ TEST(TupleCache, test_simple_data_drain) {
 
   // 300 milliseconds second
   auto cb = [&ss](EventLoopImpl::Status status) { DoneHandler(&ss, status); };
-  ss.registerTimer(std::move(cb), false, 300000);
+  ss.registerTimer(std::move(cb), false, 300_ms);
 
   ss.loop();
 


### PR DESCRIPTION
Since C++11, we are allowed to define our own suffix for constants like KB, MB etc., use this new feature to replace hard-coded "1024 * 1024".

This resolves #1758.