### PR TITLE
package ckptmgr and statefulstorages into heron-core

### DIFF
--- a/scripts/packages/BUILD
+++ b/scripts/packages/BUILD
@@ -21,6 +21,8 @@ load("/tools/rules/heron_core", "heron_core_lib_metricsmgr_files")
 load("/tools/rules/heron_core", "heron_core_lib_metricscachemgr_files")
 load("/tools/rules/heron_core", "heron_core_lib_packing_files")
 load("/tools/rules/heron_core", "heron_core_lib_statemgr_files")
+load("/tools/rules/heron_core", "heron_core_lib_ckptmgr_files")
+load("/tools/rules/heron_core", "heron_core_lib_statefulstorages_files")
 
 load("/tools/rules/heron_tools", "heron_tools_files")
 load("/tools/rules/heron_tools", "heron_tools_bin_files")
@@ -71,6 +73,8 @@ pkg_tar(
         ":heron-core-lib-metricscachemgr",
         ":heron-core-lib-statemgr",
         ":heron-core-lib-instance",
+        ":heron-core-lib-ckptmgr",
+        ":heron-core-lib-statefulstorages",
     ],
 )
 
@@ -114,6 +118,18 @@ pkg_tar(
     name = "heron-core-lib-instance",
     package_dir = "heron-core/lib/instance",
     files = heron_core_lib_instance_files(),
+)
+
+pkg_tar(
+    name = "heron-core-lib-ckptmgr",
+    package_dir = "heron-core/lib/ckptmgr",
+    files = heron_core_lib_ckptmgr_files(),
+)
+
+pkg_tar(
+    name = "heron-core-lib-statefulstorages",
+    package_dir = "heron-core/lib/statefulstorages",
+    files = heron_core_lib_statefulstorages_files(),
 )
 
 ################################################################################

--- a/tools/rules/heron_core.bzl
+++ b/tools/rules/heron_core.bzl
@@ -25,7 +25,9 @@ def heron_core_lib_files():
         heron_core_lib_packing_files() + \
         heron_core_lib_metricsmgr_files() + \
         heron_core_lib_statemgr_files() + \
-        heron_core_lib_instance_files()
+        heron_core_lib_instance_files() + \
+        heron_core_lib_ckptmgr_files() + \
+        heron_core_lib_statefulstorages_files()
 
 def heron_core_lib_scheduler_files():
     return [
@@ -61,4 +63,15 @@ def heron_core_lib_statemgr_files():
 def heron_core_lib_instance_files():
     return [
         "//heron/instance/src/java:heron-instance",
+    ]
+
+def heron_core_lib_ckptmgr_files():
+    return [
+        "//heron/ckptmgr/src/java:heron-ckptmgr",
+    ]
+
+def heron_core_lib_statefulstorages_files():
+    return [
+        "//heron/statefulstorages/src/java:heron-localfs-statefulstorage",
+        "//heron/statefulstorages/src/java:heron-hdfs-statefulstorage",
     ]


### PR DESCRIPTION
add ckptmgr and statefulstorages into heron-core for distribution. They are not used for now, and won't affect any production code.