### PR TITLE
[DO NOT MERGE] Initial Dhalion API for auto-scaling and tuning

### DIFF
--- a/contrib/dhalion/pom.xml
+++ b/contrib/dhalion/pom.xml
@@ -1,0 +1,66 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.dhalion</groupId>
+  <artifactId>dhalion</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>dhalion</name>
+  <url>http://maven.apache.org</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <version>4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject.extensions</groupId>
+      <artifactId>guice-assistedinject</artifactId>
+      <version>4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.twitter.heron</groupId>
+      <artifactId>heron-spi</artifactId>
+      <version>0.14.6</version>
+    </dependency>
+    <dependency>
+      <groupId>com.twitter.heron</groupId>
+      <artifactId>heron-scheduler</artifactId>
+      <version>0.14.6</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+      <version>1.3.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+    </plugins>
+    <sourceDirectory>src/main/java</sourceDirectory>
+    <testSourceDirectory>src/test/java</testSourceDirectory>
+  </build>
+</project>

--- a/contrib/dhalion/src/main/java/org/apache/dhalion/api/IDiagnoser.java
+++ b/contrib/dhalion/src/main/java/org/apache/dhalion/api/IDiagnoser.java
@@ -1,0 +1,41 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.apache.dhalion.api;
+
+import org.apache.dhalion.symptom.Diagnosis;
+import org.apache.dhalion.symptom.Symptom;
+
+/**
+ * A {@link IDiagnoser} evaluates one or more {@link Symptom}s and produces a {@link Diagnosis}, if
+ * any, representing a possible problem responsible for the observed {@link Symptom}s.
+ */
+public interface IDiagnoser<T extends Symptom> extends AutoCloseable {
+  /**
+   * Initializes this instance and should be invoked once by the system before its use.
+   */
+  void initialize();
+
+  /**
+   * Evaluates available {@link Symptom}s and determines if a problem exists
+   *
+   * @return a {@link Diagnosis} instance representing a problem
+   */
+  Diagnosis<T> diagnose();
+
+  /**
+   * Release all acquired resources and prepare for termination of this instance
+   */
+  default void close() {
+  }
+}

--- a/contrib/dhalion/src/main/java/org/apache/dhalion/api/IHealthPolicy.java
+++ b/contrib/dhalion/src/main/java/org/apache/dhalion/api/IHealthPolicy.java
@@ -1,0 +1,38 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.apache.dhalion.api;
+
+/**
+ * A {@link IHealthPolicy} strives to keep a distributed application healthy. It uses one or more of
+ * of {@link ISymptomDetector}s, {@link IDiagnoser}s and {@link IResolver}s to achieve this. It is
+ * expected that the policy will be executed periodically.
+ */
+public interface IHealthPolicy extends AutoCloseable {
+  /**
+   * Initializes this instance and should be invoked once by the system before its use.
+   */
+  void initialize();
+
+  /**
+   * Invoked periodically, this method orchestrates execution of {@link ISymptomDetector}s,
+   * {@link IDiagnoser}s and {@link IResolver}s to keep the system healthy
+   */
+  void execute();
+
+  /**
+   * Release all acquired resources and prepare for termination of this instance
+   */
+  void close();
+}

--- a/contrib/dhalion/src/main/java/org/apache/dhalion/api/IResolver.java
+++ b/contrib/dhalion/src/main/java/org/apache/dhalion/api/IResolver.java
@@ -1,0 +1,46 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.apache.dhalion.api;
+
+import java.util.Collection;
+
+import org.apache.dhalion.symptom.Diagnosis;
+import org.apache.dhalion.symptom.Symptom;
+import org.apache.dhalion.resolver.Action;
+
+/**
+ * A {@link IResolver}'s major goal is to resolve the anomaly identified by a {@link Diagnosis}.
+ * Input to a {@link IResolver} is a {@link Diagnosis} instance and based on that, it executes
+ * appropriate action to bring a linked component or system back to a healthy state.
+ */
+public interface IResolver<T extends Symptom> extends AutoCloseable {
+  /**
+   * This method is invoked once to initialize the {@link IResolver} instance
+   */
+  void initialize();
+
+  /**
+   * {@link IResolver#resolve} is invoked to fix one or more problems identified in the
+   * {@link Diagnosis} instance.
+   *
+   * @return all the actions executed by this resolver to mitigate the problems
+   */
+  Collection<Action> resolve(Diagnosis<T> diagnosis);
+
+  /**
+   * Release all acquired resources and prepare for termination of this instance
+   */
+  default void close() {
+  }
+}

