### PR TITLE
return errno instead of -1

### DIFF
--- a/heron/common/src/cpp/network/baseserver.cpp
+++ b/heron/common/src/cpp/network/baseserver.cpp
@@ -101,7 +101,7 @@ sp_int32 BaseServer::Start_Base() {
 
   // Ask the EventLoop to deliver any read events
   if (eventLoop_->registerForRead(listen_fd_, on_new_connection_callback_, true) < 0) {
-    PLOG(ERROR) << "register for read of the socket failed in server";
+    LOG(ERROR) << "register for read of the socket failed in server";
     close(listen_fd_);
     return -1;
   }

--- a/heron/common/src/cpp/network/baseserver.cpp
+++ b/heron/common/src/cpp/network/baseserver.cpp
@@ -49,7 +49,7 @@ sp_int32 BaseServer::Start_Base() {
   errno = 0;
   listen_fd_ = socket(options_.get_socket_family(), SOCK_STREAM, 0);
   if (listen_fd_ < 0) {
-    LOG(ERROR) << "Opening of a socket failed in server: " << strerror(errno);
+    PLOG(ERROR) << "Opening of a socket failed in server";
     return errno;
   }
 
@@ -60,7 +60,7 @@ sp_int32 BaseServer::Start_Base() {
 
   // Set the socket option for addr reuse
   if (SockUtils::setReuseAddress(listen_fd_) < 0) {
-    LOG(ERROR) << "setsockopt of a socket failed in server: " << strerror(errno);
+    PLOG(ERROR) << "setsockopt of a socket failed in server";
     close(listen_fd_);
     return errno;
   }
@@ -87,21 +87,21 @@ sp_int32 BaseServer::Start_Base() {
 
   // Bind to the address
   if (bind(listen_fd_, serv_addr, sockaddr_len) < 0) {
-    LOG(ERROR) << "bind of a socket failed in server: " << strerror(errno);
+    PLOG(ERROR) << "bind of a socket failed in server";
     close(listen_fd_);
     return errno;
   }
 
   // Listen for new connections
   if (listen(listen_fd_, 100) < 0) {
-    LOG(ERROR) << "listen of a socket failed in server: " << strerror(errno);
+    PLOG(ERROR) << "listen of a socket failed in server";
     close(listen_fd_);
     return errno;
   }
 
   // Ask the EventLoop to deliver any read events
   if (eventLoop_->registerForRead(listen_fd_, on_new_connection_callback_, true) < 0) {
-    LOG(ERROR) << "register for read of the socket failed in server\n";
+    PLOG(ERROR) << "register for read of the socket failed in server";
     close(listen_fd_);
     return -1;
   }

--- a/heron/common/src/cpp/network/baseserver.cpp
+++ b/heron/common/src/cpp/network/baseserver.cpp
@@ -54,9 +54,8 @@ sp_int32 BaseServer::Start_Base() {
   }
 
   if (SockUtils::setSocketDefaults(listen_fd_) < 0) {
-    LOG(ERROR) << "SockUtils::setSocketDefaults() failed: " << strerror(errno);
     close(listen_fd_);
-    return errno;
+    return -1;
   }
 
   // Set the socket option for addr reuse

--- a/heron/common/src/cpp/network/baseserver.cpp
+++ b/heron/common/src/cpp/network/baseserver.cpp
@@ -49,20 +49,21 @@ sp_int32 BaseServer::Start_Base() {
   errno = 0;
   listen_fd_ = socket(options_.get_socket_family(), SOCK_STREAM, 0);
   if (listen_fd_ < 0) {
-    LOG(ERROR) << "Opening of a socket failed in server " << errno << "\n";
-    return -1;
+    LOG(ERROR) << "Opening of a socket failed in server: " << strerror(errno);
+    return errno;
   }
 
   if (SockUtils::setSocketDefaults(listen_fd_) < 0) {
+    LOG(ERROR) << "SockUtils::setSocketDefaults() failed: " << strerror(errno);
     close(listen_fd_);
-    return -1;
+    return errno;
   }
 
   // Set the socket option for addr reuse
   if (SockUtils::setReuseAddress(listen_fd_) < 0) {
-    LOG(ERROR) << "setsockopt of a socket failed in server " << errno << "\n";
+    LOG(ERROR) << "setsockopt of a socket failed in server: " << strerror(errno);
     close(listen_fd_);
-    return -1;
+    return errno;
   }
 
   // Set the address
@@ -87,16 +88,16 @@ sp_int32 BaseServer::Start_Base() {
 
   // Bind to the address
   if (bind(listen_fd_, serv_addr, sockaddr_len) < 0) {
-    LOG(ERROR) << "bind of a socket failed in server " << errno << "\n";
+    LOG(ERROR) << "bind of a socket failed in server: " << strerror(errno);
     close(listen_fd_);
-    return -1;
+    return errno;
   }
 
   // Listen for new connections
   if (listen(listen_fd_, 100) < 0) {
-    LOG(ERROR) << "listen of a socket failed in server " << errno << "\n";
+    LOG(ERROR) << "listen of a socket failed in server: " << strerror(errno);
     close(listen_fd_);
-    return -1;
+    return errno;
   }
 
   // Ask the EventLoop to deliver any read events


### PR DESCRIPTION
return errno instead of -1, so that the test can tell why the start() fails