### PR TITLE
Rewrite stream manager back presssure algorithm

### DIFF
--- a/heron/common/src/cpp/basics/BUILD
+++ b/heron/common/src/cpp/basics/BUILD
@@ -33,6 +33,7 @@ cc_library(
         "sptest.h",
         "sptypes.h",
         "strutils.h",
+        "spmultimap.h"
     ],
     hdrs = [ 
         "basics.h",

--- a/heron/common/src/cpp/basics/spmultimap.h
+++ b/heron/common/src/cpp/basics/spmultimap.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __SP_MULTIMAP_H
+#define __SP_MULTIMAP_H
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <utility>
+
+template <typename _Key, typename _Tp,
+          typename _Compare = std::less<_Key>,
+          typename _Alloc = std::allocator<std::pair<const _Key, _Tp>>>
+class sp_multimap : public std::multimap<_Key, _Tp, _Compare, _Alloc> {
+ public:
+  typedef typename std::multimap<_Key, _Tp, _Compare, _Alloc>::value_type value_type;
+  typedef typename std::multimap<_Key, _Tp, _Compare, _Alloc>::size_type size_type;
+
+  using std::multimap<_Key, _Tp, _Compare, _Alloc>::erase;
+
+  size_type erase(const value_type& v) {
+    auto iterpair = this->equal_range(v.first);
+    size_type num = 0;
+
+    for (auto it = iterpair.first; it != iterpair.second;) {
+      if (it->second == v.second) {
+        it = erase(it);
+        num++;
+      } else {
+        it++;
+      }
+    }
+
+    return num;
+  }
+};
+
+#endif

--- a/heron/common/src/cpp/network/connection.h
+++ b/heron/common/src/cpp/network/connection.h
@@ -102,7 +102,7 @@ class Connection : public BaseConnection {
   void setCausedBackPressure() { mCausedBackPressure = true; }
   void unsetCausedBackPressure() { mCausedBackPressure = false; }
   bool hasCausedBackPressure() const { return mCausedBackPressure; }
-  bool isUnderBackPressure() const { return mUnderBackPressure; }
+  bool isUnderBackPressure() const { return mUnderBackPressure > 0; }
 
   sp_int32 putBackPressure();
   sp_int32 removeBackPressure();
@@ -153,7 +153,7 @@ class Connection : public BaseConnection {
   // Have we caused back pressure?
   bool mCausedBackPressure;
   // Are our reads being throttled?
-  bool mUnderBackPressure;
+  sp_int32 mUnderBackPressure;
   // How many times have we enqueued data and found that we had outstanding bytes >
   // HWM of back pressure threshold
   sp_uint8 mNumEnqueuesWithBufferFull;

--- a/heron/proto/stmgr.proto
+++ b/heron/proto/stmgr.proto
@@ -63,6 +63,7 @@ message StartBackPressureMessage {
   required string topology_id = 2;
   required string stmgr = 3;
   required string message_id = 4;
+  required int32 task_id = 5;
 }
 
 message StopBackPressureMessage {
@@ -70,6 +71,7 @@ message StopBackPressureMessage {
   required string topology_id = 2;
   required string stmgr = 3;
   required string message_id = 4;
+  required int32 task_id = 5;
 }
 
 // Tuples exchanged between stream managers and instances

--- a/heron/stmgr/src/cpp/manager/stmgr-client.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-client.cpp
@@ -148,9 +148,6 @@ void StMgrClient::HandleHelloResponse(void*, proto::stmgr::StrMgrHelloResponse* 
     Stop();
   }
   delete _response;
-  if (client_manager_->DidAnnounceBackPressure()) {
-    SendStartBackPressureMessage();
-  }
 }
 
 void StMgrClient::OnReConnectTimer() { Start(); }
@@ -195,7 +192,7 @@ void StMgrClient::StopBackPressureConnectionCb(Connection* _connection) {
   client_manager_->StopBackPressureOnServer(other_stmgr_id_);
 }
 
-void StMgrClient::SendStartBackPressureMessage() {
+void StMgrClient::SendStartBackPressureMessage(const sp_int32 _task_id) {
   REQID_Generator generator;
   REQID rand = generator.generate();
   // generator.generate(rand);
@@ -205,12 +202,13 @@ void StMgrClient::SendStartBackPressureMessage() {
   message->set_topology_id(topology_id_);
   message->set_stmgr(our_stmgr_id_);
   message->set_message_id(rand.str());
+  message->set_task_id(_task_id);
   SendMessage(*message);
 
   release(message);
 }
 
-void StMgrClient::SendStopBackPressureMessage() {
+void StMgrClient::SendStopBackPressureMessage(const sp_int32 _task_id) {
   REQID_Generator generator;
   REQID rand = generator.generate();
   // generator.generate(rand);
@@ -220,6 +218,7 @@ void StMgrClient::SendStopBackPressureMessage() {
   message->set_topology_id(topology_id_);
   message->set_stmgr(our_stmgr_id_);
   message->set_message_id(rand.str());
+  message->set_task_id(_task_id);
   SendMessage(*message);
 
   release(message);

--- a/heron/stmgr/src/cpp/manager/stmgr-client.h
+++ b/heron/stmgr/src/cpp/manager/stmgr-client.h
@@ -44,8 +44,8 @@ class StMgrClient : public Client {
   void Quit();
 
   void SendTupleStreamMessage(proto::stmgr::TupleStreamMessage2& _msg);
-  void SendStartBackPressureMessage();
-  void SendStopBackPressureMessage();
+  void SendStartBackPressureMessage(const sp_int32 _task_id);
+  void SendStopBackPressureMessage(const sp_int32 _task_id);
 
  protected:
   virtual void HandleConnect(NetworkErrorCode status);

--- a/heron/stmgr/src/cpp/manager/stmgr-clientmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-clientmgr.cpp
@@ -77,6 +77,7 @@ void StMgrClientMgr::NewPhysicalPlan(const proto::system::PhysicalPlan* _pplan) 
         // This stmgr has actually moved to a different host/port
         clients_[s.id()]->Quit();  // this will delete itself.
         clients_[s.id()] = CreateClient(s.id(), s.host_name(), s.data_port());
+        instance_stats_[s.id()].clear();
       } else {
         // This stmgr has remained the same. Don't do anything
       }
@@ -101,11 +102,8 @@ void StMgrClientMgr::NewPhysicalPlan(const proto::system::PhysicalPlan* _pplan) 
     LOG(INFO) << "Stmgr " << *iter << " no longer required";
     clients_[*iter]->Quit();  // This will delete itself.
     clients_.erase(*iter);
+    instance_stats_.erase(*iter);
   }
-}
-
-bool StMgrClientMgr::DidAnnounceBackPressure() {
-  return stream_manager_->DidAnnounceBackPressure();
 }
 
 StMgrClient* StMgrClientMgr::CreateClient(const sp_string& _other_stmgr_id,
@@ -125,11 +123,26 @@ StMgrClient* StMgrClientMgr::CreateClient(const sp_string& _other_stmgr_id,
   return client;
 }
 
+sp_int32 StMgrClientMgr::FindBusiestTaskOnStmgr(const sp_string& _stmgr_id) {
+  sp_int32 task_id;
+  sp_int64 max = 0;
+  for (auto iter = instance_stats_[_stmgr_id].begin();
+       iter!= instance_stats_[_stmgr_id].end();
+       iter++) {
+    if (iter->second > max) {
+      task_id = iter->first;
+      max = iter->second;
+    }
+  }
+  return task_id;
+}
+
 void StMgrClientMgr::SendTupleStreamMessage(sp_int32 _task_id, const sp_string& _stmgr_id,
                                             const proto::system::HeronTupleSet2& _msg) {
   auto iter = clients_.find(_stmgr_id);
   CHECK(iter != clients_.end());
 
+  instance_stats_[_stmgr_id][_task_id] += _msg.GetCachedSize();
   // Acquire the message
   proto::stmgr::TupleStreamMessage2* out = nullptr;
   out = clients_[_stmgr_id]->acquire(out);
@@ -151,15 +164,15 @@ void StMgrClientMgr::StopBackPressureOnServer(const sp_string& _other_stmgr_id) 
   stream_manager_->StopBackPressureOnServer(_other_stmgr_id);
 }
 
-void StMgrClientMgr::SendStartBackPressureToOtherStMgrs() {
+void StMgrClientMgr::SendStartBackPressureToOtherStMgrs(const sp_int32 _task_id) {
   for (auto iter = clients_.begin(); iter != clients_.end(); ++iter) {
-    iter->second->SendStartBackPressureMessage();
+    iter->second->SendStartBackPressureMessage(_task_id);
   }
 }
 
-void StMgrClientMgr::SendStopBackPressureToOtherStMgrs() {
+void StMgrClientMgr::SendStopBackPressureToOtherStMgrs(const sp_int32 _task_id) {
   for (auto iter = clients_.begin(); iter != clients_.end(); ++iter) {
-    iter->second->SendStopBackPressureMessage();
+    iter->second->SendStopBackPressureMessage(_task_id);
   }
 }
 

--- a/heron/stmgr/src/cpp/manager/stmgr-clientmgr.h
+++ b/heron/stmgr/src/cpp/manager/stmgr-clientmgr.h
@@ -53,9 +53,9 @@ class StMgrClientMgr {
   void StopBackPressureOnServer(const sp_string& _other_stmgr_id);
   // Used by the server to tell the client to send the back pressure related
   // messages
-  void SendStartBackPressureToOtherStMgrs();
-  void SendStopBackPressureToOtherStMgrs();
-  bool DidAnnounceBackPressure();
+  void SendStartBackPressureToOtherStMgrs(const sp_int32 _task_id);
+  void SendStopBackPressureToOtherStMgrs(const sp_int32 _task_id);
+  sp_int32 FindBusiestTaskOnStmgr(const sp_string& _stmgr_id);
 
  private:
   StMgrClient* CreateClient(const sp_string& _other_stmgr_id, const sp_string& _host_name,
@@ -76,6 +76,9 @@ class StMgrClientMgr {
 
   sp_int64 high_watermark_;
   sp_int64 low_watermark_;
+
+  // Counters for remote instance traffic, this is used for back pressure
+  std::unordered_map<sp_string, std::unordered_map<sp_int32, sp_int64>> instance_stats_;
 };
 
 }  // namespace stmgr

--- a/heron/stmgr/src/cpp/manager/stmgr-server.h
+++ b/heron/stmgr/src/cpp/manager/stmgr-server.h
@@ -24,6 +24,7 @@
 #include "proto/messages.h"
 #include "network/network.h"
 #include "basics/basics.h"
+#include "basics/spmultimap.h"
 
 namespace heron {
 namespace common {
@@ -57,9 +58,9 @@ class StMgrServer : public Server {
   void BroadcastNewPhysicalPlan(const proto::system::PhysicalPlan& _pplan);
 
   // Do back pressure
-  void StartBackPressureClientCb(const sp_string& _other_stmgr_id);
+  void StartBackPressureClientCb(const sp_string& _other_stmgr_id, sp_int32 task_id);
   // Relieve back pressure
-  void StopBackPressureClientCb(const sp_string& _other_stmgr_id);
+  void StopBackPressureClientCb(const sp_string& _other_stmgr_id, sp_int32 task_id);
 
   bool HaveAllInstancesConnectedToUs() const {
     return active_instances_.size() == expected_instances_.size();
@@ -97,8 +98,8 @@ class StMgrServer : public Server {
                                       proto::stmgr::StartBackPressureMessage* _message);
   void HandleStopBackPressureMessage(Connection* _conn,
                                      proto::stmgr::StopBackPressureMessage* _message);
-  void SendStartBackPressureToOtherStMgrs();
-  void SendStopBackPressureToOtherStMgrs();
+  void SendStartBackPressureToOtherStMgrs(const sp_int32 _task_id);
+  void SendStopBackPressureToOtherStMgrs(const sp_int32 _task_id);
 
   // Back pressure related connection callbacks
   // Do back pressure
@@ -106,10 +107,10 @@ class StMgrServer : public Server {
   // Relieve back pressure
   void StopBackPressureConnectionCb(Connection* _connection);
 
-  // Can we free the back pressure on the spouts?
-  void AttemptStopBackPressureFromSpouts();
-  // Start back pressure on the spouts
-  void StartBackPressureOnSpouts();
+  // Can we free the back pressure on the instances?
+  void AttemptStopBackPressureFromInstances(const sp_int32 _task_id, bool initiated);
+  // Start back pressure on the instances
+  void StartBackPressureOnInstances(const sp_int32 _task_id, bool initiated);
 
   // Compute the LocalSpouts from Physical Plan
   void ComputeLocalSpouts(const proto::system::PhysicalPlan& _pplan);
@@ -154,8 +155,8 @@ class StMgrServer : public Server {
 
   // instances/stream mgrs causing back pressure
   std::unordered_set<sp_string> remote_ends_who_caused_back_pressure_;
-  // stream managers that have announced back pressure
-  std::unordered_set<sp_string> stmgrs_who_announced_back_pressure_;
+  // (stream manager, task id) pairs who have announced back pressure
+  sp_multimap<sp_string, sp_int32> stmgrs_who_announced_back_pressure_;
 
   sp_string topology_name_;
   sp_string topology_id_;
@@ -169,7 +170,7 @@ class StMgrServer : public Server {
   heron::common::TimeSpentMetric* back_pressure_metric_aggr_;
   heron::common::TimeSpentMetric* back_pressure_metric_initiated_;
 
-  bool spouts_under_back_pressure_;
+  sp_int32 instances_under_back_pressure_;
 };
 
 }  // namespace stmgr

--- a/heron/stmgr/src/cpp/manager/stmgr.h
+++ b/heron/stmgr/src/cpp/manager/stmgr.h
@@ -17,13 +17,14 @@
 #ifndef SRC_CPP_SVCS_STMGR_SRC_MANAGER_STMGR_H_
 #define SRC_CPP_SVCS_STMGR_SRC_MANAGER_STMGR_H_
 
-#include <list>
 #include <map>
+#include <queue>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 #include <chrono>
 #include <typeindex>
+#include <unordered_set>
 #include "proto/messages.h"
 #include "network/network.h"
 #include "basics/basics.h"
@@ -73,12 +74,13 @@ class StMgr {
   virtual void StopBackPressureOnServer(const sp_string& _other_stmgr_id);
   // Used by the server to tell the client to send the back pressure related
   // messages
-  void SendStartBackPressureToOtherStMgrs();
-  void SendStopBackPressureToOtherStMgrs();
+  void SendStartBackPressureToOtherStMgrs(const sp_int32 _task_id);
+  void SendStopBackPressureToOtherStMgrs(const sp_int32 _task_id);
   void StartTMasterClient();
-  bool DidAnnounceBackPressure();
+  std::unordered_set<sp_int32> GetUpstreamInstances(const sp_int32 _task_id);
 
  private:
+  void _GetUpstreamInstances(const sp_int32 _task_id, std::unordered_set<sp_int32>& result);
   void OnTMasterLocationFetch(proto::tmaster::TMasterLocation* _tmaster, proto::system::StatusCode);
   void OnMetricsCacheLocationFetch(
          proto::tmaster::MetricsCacheLocation* _tmaster, proto::system::StatusCode);
@@ -92,6 +94,7 @@ class StMgr {
   void PopulateStreamConsumers(
       proto::api::Topology* _topology,
       const std::map<sp_string, std::vector<sp_int32> >& _component_to_task_ids);
+  void PopulateUpstreamTasks(proto::system::PhysicalPlan* _pplan);
   void PopulateXorManagers(
       const proto::api::Topology& _topology, sp_int32 _message_timeout,
       const std::map<sp_string, std::vector<sp_int32> >& _component_to_task_ids);
@@ -136,6 +139,8 @@ class StMgr {
   std::unordered_map<sp_int32, sp_string> task_id_to_stmgr_;
   // map of <component, streamid> to its consumers
   std::unordered_map<std::pair<sp_string, sp_string>, StreamConsumers*> stream_consumers_;
+  // The graph of all the tasks
+  std::unordered_map<sp_int32, std::unordered_set<sp_int32>> tasks_mapping_;
   // xor managers
   XorManager* xor_mgrs_;
   // Tuple Cache to optimize message building
@@ -169,6 +174,7 @@ class StMgr {
 
   sp_int64 high_watermark_;
   sp_int64 low_watermark_;
+  std::queue<sp_int32> backpressure_starters_;
 };
 
 }  // namespace stmgr


### PR DESCRIPTION
The current back pressure algorithm we use in stream manager is problematic in several ways:

1) It simply throttles all spouts in the whole topology when congestion happens in even just one container. This unfairly penalizes irrelevant paths in the topology;

2) It does not do anything to these bolts in the middle even when they generate tuples too hence contribute to the congestion;

3) In an entire topology at one time there is only one instance could trigger back pressure, we don't allow multiple instances to trigger back pressure again because all spouts are already throttled so we don't need to throttle them again.

We could improve it by:

1) Stream managers need to learn all the paths in the topology and penalize all the bolts and spouts upstream along its paths, because they all could contribute to the congestion;

2) For congestions on the data path between two stream managers, there is no way to define "upstream" by the design of Heron, but we could add some counters to count packets from which instances contribute most to the congestion and do back pressure on behalf of these instances;

3) Back pressure should be able to trigger multiple times in a whole topology to reflect the fact that multiple instances in different paths of the topology could have congestions. Therefore, we need a real "reference counting" to make it work correctly.