--- a/contrib/dhalion/src/main/java/org/apache/dhalion/api/ISymptomDetector.java
+++ b/contrib/dhalion/src/main/java/org/apache/dhalion/api/ISymptomDetector.java
@@ -1,0 +1,36 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License
+package org.apache.dhalion.api;
+
+import java.util.Collection;
+
+import org.apache.dhalion.symptom.Symptom;
+
+public interface ISymptomDetector<T extends Symptom> extends AutoCloseable {
+  /**
+   * Initializes this instance and should be invoked once by the system before its use.
+   */
+  void initialize();
+
+  /**
+   * Detects a problem or issue with the distributed application
+   */
+  Collection<T> detect();
+
+  /**
+   * Release all acquired resources and prepare for termination of this instance
+   */
+  default void close() {
+  }
+}

--- a/contrib/dhalion/src/main/java/org/apache/dhalion/api/MetricsProvider.java
+++ b/contrib/dhalion/src/main/java/org/apache/dhalion/api/MetricsProvider.java
@@ -1,0 +1,38 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.apache.dhalion.api;
+
+import org.apache.dhalion.metrics.MetricsInfo;
+import org.apache.dhalion.symptom.ComponentInfo;
+import org.apache.dhalion.symptom.InstanceInfo;
+
+/**
+ * A {@link MetricsProvider} implementation will fetch and provide metrics to the consumers. For
+ * e.g. a {@link ISymptomDetector} may use it to get execute latency for a component.
+ */
+public interface MetricsProvider extends AutoCloseable {
+  <T extends ComponentInfo> MetricsInfo getComponentMetric(String metricName,
+                                                           T component,
+                                                           long duration);
+
+  <T extends InstanceInfo> MetricsInfo getInstanceMetric(String metricName,
+                                                         T instance,
+                                                         long duration);
+
+  /**
+   * Release all acquired resources and prepare for termination of this instance
+   */
+  default void close() {
+  }
+}

--- a/contrib/dhalion/src/main/java/org/apache/dhalion/heron/common/BaseHeronDetector.java
+++ b/contrib/dhalion/src/main/java/org/apache/dhalion/heron/common/BaseHeronDetector.java
@@ -1,0 +1,39 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License
+package org.apache.dhalion.heron.common;
+
+import javax.inject.Inject;
+
+import org.apache.dhalion.api.ISymptomDetector;
+import org.apache.dhalion.api.MetricsProvider;
+import org.apache.dhalion.symptom.Symptom;
+
+import com.twitter.heron.spi.common.Config;
+
+public abstract class BaseHeronDetector<T extends Symptom> implements ISymptomDetector<T> {
+  @Inject
+  protected Config config;
+  @Inject
+  protected Config runtimeConfig;
+  @Inject
+  protected MetricsProvider metricsProvider;
+  @Inject
+  protected TopologyProvider topologyProvider;
+  @Inject
+  protected PackingPlanProvider packingPlanProvider;
+
+  @Override
+  public void initialize() {
+  }
+}

