### PR TITLE
Fix flaky test IntegrationTest_MultiSpoutsMultiTasks

### DIFF
--- a/integration-test/src/java/com/twitter/heron/integration_test/core/IntegrationTestBolt.java
+++ b/integration-test/src/java/com/twitter/heron/integration_test/core/IntegrationTestBolt.java
@@ -81,7 +81,6 @@ public class IntegrationTestBolt implements IRichBolt, IUpdatable {
 
   @Override
   public void execute(Tuple tuple) {
-    tuplesReceived++;
     String streamID = tuple.getSourceStreamId();
 
     LOG.info("Received a tuple: " + tuple + " ; from: " + streamID);
@@ -105,6 +104,7 @@ public class IntegrationTestBolt implements IRichBolt, IUpdatable {
             "Received a terminal, need to receive %s more", terminalsToReceive));
       }
     } else {
+      tuplesReceived++;
       currentTupleProcessing = tuple;
       delegateBolt.execute(tuple);
       // We ack only the tuples in user's logic

--- a/integration-test/src/python/test_runner/resources/test.json
+++ b/integration-test/src/python/test_runner/resources/test.json
@@ -58,6 +58,11 @@
       "expectedResultRelativePath" : "bolt_double_emit_tuples/resources/BoltDoubleEmitTuples.json"
     },
     {
+      "topologyName" : "IntegrationTest_MultiSpoutsMultiTasks",
+      "classPath"    : "multi_spouts_multi_tasks.MultiSpoutsMultiTasks",
+      "expectedResultRelativePath" : "multi_spouts_multi_tasks/resources/MultiSpoutsMultiTasks.json"
+    },
+    {
       "topologyName" : "IntegrationTest_OneBoltMultiTasks",
       "classPath"    : "one_bolt_multi_tasks.OneBoltMultiTasks",
       "expectedResultRelativePath" : "one_bolt_multi_tasks/resources/OneBoltMultiTasks.json"


### PR DESCRIPTION
Fix
https://github.com/twitter/heron/issues/1561
https://github.com/twitter/heron/issues/1691
https://github.com/twitter/heron/pull/1687
https://github.com/twitter/heron/pull/1700

The cause is:
tuple count includes 'termination tuple', which leads to multiple same acking tuples and stmgr failure to cancel out markers in xor_manager.
https://travis-ci.org/twitter/heron/builds/225447993

Fix:
count only normal tuples
https://travis-ci.org/twitter/heron/builds/225471892

