### PR TITLE
Fail Heron-instance fast for errors

### DIFF
--- a/heron/instance/src/java/com/twitter/heron/instance/HeronInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/HeronInstance.java
@@ -233,6 +233,15 @@ public class HeronInstance {
 
     // The actual uncaught exceptions handing logic
     private void handleException(Thread thread, Throwable exception) {
+      // We would fail fast when errors occur to avoid unexpected bad situations
+      if (exception instanceof Error) {
+        LOG.log(Level.SEVERE,
+            "Error caught in thread: " + thread.getName()
+                + " with thread id: " + thread.getId() + ". Process halting...",
+            exception);
+        Runtime.getRuntime().halt(1);
+      }
+
       LOG.log(Level.SEVERE,
           String.format("Exception caught in thread: %s with id: %d",
               thread.getName(), thread.getId()), exception);


### PR DESCRIPTION
Currently heron-instance will try best-effort to clean the resources,
when uncaught exceptions happen. However, if it meets an error, for instance,
"java.lang.OutOfMemoryError: Java heap space", any consequent operations are not guaranteed to be done,
and it can lead the process to a bad state, for instance, hanging forever.

This pull request fixes it by making heron-instance fail fast for errors. And this issue is raised by ADs team from Twitter.

Tested with LocalScheduler.