--- a/contrib/dhalion/src/main/java/org/apache/dhalion/heron/common/BaseHeronDiagnoser.java
+++ b/contrib/dhalion/src/main/java/org/apache/dhalion/heron/common/BaseHeronDiagnoser.java
@@ -1,0 +1,35 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License
+package org.apache.dhalion.heron.common;
+
+
+import javax.inject.Inject;
+
+import org.apache.dhalion.api.IDiagnoser;
+import org.apache.dhalion.symptom.ComponentSymptom;
+
+import com.twitter.heron.spi.common.Config;
+
+public abstract class BaseHeronDiagnoser implements IDiagnoser<ComponentSymptom> {
+  @Inject
+  protected Config config;
+  @Inject
+  protected Config runtimeConfig;
+  @Inject
+  protected TopologyProvider topologyProvider;
+
+  @Override
+  public void initialize() {
+  }
+}

--- a/contrib/dhalion/src/main/java/org/apache/dhalion/heron/common/BaseHeronPolicy.java
+++ b/contrib/dhalion/src/main/java/org/apache/dhalion/heron/common/BaseHeronPolicy.java
@@ -1,0 +1,35 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License
+package org.apache.dhalion.heron.common;
+
+import javax.inject.Inject;
+
+import org.apache.dhalion.api.IHealthPolicy;
+import org.apache.dhalion.api.IResolver;
+import org.apache.dhalion.symptom.ComponentSymptom;
+
+import com.twitter.heron.spi.common.Config;
+
+public abstract class BaseHeronPolicy implements IHealthPolicy {
+  @Inject
+  protected Config config;
+  @Inject
+  protected Config runtimeConfig;
+  @Inject
+  protected TopologyProvider topologyProvider;
+
+  @Override
+  public void initialize() {
+  }
+}

--- a/contrib/dhalion/src/main/java/org/apache/dhalion/heron/common/BaseHeronResolver.java
+++ b/contrib/dhalion/src/main/java/org/apache/dhalion/heron/common/BaseHeronResolver.java
@@ -1,0 +1,36 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License
+package org.apache.dhalion.heron.common;
+
+
+import javax.inject.Inject;
+
+import org.apache.dhalion.api.IDiagnoser;
+import org.apache.dhalion.api.IResolver;
+import org.apache.dhalion.symptom.ComponentSymptom;
+
+import com.twitter.heron.spi.common.Config;
+
+public abstract class BaseHeronResolver implements IResolver<ComponentSymptom> {
+  @Inject
+  protected Config config;
+  @Inject
+  protected Config runtimeConfig;
+  @Inject
+  protected TopologyProvider topologyProvider;
+
+  @Override
+  public void initialize() {
+  }
+}

--- a/contrib/dhalion/src/main/java/org/apache/dhalion/heron/common/HeronComponentInfo.java
+++ b/contrib/dhalion/src/main/java/org/apache/dhalion/heron/common/HeronComponentInfo.java
@@ -1,0 +1,30 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.apache.dhalion.heron.common;
+
+import java.util.Collection;
+
+import org.apache.dhalion.symptom.InstanceInfo;
+
+/**
+ * An {@link HeronComponentInfo} holds information pertinent to a Heron topology component. For
+ * e.g. has aggregate count of tuples emitted by all the spout intances, {@link InstanceInfo}.
+ */
+public class HeronComponentInfo {
+  private Collection<InstanceInfo> instances;
+
+  public HeronComponentInfo(Collection<InstanceInfo> instances) {
+    this.instances = instances;
+  }
+}

--- a/contrib/dhalion/src/main/java/org/apache/dhalion/heron/common/HeronInstanceInfo.java
+++ b/contrib/dhalion/src/main/java/org/apache/dhalion/heron/common/HeronInstanceInfo.java
@@ -1,0 +1,32 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.apache.dhalion.heron.common;
+
+import org.apache.dhalion.symptom.InstanceInfo;
+
+import com.twitter.heron.spi.packing.PackingPlan;
+
+/**
+ * An {@link HeronInstanceInfo} holds information pertinent to a instance of a Heron topology
+ * component. For e.g. has task id of a bolt instance.
+ */
+public class HeronInstanceInfo extends InstanceInfo {
+  private int containerId;
+  private PackingPlan.InstancePlan instance;
+
+  public HeronInstanceInfo(int containerId, PackingPlan.InstancePlan instance) {
+    this.containerId = containerId;
+    this.instance = instance;
+  }
+}

