### PR TITLE
UpdateTopologyManager test should not assert re-activation with mocks

### DIFF
--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/UpdateTopologyManagerTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/UpdateTopologyManagerTest.java
@@ -158,6 +158,12 @@ public class UpdateTopologyManagerTest {
         any(String.class), eq(TOPOLOGY_NAME),
         eq(mockStateMgr), any(NetworkUtils.TunnelConfig.class));
 
+    // reactivation won't happen since topology state is still running due to mock state manager
+    PowerMockito.doNothing().when(TMasterUtils.class, "transitionTopologyState",
+        eq(TOPOLOGY_NAME), eq(TMasterUtils.TMasterCommand.ACTIVATE), eq(mockStateMgr),
+        eq(TopologyAPI.TopologyState.PAUSED), eq(TopologyAPI.TopologyState.RUNNING),
+        any(NetworkUtils.TunnelConfig.class));
+
     spyUpdateManager.updateTopology(currentProtoPlan, proposedProtoPlan);
 
     verify(spyUpdateManager).deactivateTopology(eq(mockStateMgr), eq(testTopology));

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/TMasterUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/TMasterUtils.java
@@ -136,9 +136,10 @@ public final class TMasterUtils {
     }
 
     if (state == expectedState) {
-      throw new TMasterException(String.format(
-          "Topology %s command received topology '%s' but already in state %s",
+      LOG.warning(String.format(
+          "Topology %s command received but topology '%s' already in state %s",
           topologyStateControlCommand, topologyName, state));
+      return;
     }
 
     if (state != startState) {


### PR DESCRIPTION
Fixing a flakey `UpdateTopologyManagerTest` test where the re-enable thread of the update topology flow can throw. It was doing a strict assertion that the state change request went from DEACTIVE -> RUNNING, but since we use a mocked state manager, the earlier transition from RUNNING -> DEACTIVE never actually changed state. Changing that check to be more flexible.