### PR TITLE
Revert removal of setters that take long bytes

### DIFF
--- a/heron/api/src/java/com/twitter/heron/api/Config.java
+++ b/heron/api/src/java/com/twitter/heron/api/Config.java
@@ -282,7 +282,7 @@ public class Config extends HashMap<String, Object> {
   /**
    * Users should use the version of this method at uses ByteAmount
    * @deprecated use
-   * setContainerDiskRequested(Map<String, Object> conf, ByteAmount nbytes)
+   * setContainerDiskRequested(Map&lt;String, Object&gt; conf, ByteAmount nbytes)
    */
   @Deprecated
   public static void setContainerDiskRequested(Map<String, Object> conf, long nbytes) {
@@ -296,7 +296,7 @@ public class Config extends HashMap<String, Object> {
   /**
    * Users should use the version of this method at uses ByteAmount
    * @deprecated use
-   * setContainerRamRequested(Map<String, Object> conf, ByteAmount nbytes)
+   * setContainerRamRequested(Map&lt;String, Object&gt; conf, ByteAmount nbytes)
    */
   @Deprecated
   public static void setContainerRamRequested(Map<String, Object> conf, long nbytes) {
@@ -338,7 +338,7 @@ public class Config extends HashMap<String, Object> {
   /**
    * Users should use the version of this method at uses ByteAmount
    * @deprecated use
-   * setComponentRam(Map<String, Object> conf, String component, ByteAmount ramInBytes)
+   * setComponentRam(Map&lt;String, Object&gt; conf, String component, ByteAmount ramInBytes)
    */
   @Deprecated
   public static void setComponentRam(Map<String, Object> conf,

--- a/heron/api/src/java/com/twitter/heron/api/Config.java
+++ b/heron/api/src/java/com/twitter/heron/api/Config.java
@@ -279,8 +279,28 @@ public class Config extends HashMap<String, Object> {
     conf.put(Config.TOPOLOGY_CONTAINER_CPU_REQUESTED, Float.toString(ncpus));
   }
 
+  /**
+   * Users should use the version of this method at uses ByteAmount
+   * @deprecated use
+   * setContainerDiskRequested(Map<String, Object> conf, ByteAmount nbytes)
+   */
+  @Deprecated
+  public static void setContainerDiskRequested(Map<String, Object> conf, long nbytes) {
+    setContainerDiskRequested(conf, ByteAmount.fromBytes(nbytes));
+  }
+
   public static void setContainerDiskRequested(Map<String, Object> conf, ByteAmount nbytes) {
     conf.put(Config.TOPOLOGY_CONTAINER_DISK_REQUESTED, Long.toString(nbytes.asBytes()));
+  }
+
+  /**
+   * Users should use the version of this method at uses ByteAmount
+   * @deprecated use
+   * setContainerRamRequested(Map<String, Object> conf, ByteAmount nbytes)
+   */
+  @Deprecated
+  public static void setContainerRamRequested(Map<String, Object> conf, long nbytes) {
+    setContainerRamRequested(conf, ByteAmount.fromBytes(nbytes));
   }
 
   public static void setContainerRamRequested(Map<String, Object> conf, ByteAmount nbytes) {
@@ -313,6 +333,17 @@ public class Config extends HashMap<String, Object> {
 
   public static List<String> getAutoTaskHooks(Map<String, Object> conf) {
     return TypeUtils.getListOfStrings(conf.get(Config.TOPOLOGY_AUTO_TASK_HOOKS));
+  }
+
+  /**
+   * Users should use the version of this method at uses ByteAmount
+   * @deprecated use
+   * setComponentRam(Map<String, Object> conf, String component, ByteAmount ramInBytes)
+   */
+  @Deprecated
+  public static void setComponentRam(Map<String, Object> conf,
+                                     String component, long ramInBytes) {
+    setComponentRam(conf, component, ByteAmount.fromBytes(ramInBytes));
   }
 
   public static void setComponentRam(Map<String, Object> conf,


### PR DESCRIPTION
The removal of these methods is making upgrading difficult. Putting them back in as deprecated. Once we upgrade we can refactor callers to use the ```ByteAmount``` signatures and then remove these methods again in a future release.