### PR TITLE
fix aurora to use maximum resources to start containers

### DIFF
--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
@@ -30,6 +30,7 @@ import com.google.common.base.Optional;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.FileUtils;
+import com.twitter.heron.packing.builder.Container;
 import com.twitter.heron.proto.scheduler.Scheduler;
 import com.twitter.heron.scheduler.UpdateTopologyManager;
 import com.twitter.heron.scheduler.utils.Runtime;
@@ -92,13 +93,14 @@ public class AuroraScheduler implements IScheduler, IScalable {
 
     LOG.info("Launching topology in aurora");
 
-    // Align the cpu, ram, disk to the maximal one
+    // Align the cpu, ram, disk to the maximal one, and set them to ScheduledResource
     PackingPlan updatedPackingPlan = packing.cloneWithHomogeneousScheduledResource();
     SchedulerUtils.persistUpdatedPackingPlan(Runtime.topologyName(runtime), updatedPackingPlan,
         Runtime.schedulerStateManagerAdaptor(runtime));
 
+    // Use the ScheduledResource to request aurora resources
     Resource containerResource =
-        updatedPackingPlan.getContainers().iterator().next().getRequiredResource();
+        updatedPackingPlan.getContainers().iterator().next().getScheduledResource().get();
     Map<AuroraField, String> auroraProperties = createAuroraProperties(containerResource);
 
     return controller.createJob(auroraProperties);

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
@@ -30,7 +30,6 @@ import com.google.common.base.Optional;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.FileUtils;
-import com.twitter.heron.packing.builder.Container;
 import com.twitter.heron.proto.scheduler.Scheduler;
 import com.twitter.heron.scheduler.UpdateTopologyManager;
 import com.twitter.heron.scheduler.utils.Runtime;
@@ -98,7 +97,9 @@ public class AuroraScheduler implements IScheduler, IScalable {
     SchedulerUtils.persistUpdatedPackingPlan(Runtime.topologyName(runtime), updatedPackingPlan,
         Runtime.schedulerStateManagerAdaptor(runtime));
 
-    // Use the ScheduledResource to request aurora resources
+    // Use the ScheduledResource to create aurora properties
+    // the ScheduledResource is guaranteed to be set after calling
+    // cloneWithHomogeneousScheduledResource in the above code
     Resource containerResource =
         updatedPackingPlan.getContainers().iterator().next().getScheduledResource().get();
     Map<AuroraField, String> auroraProperties = createAuroraProperties(containerResource);


### PR DESCRIPTION
`getRequiredResource()` returns the amount of minimum resource needed by each container generated by packing plan, while `getScheduledResource()` returns the maximum resource among all of them.

To start a aurora container with enough resource, `scheduled resource` should be used. If `required resource` is used, there's a chance that aurora container doesn't reserve enough rams. Containers get  out of memory error and are restarted constantly.

This change is tested with actual topologies within twitter environment.