### PR TITLE
Stream subprocess stdout and stderr in heron-executor

### DIFF
--- a/heron/common/src/python/utils/log.py
+++ b/heron/common/src/python/utils/log.py
@@ -44,7 +44,10 @@ def stream_process_stdout(process, log_fn):
   :param log_fn: a function that will be called for each log line
   :return: None
   """
-  for line in iter(process.stdout.readline, b''):
+  while 1:
+    line = process.stdout.readline()
+    if not line:
+      break
     log_fn(line)
 
 def configure(level=logging.INFO, logfile=None):

--- a/heron/common/src/python/utils/log.py
+++ b/heron/common/src/python/utils/log.py
@@ -34,6 +34,10 @@ def async_stream_process_stdout(process, log_fn):
   :return: None
   """
   logging_thread = Thread(target=stream_process_stdout, args=(process, log_fn, ))
+
+  # Setting the logging thread as a daemon thread will allow it to exit with the program
+  # rather than blocking the exit waiting for it to be handled manually.
+  logging_thread.daemon = True
   logging_thread.start()
 
   return logging_thread

--- a/heron/common/src/python/utils/log.py
+++ b/heron/common/src/python/utils/log.py
@@ -15,6 +15,7 @@
 import logging
 from logging.handlers import RotatingFileHandler
 import colorlog
+from threading import Thread
 
 # Create the logger
 # pylint: disable=invalid-name
@@ -25,6 +26,26 @@ Log = logging.getLogger()
 # e.g. "08/16/1988 21:30:00 +1030"
 # see time formatter documentation for more
 date_format = "%Y-%m-%d %H:%M:%S %z"