--- a/contrib/dhalion/src/main/java/org/apache/dhalion/heron/common/PackingPlanProvider.java
+++ b/contrib/dhalion/src/main/java/org/apache/dhalion/heron/common/PackingPlanProvider.java
@@ -1,0 +1,33 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.apache.dhalion.heron.common;
+
+
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import com.twitter.heron.api.generated.TopologyAPI;
+import com.twitter.heron.spi.packing.PackingPlan;
+
+/**
+ * A topology may be updated after initial deployment. This provider is used to provide the latest
+ * version to any dependent components.
+ */
+@Singleton
+public class PackingPlanProvider implements Provider<PackingPlan> {
+  @Override
+  public PackingPlan get() {
+    return null;
+  }
+}

--- a/contrib/dhalion/src/main/java/org/apache/dhalion/heron/common/TopologyProvider.java
+++ b/contrib/dhalion/src/main/java/org/apache/dhalion/heron/common/TopologyProvider.java
@@ -1,0 +1,32 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.apache.dhalion.heron.common;
+
+
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import com.twitter.heron.api.generated.TopologyAPI;
+
+/**
+ * A topology may be updated after initial deployment. This provider is used to provide the latest
+ * version to any dependent components.
+ */
+@Singleton
+public class TopologyProvider implements Provider<TopologyAPI.Topology> {
+  @Override
+  public TopologyAPI.Topology get() {
+    return null;
+  }
+}

--- a/contrib/dhalion/src/main/java/org/apache/dhalion/metrics/MetricsInfo.java
+++ b/contrib/dhalion/src/main/java/org/apache/dhalion/metrics/MetricsInfo.java
@@ -1,0 +1,53 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.apache.dhalion.metrics;
+
+/**
+ * An {@link MetricsInfo} holds information pertinent to a specific metric. For e.g. has latency
+ * metric of a bolt instance for a Storm or Heron topology.
+ */
+public abstract class MetricsInfo {
+  private String name;
+  private MetricValue value;
+  private long timestamp;
+  private long duration;
+
+  public String getName() {
+    return name;
+  }
+
+  public MetricValue getValue() {
+    return value;
+  }
+
+  public static class MetricValue implements Comparable<MetricValue> {
+    Double value;
+
+    public int asInt() {
+      return value.intValue();
+    }
+
+    @Override
+    public int compareTo(MetricValue o) {
+      throw new UnsupportedOperationException("Needs to be implemented");
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == null)
+        return false;
+      throw new UnsupportedOperationException("Needs to be implemented");
+    }
+  }
+}

--- a/contrib/dhalion/src/main/java/org/apache/dhalion/resolver/Action.java
+++ b/contrib/dhalion/src/main/java/org/apache/dhalion/resolver/Action.java
@@ -1,0 +1,24 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.apache.dhalion.resolver;
+
+import org.apache.dhalion.api.IResolver;
+import org.apache.dhalion.symptom.Diagnosis;
+
+/**
+ * {@link Action} is a representation of a action taken by {@link IResolver} to fix a
+ * {@link Diagnosis}
+ */
+public class Action {
+}

--- a/contrib/dhalion/src/main/java/org/apache/dhalion/symptom/ComponentInfo.java
+++ b/contrib/dhalion/src/main/java/org/apache/dhalion/symptom/ComponentInfo.java
@@ -1,0 +1,29 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.apache.dhalion.symptom;
+
+import java.util.Collection;
+
+/**
+ * An {@link ComponentInfo} holds information pertinent to a component of a distributed application.
+ * For e.g. has aggregate count of tuples emitted by all the spout intances, {@link InstanceInfo}.
+ */
+public abstract class ComponentInfo {
+  Collection<InstanceInfo> instances;
+  String name;
+
+  public String getName() {
+    return name;
+  }
+}

