### PR TITLE
Fixes the SIGSEGV during UpdateQueueMetrics from a restarted instance

### DIFF
--- a/heron/stmgr/src/cpp/manager/stmgr-server.h
+++ b/heron/stmgr/src/cpp/manager/stmgr-server.h
@@ -139,7 +139,6 @@ class StMgrServer : public Server {
   typedef std::unordered_map<Connection*, sp_int32> ConnectionTaskIdMap;
   ConnectionTaskIdMap active_instances_;
   // map of task id to InstanceData
-  // Once populated, will not change
   typedef std::unordered_map<sp_int32, InstanceData*> TaskIdInstanceDataMap;
   TaskIdInstanceDataMap instance_info_;
 


### PR DESCRIPTION
This pull request fixes the SIGSEGV during UpdateQueueMetrics from a restarted instance

Current stmgr will clean only connection_buffer_metric_map_ during HandleConnectionClose.
However, during HandleRegisterInstanceRequest(), before adding necessary meta-info, stmgr will check the existence of instance basing on instance_info_, which is not cleaned. So connection_buffer_metric_map_ will no longer contain the entry of instance once it is restarted, since it will not be added. And accessing to that entry returns SIGSEGV.

Besides that, this pull request also fixes potential memory leaks.

Tested and verified on LocalScheduler.