### PR TITLE
Refactor to centralize duplicate TopologyAPI.Config logic

### DIFF
--- a/heron/api/src/java/com/twitter/heron/api/HeronTopology.java
+++ b/heron/api/src/java/com/twitter/heron/api/HeronTopology.java
@@ -15,10 +15,7 @@
 package com.twitter.heron.api;
 
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
-
-import com.google.protobuf.ByteString;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.api.utils.Utils;
@@ -35,26 +32,6 @@ public class HeronTopology {
 
   public HeronTopology(TopologyAPI.Topology.Builder topologyBuilder) {
     this.topologyBuilder = topologyBuilder;
-  }
-
-  private static TopologyAPI.Config.Builder getConfigBuilder(Config config) {
-    TopologyAPI.Config.Builder cBldr = TopologyAPI.Config.newBuilder();
-    Set<String> apiVars = config.getApiVars();
-    for (String key : config.keySet()) {
-      Object value = config.get(key);
-      TopologyAPI.Config.KeyValue.Builder b = TopologyAPI.Config.KeyValue.newBuilder();
-      b.setKey(key);
-      if (apiVars.contains(key)) {
-        b.setType(TopologyAPI.ConfigValueType.STRING_VALUE);
-        b.setValue(value.toString());
-      } else {
-        b.setType(TopologyAPI.ConfigValueType.JAVA_SERIALIZED_VALUE);
-        b.setSerializedValue(ByteString.copyFrom(Utils.serialize(value)));
-      }
-      cBldr.addKvs(b);
-    }
-
-    return cBldr;
   }
 
   private static void addDefaultTopologyConfig(Map<String, Object> userConfig) {
@@ -96,7 +73,7 @@ public class HeronTopology {
     addDefaultTopologyConfig(heronConfig);
     heronConfig.put(Config.TOPOLOGY_NAME, name);
 
-    topologyBuilder.setTopologyConfig(getConfigBuilder(heronConfig));
+    topologyBuilder.setTopologyConfig(Utils.getConfigBuilder(heronConfig));
 
     return topologyBuilder.build();
   }

--- a/heron/api/src/java/com/twitter/heron/api/topology/BaseComponentDeclarer.java
+++ b/heron/api/src/java/com/twitter/heron/api/topology/BaseComponentDeclarer.java
@@ -14,9 +14,7 @@
 
 package com.twitter.heron.api.topology;
 
-import java.util.HashMap;
 import java.util.Map;
-import java.util.logging.Logger;
 
 import com.google.protobuf.ByteString;
 
@@ -26,24 +24,22 @@ import com.twitter.heron.api.utils.Utils;
 
 public abstract class BaseComponentDeclarer<T extends ComponentConfigurationDeclarer<?>>
     extends BaseConfigurationDeclarer<T> {
-  private static final Logger LOG = Logger.getLogger(BaseComponentDeclarer.class.getName());
   private String name;
   private IComponent component;
-  private Map<String, Object> componentConfiguration;
+  private Config componentConfiguration;
 
   public BaseComponentDeclarer(String name, IComponent comp, Number taskParallelism) {
     this.name = name;
     this.component = comp;
-    this.componentConfiguration = comp.getComponentConfiguration();
-    if (this.componentConfiguration == null) {
-      this.componentConfiguration = new HashMap<>();
+    if (comp.getComponentConfiguration() != null) {
+      this.componentConfiguration = new Config(comp.getComponentConfiguration());
+    } else {
+      this.componentConfiguration = new Config();
     }
     if (taskParallelism != null) {
-      this.componentConfiguration.put(Config.TOPOLOGY_COMPONENT_PARALLELISM,
-          taskParallelism.toString());
+      Config.setComponentParallelism(this.componentConfiguration, taskParallelism.intValue());
     } else {
-      this.componentConfiguration.put(Config.TOPOLOGY_COMPONENT_PARALLELISM,
-          "1");
+      Config.setComponentParallelism(this.componentConfiguration, 1);
     }
   }
 
@@ -63,23 +59,6 @@ public abstract class BaseComponentDeclarer<T extends ComponentConfigurationDecl
     bldr.setName(name);
     bldr.setSpec(TopologyAPI.ComponentObjectSpec.JAVA_SERIALIZED_OBJECT);
     bldr.setSerializedObject(ByteString.copyFrom(Utils.serialize(component)));
-
-    TopologyAPI.Config.Builder cBldr = TopologyAPI.Config.newBuilder();
-    for (Map.Entry<String, Object> entry : componentConfiguration.entrySet()) {
-      if (entry.getKey() == null) {
-        LOG.warning("ignore: config key is null");
-        continue;
-      }
-      if (entry.getValue() == null) {
-        LOG.warning("ignore: config key " + entry.getKey() + " has null value");
-        continue;
-      }
-      TopologyAPI.Config.KeyValue.Builder kvBldr = TopologyAPI.Config.KeyValue.newBuilder();
-      kvBldr.setKey(entry.getKey());
-      kvBldr.setValue(entry.getValue().toString());
-      kvBldr.setType(TopologyAPI.ConfigValueType.STRING_VALUE);
-      cBldr.addKvs(kvBldr);
-    }
-    bldr.setConfig(cBldr);
+    bldr.setConfig(Utils.getConfigBuilder(componentConfiguration));
   }
 }

--- a/heron/api/src/java/com/twitter/heron/api/utils/Utils.java
+++ b/heron/api/src/java/com/twitter/heron/api/utils/Utils.java
@@ -31,11 +31,10 @@ import java.util.logging.Logger;
 import com.google.protobuf.ByteString;
 
 import com.twitter.heron.api.Config;
-import com.twitter.heron.api.HeronTopology;
 import com.twitter.heron.api.generated.TopologyAPI;
 
 public final class Utils {
-  private static final Logger LOG = Logger.getLogger(HeronTopology.class.getName());
+  private static final Logger LOG = Logger.getLogger(Utils.class.getName());
 
   public static final String DEFAULT_STREAM_ID = "default";
 

--- a/heron/api/src/java/com/twitter/heron/api/utils/Utils.java
+++ b/heron/api/src/java/com/twitter/heron/api/utils/Utils.java
@@ -124,11 +124,11 @@ public final class Utils {
     TopologyAPI.Config.Builder cBldr = TopologyAPI.Config.newBuilder();
     Set<String> apiVars = config.getApiVars();
     for (String key : config.keySet()) {
-      Object value = config.get(key);
       if (key == null) {
         LOG.warning("ignore: null config key found");
         continue;
       }
+      Object value = config.get(key);
       if (value == null) {
         LOG.warning("ignore: config key " + key + " has null value");
         continue;

--- a/heron/common/src/java/com/twitter/heron/common/utils/misc/PhysicalPlanHelper.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/misc/PhysicalPlanHelper.java
@@ -193,29 +193,26 @@ public class PhysicalPlanHelper {
 
   public void setTopologyContext(MetricsCollector metricsCollector) {
     topologyContext =
-        new TopologyContextImpl(constructConfig(pplan.getTopology().getTopologyConfig(), component),
+        new TopologyContextImpl(mergeConfigs(pplan.getTopology().getTopologyConfig(), component),
             pplan.getTopology(), makeTaskToComponentMap(), myTaskId, metricsCollector);
   }
 
-  private Map<String, Object> constructConfig(TopologyAPI.Config config,
-                                              TopologyAPI.Component acomponent) {
-    Map<String, Object> retval = new HashMap<String, Object>();
+  private Map<String, Object> mergeConfigs(TopologyAPI.Config config,
+                                           TopologyAPI.Component acomponent) {
+    Map<String, Object> map = new HashMap<>();
+    addConfigsToMap(config, map);
+    addConfigsToMap(acomponent.getConfig(), map); // Override any component specific configs
+    return map;
+  }
+
+  private void addConfigsToMap(TopologyAPI.Config config, Map<String, Object> map) {
     for (TopologyAPI.Config.KeyValue kv : config.getKvsList()) {
       if (kv.hasValue()) {
-        retval.put(kv.getKey(), kv.getValue());
+        map.put(kv.getKey(), kv.getValue());
       } else {
-        retval.put(kv.getKey(), Utils.deserialize(kv.getSerializedValue().toByteArray()));
+        map.put(kv.getKey(), Utils.deserialize(kv.getSerializedValue().toByteArray()));
       }
     }
-    // Override any component specific configs
-    for (TopologyAPI.Config.KeyValue kv : acomponent.getConfig().getKvsList()) {
-      if (kv.hasValue()) {
-        retval.put(kv.getKey(), kv.getValue());
-      } else {
-        retval.put(kv.getKey(), Utils.deserialize(kv.getSerializedValue().toByteArray()));
-      }
-    }
-    return retval;
   }
 
   private Map<Integer, String> makeTaskToComponentMap() {


### PR DESCRIPTION
This inconsistency bit me during hackweek. Refactoring to share duplicate config handling logic.