--- a/contrib/dhalion/src/main/java/org/apache/dhalion/symptom/ComponentSymptom.java
+++ b/contrib/dhalion/src/main/java/org/apache/dhalion/symptom/ComponentSymptom.java
@@ -1,0 +1,72 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.apache.dhalion.symptom;
+
+import java.util.Collection;
+
+import org.apache.dhalion.metrics.MetricsInfo;
+
+/**
+ * {@link ComponentSymptom} represents a issue with a component in a distributed system. The issue
+ * could be result of multiple {@link InstanceSymptom}s.
+ */
+public class ComponentSymptom extends Symptom {
+  private ComponentInfo componentInfo;
+  private Collection<InstanceSymptom> instanceSymptoms;
+
+  public ComponentSymptom(ComponentInfo componentInfo) {
+    this.componentInfo = componentInfo;
+  }
+
+  public void addInstanceSymptom(InstanceSymptom instanceSymptom) {
+    instanceSymptoms.add(instanceSymptom);
+  }
+
+  @Override
+  public String toString() {
+    return "ComponentSymptom{" +
+        "componentInfo=" + componentInfo +
+        ", instancesSymptoms=" + instanceSymptoms +
+        '}';
+  }
+
+  public ComponentInfo getComponentInfo() {
+    return componentInfo;
+  }
+
+  public Collection<InstanceSymptom> getInstanceSymptoms() {
+    return instanceSymptoms;
+  }
+
+  public boolean hasMetric(String metricName) {
+    return hasMetric(metricName, null);
+  }
+
+  public boolean hasMetric(String metricName, MetricsInfo.MetricValue value) {
+    return instanceSymptoms
+        .stream()
+        .filter(x -> x.hasMetric(metricName, value).isPresent())
+        .findAny()
+        .isPresent();
+  }
+
+  public boolean hasMetricBelowLimit(String metricName, MetricsInfo.MetricValue limit) {
+    return instanceSymptoms
+        .stream()
+        .filter(x -> x.hasMetricBelowLimit(metricName, limit).isPresent())
+        .findAny()
+        .isPresent();
+  }
+}
+

--- a/contrib/dhalion/src/main/java/org/apache/dhalion/symptom/Diagnosis.java
+++ b/contrib/dhalion/src/main/java/org/apache/dhalion/symptom/Diagnosis.java
@@ -1,0 +1,49 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.apache.dhalion.symptom;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A {@link Diagnosis} instance is a representation of a possible causes of one or more
+ * {@link Symptom}s. A {@link Symptom} could result in creation of one or more {@link Diagnosis}.
+ * Similarly, correlated {@link Symptom}s can result in generation of a {@link Diagnosis} instance.
+ */
+public class Diagnosis<T extends Symptom> {
+  private Set<T> symptoms;
+
+  public Diagnosis() {
+    symptoms = new HashSet<>();
+  }
+
+  public Diagnosis(Set<T> correlatedSymptoms) {
+    this.symptoms = correlatedSymptoms;
+  }
+
+  public Set<T> getSymptoms() {
+    return symptoms;
+  }
+
+  public void addSymptom(T item) {
+    symptoms.add(item);
+  }
+
+  @Override
+  public String toString() {
+    return "Diagnosis{" +
+        "symptom=" + symptoms +
+        '}';
+  }
+}

--- a/contrib/dhalion/src/main/java/org/apache/dhalion/symptom/InstanceInfo.java
+++ b/contrib/dhalion/src/main/java/org/apache/dhalion/symptom/InstanceInfo.java
@@ -1,0 +1,26 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.apache.dhalion.symptom;
+
+/**
+ * An {@link InstanceInfo} holds information pertinent to a specific instance of a component of a
+ * distributed application. For e.g. has task id of a bolt instance for a Storm or Heron topology.
+ */
+public abstract class InstanceInfo {
+  private String name;
+
+  public String getName() {
+    return name;
+  }
+}

