### PR TITLE
Fixes the NPE in CustomGrouping

### DIFF
--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
@@ -42,7 +42,7 @@ import com.twitter.heron.proto.system.HeronTuples;
 
 public class BoltInstance implements IInstance {
 
-  protected final PhysicalPlanHelper helper;
+  protected PhysicalPlanHelper helper;
   protected final IBolt bolt;
   protected final BoltOutputCollectorImpl collector;
   protected final IPluggableSerializer serializer;
@@ -99,6 +99,11 @@ public class BoltInstance implements IInstance {
       ((IUpdatable) bolt).update(physicalPlanHelper.getTopologyContext());
     }
     collector.updatePhysicalPlanHelper(physicalPlanHelper);
+
+    // Re-prepare the CustomStreamGrouping since the downstream tasks can change
+    physicalPlanHelper.prepareForCustomStreamGrouping();
+    // Reset the helper
+    helper = physicalPlanHelper;
   }
 
   @Override

--- a/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutInstance.java
@@ -117,6 +117,11 @@ public class SpoutInstance implements IInstance {
       ((IUpdatable) spout).update(physicalPlanHelper.getTopologyContext());
     }
     collector.updatePhysicalPlanHelper(physicalPlanHelper);
+
+    // Re-prepare the CustomStreamGrouping since the downstream tasks can change
+    physicalPlanHelper.prepareForCustomStreamGrouping();
+    // Reset the helper
+    helper = physicalPlanHelper;
   }
 
   @Override


### PR DESCRIPTION
Current heron replaces the an existing PhysicalPlanHelper with a new old during update(), which is triggered by an incoming new PhysicalPlan.
However, it creates a new instance of CustomGrouping without initializing it, i.e. without invoking CustomStreamGrouping.prepare(..)

So it is very possible that during chooseTasks(..), topology developers uses a object, which is expected to be initialized in prepare(..) but turns out not initialized.

This pull request fixes this bug.
Tested and Verified in LocalScheduler.