### PR TITLE
[Do not merge] change log FATAL to ERROR to avoid crashing stmgr

### DIFF
--- a/heron/common/src/cpp/network/client.cpp
+++ b/heron/common/src/cpp/network/client.cpp
@@ -181,8 +181,10 @@ void Client::OnNewPacket(IncomingPacket* _ipkt) {
 
   if (_ipkt->UnPackString(&typname) != 0) {
     Connection* conn = static_cast<Connection*>(conn_);
-    LOG(FATAL) << "UnPackString failed from connection " << conn << " from hostport "
+    LOG(ERROR) << "UnPackString failed from connection " << conn << " from hostport "
                << conn->getIPAddress() << ":" << conn->getPort();
+    delete _ipkt;
+    return;
   }
 
   if (messageHandlers.count(typname) > 0) {


### PR DESCRIPTION
There were corrupt events in EventBus which were crashing stream manager. With errors such as this:
last message is : F0120 09:03:24.136044 55260 client.cpp:226] UnPackString failed from connection 0x28da580 from hostport 10.44.144.115:31661

Heron should be resilient to such issues. Corrupt packets should be dropped and not crash the Stream Manager.