+
+def async_stream_process_stdout(process, log_fn):
+  """ Stream the stdout and stderr for a process out to display async
+  :param process: the process to stream the log for
+  :param log_fn: a function that will be called for each log line
+  :return: None
+  """
+  logging_thread = Thread(target=stream_process_stdout, args=(process, log_fn, ))
+  logging_thread.start()
+
+  return logging_thread
+
+def stream_process_stdout(process, log_fn):
+  """ Stream the stdout and stderr for a process out to display
+  :param process: the process to stream the logs for
+  :param log_fn: a function that will be called for each log line
+  :return: None
+  """
+  for line in iter(process.stdout.readline, b''):
+    log_fn(line)
 
 def configure(level=logging.INFO, logfile=None):
   """ Configure logger which dumps log on terminal

--- a/heron/common/tests/python/utils/BUILD
+++ b/heron/common/tests/python/utils/BUILD
@@ -185,7 +185,6 @@ pex_test(
         "//heron/common/tests/python/utils:common-utils-mock"
     ],
     reqs = [
-        "py==1.4.27",
         "pytest==2.6.4",
         "unittest2==0.5.1",
     ],

--- a/heron/common/tests/python/utils/BUILD
+++ b/heron/common/tests/python/utils/BUILD
@@ -176,3 +176,18 @@ pex_test(
     ],
     size = "small",
 )
+
+pex_test(
+    name = "log_unittest",
+    srcs = ["log_unittest.py"],
+    deps = [
+        "//heron/common/tests/python:pytest-py",
+        "//heron/common/tests/python/utils:common-utils-mock"
+    ],
+    reqs = [
+        "py==1.4.27",
+        "pytest==2.6.4",
+        "unittest2==0.5.1",
+    ],
+    size = "small",
+)

--- a/heron/common/tests/python/utils/log_unittest.py
+++ b/heron/common/tests/python/utils/log_unittest.py
@@ -1,0 +1,44 @@
+# Copyright 2016 Twitter. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=missing-docstring
+
+import unittest
+from mock import patch, Mock, call
+from io import StringIO
+
+from heron.common.src.python.utils import log
+
+class LogTest(unittest.TestCase):
+  def setUp(self):
+    pass
+
+  def test_stream_process_stdout(self):
+    ret = StringIO(u'hello\nworld\n')
+    log_fn = Mock()
+    with patch("subprocess.Popen") as mock_process:
+      mock_process.stdout = ret
+      log.stream_process_stdout(mock_process, log_fn)
+
+    log_fn.assert_has_calls([call(u'hello\n'), call(u'world\n')])
+
+  def test_async_stream_process_stdout(self):
+    ret = StringIO(u'hello\nworld\n')
+    log_fn = Mock()
+    with patch("subprocess.Popen") as mock_process:
+      mock_process.stdout = ret
+      thread = log.async_stream_process_stdout(mock_process, log_fn)
+      thread.join()
+
+    log_fn.assert_has_calls([call(u'hello\n'), call(u'world\n')])

--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -30,6 +30,7 @@ import threading
 import time
 import yaml
 import socket
+import traceback
 
 from functools import partial
 
@@ -107,6 +108,14 @@ def log_pid_for_process(process_name, pid):
 
 def is_docker_environment():
   return os.path.isfile('/.dockerenv')
+
+def stdout_log_fn(cmd):
+  """Simple function callback that is used to log the streaming output of a subprocess command
+  :param cmd: the name of the command which will be added to the log line
+  :return: None
+  """
+  # Log the messages to stdout and strip off the newline because Log.info adds one automatically
+  return lambda line: Log.info("%s stdout: %s", cmd, line.rstrip('\n'))
 
 class ProcessInfo(object):
   def __init__(self, process, name, command, attempts=1):
@@ -610,24 +619,37 @@ class HeronExecutor(object):
   # pylint: disable=no-self-use
   def _wait_process_std_out_err(self, name, process):
     ''' Wait for the termination of a process and log its stdout & stderr '''
-    (process_stdout, process_stderr) = process.communicate()
-    if process_stdout:
-      Log.info("%s stdout: %s" %(name, process_stdout))
-    if process_stderr:
-      Log.info("%s stderr: %s" %(name, process_stderr))
+    log.stream_process_stdout(process, stdout_log_fn(name))
+    process.wait()
 
   def _run_process(self, name, cmd, env_to_exec=None):
     Log.info("Running %s process as %s" % (name, ' '.join(cmd)))
-    return subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                            env=env_to_exec)
+    try:
+      # stderr is redirected to stdout so that it can more easily be logged. stderr has a max buffer
+      # size and can cause the child process to deadlock if it fills up
+      process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                 env=env_to_exec)
 
-  def _run_blocking_process(self, cmd, is_shell, env_to_exec=None):
+      log.async_stream_process_stdout(process, stdout_log_fn(name))
+    except Exception:
+      Log.info("Exception running command %:", cmd)
+      traceback.print_exc()
+
+    return process
+
+  def _run_blocking_process(self, cmd, is_shell=False, env_to_exec=None):
     Log.info("Running blocking process as %s" % cmd)
-    process = subprocess.Popen(cmd, shell=is_shell, stdout=subprocess.PIPE,
-                               stderr=subprocess.PIPE, env=env_to_exec)
+    try:
+      # stderr is redirected to stdout so that it can more easily be logged. stderr has a max buffer
+      # size and can cause the child process to deadlock if it fills up
+      process = subprocess.Popen(cmd, shell=is_shell, stdout=subprocess.PIPE,
+                                 stderr=subprocess.STDOUT, env=env_to_exec)
 
-    # wait for termination
-    self._wait_process_std_out_err("", process)
+      # wait for termination
+      self._wait_process_std_out_err(cmd, process)
+    except Exception:
+      Log.info("Exception running command %:", cmd)
+      traceback.print_exc()
 
     # return the exit code
     return process.returncode

--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -628,7 +628,7 @@ class HeronExecutor(object):
       # stderr is redirected to stdout so that it can more easily be logged. stderr has a max buffer
       # size and can cause the child process to deadlock if it fills up
       process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                                 env=env_to_exec)
+                                 env=env_to_exec, bufsize=1)
 
       log.async_stream_process_stdout(process, stdout_log_fn(name))
     except Exception:


### PR DESCRIPTION
The logs for subprocesses launched by the heron-executor were
not actually streamed to the heron-executor log file. Using
`communicate` to read the output of a subprocess will wait until the
process is closed before actually reading the logs. In the non-blocking
case the stdout and stderr were sent to a pipe but were not actually
read from which results in a deadlock if the subprocess logs enough
information into the stderr buffer
([python docs on subprocess and
pipes](https://docs.python.org/2/library/subprocess.html#subprocess.check_call)).

> Do not use stdout=PIPE or stderr=PIPE with this function as that can
deadlock based on the child process output volume.

Heron uses glog to log messages to a file however zookeeper defaults to
using stderr with no easy way to tell it to use glog instead. As such
whenever zookeeper logged a message it would get written to the
subprocess stderr buffer and fill it up ultimately causing a deadlock in
the zookeeper thread in the tmaster trying to write to stderr. This then
manifests itself by the zookeeper client not being able to heartbeat and
having its session expire without being able to callback and restart the
process.

With `subprocess.communicate` the data is [buffered in
memory](https://docs.python.org/2/library/subprocess.html#subprocess.Popen.communicate) until end-of-line is reached
and the subprocess is terminated so it is not suitable for long running processes.

One design consideration here for simplicity is the redirection of the
subprocess stderr to stdout. This is to make reading the data easier.
The downside here is that it is not possible to tell if a log message
came from stdout or stderr but I think that information will be clear
with the content of the message. Also some dependencies like zookeeper
log all of their messages on stderr anyway regardless of the message
type.

Fixes https://github.com/twitter/heron/issues/1653