### PR TITLE
use bind port 0 to solve port conflict in switch_unittest.cpp

### DIFF
--- a/heron/common/src/cpp/network/baseserver.cpp
+++ b/heron/common/src/cpp/network/baseserver.cpp
@@ -107,7 +107,7 @@ sp_int32 BaseServer::Start_Base() {
   }
 
   // fetch the port after bind/listen port 0
-  if (options_.get_sin_family() == AF_INET) {
+  if (AF_INET == options_.get_sin_family() && 0 == options_.get_port()) {
     if (getsockname(listen_fd_, serv_addr, &sockaddr_len) != 0)  {
       LOG(ERROR) << "getsockname() error: " << strerror(errno);
       close(listen_fd_);

--- a/heron/common/src/cpp/network/baseserver.cpp
+++ b/heron/common/src/cpp/network/baseserver.cpp
@@ -106,6 +106,17 @@ sp_int32 BaseServer::Start_Base() {
     return -1;
   }
 
+  // fetch the port after bind/listen port 0
+  if (options_.get_sin_family() == AF_INET) {
+    if (getsockname(listen_fd_, serv_addr, &sockaddr_len) != 0)  {
+      LOG(ERROR) << "getsockname() error: " << strerror(errno);
+      close(listen_fd_);
+      return SP_NOTOK;
+    } else {
+      options_.set_port(ntohs(in_addr.sin_port));
+    }
+  }
+
   return 0;
 }
 

--- a/heron/common/src/cpp/network/baseserver.h
+++ b/heron/common/src/cpp/network/baseserver.h
@@ -67,6 +67,9 @@ class BaseServer {
   // Start listening on the host port pair for new requests
   // A zero return value means success. A negative value implies
   // that the server could not bind/listen on the port.
+  // If the port is 0, the actual port is stored in options_
+  // after Start_Base() called, which can be fetched through
+  // get_serveroptions()
   sp_int32 Start_Base();
 
   // Close all active connections and stop listening.
@@ -135,6 +138,8 @@ class BaseServer {
   ConnectionOptions connection_options_;
 
   // The options of this server.
+  // If the port is 0, the actual port can be fetched through
+  // get_serveroptions() after Start_Base() called.
   NetworkOptions options_;
 
   // Placeholders for various callbacks that we pass to the Connection.

--- a/heron/common/tests/cpp/network/switch_unittest.cpp
+++ b/heron/common/tests/cpp/network/switch_unittest.cpp
@@ -145,6 +145,7 @@ void start_test(sp_int32 nclients, sp_uint64 requests) {
             << std::endl;
 
   delete server_;
+  delete latch;
 }
 
 TEST(NetworkTest, test_switch_1) { start_test(1, 100); }

--- a/heron/common/tests/cpp/network/switch_unittest.cpp
+++ b/heron/common/tests/cpp/network/switch_unittest.cpp
@@ -33,8 +33,6 @@
 #include "threads/modinit.h"
 #include "network/modinit.h"
 
-static sp_uint32 SERVER_PORT;
-
 class Terminate : public Client {
  public:
   Terminate(EventLoopImpl* eventLoop, const NetworkOptions& _options)
@@ -69,10 +67,10 @@ class Terminate : public Client {
 
 static TestServer* server_;
 
-void start_server(sp_uint32 port, CountDownLatch* latch) {
+void start_server(sp_uint32* port, CountDownLatch* latch) {
   NetworkOptions options;
   options.set_host(LOCALHOST);
-  options.set_port(port);
+  options.set_port(*port);
   options.set_max_packet_size(1024 * 1024);
   options.set_socket_family(PF_INET);
 
@@ -80,7 +78,7 @@ void start_server(sp_uint32 port, CountDownLatch* latch) {
   server_ = new TestServer(&ss, options);
   EXPECT_EQ(0, server_->get_serveroptions().get_port());
   if (server_->Start() != 0) GTEST_FAIL();
-  SERVER_PORT = server_->get_serveroptions().get_port();
+  *port = server_->get_serveroptions().get_port();
   latch->countDown();
   ss.loop();
 }
@@ -112,20 +110,20 @@ void terminate_server(sp_uint32 port) {
 }
 
 void start_test(sp_int32 nclients, sp_uint64 requests) {
-  SERVER_PORT = 0;
+  sp_uint32 server_port = 0;
   CountDownLatch* latch = new CountDownLatch(1);
 
   // start the server thread
-  std::thread sthread(start_server, SERVER_PORT, latch);
+  std::thread sthread(start_server, &server_port, latch);
   latch->wait();
-  std::cout << "server port " << SERVER_PORT << std::endl;
+  std::cout << "server port " << server_port << std::endl;
 
   auto start = std::chrono::high_resolution_clock::now();
 
   // start the client threads
   std::vector<std::thread> cthreads;
   for (sp_int32 i = 0; i < nclients; i++) {
-    cthreads.push_back(std::thread(start_client, SERVER_PORT, requests));
+    cthreads.push_back(std::thread(start_client, server_port, requests));
   }
 
   // wait for the client threads to terminate
@@ -136,7 +134,7 @@ void start_test(sp_int32 nclients, sp_uint64 requests) {
   auto stop = std::chrono::high_resolution_clock::now();
 
   // now send a terminate message to server
-  terminate_server(SERVER_PORT);
+  terminate_server(server_port);
   sthread.join();
 
   ASSERT_TRUE(server_->sent_pkts() == server_->recv_pkts());

--- a/heron/common/tests/cpp/network/switch_unittest.cpp
+++ b/heron/common/tests/cpp/network/switch_unittest.cpp
@@ -78,6 +78,7 @@ void start_server(sp_uint32 port, CountDownLatch* latch) {
 
   EventLoopImpl ss;
   server_ = new TestServer(&ss, options);
+  EXPECT_EQ(0, server_->get_serveroptions().get_port());
   if (server_->Start() != 0) GTEST_FAIL();
   SERVER_PORT = server_->get_serveroptions().get_port();
   latch->countDown();

--- a/heron/common/tests/cpp/network/switch_unittest.cpp
+++ b/heron/common/tests/cpp/network/switch_unittest.cpp
@@ -26,6 +26,7 @@
 #include "basics/basics.h"
 #include "errors/errors.h"
 #include "threads/threads.h"
+#include "threads/spcountdownlatch.h"
 #include "network/network.h"
 #include "basics/modinit.h"
 #include "errors/modinit.h"

--- a/heron/common/tests/cpp/network/switch_unittest.cpp
+++ b/heron/common/tests/cpp/network/switch_unittest.cpp
@@ -32,7 +32,7 @@
 #include "threads/modinit.h"
 #include "network/modinit.h"
 
-static const sp_uint32 SERVER_PORT = 61000;
+static sp_uint32 SERVER_PORT;
 
 class Terminate : public Client {
  public:
@@ -78,6 +78,7 @@ void start_server(sp_uint32 port) {
   EventLoopImpl ss;
   server_ = new TestServer(&ss, options);
   if (server_->Start() != 0) GTEST_FAIL();
+  SERVER_PORT = server_->get_serveroptions().get_port();
   ss.loop();
 }
 
@@ -108,6 +109,8 @@ void terminate_server(sp_uint32 port) {
 }
 
 void start_test(sp_int32 nclients, sp_uint64 requests) {
+  SERVER_PORT = 0;
+
   // start the server thread
   std::thread sthread(start_server, SERVER_PORT);
 


### PR DESCRIPTION
This PR is to replace #1833

The port returned by getFreePort() may be occupied before Start().
This PR let server bind port 0 and get the actual port after binding.