### PR TITLE
Throttle the amount of 'Stop reading due to not yet connected to Stream Manager' log messages emitted

### DIFF
--- a/heron/instance/src/java/com/twitter/heron/network/StreamManagerClient.java
+++ b/heron/instance/src/java/com/twitter/heron/network/StreamManagerClient.java
@@ -254,7 +254,7 @@ public class StreamManagerClient extends HeronClient {
       }
     } else {
       long now = System.currentTimeMillis();
-      if (now - lastNotConnectedLogTime > lastNotConnectedLogThrottleSeconds * 5000) {
+      if (now - lastNotConnectedLogTime > lastNotConnectedLogThrottleSeconds * 1000) {
         LOG.info(String.format("Stop reading due to not yet connected to Stream Manager. This "
             + "message is throttled to emit no more than once every %d seconds.",
             lastNotConnectedLogThrottleSeconds));

--- a/heron/instance/src/java/com/twitter/heron/network/StreamManagerClient.java
+++ b/heron/instance/src/java/com/twitter/heron/network/StreamManagerClient.java
@@ -67,6 +67,8 @@ public class StreamManagerClient extends HeronClient {
 
   private PhysicalPlanHelper helper;
 
+  private long lastNotConnectedLogTime = 0;
+
   public StreamManagerClient(NIOLooper s, String streamManagerHost, int streamManagerPort,
                              String topologyName, String topologyId,
                              PhysicalPlans.Instance instance,
@@ -240,6 +242,8 @@ public class StreamManagerClient extends HeronClient {
   }
 
   private void readStreamMessageIfNeeded() {
+    final long lastNotConnectedLogThrottleSeconds = 5;
+
     // If client is not connected, just return
     if (isConnected()) {
       if (isInQueuesAvailable() || helper == null) {
@@ -249,7 +253,13 @@ public class StreamManagerClient extends HeronClient {
         stopReading();
       }
     } else {
-      LOG.info("Stop reading due to not yet connected to Stream Manager.");
+      long now = System.currentTimeMillis();
+      if (now - lastNotConnectedLogTime > lastNotConnectedLogThrottleSeconds * 5000) {
+        LOG.info(String.format("Stop reading due to not yet connected to Stream Manager. This "
+            + "message is throttled to emit no more than once every %d seconds.",
+            lastNotConnectedLogThrottleSeconds));
+        lastNotConnectedLogTime = now;
+      }
     }
   }
 


### PR DESCRIPTION
We stream massive amounts of these to the logs upon startup, many per second. This changes throttles that log message.