--- a/contrib/dhalion/src/main/java/org/apache/dhalion/symptom/InstanceSymptom.java
+++ b/contrib/dhalion/src/main/java/org/apache/dhalion/symptom/InstanceSymptom.java
@@ -1,0 +1,53 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.apache.dhalion.symptom;
+
+import java.util.Collection;
+import java.util.Optional;
+
+import org.apache.dhalion.metrics.MetricsInfo;
+import org.apache.dhalion.metrics.MetricsInfo.MetricValue;
+
+/**
+ * {@link InstanceSymptom} hasMetric relevant {@link MetricsInfo} of an unhealthy
+ * {@link InstanceInfo}
+ */
+public class InstanceSymptom extends Symptom {
+  private InstanceInfo instanceInfo;
+  private Collection<MetricsInfo> metrics;
+
+  public InstanceSymptom(InstanceInfo instanceInfo, Collection<MetricsInfo> metrics) {
+    this.instanceInfo = instanceInfo;
+    this.metrics = metrics;
+  }
+
+  public InstanceInfo getInstanceInfo() {
+    return instanceInfo;
+  }
+
+  public Optional<MetricsInfo> hasMetric(String metricName) {
+    return hasMetric(metricName, null);
+  }
+
+  public Optional<MetricsInfo> hasMetric(String metricName, MetricValue value) {
+    return metrics
+        .stream()
+        .filter(x -> x.getName().equals(metricName) && x.getValue().equals(value))
+        .findFirst();
+  }
+
+  public Optional<MetricsInfo> hasMetricBelowLimit(String metricName, MetricValue value) {
+    return metrics.stream().filter(x -> value.compareTo(x.getValue()) > 0).findFirst();
+  }
+}

--- a/contrib/dhalion/src/main/java/org/apache/dhalion/symptom/Symptom.java
+++ b/contrib/dhalion/src/main/java/org/apache/dhalion/symptom/Symptom.java
@@ -1,0 +1,32 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.apache.dhalion.symptom;
+
+/**
+ * A {@link Symptom} identifies an anomaly or a potential health issue in a specific component or
+ * in the distributed application in general. For e.g. identification of irregular processing
+ * latency.
+ */
+public abstract class Symptom {
+  long observedAt;
+  long duration;
+
+  public long getObservedAt() {
+    return observedAt;
+  }
+
+  public long getDuration() {
+    return duration;
+  }
+}


### PR DESCRIPTION
This is initial review request for Dhalion. The aim of this PR is to review Dhalion API and the general direction. This is work in progress.

Dhalion is a toolkit for auto-scaling and auto-tuning a topology dynamically. Highlights:
1.  Dhalion will provide a set of algorithms to monitor a topology (`ISymptomDetector.java`), correlate the observations to identify the problem (`IDiagnoser.java`) and potentially resolve the issue (`IResolver.java`).
1. The algorithms above will become the building blocks for a policy, `IHealthPolicy.java`. An admin would compose a health policy using one or more algorithm implementations and provide configuration to customize the behavior of the policy. 
1. A `HealthManager` will periodically execute the health policies to keep a running topology healthy. The `HealthManager` process could manage the topology using one or more policies. 
1. Dhalion depends on metrics provided by `heron-tracker` or `metrics-cache` and employs `heron update` feature to manage the topology configuration.
1. Some of the algorithms are generic and could be integrated with other streaming systems, for e.g. Storm. With this goal, we plan to keep the code in a separate package and minimize dependency on Heron.

Code structure
1. The core api's are part of `org/apache/dhalion/api/` package.
1. Implementation of the core api specific to Heron are in `org/apache/dhalion/heron` package.
