### PR TITLE
fix the flaky ckptmgr server test

### DIFF
--- a/heron/ckptmgr/tests/java/com/twitter/heron/ckptmgr/CheckpointManagerServerTest.java
+++ b/heron/ckptmgr/tests/java/com/twitter/heron/ckptmgr/CheckpointManagerServerTest.java
@@ -68,11 +68,12 @@ public class CheckpointManagerServerTest {
   private CheckpointManagerServer checkpointManagerServer;
   private SimpleCheckpointManagerClient simpleCheckpointManagerClient;
 
+  private CountDownLatch finishedSignal;
+  private CountDownLatch serverStartedSignal;
+
   private NIOLooper serverLooper;
   private NIOLooper clientLooper;
   private ExecutorService threadPools;
-  private CountDownLatch finishedSignal;
-
   private IStatefulStorage backendStorage;
 
   @BeforeClass
@@ -131,6 +132,7 @@ public class CheckpointManagerServerTest {
   @Before
   public void before() throws Exception {
     finishedSignal = new CountDownLatch(1);
+    serverStartedSignal = new CountDownLatch(1);
 
     serverLooper = new NIOLooper();
     clientLooper = new NIOLooper();
@@ -162,7 +164,6 @@ public class CheckpointManagerServerTest {
 
     if (simpleCheckpointManagerClient != null) {
       simpleCheckpointManagerClient.stop();
-
       simpleCheckpointManagerClient.getNIOLooper().exitLoop();
     }
 
@@ -262,6 +263,7 @@ public class CheckpointManagerServerTest {
       @Override
       public void run() {
         checkpointManagerServer.start();
+        serverStartedSignal.countDown();
         checkpointManagerServer.getNIOLooper().loop();
       }
     };
@@ -272,8 +274,14 @@ public class CheckpointManagerServerTest {
     Runnable runClient = new Runnable() {
       @Override
       public void run() {
-        client.start();
-        client.getNIOLooper().loop();
+        try {
+          // wait for the server start before connecting
+          serverStartedSignal.await(2, TimeUnit.SECONDS);
+          client.start();
+          client.getNIOLooper().loop();
+        } catch (InterruptedException ex) {
+          throw new RuntimeException("Client failed to connect to server", ex);
+        }
       }
     };
     threadPools.execute(runClient);


### PR DESCRIPTION
@objmagic found the test failed with the connection error (detailed error message is attached). The cause of the failure is client trying to connect to server before the serve starts. The fix is adding another CountDownLatch to synchronize the client and server.

This fix unblocks https://github.com/twitter/heron/pull/1857

```
18:09:27 FAIL: //heron/ckptmgr/tests/java:CheckpointManagerServerTest (see /var/lib/jenkins/.cache/bazel/_bazel_jenkins/fe81da57b028a6fdc8903fcaa04d2374/execroot/heron-mirror-release_7/bazel-out/local-opt/testlogs/heron/ckptmgr/tests/java/CheckpointManagerServerTest/test.log)
18:09:27 ____From Testing //heron/ckptmgr/tests/java:CheckpointManagerServerTest:
18:09:27 ==================== Test output for //heron/ckptmgr/tests/java:CheckpointManagerServerTest:
18:09:27 JUnit4 Test Runner
18:09:27 .May 15, 2017 1:09:25 AM com.twitter.heron.common.network.HeronClient start
18:09:27 INFO: Connecting to endpoint: /127.0.0.1:59373
18:09:27 May 15, 2017 1:09:25 AM com.twitter.heron.ckptmgr.CheckpointManagerServer onConnect
18:09:27 INFO: Got a new connection from host:port /127.0.0.1:34527
18:09:27 May 15, 2017 1:09:25 AM com.twitter.heron.ckptmgr.CheckpointManagerServer handleSaveInstanceStateRequest
18:09:27 INFO: Got a save checkpoint request for checkpointId checkpoint_id  component component_name instance instance_id on connection /127.0.0.1:34527
18:09:27 May 15, 2017 1:09:25 AM com.twitter.heron.ckptmgr.CheckpointManagerServer handleSaveInstanceStateRequest
18:09:27 INFO: Saved checkpoint for checkpointId checkpoint_id compnent component_name instance instance_id
18:09:27 May 15, 2017 1:09:25 AM com.twitter.heron.common.network.HeronServer stop
18:09:27 INFO: Closing connected channel from client: /127.0.0.1:34527
18:09:27 May 15, 2017 1:09:25 AM com.twitter.heron.common.network.HeronServer stop
18:09:27 INFO: Removing all interest on channel: /127.0.0.1:34527
18:09:27 May 15, 2017 1:09:25 AM com.twitter.heron.ckptmgr.CheckpointManagerServer onClose
18:09:27 SEVERE: Got a connection close from remote socket address: /127.0.0.1:34527
18:09:27 May 15, 2017 1:09:25 AM com.twitter.heron.common.network.SocketChannelHelper forceFlushWithBestEffort
18:09:27 INFO: Forcing to flush data to socket with best effort.
18:09:27 May 15, 2017 1:09:25 AM com.twitter.heron.common.network.HeronClient stop
18:09:27 INFO: To stop the HeronClient.
18:09:27 .May 15, 2017 1:09:25 AM com.twitter.heron.common.network.HeronClient start
18:09:27 INFO: Connecting to endpoint: /127.0.0.1:40491
18:09:27 May 15, 2017 1:09:25 AM com.twitter.heron.ckptmgr.CheckpointManagerServer onConnect
18:09:27 INFO: Got a new connection from host:port /127.0.0.1:50254
18:09:27 May 15, 2017 1:09:25 AM com.twitter.heron.ckptmgr.CheckpointManagerServer handleCleanStatefulCheckpointRequest
18:09:27 INFO: Got a clean request from oldest_checkpoint_preserved: "checkpoint_id"
18:09:27 clean_all_checkpoints: true
18:09:27  running at host:port /127.0.0.1:50254
18:09:27 May 15, 2017 1:09:25 AM com.twitter.heron.ckptmgr.CheckpointManagerServer handleCleanStatefulCheckpointRequest
18:09:27 INFO: Dispose checkpoint successful
18:09:27 May 15, 2017 1:09:25 AM com.twitter.heron.common.network.HeronServer stop
18:09:27 INFO: Closing connected channel from client: /127.0.0.1:50254
18:09:27 May 15, 2017 1:09:25 AM com.twitter.heron.common.network.HeronServer stop
18:09:27 INFO: Removing all interest on channel: /127.0.0.1:50254
18:09:27 May 15, 2017 1:09:25 AM com.twitter.heron.ckptmgr.CheckpointManagerServer onClose
18:09:27 SEVERE: Got a connection close from remote socket address: /127.0.0.1:50254
18:09:27 May 15, 2017 1:09:25 AM com.twitter.heron.common.network.SocketChannelHelper forceFlushWithBestEffort
18:09:27 INFO: Forcing to flush data to socket with best effort.
18:09:27 May 15, 2017 1:09:25 AM com.twitter.heron.common.network.HeronClient stop
18:09:27 INFO: To stop the HeronClient.
18:09:27 .May 15, 2017 1:09:25 AM com.twitter.heron.common.network.HeronClient start
18:09:27 INFO: Connecting to endpoint: /127.0.0.1:44505
18:09:27 May 15, 2017 1:09:25 AM com.twitter.heron.common.network.HeronClient handleConnect
18:09:27 SEVERE: Failed to FinishConnect to endpoint: /127.0.0.1:44505
18:09:27 java.net.ConnectException: Connection refused
18:09:27 	at sun.nio.ch.SocketChannelImpl.checkConnect(Native Method)
18:09:27 	at sun.nio.ch.SocketChannelImpl.finishConnect(SocketChannelImpl.java:717)
18:09:27 	at com.twitter.heron.common.network.HeronClient.handleConnect(HeronClient.java:244)
18:09:27 	at com.twitter.heron.common.basics.NIOLooper.handleSelectedKeys(NIOLooper.java:115)
18:09:27 	at com.twitter.heron.common.basics.NIOLooper.access$000(NIOLooper.java:32)
18:09:27 	at com.twitter.heron.common.basics.NIOLooper$1.run(NIOLooper.java:45)
18:09:27 	at com.twitter.heron.common.basics.WakeableLooper.executeTasksOnWakeup(WakeableLooper.java:142)
18:09:27 	at com.twitter.heron.common.basics.WakeableLooper.runOnce(WakeableLooper.java:74)
18:09:27 	at com.twitter.heron.common.basics.WakeableLooper.loop(WakeableLooper.java:64)
18:09:27 	at com.twitter.heron.ckptmgr.CheckpointManagerServerTest$2.run(CheckpointManagerServerTest.java:276)
18:09:27 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
18:09:27 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
18:09:27 	at java.lang.Thread.run(Thread.java:748)
18:09:27 
18:09:27 Exception in thread "pool-3-thread-2" java.lang.AssertionError: Connection with server failed
18:09:27 	at org.junit.Assert.fail(Assert.java:88)
18:09:27 	at com.twitter.heron.ckptmgr.CheckpointManagerServerTest$SimpleCheckpointManagerClient.onConnect(CheckpointManagerServerTest.java:313)
18:09:27 	at com.twitter.heron.common.network.HeronClient$3.run(HeronClient.java:253)
18:09:27 	at com.twitter.heron.common.basics.WakeableLooper.triggerExpiredTimers(WakeableLooper.java:151)
18:09:27 	at com.twitter.heron.common.basics.WakeableLooper.runOnce(WakeableLooper.java:76)
18:09:27 	at com.twitter.heron.common.basics.WakeableLooper.loop(WakeableLooper.java:64)
18:09:27 	at com.twitter.heron.ckptmgr.CheckpointManagerServerTest$2.run(CheckpointManagerServerTest.java:276)
18:09:27 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
18:09:27 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
18:09:27 	at java.lang.Thread.run(Thread.java:748)
18:09:27 E.May 15, 2017 1:09:27 AM com.twitter.heron.common.network.HeronClient start
18:09:27 INFO: Connecting to endpoint: /127.0.0.1:50998
18:09:27 May 15, 2017 1:09:27 AM com.twitter.heron.ckptmgr.CheckpointManagerServer onConnect
18:09:27 INFO: Got a new connection from host:port /127.0.0.1:57664
18:09:27 May 15, 2017 1:09:27 AM com.twitter.heron.ckptmgr.CheckpointManagerServer handleStMgrRegisterRequest
18:09:27 INFO: Got a StMgr register request from stmgr_id running on host:port /127.0.0.1:57664
18:09:27 May 15, 2017 1:09:27 AM com.twitter.heron.common.network.HeronServer stop
18:09:27 INFO: Closing connected channel from client: /127.0.0.1:57664
18:09:27 May 15, 2017 1:09:27 AM com.twitter.heron.common.network.HeronServer stop
18:09:27 INFO: Removing all interest on channel: /127.0.0.1:57664
18:09:27 May 15, 2017 1:09:27 AM com.twitter.heron.ckptmgr.CheckpointManagerServer onClose
18:09:27 SEVERE: Got a connection close from remote socket address: /127.0.0.1:57664
18:09:27 May 15, 2017 1:09:27 AM com.twitter.heron.common.network.SocketChannelHelper forceFlushWithBestEffort
18:09:27 INFO: Forcing to flush data to socket with best effort.
18:09:27 May 15, 2017 1:09:27 AM com.twitter.heron.common.network.HeronClient stop
18:09:27 INFO: To stop the HeronClient.
18:09:27 .May 15, 2017 1:09:27 AM com.twitter.heron.common.network.HeronClient start
18:09:27 INFO: Connecting to endpoint: /127.0.0.1:42091
18:09:27 May 15, 2017 1:09:27 AM com.twitter.heron.ckptmgr.CheckpointManagerServer onConnect
18:09:27 INFO: Got a new connection from host:port /127.0.0.1:58053
18:09:27 May 15, 2017 1:09:27 AM com.twitter.heron.ckptmgr.CheckpointManagerServer handleGetInstanceStateRequest
18:09:27 INFO: Got a get checkpoint request for checkpointId checkpoint_id  component component_name taskId 1 on connection /127.0.0.1:58053
18:09:27 May 15, 2017 1:09:27 AM com.twitter.heron.ckptmgr.CheckpointManagerServer handleGetInstanceStateRequest
18:09:27 INFO: Get checkpoint successful for checkpointId checkpoint_id component component_name taskId 1
18:09:27 May 15, 2017 1:09:27 AM com.twitter.heron.common.network.HeronServer stop
18:09:27 INFO: Closing connected channel from client: /127.0.0.1:58053
18:09:27 May 15, 2017 1:09:27 AM com.twitter.heron.common.network.HeronServer stop
18:09:27 INFO: Removing all interest on channel: /127.0.0.1:58053
18:09:27 May 15, 2017 1:09:27 AM com.twitter.heron.ckptmgr.CheckpointManagerServer onClose
18:09:27 SEVERE: Got a connection close from remote socket address: /127.0.0.1:58053
18:09:27 May 15, 2017 1:09:27 AM com.twitter.heron.common.network.SocketChannelHelper forceFlushWithBestEffort
18:09:27 INFO: Forcing to flush data to socket with best effort.
18:09:27 May 15, 2017 1:09:27 AM com.twitter.heron.common.network.HeronClient stop
18:09:27 INFO: To stop the HeronClient.
18:09:27 
18:09:27 Time: 3.218
18:09:27 There was 1 failure:
18:09:27 1) testRegiseterTMaster(com.twitter.heron.ckptmgr.CheckpointManagerServerTest)
18:09:27 java.lang.AssertionError
18:09:27 	at org.junit.Assert.fail(Assert.java:86)
18:09:27 	at org.junit.Assert.assertTrue(Assert.java:41)
18:09:27 	at org.junit.Assert.assertTrue(Assert.java:52)
18:09:27 	at com.twitter.heron.ckptmgr.CheckpointManagerServerTest.testRegiseterTMaster(CheckpointManagerServerTest.java:235)
18:09:27 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
18:09:27 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
18:09:27 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
18:09:27 	at java.lang.reflect.Method.invoke(Method.java:498)
18:09:27 	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
18:09:27 	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
18:09:27 	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
18:09:27 	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
18:09:27 	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
18:09:27 	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
18:09:27 	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
18:09:27 	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
18:09:27 	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
18:09:27 	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
18:09:27 	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
18:09:27 	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
18:09:27 	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
18:09:27 	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
18:09:27 	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
18:09:27 	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
18:09:27 	at com.google.testing.junit.runner.junit4.CancellableRequestFactory$CancellableRunner.run(CancellableRequestFactory.java:89)
18:09:27 	at org.junit.runner.JUnitCore.run(JUnitCore.java:160)
18:09:27 	at org.junit.runner.JUnitCore.run(JUnitCore.java:138)
18:09:27 	at com.google.testing.junit.runner.junit4.JUnit4Runner.run(JUnit4Runner.java:114)
18:09:27 	at com.google.testing.junit.runner.BazelTestRunner.runTestsInSuite(BazelTestRunner.java:152)
18:09:27 	at com.google.testing.junit.runner.BazelTestRunner.main(BazelTestRunner.java:91)
18:09:27 
18:09:27 FAILURES!!!
18:09:27 Tests run: 5,  Failures: 1
18:09:27 
18:09:27 
```