### PR TITLE
One-liner to fix Heron Tracker when results aren't found

### DIFF
--- a/heron/tools/common/src/python/access/heron_api.py
+++ b/heron/tools/common/src/python/access/heron_api.py
@@ -729,6 +729,7 @@ class HeronQueryHandler(QueryHandler):
 
     components = [component] if component != "*" else (yield get_comps(cluster, environ, topology))
 
+    result = {}
     futures = []
     for comp in components:
       query = self.get_query(metric, comp, instance)


### PR DESCRIPTION
When components are not found, a None exception is returned. With this fix, a valid response is returned instead.