### PR TITLE
Change SystemConfig and HeronSocketOptions to use ByteAmount

### DIFF
--- a/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/CheckpointManager.java
+++ b/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/CheckpointManager.java
@@ -27,7 +27,6 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
-import com.twitter.heron.common.basics.Constants;
 import com.twitter.heron.common.basics.NIOLooper;
 import com.twitter.heron.common.basics.SingletonRegistry;
 import com.twitter.heron.common.config.SystemConfig;
@@ -140,9 +139,9 @@ public class CheckpointManager {
 
     HeronSocketOptions serverSocketOptions =
         new HeronSocketOptions(
-            checkpointManagerConfig.getWriteBatchSizeBytes(),
+            checkpointManagerConfig.getWriteBatchSize(),
             checkpointManagerConfig.getWriteBatchTimeMs(),
-            checkpointManagerConfig.getReadBatchSizeBytes(),
+            checkpointManagerConfig.getReadBatchSize(),
             checkpointManagerConfig.getReadBatchTimeMs(),
             checkpointManagerConfig.getSocketSendSize(),
             checkpointManagerConfig.getSocketReceiveSize());
@@ -226,7 +225,7 @@ public class CheckpointManager {
     LoggingHelper.loggerInit(loggingLevel, true);
     LoggingHelper.addLoggingHandler(
         LoggingHelper.getFileHandler(ckptmgrId, loggingDir, true,
-            systemConfig.getHeronLoggingMaximumSizeMb() * Constants.MB_TO_BYTES,
+            systemConfig.getHeronLoggingMaximumSize(),
             systemConfig.getHeronLoggingMaximumFiles()));
     LoggingHelper.addLoggingHandler(new ErrorReportLoggingHandler());
 

--- a/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/CheckpointManagerConfig.java
+++ b/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/CheckpointManagerConfig.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.common.basics.TypeUtils;
 import com.twitter.heron.common.config.ConfigReader;
 
@@ -50,28 +51,28 @@ public final class CheckpointManagerConfig {
     return getString(CheckpointManagerConfigKey.STORAGE_CLASSNAME);
   }
 
-  public Long getWriteBatchSizeBytes() {
-    return getLong(CheckpointManagerConfigKey.WRITE_BATCH_SIZE);
+  public ByteAmount getWriteBatchSize() {
+    return getByteAmount(CheckpointManagerConfigKey.WRITE_BATCH_SIZE);
   }
 
   public Long getWriteBatchTimeMs() {
     return getLong(CheckpointManagerConfigKey.WRITE_BATCH_TIME);
   }
 
-  public Long getReadBatchSizeBytes() {
-    return getLong(CheckpointManagerConfigKey.READ_BATCH_SIZE);
+  public ByteAmount getReadBatchSize() {
+    return getByteAmount(CheckpointManagerConfigKey.READ_BATCH_SIZE);
   }
 
   public Long getReadBatchTimeMs() {
     return getLong(CheckpointManagerConfigKey.READ_BATCH_TIME);
   }
 
-  public Integer getSocketSendSize() {
-    return getInteger(CheckpointManagerConfigKey.SOCKET_SEND_SIZE);
+  public ByteAmount getSocketSendSize() {
+    return getByteAmount(CheckpointManagerConfigKey.SOCKET_SEND_SIZE);
   }
 
-  public Integer getSocketReceiveSize() {
-    return getInteger(CheckpointManagerConfigKey.SOCKET_RECEIVE_SIZE);
+  public ByteAmount getSocketReceiveSize() {
+    return getByteAmount(CheckpointManagerConfigKey.SOCKET_RECEIVE_SIZE);
   }
 
   private String getString(CheckpointManagerConfigKey key) {
@@ -87,6 +88,11 @@ public final class CheckpointManagerConfig {
   private Long getLong(CheckpointManagerConfigKey key) {
     assertType(key, CheckpointManagerConfigKey.Type.LONG);
     return TypeUtils.getLong(get(key));
+  }
+
+  private ByteAmount getByteAmount(CheckpointManagerConfigKey key) {
+    assertType(key, CheckpointManagerConfigKey.Type.BYTE_AMOUNT);
+    return TypeUtils.getByteAmount(get(key));
   }
 
   private Object get(CheckpointManagerConfigKey key) {
@@ -151,6 +157,9 @@ public final class CheckpointManagerConfig {
                                       Object value) {
       if (key != null) {
         switch (key.getType()) {
+          case BYTE_AMOUNT:
+            config.put(key.value(), TypeUtils.getByteAmount(value));
+            break;
           case INTEGER:
             config.put(key.value(), TypeUtils.getInteger(value));
             break;

--- a/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/CheckpointManagerConfigKey.java
+++ b/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/CheckpointManagerConfigKey.java
@@ -34,7 +34,7 @@ public enum CheckpointManagerConfigKey {
   /**
    * The batch size in bytes for write operation
    */
-  WRITE_BATCH_SIZE("heron.ckptmgr.network.write.batch.size.bytes", Type.LONG),
+  WRITE_BATCH_SIZE("heron.ckptmgr.network.write.batch.size.bytes", Type.BYTE_AMOUNT),
 
   /**
    * The time for ckptmgr write batch
@@ -44,7 +44,7 @@ public enum CheckpointManagerConfigKey {
   /**
    * The batch size in bytes for read operation
    */
-  READ_BATCH_SIZE("heron.ckptmgr.network.read.batch.size.bytes", Type.LONG),
+  READ_BATCH_SIZE("heron.ckptmgr.network.read.batch.size.bytes", Type.BYTE_AMOUNT),
 
   /**
    * The time for ckptmger read batch
@@ -54,19 +54,20 @@ public enum CheckpointManagerConfigKey {
   /**
    * The size for socket send buffer in bytes
    */
-  SOCKET_SEND_SIZE("heron.ckptmgr.network.options.socket.send.buffer.size.bytes", Type.INTEGER),
+  SOCKET_SEND_SIZE("heron.ckptmgr.network.options.socket.send.buffer.size.bytes", Type.BYTE_AMOUNT),
 
   /**
    * The size for socket receive buffer in bytes
    */
   SOCKET_RECEIVE_SIZE(
-      "heron.ckptmgr.network.options.socket.receive.buffer.size.bytes", Type.INTEGER);
+      "heron.ckptmgr.network.options.socket.receive.buffer.size.bytes", Type.BYTE_AMOUNT);
 
   private final String value;
   private final Object defaultValue;
   private final Type type;
 
   public enum Type {
+    BYTE_AMOUNT,
     INTEGER,
     LONG,
     STRING,

--- a/heron/ckptmgr/tests/java/com/twitter/heron/ckptmgr/CheckpointManagerServerTest.java
+++ b/heron/ckptmgr/tests/java/com/twitter/heron/ckptmgr/CheckpointManagerServerTest.java
@@ -27,6 +27,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.common.basics.NIOLooper;
 import com.twitter.heron.common.basics.SysUtils;
 import com.twitter.heron.common.network.HeronClient;
@@ -54,6 +55,12 @@ public class CheckpointManagerServerTest {
   private static final String CHECKPOINT_MANAGER_ID = "ckptmgr_id";
 
   private static final String SERVER_HOST = "127.0.0.1";
+  private static final HeronSocketOptions TEST_SOCKET_OPTIONS = new HeronSocketOptions(
+      ByteAmount.fromMegabytes(100), 100,
+      ByteAmount.fromMegabytes(100), 100,
+      ByteAmount.fromMegabytes(5),
+      ByteAmount.fromMegabytes(5));
+
   private static int serverPort;
 
   private static CheckpointManager.InstanceStateCheckpoint instanceStateCheckpoint;
@@ -138,17 +145,11 @@ public class CheckpointManagerServerTest {
 
     backendStorage = mock(IStatefulStorage.class);
 
-    HeronSocketOptions serverSocketOptions =
-        new HeronSocketOptions(100 * 1024 * 1024, 100,
-            100 * 1024 * 1024, 100,
-            5 * 1024 * 1024,
-            5 * 1024 * 1024);
-
     serverPort = SysUtils.getFreePort();
     checkpointManagerServer = new CheckpointManagerServer(
         TOPOLOGY_NAME, TOPOLOGY_ID,
         CHECKPOINT_MANAGER_ID, backendStorage,
-        serverLooper, SERVER_HOST, serverPort, serverSocketOptions);
+        serverLooper, SERVER_HOST, serverPort, TEST_SOCKET_OPTIONS);
 
     runServer();
   }
@@ -296,12 +297,7 @@ public class CheckpointManagerServerTest {
     SimpleCheckpointManagerClient(NIOLooper looper, String host,
                                   int port, CountDownLatch finishedSignal,
                                   RequestType requestType) {
-      super(looper, host, port,
-          new HeronSocketOptions(100 * 1024 * 1024, 100,
-              100 * 1024 * 1024, 100,
-              5 * 1024 * 1024,
-              5 * 1024 * 1024));
-
+      super(looper, host, port, TEST_SOCKET_OPTIONS);
       this.finishedSignal = finishedSignal;
       this.requestType = requestType;
       this.responseStatus = StatusCode.TIMEOUT_ERROR;

--- a/heron/common/src/java/com/twitter/heron/common/basics/Constants.java
+++ b/heron/common/src/java/com/twitter/heron/common/basics/Constants.java
@@ -18,7 +18,6 @@ public final class Constants {
   public static final long SECONDS_TO_NANOSECONDS = 1000 * 1000 * 1000;
   public static final long MILLISECONDS_TO_NANOSECONDS = 1000 * 1000;
   public static final long SECONDS_TO_MILLISECONDS = 1000;
-  public static final int MB_TO_BYTES = 1024 * 1024;
 
   private Constants() {
   }

--- a/heron/common/src/java/com/twitter/heron/common/config/SystemConfig.java
+++ b/heron/common/src/java/com/twitter/heron/common/config/SystemConfig.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.common.basics.TypeUtils;
 
 /**
@@ -53,8 +54,8 @@ public final class SystemConfig {
     return getInteger(SystemConfigKey.INSTANCE_SET_DATA_TUPLE_CAPACITY);
   }
 
-  public long getInstanceSetDataTupleSizeBytes() {
-    return getLong(SystemConfigKey.INSTANCE_SET_DATA_TUPLE_SIZE_BYTES);
+  public ByteAmount getInstanceSetDataTupleSize() {
+    return getByteAmount(SystemConfigKey.INSTANCE_SET_DATA_TUPLE_SIZE);
   }
 
   public int getInstanceSetControlTupleCapacity() {
@@ -109,8 +110,8 @@ public final class SystemConfig {
     return getString(SystemConfigKey.HERON_LOGGING_DIRECTORY);
   }
 
-  public int getHeronLoggingMaximumSizeMb() {
-    return getInteger(SystemConfigKey.HERON_LOGGING_MAXIMUM_SIZE_MB);
+  public ByteAmount getHeronLoggingMaximumSize() {
+    return ByteAmount.fromMegabytes(getInteger(SystemConfigKey.HERON_LOGGING_MAXIMUM_SIZE_MB));
   }
 
   public int getHeronLoggingMaximumFiles() {
@@ -125,40 +126,40 @@ public final class SystemConfig {
     return getLong(SystemConfigKey.INSTANCE_NETWORK_READ_BATCH_TIME_MS);
   }
 
-  public long getInstanceNetworkReadBatchSizeBytes() {
-    return getLong(SystemConfigKey.INSTANCE_NETWORK_READ_BATCH_SIZE_BYTES);
+  public ByteAmount getInstanceNetworkReadBatchSize() {
+    return getByteAmount(SystemConfigKey.INSTANCE_NETWORK_READ_BATCH_SIZE);
   }
 
   public long getInstanceNetworkWriteBatchTimeMs() {
     return getLong(SystemConfigKey.INSTANCE_NETWORK_WRITE_BATCH_TIME_MS);
   }
 
-  public long getInstanceNetworkWriteBatchSizeBytes() {
-    return getLong(SystemConfigKey.INSTANCE_NETWORK_WRITE_BATCH_SIZE_BYTES);
+  public ByteAmount getInstanceNetworkWriteBatchSize() {
+    return getByteAmount(SystemConfigKey.INSTANCE_NETWORK_WRITE_BATCH_SIZE);
   }
 
-  public int getInstanceNetworkOptionsSocketReceivedBufferSizeBytes() {
-    return getInteger(SystemConfigKey.INSTANCE_NETWORK_OPTIONS_SOCKET_RECEIVED_BUFFER_SIZE_BYTES);
+  public ByteAmount getInstanceNetworkOptionsSocketReceivedBufferSize() {
+    return getByteAmount(SystemConfigKey.INSTANCE_NETWORK_OPTIONS_SOCKET_RECEIVED_BUFFER_SIZE);
   }
 
-  public int getInstanceNetworkOptionsSocketSendBufferSizeBytes() {
-    return getInteger(SystemConfigKey.INSTANCE_NETWORK_OPTIONS_SOCKET_SEND_BUFFER_SIZE_BYTES);
+  public ByteAmount getInstanceNetworkOptionsSocketSendBufferSize() {
+    return getByteAmount(SystemConfigKey.INSTANCE_NETWORK_OPTIONS_SOCKET_SEND_BUFFER_SIZE);
   }
 
   public long getInstanceEmitBatchTimeMs() {
     return getLong(SystemConfigKey.INSTANCE_EMIT_BATCH_TIME_MS);
   }
 
-  public long getInstanceEmitBatchSizeBytes() {
-    return getLong(SystemConfigKey.INSTANCE_EMIT_BATCH_SIZE_BYTES);
+  public ByteAmount getInstanceEmitBatchSize() {
+    return getByteAmount(SystemConfigKey.INSTANCE_EMIT_BATCH_SIZE);
   }
 
   public long getInstanceExecuteBatchTimeMs() {
     return getLong(SystemConfigKey.INSTANCE_EXECUTE_BATCH_TIME_MS);
   }
 
-  public long getInstanceExecuteBatchSizeBytes() {
-    return getLong(SystemConfigKey.INSTANCE_EXECUTE_BATCH_SIZE_BYTES);
+  public ByteAmount getInstanceExecuteBatchSize() {
+    return getByteAmount(SystemConfigKey.INSTANCE_EXECUTE_BATCH_SIZE);
   }
 
   public int getInstanceReconnectStreammgrIntervalSec() {
@@ -193,24 +194,24 @@ public final class SystemConfig {
     return getLong(SystemConfigKey.METRICSMGR_NETWORK_READ_BATCH_TIME_MS);
   }
 
-  public long getMetricsMgrNetworkReadBatchSizeBytes() {
-    return getLong(SystemConfigKey.METRICSMGR_NETWORK_READ_BATCH_SIZE_BYTES);
+  public ByteAmount getMetricsMgrNetworkReadBatchSize() {
+    return getByteAmount(SystemConfigKey.METRICSMGR_NETWORK_READ_BATCH_SIZE);
   }
 
   public long getMetricsMgrNetworkWriteBatchTimeMs() {
     return getLong(SystemConfigKey.METRICSMGR_NETWORK_WRITE_BATCH_TIME_MS);
   }
 
-  public long getMetricsMgrNetworkWriteBatchSizeBytes() {
-    return getLong(SystemConfigKey.METRICSMGR_NETWORK_WRITE_BATCH_SIZE_BYTES);
+  public ByteAmount getMetricsMgrNetworkWriteBatchSize() {
+    return getByteAmount(SystemConfigKey.METRICSMGR_NETWORK_WRITE_BATCH_SIZE);
   }
 
-  public int getMetricsMgrNetworkOptionsSocketReceivedBufferSizeBytes() {
-    return getInteger(SystemConfigKey.METRICSMGR_NETWORK_OPTIONS_SOCKET_RECEIVED_BUFFER_SIZE_BYTES);
+  public ByteAmount getMetricsMgrNetworkOptionsSocketReceivedBufferSize() {
+    return getByteAmount(SystemConfigKey.METRICSMGR_NETWORK_OPTIONS_SOCKET_RECEIVED_BUFFER_SIZE);
   }
 
-  public int getMetricsMgrNetworkOptionsSocketSendBufferSizeBytes() {
-    return getInteger(SystemConfigKey.METRICSMGR_NETWORK_OPTIONS_SOCKET_SEND_BUFFER_SIZE_BYTES);
+  public ByteAmount getMetricsMgrNetworkOptionsSocketSendBufferSize() {
+    return getByteAmount(SystemConfigKey.METRICSMGR_NETWORK_OPTIONS_SOCKET_SEND_BUFFER_SIZE);
   }
 
   public int getHeronMetricsMaxExceptionsPerMessageCount() {
@@ -259,6 +260,11 @@ public final class SystemConfig {
   private Double getDouble(SystemConfigKey key) {
     assertType(key, SystemConfigKey.Type.DOUBLE);
     return TypeUtils.getDouble(get(key));
+  }
+
+  private ByteAmount getByteAmount(SystemConfigKey key) {
+    assertType(key, SystemConfigKey.Type.BYTE_AMOUNT);
+    return TypeUtils.getByteAmount(get(key));
   }
 
   private Object get(SystemConfigKey key) {

--- a/heron/common/src/java/com/twitter/heron/common/config/SystemConfigKey.java
+++ b/heron/common/src/java/com/twitter/heron/common/config/SystemConfigKey.java
@@ -94,8 +94,8 @@ public enum SystemConfigKey {
   /**
    * Size based,the maximum batch size in bytes to read from stream manager
    */
-  INSTANCE_NETWORK_READ_BATCH_SIZE_BYTES(
-      "heron.instance.network.read.batch.size.bytes", Type.LONG),
+  INSTANCE_NETWORK_READ_BATCH_SIZE(
+      "heron.instance.network.read.batch.size.bytes", Type.BYTE_AMOUNT),
 
   /**
    * Time based, the maximum batch time in ms for instance to read from stream manager per attempt
@@ -105,20 +105,20 @@ public enum SystemConfigKey {
   /**
    * Size based, the maximum batch size in bytes to write to stream manager
    */
-  INSTANCE_NETWORK_WRITE_BATCH_SIZE_BYTES(
-      "heron.instance.network.write.batch.size.bytes", Type.LONG),
+  INSTANCE_NETWORK_WRITE_BATCH_SIZE(
+      "heron.instance.network.write.batch.size.bytes", Type.BYTE_AMOUNT),
 
   /**
    * # The maximum socket's received buffer size in bytes of instance's network options
    */
-  INSTANCE_NETWORK_OPTIONS_SOCKET_RECEIVED_BUFFER_SIZE_BYTES(
-      "heron.instance.network.options.socket.received.buffer.size.bytes", Type.INTEGER),
+  INSTANCE_NETWORK_OPTIONS_SOCKET_RECEIVED_BUFFER_SIZE(
+      "heron.instance.network.options.socket.received.buffer.size.bytes", Type.BYTE_AMOUNT),
 
   /**
    * The maximum socket's send buffer size in bytes
    */
-  INSTANCE_NETWORK_OPTIONS_SOCKET_SEND_BUFFER_SIZE_BYTES(
-      "heron.instance.network.options.socket.send.buffer.size.bytes", Type.INTEGER),
+  INSTANCE_NETWORK_OPTIONS_SOCKET_SEND_BUFFER_SIZE(
+      "heron.instance.network.options.socket.send.buffer.size.bytes", Type.BYTE_AMOUNT),
 
   /**
    * The maximum # of data tuple to batch in a HeronDataTupleSet protobuf
@@ -128,7 +128,8 @@ public enum SystemConfigKey {
   /**
    * The maximum size in bytes of data tuple to batch in a HeronDataTupleSet protobuf
    */
-  INSTANCE_SET_DATA_TUPLE_SIZE_BYTES("heron.instance.set.data.tuple.size.bytes", Long.MAX_VALUE),
+  INSTANCE_SET_DATA_TUPLE_SIZE(
+      "heron.instance.set.data.tuple.size.bytes", ByteAmount.fromBytes(Long.MAX_VALUE)),
 
   /**
    * The size of packets read from stream manager will be determined by the minimal of
@@ -158,7 +159,7 @@ public enum SystemConfigKey {
   /**
    * The maximum batch size in bytes for an spout instance to emit tuples per attempt
    */
-  INSTANCE_EMIT_BATCH_SIZE_BYTES("heron.instance.emit.batch.size.bytes", Type.LONG),
+  INSTANCE_EMIT_BATCH_SIZE("heron.instance.emit.batch.size.bytes", Type.BYTE_AMOUNT),
 
   /**
    * The maximum time in ms for an bolt instance to execute tuples per attempt
@@ -168,7 +169,7 @@ public enum SystemConfigKey {
   /**
    * The maximum batch size in bytes for an bolt instance to execute tuples per attempt
    */
-  INSTANCE_EXECUTE_BATCH_SIZE_BYTES("heron.instance.execute.batch.size.bytes", Type.LONG),
+  INSTANCE_EXECUTE_BATCH_SIZE("heron.instance.execute.batch.size.bytes", Type.BYTE_AMOUNT),
 
   /**
    * The time interval for an instance to check the state change, for instance,
@@ -268,8 +269,8 @@ public enum SystemConfigKey {
   /**
    * Size based,the maximum batch size in bytes to read from socket
    */
-  METRICSMGR_NETWORK_READ_BATCH_SIZE_BYTES(
-      "heron.metricsmgr.network.read.batch.size.bytes", Type.LONG),
+  METRICSMGR_NETWORK_READ_BATCH_SIZE(
+      "heron.metricsmgr.network.read.batch.size.bytes", Type.BYTE_AMOUNT),
 
   /**
    * The size of packets written to socket will be determined by the minimal of
@@ -283,20 +284,20 @@ public enum SystemConfigKey {
   /**
    * Size based, the maximum batch size in bytes to write to socket
    */
-  METRICSMGR_NETWORK_WRITE_BATCH_SIZE_BYTES(
-      "heron.metricsmgr.network.write.batch.size.bytes", Type.LONG),
+  METRICSMGR_NETWORK_WRITE_BATCH_SIZE(
+      "heron.metricsmgr.network.write.batch.size.bytes", Type.BYTE_AMOUNT),
 
   /**
    * The maximum socket's received buffer size in bytes
    */
-  METRICSMGR_NETWORK_OPTIONS_SOCKET_RECEIVED_BUFFER_SIZE_BYTES(
-      "heron.metricsmgr.network.options.socket.received.buffer.size.bytes", Type.INTEGER),
+  METRICSMGR_NETWORK_OPTIONS_SOCKET_RECEIVED_BUFFER_SIZE(
+      "heron.metricsmgr.network.options.socket.received.buffer.size.bytes", Type.BYTE_AMOUNT),
 
   /**
    * The maximum socket's send buffer size in bytes
    */
-  METRICSMGR_NETWORK_OPTIONS_SOCKET_SEND_BUFFER_SIZE_BYTES(
-      "heron.metricsmgr.network.options.socket.send.buffer.size.bytes", Type.INTEGER),
+  METRICSMGR_NETWORK_OPTIONS_SOCKET_SEND_BUFFER_SIZE(
+      "heron.metricsmgr.network.options.socket.send.buffer.size.bytes", Type.BYTE_AMOUNT),
 
   /**
    *The maximum exception count be kept in tmaster

--- a/heron/common/src/java/com/twitter/heron/common/network/HeronClient.java
+++ b/heron/common/src/java/com/twitter/heron/common/network/HeronClient.java
@@ -109,9 +109,10 @@ public abstract class HeronClient implements ISelectHandler {
       socketChannel.configureBlocking(false);
 
       // Set the maximum possible send and receive buffers
-      socketChannel.socket().setSendBufferSize(socketOptions.getSocketSendBufferSizeInBytes());
+      socketChannel.socket().setSendBufferSize(
+          (int) socketOptions.getSocketSendBufferSize().asBytes());
       socketChannel.socket().setReceiveBufferSize(
-          socketOptions.getSocketReceivedBufferSizeInBytes());
+          (int) socketOptions.getSocketReceivedBufferSize().asBytes());
       socketChannel.socket().setTcpNoDelay(true);
 
       // If the socketChannel has already connect to endpoint, call handleConnect()

--- a/heron/common/src/java/com/twitter/heron/common/network/HeronServer.java
+++ b/heron/common/src/java/com/twitter/heron/common/network/HeronServer.java
@@ -131,9 +131,10 @@ public abstract class HeronServer implements ISelectHandler {
       if (socketChannel != null) {
         socketChannel.configureBlocking(false);
         // Set the maximum possible send and receive buffers
-        socketChannel.socket().setSendBufferSize(socketOptions.getSocketSendBufferSizeInBytes());
+        socketChannel.socket().setSendBufferSize(
+            (int) socketOptions.getSocketSendBufferSize().asBytes());
         socketChannel.socket().setReceiveBufferSize(
-            socketOptions.getSocketReceivedBufferSizeInBytes());
+            (int) socketOptions.getSocketReceivedBufferSize().asBytes());
         socketChannel.socket().setTcpNoDelay(true);
         SocketChannelHelper helper = new SocketChannelHelper(nioLooper, this, socketChannel,
             socketOptions);

--- a/heron/common/src/java/com/twitter/heron/common/network/HeronSocketOptions.java
+++ b/heron/common/src/java/com/twitter/heron/common/network/HeronSocketOptions.java
@@ -14,78 +14,56 @@
 
 package com.twitter.heron.common.network;
 
+import com.twitter.heron.common.basics.ByteAmount;
+
 /**
  * Options that Heron Server/Client passes to config
  * 1. JAVA SocketChannel
  * 2. SocketChannelHelper
  */
 public class HeronSocketOptions {
-  private long networkWriteBatchSizeInBytes;
+  private ByteAmount networkWriteBatchSize;
   private long networkWriteBatchTimeInMs;
-  private long networkReadBatchSizeInBytes;
+  private ByteAmount networkReadBatchSize;
   private long networkReadBatchTimeInMs;
-  private int socketSendBufferSizeInBytes;
-  private int socketReceivedBufferSizeInBytes;
+  private ByteAmount socketSendBufferSize;
+  private ByteAmount socketReceivedBufferSize;
 
-  public HeronSocketOptions(long networkWriteBatchSizeInBytes,
+  public HeronSocketOptions(ByteAmount networkWriteBatchSize,
                             long networkWriteBatchTimeInMs,
-                            long networkReadBatchSizeInBytes,
+                            ByteAmount networkReadBatchSize,
                             long networkReadBatchTimeInMs,
-                            int socketSendBufferSizeInBytes,
-                            int socketReceivedBufferSizeInBytes) {
-    this.networkWriteBatchSizeInBytes = networkWriteBatchSizeInBytes;
+                            ByteAmount socketSendBufferSize,
+                            ByteAmount socketReceivedBufferSize) {
+    this.networkWriteBatchSize = networkWriteBatchSize;
     this.networkWriteBatchTimeInMs = networkWriteBatchTimeInMs;
-    this.networkReadBatchSizeInBytes = networkReadBatchSizeInBytes;
+    this.networkReadBatchSize = networkReadBatchSize;
     this.networkReadBatchTimeInMs = networkReadBatchTimeInMs;
-    this.socketSendBufferSizeInBytes = socketSendBufferSizeInBytes;
-    this.socketReceivedBufferSizeInBytes = socketReceivedBufferSizeInBytes;
+    this.socketSendBufferSize = socketSendBufferSize;
+    this.socketReceivedBufferSize = socketReceivedBufferSize;
   }
 
-  public long getNetworkWriteBatchSizeInBytes() {
-    return networkWriteBatchSizeInBytes;
-  }
-
-  public void setNetworkWriteBatchSizeInBytes(long networkWriteBatchSizeInBytes) {
-    this.networkWriteBatchSizeInBytes = networkWriteBatchSizeInBytes;
+  public ByteAmount getNetworkWriteBatchSize() {
+    return networkWriteBatchSize;
   }
 
   public long getNetworkWriteBatchTimeInMs() {
     return networkWriteBatchTimeInMs;
   }
 
-  public void setNetworkWriteBatchTimeInMs(long networkWriteBatchTimeInMs) {
-    this.networkWriteBatchTimeInMs = networkWriteBatchTimeInMs;
-  }
-
-  public long getNetworkReadBatchSizeInBytes() {
-    return networkReadBatchSizeInBytes;
-  }
-
-  public void setNetworkReadBatchSizeInBytes(long networkReadBatchSizeInBytes) {
-    this.networkReadBatchSizeInBytes = networkReadBatchSizeInBytes;
+  public ByteAmount getNetworkReadBatchSize() {
+    return networkReadBatchSize;
   }
 
   public long getNetworkReadBatchTimeInMs() {
     return networkReadBatchTimeInMs;
   }
 
-  public void setNetworkReadBatchTimeInMs(long networkReadBatchTimeInMs) {
-    this.networkReadBatchTimeInMs = networkReadBatchTimeInMs;
+  public ByteAmount getSocketSendBufferSize() {
+    return socketSendBufferSize;
   }
 
-  public int getSocketSendBufferSizeInBytes() {
-    return socketSendBufferSizeInBytes;
-  }
-
-  public void setSocketSendBufferSizeInBytes(int socketSendBufferSizeInBytes) {
-    this.socketSendBufferSizeInBytes = socketSendBufferSizeInBytes;
-  }
-
-  public int getSocketReceivedBufferSizeInBytes() {
-    return socketReceivedBufferSizeInBytes;
-  }
-
-  public void setSocketReceivedBufferSizeInBytes(int socketReceivedBufferSizeInBytes) {
-    this.socketReceivedBufferSizeInBytes = socketReceivedBufferSizeInBytes;
+  public ByteAmount getSocketReceivedBufferSize() {
+    return socketReceivedBufferSize;
   }
 }

--- a/heron/common/src/java/com/twitter/heron/common/utils/logging/LoggingHelper.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/logging/LoggingHelper.java
@@ -19,12 +19,15 @@ import java.io.IOException;
 import java.io.InvalidObjectException;
 import java.io.ObjectStreamException;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.FileHandler;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
+
+import com.twitter.heron.common.basics.ByteAmount;
 
 /**
  * A helper class to init corresponding LOGGER setting
@@ -33,8 +36,8 @@ import java.util.logging.SimpleFormatter;
  * Credits: https://blogs.oracle.com/nickstephen/entry/java_redirecting_system_out_and
  */
 public final class LoggingHelper {
-  public static final String FORMAT_PROP_KEY = "java.util.logging.SimpleFormatter.format";
-  public static final String DEFAULT_FORMAT = "[%1$tF %1$tT %1$tz] [%4$s] %3$s: %5$s %6$s %n";
+  private static final String FORMAT_PROP_KEY = "java.util.logging.SimpleFormatter.format";
+  private static final String DEFAULT_FORMAT = "[%1$tF %1$tT %1$tz] [%4$s] %3$s: %5$s %6$s %n";
 
   private LoggingHelper() {
   }
@@ -136,15 +139,15 @@ public final class LoggingHelper {
   public static FileHandler getFileHandler(String processId,
                                            String loggingDir,
                                            boolean append,
-                                           int limit,
+                                           ByteAmount limit,
                                            int count) throws IOException, SecurityException {
 
     String pattern = loggingDir + "/" + processId + ".log.%g";
 
 
-    FileHandler fileHandler = new FileHandler(pattern, limit, count, append);
+    FileHandler fileHandler = new FileHandler(pattern, (int) limit.asBytes(), count, append);
     fileHandler.setFormatter(new SimpleFormatter());
-    fileHandler.setEncoding("UTF-8");
+    fileHandler.setEncoding(StandardCharsets.UTF_8.toString());
 
     return fileHandler;
   }

--- a/heron/common/src/java/com/twitter/heron/common/utils/metrics/JVMMetrics.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/metrics/JVMMetrics.java
@@ -31,6 +31,7 @@ import com.twitter.heron.api.metric.MeanReducer;
 import com.twitter.heron.api.metric.MeanReducerState;
 import com.twitter.heron.api.metric.MultiAssignableMetric;
 import com.twitter.heron.api.metric.ReducedMetric;
+import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.common.basics.Constants;
 import com.twitter.heron.common.basics.SingletonRegistry;
 import com.twitter.heron.common.config.SystemConfig;
@@ -277,23 +278,23 @@ public class JVMMetrics {
         updateMemoryPoolMetrics();
         updateBufferPoolMetrics();
 
-        long freeMemory = runtime.freeMemory();
-        long totalMemory = runtime.totalMemory();
-        jvmMemoryFreeMB.update(freeMemory / Constants.MB_TO_BYTES);
-        jvmMemoryTotalMB.update(totalMemory / Constants.MB_TO_BYTES);
-        jvmMemoryUsedMB.update((totalMemory - freeMemory) / Constants.MB_TO_BYTES);
+        ByteAmount freeMemory = ByteAmount.fromBytes(runtime.freeMemory());
+        ByteAmount totalMemory = ByteAmount.fromBytes(runtime.totalMemory());
+        jvmMemoryFreeMB.update(freeMemory.asMegabytes());
+        jvmMemoryTotalMB.update(totalMemory.asMegabytes());
+        jvmMemoryUsedMB.update(totalMemory.asMegabytes() - freeMemory.asMegabytes());
         jvmMemoryHeapUsedMB.update(
-            memoryBean.getHeapMemoryUsage().getUsed() / Constants.MB_TO_BYTES);
+            ByteAmount.fromBytes(memoryBean.getHeapMemoryUsage().getUsed()).asMegabytes());
         jvmMemoryHeapCommittedMB.update(
-            memoryBean.getHeapMemoryUsage().getCommitted() / Constants.MB_TO_BYTES);
+            ByteAmount.fromBytes(memoryBean.getHeapMemoryUsage().getCommitted()).asMegabytes());
         jvmMemoryHeapMaxMB.update(
-            memoryBean.getHeapMemoryUsage().getMax() / Constants.MB_TO_BYTES);
+            ByteAmount.fromBytes(memoryBean.getHeapMemoryUsage().getMax()).asMegabytes());
         jvmMemoryNonHeapUsedMB.update(
-            memoryBean.getNonHeapMemoryUsage().getUsed() / Constants.MB_TO_BYTES);
+            ByteAmount.fromBytes(memoryBean.getNonHeapMemoryUsage().getUsed()).asMegabytes());
         jvmMemoryNonHeapCommittedMB.update(
-            memoryBean.getNonHeapMemoryUsage().getCommitted() / Constants.MB_TO_BYTES);
+            ByteAmount.fromBytes(memoryBean.getNonHeapMemoryUsage().getCommitted()).asMegabytes());
         jvmMemoryNonHeapMaxMB.update(
-            memoryBean.getNonHeapMemoryUsage().getMax() / Constants.MB_TO_BYTES);
+            ByteAmount.fromBytes(memoryBean.getNonHeapMemoryUsage().getMax()).asMegabytes());
       }
     };
     return sampleRunnable;
@@ -305,19 +306,21 @@ public class JVMMetrics {
     for (BufferPoolMXBean bufferPoolMXBean : bufferPoolMXBeanList) {
       String normalizedKeyName = bufferPoolMXBean.getName().replaceAll("[^\\w]", "-");
 
-      final long memoryUsedMB = bufferPoolMXBean.getMemoryUsed() / Constants.MB_TO_BYTES;
-      final long totalCapacityMB = bufferPoolMXBean.getTotalCapacity() / Constants.MB_TO_BYTES;
-      final long countMB = bufferPoolMXBean.getCount() / Constants.MB_TO_BYTES;
+      final ByteAmount memoryUsed = ByteAmount.fromBytes(bufferPoolMXBean.getMemoryUsed());
+      final ByteAmount totalCapacity = ByteAmount.fromBytes(bufferPoolMXBean.getTotalCapacity());
+      final ByteAmount count = ByteAmount.fromBytes(bufferPoolMXBean.getCount());
 
       // The estimated memory the JVM is using for this buffer pool
-      jvmBufferPoolMemoryUsage.safeScope(normalizedKeyName + "-memory-used").setValue(memoryUsedMB);
+      jvmBufferPoolMemoryUsage.safeScope(normalizedKeyName + "-memory-used")
+          .setValue(memoryUsed.asMegabytes());
 
       // The estimated total capacity of the buffers in this pool
-      jvmBufferPoolMemoryUsage.safeScope(
-          normalizedKeyName + "-total-capacity").setValue(totalCapacityMB);
+      jvmBufferPoolMemoryUsage.safeScope(normalizedKeyName + "-total-capacity")
+          .setValue(totalCapacity.asMegabytes());
 
       // THe estimated number of buffers in this pool
-      jvmBufferPoolMemoryUsage.safeScope(normalizedKeyName + "-count").setValue(countMB);
+      jvmBufferPoolMemoryUsage.safeScope(normalizedKeyName + "-count")
+          .setValue(count.asMegabytes());
     }
   }
 
@@ -328,37 +331,32 @@ public class JVMMetrics {
       String normalizedKeyName = memoryPoolMXBean.getName().replaceAll("[^\\w]", "-");
       MemoryUsage peakUsage = memoryPoolMXBean.getPeakUsage();
       if (peakUsage != null) {
-        jvmPeakUsagePerMemoryPool.safeScope(
-            normalizedKeyName + "-used").setValue(peakUsage.getUsed() / Constants.MB_TO_BYTES);
-        jvmPeakUsagePerMemoryPool.safeScope(
-            normalizedKeyName + "-committed").setValue(
-                peakUsage.getCommitted() / Constants.MB_TO_BYTES);
-        jvmPeakUsagePerMemoryPool.safeScope(
-            normalizedKeyName + "-max").setValue(peakUsage.getMax() / Constants.MB_TO_BYTES);
+        jvmPeakUsagePerMemoryPool.safeScope(normalizedKeyName + "-used")
+            .setValue(ByteAmount.fromBytes(peakUsage.getUsed()).asMegabytes());
+        jvmPeakUsagePerMemoryPool.safeScope(normalizedKeyName + "-committed")
+            .setValue(ByteAmount.fromBytes(peakUsage.getCommitted()).asMegabytes());
+        jvmPeakUsagePerMemoryPool.safeScope(normalizedKeyName + "-max")
+            .setValue(ByteAmount.fromBytes(peakUsage.getMax()).asMegabytes());
       }
 
       MemoryUsage collectionUsage = memoryPoolMXBean.getCollectionUsage();
       if (collectionUsage != null) {
-        jvmCollectionUsagePerMemoryPool.safeScope(
-            normalizedKeyName + "-used").setValue(
-                collectionUsage.getUsed() / Constants.MB_TO_BYTES);
-        jvmCollectionUsagePerMemoryPool.safeScope(
-            normalizedKeyName + "-committed").setValue(
-                collectionUsage.getCommitted() / Constants.MB_TO_BYTES);
-        jvmCollectionUsagePerMemoryPool.safeScope(
-            normalizedKeyName + "-max").setValue(
-                collectionUsage.getMax() / Constants.MB_TO_BYTES);
+        jvmCollectionUsagePerMemoryPool.safeScope(normalizedKeyName + "-used")
+            .setValue(ByteAmount.fromBytes(collectionUsage.getUsed()).asMegabytes());
+        jvmCollectionUsagePerMemoryPool.safeScope(normalizedKeyName + "-committed")
+            .setValue(ByteAmount.fromBytes(collectionUsage.getCommitted()).asMegabytes());
+        jvmCollectionUsagePerMemoryPool.safeScope(normalizedKeyName + "-max")
+            .setValue(ByteAmount.fromBytes(collectionUsage.getMax()).asMegabytes());
       }
 
       MemoryUsage estimatedUsage = memoryPoolMXBean.getUsage();
       if (estimatedUsage != null) {
-        jvmEstimatedUsagePerMemoryPool.safeScope(
-            normalizedKeyName + "-used").setValue(estimatedUsage.getUsed() / Constants.MB_TO_BYTES);
-        jvmEstimatedUsagePerMemoryPool.safeScope(
-            normalizedKeyName + "-committed").setValue(
-                estimatedUsage.getCommitted() / Constants.MB_TO_BYTES);
-        jvmEstimatedUsagePerMemoryPool.safeScope(
-            normalizedKeyName + "-max").setValue(estimatedUsage.getMax() / Constants.MB_TO_BYTES);
+        jvmEstimatedUsagePerMemoryPool.safeScope(normalizedKeyName + "-used")
+            .setValue(ByteAmount.fromBytes(estimatedUsage.getUsed()).asMegabytes());
+        jvmEstimatedUsagePerMemoryPool.safeScope(normalizedKeyName + "-committed")
+            .setValue(ByteAmount.fromBytes(estimatedUsage.getCommitted()).asMegabytes());
+        jvmEstimatedUsagePerMemoryPool.safeScope(normalizedKeyName + "-max")
+            .setValue(ByteAmount.fromBytes(estimatedUsage.getMax()).asMegabytes());
       }
     }
   }

--- a/heron/common/tests/java/com/twitter/heron/common/config/SystemConfigTest.java
+++ b/heron/common/tests/java/com/twitter/heron/common/config/SystemConfigTest.java
@@ -42,7 +42,7 @@ public class SystemConfigTest {
         .putAll(file.getAbsolutePath(), true)
         .build();
     Assert.assertEquals("log-files", systemConfig.getHeronLoggingDirectory());
-    Assert.assertEquals(100, systemConfig.getHeronLoggingMaximumSizeMb());
+    Assert.assertEquals(100, systemConfig.getHeronLoggingMaximumSize().asMegabytes());
     Assert.assertEquals(5, systemConfig.getHeronLoggingMaximumFiles());
     Assert.assertEquals(60, systemConfig.getHeronMetricsExportIntervalSec());
   }

--- a/heron/common/tests/java/com/twitter/heron/common/network/EchoTest.java
+++ b/heron/common/tests/java/com/twitter/heron/common/network/EchoTest.java
@@ -29,6 +29,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.common.basics.NIOLooper;
 import com.twitter.heron.common.basics.SysUtils;
 import com.twitter.heron.proto.testing.Tests;
@@ -36,6 +37,11 @@ import com.twitter.heron.proto.testing.Tests;
 public class EchoTest {
   private static int serverPort;
   private ExecutorService threadsPool;
+  private static final HeronSocketOptions TEST_SOCKET_OPTIONS = new HeronSocketOptions(
+      ByteAmount.fromMegabytes(100), 100,
+      ByteAmount.fromMegabytes(100),100,
+      ByteAmount.fromMegabytes(5),
+      ByteAmount.fromMegabytes(5));
 
   @BeforeClass
   public static void beforeClass() throws Exception {
@@ -106,12 +112,7 @@ public class EchoTest {
     private int maxRequests;
 
     EchoServer(NIOLooper looper, int port, int maxRequests) {
-      super(looper, "localhost", port,
-          new HeronSocketOptions(100 * 1024 * 1024, 100,
-              100 * 1024 * 1024,
-              100,
-              5 * 1024 * 1024,
-              5 * 1024 * 1024));
+      super(looper, "localhost", port, TEST_SOCKET_OPTIONS);
       nRequests = 0;
       this.maxRequests = maxRequests;
       registerOnRequest(Tests.EchoServerRequest.newBuilder());
@@ -168,11 +169,7 @@ public class EchoTest {
     private int maxRequests;
 
     EchoClient(NIOLooper looper, int port, int maxRequests) {
-      super(looper, "localhost", port,
-          new HeronSocketOptions(100 * 1024 * 1024, 100,
-              100 * 1024 * 1024, 100,
-              5 * 1024 * 1024,
-              5 * 1024 * 1024));
+      super(looper, "localhost", port, TEST_SOCKET_OPTIONS);
       nRequests = 0;
       this.maxRequests = maxRequests;
     }

--- a/heron/common/tests/java/com/twitter/heron/common/network/EchoTest.java
+++ b/heron/common/tests/java/com/twitter/heron/common/network/EchoTest.java
@@ -39,7 +39,7 @@ public class EchoTest {
   private ExecutorService threadsPool;
   private static final HeronSocketOptions TEST_SOCKET_OPTIONS = new HeronSocketOptions(
       ByteAmount.fromMegabytes(100), 100,
-      ByteAmount.fromMegabytes(100),100,
+      ByteAmount.fromMegabytes(100), 100,
       ByteAmount.fromMegabytes(5),
       ByteAmount.fromMegabytes(5));
 

--- a/heron/common/tests/java/com/twitter/heron/common/network/HeronServerTest.java
+++ b/heron/common/tests/java/com/twitter/heron/common/network/HeronServerTest.java
@@ -31,6 +31,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.common.basics.NIOLooper;
 import com.twitter.heron.common.basics.SysUtils;
 import com.twitter.heron.proto.testing.Tests;
@@ -44,6 +45,11 @@ public class HeronServerTest {
   private static final String MESSAGE = "message";
   private static final Logger LOG = Logger.getLogger(HeronServerTest.class.getName());
   private static final String SERVER_HOST = "127.0.0.1";
+  private static final HeronSocketOptions TEST_SOCKET_OPTIONS = new HeronSocketOptions(
+      ByteAmount.fromMegabytes(100), 100,
+      ByteAmount.fromMegabytes(100),100,
+      ByteAmount.fromMegabytes(5),
+      ByteAmount.fromMegabytes(5));
   private static int serverPort;
   // Following are state variable to test correctness
   private volatile boolean isOnConnectedInvoked = false;
@@ -394,10 +400,7 @@ public class HeronServerTest {
   private class SimpleHeronServer extends HeronServer {
 
     SimpleHeronServer(NIOLooper s, String host, int port) {
-      super(s, host, port, new HeronSocketOptions(100 * 1024 * 1024, 100,
-          100 * 1024 * 1024, 100,
-          5 * 1024 * 1024,
-          5 * 1024 * 1024));
+      super(s, host, port, TEST_SOCKET_OPTIONS);
     }
 
     @Override
@@ -466,11 +469,7 @@ public class HeronServerTest {
 
   private class SimpleHeronClient extends HeronClient {
     SimpleHeronClient(NIOLooper looper, String host, int port) {
-      super(looper, host, port,
-          new HeronSocketOptions(100 * 1024 * 1024, 100,
-              100 * 1024 * 1024, 100,
-              5 * 1024 * 1024,
-              5 * 1024 * 1024));
+      super(looper, host, port, TEST_SOCKET_OPTIONS);
     }
 
     @Override

--- a/heron/common/tests/java/com/twitter/heron/common/network/HeronServerTest.java
+++ b/heron/common/tests/java/com/twitter/heron/common/network/HeronServerTest.java
@@ -47,7 +47,7 @@ public class HeronServerTest {
   private static final String SERVER_HOST = "127.0.0.1";
   private static final HeronSocketOptions TEST_SOCKET_OPTIONS = new HeronSocketOptions(
       ByteAmount.fromMegabytes(100), 100,
-      ByteAmount.fromMegabytes(100),100,
+      ByteAmount.fromMegabytes(100), 100,
       ByteAmount.fromMegabytes(5),
       ByteAmount.fromMegabytes(5));
   private static int serverPort;

--- a/heron/instance/src/java/com/twitter/heron/instance/Gateway.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/Gateway.java
@@ -95,12 +95,12 @@ public class Gateway implements Runnable, AutoCloseable {
 
     // Initialize the corresponding 2 socket clients with corresponding socket options
     HeronSocketOptions socketOptions = new HeronSocketOptions(
-        systemConfig.getInstanceNetworkWriteBatchSizeBytes(),
+        systemConfig.getInstanceNetworkWriteBatchSize(),
         systemConfig.getInstanceNetworkWriteBatchTimeMs(),
-        systemConfig.getInstanceNetworkReadBatchSizeBytes(),
+        systemConfig.getInstanceNetworkReadBatchSize(),
         systemConfig.getInstanceNetworkReadBatchTimeMs(),
-        systemConfig.getInstanceNetworkOptionsSocketSendBufferSizeBytes(),
-        systemConfig.getInstanceNetworkOptionsSocketReceivedBufferSizeBytes()
+        systemConfig.getInstanceNetworkOptionsSocketSendBufferSize(),
+        systemConfig.getInstanceNetworkOptionsSocketReceivedBufferSize()
     );
     this.streamManagerClient =
         new StreamManagerClient(gatewayLooper, STREAM_MGR_HOST, streamPort,

--- a/heron/instance/src/java/com/twitter/heron/instance/HeronInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/HeronInstance.java
@@ -26,7 +26,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.twitter.heron.common.basics.Communicator;
-import com.twitter.heron.common.basics.Constants;
 import com.twitter.heron.common.basics.NIOLooper;
 import com.twitter.heron.common.basics.SingletonRegistry;
 import com.twitter.heron.common.basics.SlaveLooper;

--- a/heron/instance/src/java/com/twitter/heron/instance/HeronInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/HeronInstance.java
@@ -166,7 +166,7 @@ public class HeronInstance {
     LoggingHelper.loggerInit(loggingLevel, true);
     LoggingHelper.addLoggingHandler(
         LoggingHelper.getFileHandler(instanceId, loggingDir, true,
-            systemConfig.getHeronLoggingMaximumSizeMb() * Constants.MB_TO_BYTES,
+            systemConfig.getHeronLoggingMaximumSize(),
             systemConfig.getHeronLoggingMaximumFiles()));
     LoggingHelper.addLoggingHandler(new ErrorReportLoggingHandler());
 

--- a/heron/instance/tests/java/com/twitter/heron/network/ConnectTest.java
+++ b/heron/instance/tests/java/com/twitter/heron/network/ConnectTest.java
@@ -220,12 +220,12 @@ public class ConnectTest {
                   SystemConfig.HERON_SYSTEM_CONFIG);
 
           HeronSocketOptions socketOptions = new HeronSocketOptions(
-              systemConfig.getInstanceNetworkWriteBatchSizeBytes(),
+              systemConfig.getInstanceNetworkWriteBatchSize(),
               systemConfig.getInstanceNetworkWriteBatchTimeMs(),
-              systemConfig.getInstanceNetworkReadBatchSizeBytes(),
+              systemConfig.getInstanceNetworkReadBatchSize(),
               systemConfig.getInstanceNetworkReadBatchTimeMs(),
-              systemConfig.getInstanceNetworkOptionsSocketSendBufferSizeBytes(),
-              systemConfig.getInstanceNetworkOptionsSocketReceivedBufferSizeBytes()
+              systemConfig.getInstanceNetworkOptionsSocketSendBufferSize(),
+              systemConfig.getInstanceNetworkOptionsSocketReceivedBufferSize()
           );
 
           streamManagerClient = new StreamManagerClient(nioLooper, HOST, serverPort,

--- a/heron/instance/tests/java/com/twitter/heron/network/HandleReadTest.java
+++ b/heron/instance/tests/java/com/twitter/heron/network/HandleReadTest.java
@@ -278,12 +278,12 @@ public class HandleReadTest {
                   SystemConfig.HERON_SYSTEM_CONFIG);
 
           HeronSocketOptions socketOptions = new HeronSocketOptions(
-              systemConfig.getInstanceNetworkWriteBatchSizeBytes(),
+              systemConfig.getInstanceNetworkWriteBatchSize(),
               systemConfig.getInstanceNetworkWriteBatchTimeMs(),
-              systemConfig.getInstanceNetworkReadBatchSizeBytes(),
+              systemConfig.getInstanceNetworkReadBatchSize(),
               systemConfig.getInstanceNetworkReadBatchTimeMs(),
-              systemConfig.getInstanceNetworkOptionsSocketSendBufferSizeBytes(),
-              systemConfig.getInstanceNetworkOptionsSocketReceivedBufferSizeBytes()
+              systemConfig.getInstanceNetworkOptionsSocketSendBufferSize(),
+              systemConfig.getInstanceNetworkOptionsSocketReceivedBufferSize()
           );
 
           streamManagerClient = new StreamManagerClient(nioLooper, HOST, serverPort,

--- a/heron/instance/tests/java/com/twitter/heron/network/HandleWriteTest.java
+++ b/heron/instance/tests/java/com/twitter/heron/network/HandleWriteTest.java
@@ -239,12 +239,12 @@ public class HandleWriteTest {
                   SystemConfig.HERON_SYSTEM_CONFIG);
 
           HeronSocketOptions socketOptions = new HeronSocketOptions(
-              systemConfig.getInstanceNetworkWriteBatchSizeBytes(),
+              systemConfig.getInstanceNetworkWriteBatchSize(),
               systemConfig.getInstanceNetworkWriteBatchTimeMs(),
-              systemConfig.getInstanceNetworkReadBatchSizeBytes(),
+              systemConfig.getInstanceNetworkReadBatchSize(),
               systemConfig.getInstanceNetworkReadBatchTimeMs(),
-              systemConfig.getInstanceNetworkOptionsSocketSendBufferSizeBytes(),
-              systemConfig.getInstanceNetworkOptionsSocketReceivedBufferSizeBytes()
+              systemConfig.getInstanceNetworkOptionsSocketSendBufferSize(),
+              systemConfig.getInstanceNetworkOptionsSocketReceivedBufferSize()
           );
 
           streamManagerClient = new StreamManagerClient(nioLooper, HOST, serverPort,

--- a/heron/metricscachemgr/src/java/com/twitter/heron/metricscachemgr/MetricsCacheManager.java
+++ b/heron/metricscachemgr/src/java/com/twitter/heron/metricscachemgr/MetricsCacheManager.java
@@ -108,12 +108,12 @@ public class MetricsCacheManager {
 
     // Init the HeronSocketOptions
     HeronSocketOptions serverSocketOptions =
-        new HeronSocketOptions(systemConfig.getMetricsMgrNetworkWriteBatchSizeBytes(),
+        new HeronSocketOptions(systemConfig.getMetricsMgrNetworkWriteBatchSize(),
             systemConfig.getMetricsMgrNetworkWriteBatchTimeMs(),
-            systemConfig.getMetricsMgrNetworkReadBatchSizeBytes(),
+            systemConfig.getMetricsMgrNetworkReadBatchSize(),
             systemConfig.getMetricsMgrNetworkReadBatchTimeMs(),
-            systemConfig.getMetricsMgrNetworkOptionsSocketSendBufferSizeBytes(),
-            systemConfig.getMetricsMgrNetworkOptionsSocketReceivedBufferSizeBytes());
+            systemConfig.getMetricsMgrNetworkOptionsSocketSendBufferSize(),
+            systemConfig.getMetricsMgrNetworkOptionsSocketReceivedBufferSize());
 
     // Construct the server to accepts messages from sinks
     metricsCacheManagerServer = new MetricsCacheManagerServer(metricsCacheManagerServerLoop,
@@ -293,7 +293,7 @@ public class MetricsCacheManager {
     LoggingHelper.loggerInit(logLevel, true);
     LoggingHelper.addLoggingHandler(LoggingHelper.getFileHandler(metricsCacheMgrId,
         systemConfig.getHeronLoggingDirectory(), true,
-        systemConfig.getHeronLoggingMaximumSizeMb() * Constants.MB_TO_BYTES,
+        systemConfig.getHeronLoggingMaximumSize(),
         systemConfig.getHeronLoggingMaximumFiles()));
     LoggingHelper.addLoggingHandler(new ErrorReportLoggingHandler());
 

--- a/heron/metricscachemgr/src/java/com/twitter/heron/metricscachemgr/MetricsCacheManager.java
+++ b/heron/metricscachemgr/src/java/com/twitter/heron/metricscachemgr/MetricsCacheManager.java
@@ -28,7 +28,6 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
-import com.twitter.heron.common.basics.Constants;
 import com.twitter.heron.common.basics.NIOLooper;
 import com.twitter.heron.common.basics.SysUtils;
 import com.twitter.heron.common.config.SystemConfig;

--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/MetricsManager.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/MetricsManager.java
@@ -141,12 +141,12 @@ public class MetricsManager {
 
     // Init the HeronSocketOptions
     HeronSocketOptions serverSocketOptions =
-        new HeronSocketOptions(systemConfig.getMetricsMgrNetworkWriteBatchSizeBytes(),
+        new HeronSocketOptions(systemConfig.getMetricsMgrNetworkWriteBatchSize(),
             systemConfig.getMetricsMgrNetworkWriteBatchTimeMs(),
-            systemConfig.getMetricsMgrNetworkReadBatchSizeBytes(),
+            systemConfig.getMetricsMgrNetworkReadBatchSize(),
             systemConfig.getMetricsMgrNetworkReadBatchTimeMs(),
-            systemConfig.getMetricsMgrNetworkOptionsSocketSendBufferSizeBytes(),
-            systemConfig.getMetricsMgrNetworkOptionsSocketReceivedBufferSizeBytes());
+            systemConfig.getMetricsMgrNetworkOptionsSocketSendBufferSize(),
+            systemConfig.getMetricsMgrNetworkOptionsSocketReceivedBufferSize());
 
     // Set the MultiCountMetric for MetricsManagerServer
     MultiCountMetric serverCounters = new MultiCountMetric();
@@ -228,7 +228,7 @@ public class MetricsManager {
     LoggingHelper.loggerInit(loggingLevel, true);
     LoggingHelper.addLoggingHandler(
         LoggingHelper.getFileHandler(metricsmgrId, loggingDir, true,
-            systemConfig.getHeronLoggingMaximumSizeMb() * Constants.MB_TO_BYTES,
+            systemConfig.getHeronLoggingMaximumSize(),
             systemConfig.getHeronLoggingMaximumFiles()));
     LoggingHelper.addLoggingHandler(new ErrorReportLoggingHandler());
 

--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/MetricsManager.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/MetricsManager.java
@@ -27,7 +27,6 @@ import java.util.logging.Logger;
 
 import com.twitter.heron.api.metric.MultiCountMetric;
 import com.twitter.heron.common.basics.Communicator;
-import com.twitter.heron.common.basics.Constants;
 import com.twitter.heron.common.basics.NIOLooper;
 import com.twitter.heron.common.basics.SingletonRegistry;
 import com.twitter.heron.common.basics.SlaveLooper;

--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/metricscache/MetricsCacheSink.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/metricscache/MetricsCacheSink.java
@@ -337,12 +337,18 @@ public class MetricsCacheSink implements IMetricsSink {
 
       HeronSocketOptions socketOptions =
           new HeronSocketOptions(
-              TypeUtils.getLong(metricsCacheClientConfig.get(KEY_NETWORK_WRITE_BATCH_SIZE_BYTES)),
-              TypeUtils.getLong(metricsCacheClientConfig.get(KEY_NETWORK_WRITE_BATCH_TIME_MS)),
-              TypeUtils.getLong(metricsCacheClientConfig.get(KEY_NETWORK_READ_BATCH_SIZE_BYTES)),
-              TypeUtils.getLong(metricsCacheClientConfig.get(KEY_NETWORK_READ_BATCH_TIME_MS)),
-              TypeUtils.getInteger(metricsCacheClientConfig.get(KEY_SOCKET_SEND_BUFFER_BYTES)),
-              TypeUtils.getInteger(metricsCacheClientConfig.get(KEY_SOCKET_RECEIVED_BUFFER_BYTES)));
+              TypeUtils.getByteAmount(
+                  metricsCacheClientConfig.get(KEY_NETWORK_WRITE_BATCH_SIZE_BYTES)),
+              TypeUtils.getLong(
+                  metricsCacheClientConfig.get(KEY_NETWORK_WRITE_BATCH_TIME_MS)),
+              TypeUtils.getByteAmount(
+                  metricsCacheClientConfig.get(KEY_NETWORK_READ_BATCH_SIZE_BYTES)),
+              TypeUtils.getLong(
+                  metricsCacheClientConfig.get(KEY_NETWORK_READ_BATCH_TIME_MS)),
+              TypeUtils.getByteAmount(
+                  metricsCacheClientConfig.get(KEY_SOCKET_SEND_BUFFER_BYTES)),
+              TypeUtils.getByteAmount(
+                  metricsCacheClientConfig.get(KEY_SOCKET_RECEIVED_BUFFER_BYTES)));
 
       // Reset the Consumer
       metricsCommunicator.setConsumer(looper);

--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/tmaster/TMasterSink.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/tmaster/TMasterSink.java
@@ -334,12 +334,12 @@ public class TMasterSink implements IMetricsSink {
 
       HeronSocketOptions socketOptions =
           new HeronSocketOptions(
-              TypeUtils.getLong(tmasterClientConfig.get(KEY_NETWORK_WRITE_BATCH_SIZE_BYTES)),
+              TypeUtils.getByteAmount(tmasterClientConfig.get(KEY_NETWORK_WRITE_BATCH_SIZE_BYTES)),
               TypeUtils.getLong(tmasterClientConfig.get(KEY_NETWORK_WRITE_BATCH_TIME_MS)),
-              TypeUtils.getLong(tmasterClientConfig.get(KEY_NETWORK_READ_BATCH_SIZE_BYTES)),
+              TypeUtils.getByteAmount(tmasterClientConfig.get(KEY_NETWORK_READ_BATCH_SIZE_BYTES)),
               TypeUtils.getLong(tmasterClientConfig.get(KEY_NETWORK_READ_BATCH_TIME_MS)),
-              TypeUtils.getInteger(tmasterClientConfig.get(KEY_SOCKET_SEND_BUFFER_BYTES)),
-              TypeUtils.getInteger(tmasterClientConfig.get(KEY_SOCKET_RECEIVED_BUFFER_BYTES)));
+              TypeUtils.getByteAmount(tmasterClientConfig.get(KEY_SOCKET_SEND_BUFFER_BYTES)),
+              TypeUtils.getByteAmount(tmasterClientConfig.get(KEY_SOCKET_RECEIVED_BUFFER_BYTES)));
 
       // Reset the Consumer
       metricsCommunicator.setConsumer(looper);

--- a/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/HandleTMasterLocationTest.java
+++ b/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/HandleTMasterLocationTest.java
@@ -32,6 +32,7 @@ import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 import com.twitter.heron.api.metric.MultiCountMetric;
+import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.common.basics.NIOLooper;
 import com.twitter.heron.common.basics.SingletonRegistry;
 import com.twitter.heron.common.basics.SysUtils;
@@ -56,6 +57,12 @@ import com.twitter.heron.proto.tmaster.TopologyMaster;
  */
 
 public class HandleTMasterLocationTest {
+
+  private static final HeronSocketOptions TEST_SOCKET_OPTIONS = new HeronSocketOptions(
+      ByteAmount.fromMegabytes(100), 100,
+      ByteAmount.fromMegabytes(100),100,
+      ByteAmount.fromMegabytes(5),
+      ByteAmount.fromMegabytes(5));
 
   // Two TMasterLocationRefreshMessage to verify
   private static final Metrics.TMasterLocationRefreshMessage TMASTERLOCATIONREFRESHMESSAGE0 =
@@ -92,18 +99,12 @@ public class HandleTMasterLocationTest {
 
     threadsPool = Executors.newFixedThreadPool(2);
 
-    HeronSocketOptions serverSocketOptions =
-        new HeronSocketOptions(100 * 1024 * 1024, 100,
-            100 * 1024 * 1024, 100,
-            5 * 1024 * 1024,
-            5 * 1024 * 1024);
-
     serverLooper = new NIOLooper();
 
     // Spy it for unit test
     metricsManagerServer =
         Mockito.spy(new MetricsManagerServer(serverLooper, SERVER_HOST,
-            serverPort, serverSocketOptions, new MultiCountMetric()));
+            serverPort, TEST_SOCKET_OPTIONS, new MultiCountMetric()));
   }
 
   @After
@@ -214,11 +215,7 @@ public class HandleTMasterLocationTest {
         SimpleTMasterLocationPublisher.class.getName());
 
     SimpleTMasterLocationPublisher(NIOLooper looper, String host, int port) {
-      super(looper, host, port,
-          new HeronSocketOptions(100 * 1024 * 1024, 100,
-              100 * 1024 * 1024, 100,
-              5 * 1024 * 1024,
-              5 * 1024 * 1024));
+      super(looper, host, port, TEST_SOCKET_OPTIONS);
     }
 
     @Override

--- a/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/HandleTMasterLocationTest.java
+++ b/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/HandleTMasterLocationTest.java
@@ -60,7 +60,7 @@ public class HandleTMasterLocationTest {
 
   private static final HeronSocketOptions TEST_SOCKET_OPTIONS = new HeronSocketOptions(
       ByteAmount.fromMegabytes(100), 100,
-      ByteAmount.fromMegabytes(100),100,
+      ByteAmount.fromMegabytes(100), 100,
       ByteAmount.fromMegabytes(5),
       ByteAmount.fromMegabytes(5));
 

--- a/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/MetricsManagerServerTest.java
+++ b/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/MetricsManagerServerTest.java
@@ -58,7 +58,7 @@ public class MetricsManagerServerTest {
   private static final String SERVER_HOST = "127.0.0.1";
   private static final HeronSocketOptions TEST_SOCKET_OPTIONS = new HeronSocketOptions(
       ByteAmount.fromMegabytes(100), 100,
-      ByteAmount.fromMegabytes(100),100,
+      ByteAmount.fromMegabytes(100), 100,
       ByteAmount.fromMegabytes(5),
       ByteAmount.fromMegabytes(5));
 

--- a/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/MetricsManagerServerTest.java
+++ b/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/MetricsManagerServerTest.java
@@ -27,6 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.twitter.heron.api.metric.MultiCountMetric;
+import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.basics.NIOLooper;
 import com.twitter.heron.common.basics.SysUtils;
@@ -55,6 +56,12 @@ public class MetricsManagerServerTest {
   private static final int EXCEPTION_COUNT = 20;
 
   private static final String SERVER_HOST = "127.0.0.1";
+  private static final HeronSocketOptions TEST_SOCKET_OPTIONS = new HeronSocketOptions(
+      ByteAmount.fromMegabytes(100), 100,
+      ByteAmount.fromMegabytes(100),100,
+      ByteAmount.fromMegabytes(5),
+      ByteAmount.fromMegabytes(5));
+
   private static int serverPort;
 
   private MetricsManagerServer metricsManagerServer;
@@ -70,15 +77,9 @@ public class MetricsManagerServerTest {
 
     threadsPool = Executors.newFixedThreadPool(2);
 
-    HeronSocketOptions serverSocketOptions =
-        new HeronSocketOptions(100 * 1024 * 1024, 100,
-            100 * 1024 * 1024, 100,
-            5 * 1024 * 1024,
-            5 * 1024 * 1024);
-
     serverLooper = new NIOLooper();
     metricsManagerServer = new MetricsManagerServer(serverLooper, SERVER_HOST,
-        serverPort, serverSocketOptions, new MultiCountMetric());
+        serverPort, TEST_SOCKET_OPTIONS, new MultiCountMetric());
   }
 
   @After
@@ -210,11 +211,7 @@ public class MetricsManagerServerTest {
     private int maxMessages;
 
     SimpleMetricsClient(NIOLooper looper, String host, int port, int maxMessages) {
-      super(looper, host, port,
-          new HeronSocketOptions(100 * 1024 * 1024, 100,
-              100 * 1024 * 1024, 100,
-              5 * 1024 * 1024,
-              5 * 1024 * 1024));
+      super(looper, host, port, TEST_SOCKET_OPTIONS);
       this.maxMessages = maxMessages;
     }
 

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SchedulerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SchedulerMain.java
@@ -302,7 +302,7 @@ public class SchedulerMain {
         String.format("%s-%s-%s", "heron", Context.topologyName(config), "scheduler");
     LoggingHelper.addLoggingHandler(
         LoggingHelper.getFileHandler(processId, loggingDir, true,
-            systemConfig.getHeronLoggingMaximumSizeMb() * Constants.MB_TO_BYTES,
+            systemConfig.getHeronLoggingMaximumSize(),
             systemConfig.getHeronLoggingMaximumFiles()));
 
     LOG.info("Logging setup done.");

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SchedulerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SchedulerMain.java
@@ -28,7 +28,6 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
 import com.twitter.heron.api.generated.TopologyAPI;
-import com.twitter.heron.common.basics.Constants;
 import com.twitter.heron.common.basics.FileUtils;
 import com.twitter.heron.common.basics.SysUtils;
 import com.twitter.heron.common.config.SystemConfig;

--- a/heron/simulator/src/java/com/twitter/heron/simulator/Simulator.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/Simulator.java
@@ -25,6 +25,7 @@ import java.util.logging.Logger;
 import com.twitter.heron.api.Config;
 import com.twitter.heron.api.HeronTopology;
 import com.twitter.heron.api.generated.TopologyAPI;
+import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.common.basics.SingletonRegistry;
 import com.twitter.heron.common.config.SystemConfig;
 import com.twitter.heron.common.config.SystemConfigKey;
@@ -189,9 +190,9 @@ public class Simulator {
         .put(SystemConfigKey.INSTANCE_SET_CONTROL_TUPLE_CAPACITY, 256)
         .put(SystemConfigKey.HERON_METRICS_EXPORT_INTERVAL_SEC, 60)
         .put(SystemConfigKey.INSTANCE_EXECUTE_BATCH_TIME_MS, 16)
-        .put(SystemConfigKey.INSTANCE_EXECUTE_BATCH_SIZE_BYTES, 32768)
+        .put(SystemConfigKey.INSTANCE_EXECUTE_BATCH_SIZE, ByteAmount.fromBytes(32768))
         .put(SystemConfigKey.INSTANCE_EMIT_BATCH_TIME_MS, 16)
-        .put(SystemConfigKey.INSTANCE_EMIT_BATCH_SIZE_BYTES, 32768)
+        .put(SystemConfigKey.INSTANCE_EMIT_BATCH_SIZE, ByteAmount.fromBytes(32768))
         .put(SystemConfigKey.INSTANCE_ACK_BATCH_TIME_MS, 128)
         .put(SystemConfigKey.INSTANCE_ACKNOWLEDGEMENT_NBUCKETS, 10);
 

--- a/heron/simulator/src/java/com/twitter/heron/simulator/instance/BoltInstance.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/instance/BoltInstance.java
@@ -20,6 +20,7 @@ import java.util.List;
 import com.google.protobuf.ByteString;
 
 import com.twitter.heron.api.generated.TopologyAPI;
+import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.basics.Constants;
 import com.twitter.heron.common.basics.SingletonRegistry;
@@ -33,7 +34,7 @@ public class BoltInstance
     extends com.twitter.heron.instance.bolt.BoltInstance implements IInstance {
 
   private final long instanceExecuteBatchTime;
-  private final long instanceExecuteBatchSize;
+  private final ByteAmount instanceExecuteBatchSize;
 
   public BoltInstance(PhysicalPlanHelper helper,
                       Communicator<HeronTuples.HeronTupleSet> streamInQueue,
@@ -45,7 +46,7 @@ public class BoltInstance
 
     this.instanceExecuteBatchTime
         = systemConfig.getInstanceExecuteBatchTimeMs() * Constants.MILLISECONDS_TO_NANOSECONDS;
-    this.instanceExecuteBatchSize = systemConfig.getInstanceExecuteBatchSizeBytes();
+    this.instanceExecuteBatchSize = systemConfig.getInstanceExecuteBatchSize();
 
   }
 
@@ -106,7 +107,7 @@ public class BoltInstance
 
       // To avoid emitting too much data
       if (collector.getTotalDataEmittedInBytes() - totalDataEmittedInBytesBeforeCycle
-          > instanceExecuteBatchSize) {
+          > instanceExecuteBatchSize.asBytes()) {
         break;
       }
     }

--- a/heron/simulator/src/java/com/twitter/heron/simulator/instance/SpoutInstance.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/instance/SpoutInstance.java
@@ -17,6 +17,7 @@ package com.twitter.heron.simulator.instance;
 import java.util.Map;
 
 import com.twitter.heron.api.Config;
+import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.basics.Constants;
 import com.twitter.heron.common.basics.SingletonRegistry;
@@ -32,7 +33,7 @@ public class SpoutInstance
   private final boolean ackEnabled;
   private final int maxSpoutPending;
   private final long instanceEmitBatchTime;
-  private final long instanceEmitBatchSize;
+  private final ByteAmount instanceEmitBatchSize;
 
   public SpoutInstance(PhysicalPlanHelper helper,
                        Communicator<HeronTuples.HeronTupleSet> streamInQueue,
@@ -45,7 +46,7 @@ public class SpoutInstance
     this.maxSpoutPending = TypeUtils.getInteger(config.get(Config.TOPOLOGY_MAX_SPOUT_PENDING));
     this.instanceEmitBatchTime =
         systemConfig.getInstanceEmitBatchTimeMs() * Constants.MILLISECONDS_TO_NANOSECONDS;
-    this.instanceEmitBatchSize = systemConfig.getInstanceEmitBatchSizeBytes();
+    this.instanceEmitBatchSize = systemConfig.getInstanceEmitBatchSize();
     this.ackEnabled = Boolean.parseBoolean((String) config.get(Config.TOPOLOGY_ENABLE_ACKING));
   }
 
@@ -78,7 +79,7 @@ public class SpoutInstance
       }
 
       if (collector.getTotalDataEmittedInBytes() - totalDataEmittedInBytesBeforeCycle
-          > instanceEmitBatchSize) {
+          > instanceEmitBatchSize.asBytes()) {
         break;
       }
     }


### PR DESCRIPTION
Instead of using ints and longs of bytes, MBs, GBs and doing math to convert between units, it's better to use the `ByteAmount` typed object. This change does that. The core changes are to `HeronSocketOptions`,  `SystemConfig` and `SystemConfigKey`. The rest is the refactor fallout of those changes. Also making `HeronSocketOptions` immutable.