### PR TITLE
Fix unexpected non-OK response in metricsmgr_client.py

### DIFF
--- a/heron/instance/src/python/network/metricsmgr_client.py
+++ b/heron/instance/src/python/network/metricsmgr_client.py
@@ -72,6 +72,7 @@ class MetricsManagerClient(HeronClient):
       Log.error("Error connecting to Metrics Manager with status: %s" % str(status))
       retry_interval = float(self.sys_config[constants.INSTANCE_RECONNECT_METRICSMGR_INTERVAL_SEC])
       self.looper.register_timer_task_in_sec(self.start_connect, retry_interval)
+      return
     self._send_register_req()
 
   def on_response(self, status, context, response):


### PR DESCRIPTION
metricsmgr_client.py did not return after a failed connection attempt (on_connect() & status != OK), which led to unwanted send_register_req() call and is likely the cause of issue #1479 since the request is sent without a proper connection.

In comparison, the Java counterpart does return:
https://github.com/twitter/heron/blob/0.14.6.3/heron/instance/src/java/com/twitter/heron/network/MetricsManagerClient.java#L139