### PR TITLE
Adding new HeronServerTester to simplify testing servers

### DIFF
--- a/heron/common/src/java/BUILD
+++ b/heron/common/src/java/BUILD
@@ -26,6 +26,7 @@ java_library(
     srcs = glob(["**/network/*.java"]),
     deps = [
         ":basics-java",
+        "//third_party/java:junit4",
         "@com_google_protobuf_protobuf_java//jar",
     ],
 )

--- a/heron/common/src/java/com/twitter/heron/common/basics/TestCommunicator.java
+++ b/heron/common/src/java/com/twitter/heron/common/basics/TestCommunicator.java
@@ -1,0 +1,47 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.common.basics;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Test communicator that provides the ability to await a certain number of expected offers to be
+ * received before proceeding by calling the awaitOffers method.
+ * @param <E>
+ */
+public class TestCommunicator<E> extends Communicator<E> {
+  private final CountDownLatch offersReceivedLatch;
+
+  public TestCommunicator(int numExpectedOffers) {
+    super();
+    this.offersReceivedLatch = new CountDownLatch(numExpectedOffers);
+  }
+
+  /**
+   * Returns one the number of offers received has reached numExpectedOffers.
+   * @param timeout how long to await the offers to reach numExpectedOffers
+   */
+  public void awaitOffers(Duration timeout) throws InterruptedException {
+    offersReceivedLatch.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
+  }
+
+  @Override
+  public boolean offer(E e) {
+    boolean response = super.offer(e);
+    offersReceivedLatch.countDown();
+    return response;
+  }
+}

--- a/heron/common/src/java/com/twitter/heron/common/network/HeronServer.java
+++ b/heron/common/src/java/com/twitter/heron/common/network/HeronServer.java
@@ -71,6 +71,10 @@ public abstract class HeronServer implements ISelectHandler {
     activeConnections = new HashMap<SocketChannel, SocketChannelHelper>();
   }
 
+  InetSocketAddress getEndpoint() {
+    return endpoint;
+  }
+
   // Register the protobuf Message's name with protobuf Message
   public void registerOnMessage(Message.Builder builder) {
     messageMap.put(builder.getDescriptorForType().getFullName(), builder);

--- a/heron/common/src/java/com/twitter/heron/common/network/HeronServerTester.java
+++ b/heron/common/src/java/com/twitter/heron/common/network/HeronServerTester.java
@@ -1,0 +1,257 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.common.network;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import com.google.protobuf.GeneratedMessage;
+import com.google.protobuf.Message;
+
+import com.twitter.heron.common.basics.ByteAmount;
+import com.twitter.heron.common.basics.Communicator;
+import com.twitter.heron.common.basics.NIOLooper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Class to help simplify testing HeronServer implementations by consolidating common test
+ * functionality. A new instance of this class should be used for each test. After initializing the
+ * class, tests should call start(), which does the following:
+ * <ol>
+ * <li>starts the server and waits for it to come up</li>
+ * <li>starts the client</li>
+ * <li>calls sendMessage on the client using the TestRequestHandler</li>
+ * <li>once the number of expected responses are recieved (via
+ * TestResponseHandler.numExpectedResponses()) the TestResponseHandler.handleResponse method is
+ * invoked</li>
+ * </ol>
+ * Upon test completion, the stop() method should be closed to properly release resources. This
+ * method is safe to be called on an instance that was never properly started.
+ */
+public class HeronServerTester {
+  public static final String SERVER_HOST = "127.0.0.1";
+  public static final HeronSocketOptions TEST_SOCKET_OPTIONS = new HeronSocketOptions(
+      ByteAmount.fromMegabytes(100), Duration.ofMillis(100),
+      ByteAmount.fromMegabytes(100), Duration.ofMillis(100),
+      ByteAmount.fromMegabytes(5),
+      ByteAmount.fromMegabytes(5));
+  private static final Duration SERVER_START_WAIT_TIME = Duration.ofSeconds(2);
+  public static final Duration RESPONSE_RECEIVED_WAIT_TIME = Duration.ofSeconds(10);
+
+  private final HeronServer server;
+  private final TestRequestHandler requestHandler;
+  private final TestResponseHandler responseHandler;
+  private final ExecutorService threadsPool;
+
+  private CountDownLatch serverStartedSignal;
+  private CountDownLatch responseReceivedSignal;
+  private HeronClient client;
+
+  public HeronServerTester(HeronServer server,
+                           TestRequestHandler requestHandler,
+                           TestResponseHandler responseHandler) throws IOException {
+    this.server = server;
+    this.threadsPool = Executors.newFixedThreadPool(2);
+    this.requestHandler = requestHandler;
+    this.responseHandler = responseHandler;
+    this.serverStartedSignal = new CountDownLatch(1);
+    this.responseReceivedSignal = new CountDownLatch(1);
+  }
+
+  public void start() throws InterruptedException {
+    // First run Server
+    runServer();
+
+    // Then run Client
+    runClient();
+
+    // Wait to make sure message was sent and response was received
+    responseReceivedSignal.await(RESPONSE_RECEIVED_WAIT_TIME.toMillis(), TimeUnit.MILLISECONDS);
+  }
+
+  public void stop() {
+    threadsPool.shutdownNow();
+
+    server.stop();
+
+    if (client != null) {
+      client.stop();
+      client.getNIOLooper().exitLoop();
+    }
+
+    server.getNIOLooper().exitLoop();
+  }
+
+  private void runServer() {
+    Runnable runServer = new Runnable() {
+      @Override
+      public void run() {
+        server.start();
+        serverStartedSignal.countDown();
+        server.getNIOLooper().loop();
+      }
+    };
+    threadsPool.execute(runServer);
+  }
+
+  private void runClient() {
+
+    Runnable runClient = new Runnable() {
+      @Override
+      public void run() {
+        try {
+          NIOLooper looper = new NIOLooper();
+          client = new TestClient(looper,
+              server.getEndpoint().getHostName(), server.getEndpoint().getPort(),
+              responseReceivedSignal, requestHandler, responseHandler);
+          serverStartedSignal.await(SERVER_START_WAIT_TIME.toMillis(), TimeUnit.MILLISECONDS);
+          client.start();
+          looper.loop();
+        } catch (IOException e) {
+          throw new RuntimeException("Error instantiating client", e);
+        } catch (InterruptedException e) {
+          throw new RuntimeException("Timeout waiting for server to start", e);
+        } finally {
+          client.stop();
+        }
+      }
+    };
+    threadsPool.execute(runClient);
+  }
+
+  private static class TestClient extends HeronClient {
+    private static final Logger LOG = Logger.getLogger(TestClient.class.getName());
+    private final TestRequestHandler requestHandler;
+    private final TestResponseHandler responseHandler;
+    private final CountDownLatch responseReceivedSignal;
+
+    TestClient(NIOLooper looper, String host, int port, CountDownLatch responseReceivedSignal,
+               TestRequestHandler requestHandler, TestResponseHandler responseHandler) {
+      super(looper, host, port, TEST_SOCKET_OPTIONS);
+      this.requestHandler = requestHandler;
+      this.responseHandler = responseHandler;
+      this.responseReceivedSignal = responseReceivedSignal;
+    }
+
+    @Override
+    public void onConnect(StatusCode status) {
+      if (status != StatusCode.OK) {
+        fail("Connection with server failed");
+      } else {
+        LOG.info("Connected with Metrics Manager Server");
+        sendRequest(requestHandler.getRequestMessage(), requestHandler.getResponseBuilder());
+      }
+    }
+
+    @Override
+    public void onError() {
+      fail("Error in client while talking to server");
+    }
+
+    @Override
+    public void onClose() {
+    }
+
+    @Override
+    public void onResponse(StatusCode status, Object ctx, Message response) {
+      responseReceivedSignal.countDown();
+      try {
+        responseHandler.handleResponse(this, status, ctx, response);
+        // SUPPRESS CHECKSTYLE IllegalCatch
+      } catch (Exception e) {
+        fail("Exception while handling response:" + e);
+      }
+    }
+
+    @Override
+    public void onIncomingMessage(Message request) {
+      fail("Expected message from client");
+    }
+  }
+
+  public interface TestRequestHandler {
+    Message getRequestMessage();
+    Message.Builder getResponseBuilder();
+  }
+
+  public interface TestResponseHandler {
+    void handleResponse(HeronClient client,
+                        StatusCode status,
+                        Object ctx,
+                        Message response) throws Exception;
+  }
+
+  public static class TestCommunicator<E> extends Communicator<E> {
+    private final CountDownLatch offersReceivedLatch;
+
+    public TestCommunicator(int numExpectedOffers) {
+      super();
+      this.offersReceivedLatch = new CountDownLatch(numExpectedOffers);
+    }
+
+    public void awaitOffers(Duration timeout) throws InterruptedException {
+      offersReceivedLatch.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public boolean offer(E e) {
+      boolean response = super.offer(e);
+      offersReceivedLatch.countDown();
+      return response;
+    }
+  }
+
+  /**
+   * Generic SuccessResponseHandler that asserts that the response status code is OK and that the
+   * message is of the expected type. After that assertion, delegates to delegate for additional
+   * assertions if set.
+   */
+  public static final class SuccessResponseHandler
+      implements TestResponseHandler {
+    private final Class<? extends GeneratedMessage> expectedMessageClass;
+    private final TestResponseHandler delegate;
+
+    public SuccessResponseHandler(Class<? extends GeneratedMessage> expectedMessageClass) {
+      this(expectedMessageClass, null);
+    }
+
+    public SuccessResponseHandler(Class<? extends GeneratedMessage> expectedMessageClass,
+                                  TestResponseHandler delegate) {
+      this.expectedMessageClass = expectedMessageClass;
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void handleResponse(HeronClient client,
+                               StatusCode status,
+                               Object ctx, Message response) throws Exception {
+      assertTrue(String.format(
+          "Unexpected response message class received from the server. Expected: %s, Found: %s",
+          expectedMessageClass.getName(), response.getClass().getName()),
+          expectedMessageClass.isAssignableFrom(response.getClass()));
+      assertEquals("Unexpected response code received from the server.", StatusCode.OK, status);
+      if (delegate != null) {
+        delegate.handleResponse(client, status, ctx, response);
+      }
+    }
+  }
+}

--- a/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/MetricsManagerServerTest.java
+++ b/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/MetricsManagerServerTest.java
@@ -27,6 +27,7 @@ import com.twitter.heron.api.metric.MultiCountMetric;
 import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.basics.NIOLooper;
 import com.twitter.heron.common.basics.SysUtils;
+import com.twitter.heron.common.basics.TestCommunicator;
 import com.twitter.heron.common.network.HeronClient;
 import com.twitter.heron.common.network.HeronServerTester;
 import com.twitter.heron.common.network.StatusCode;
@@ -36,6 +37,7 @@ import com.twitter.heron.spi.metricsmgr.metrics.MetricsInfo;
 import com.twitter.heron.spi.metricsmgr.metrics.MetricsRecord;
 
 import static com.twitter.heron.common.network.HeronServerTester.RESPONSE_RECEIVED_TIMEOUT;
+import static org.junit.Assert.fail;
 
 /**
  * MetricsManagerServer Tester.
@@ -96,12 +98,18 @@ public class MetricsManagerServerTest {
    */
   @Test
   public void testMetricsManagerServer() throws InterruptedException {
-    HeronServerTester.TestCommunicator<MetricsRecord> sinkCommunicator =
-        new HeronServerTester.TestCommunicator<>(MESSAGE_SIZE);
+    TestCommunicator<MetricsRecord> sinkCommunicator =
+        new TestCommunicator<>(MESSAGE_SIZE);
     metricsManagerServer.addSinkCommunicator(sinkCommunicator);
 
     serverTester.start();
-    sinkCommunicator.awaitOffers(RESPONSE_RECEIVED_TIMEOUT);
+
+    try {
+      sinkCommunicator.awaitOffers(RESPONSE_RECEIVED_TIMEOUT);
+    } catch (InterruptedException e) {
+      fail(String.format("awaitOffers failed to release until timeout of %s was reached.",
+          RESPONSE_RECEIVED_TIMEOUT));
+    }
 
     int messages = 0;
     while (!sinkCommunicator.isEmpty()) {

--- a/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/MetricsManagerServerTest.java
+++ b/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/MetricsManagerServerTest.java
@@ -35,6 +35,8 @@ import com.twitter.heron.spi.metricsmgr.metrics.ExceptionInfo;
 import com.twitter.heron.spi.metricsmgr.metrics.MetricsInfo;
 import com.twitter.heron.spi.metricsmgr.metrics.MetricsRecord;
 
+import static com.twitter.heron.common.network.HeronServerTester.RESPONSE_RECEIVED_TIMEOUT;
+
 /**
  * MetricsManagerServer Tester.
  */
@@ -61,7 +63,7 @@ public class MetricsManagerServerTest {
     serverTester = new HeronServerTester(metricsManagerServer,
         new MetricsManagerClientRequestHandler(),
         new HeronServerTester.SuccessResponseHandler(Metrics.MetricPublisherRegisterResponse.class,
-            new MetricsManagerClientResponseHandler(MESSAGE_SIZE)));
+            new MetricsManagerClientResponseHandler(MESSAGE_SIZE)), RESPONSE_RECEIVED_TIMEOUT);
   }
 
   @After
@@ -99,7 +101,7 @@ public class MetricsManagerServerTest {
     metricsManagerServer.addSinkCommunicator(sinkCommunicator);
 
     serverTester.start();
-    sinkCommunicator.awaitOffers(HeronServerTester.RESPONSE_RECEIVED_WAIT_TIME);
+    sinkCommunicator.awaitOffers(RESPONSE_RECEIVED_TIMEOUT);
 
     int messages = 0;
     while (!sinkCommunicator.isEmpty()) {

--- a/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/MetricsManagerServerTest.java
+++ b/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/MetricsManagerServerTest.java
@@ -15,10 +15,6 @@
 package com.twitter.heron.metricsmgr;
 
 import java.io.IOException;
-import java.time.Duration;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.logging.Logger;
 
 import com.google.protobuf.Message;
 
@@ -28,14 +24,12 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.twitter.heron.api.metric.MultiCountMetric;
-import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.basics.NIOLooper;
 import com.twitter.heron.common.basics.SysUtils;
 import com.twitter.heron.common.network.HeronClient;
-import com.twitter.heron.common.network.HeronSocketOptions;
+import com.twitter.heron.common.network.HeronServerTester;
 import com.twitter.heron.common.network.StatusCode;
-import com.twitter.heron.proto.system.Common;
 import com.twitter.heron.proto.system.Metrics;
 import com.twitter.heron.spi.metricsmgr.metrics.ExceptionInfo;
 import com.twitter.heron.spi.metricsmgr.metrics.MetricsInfo;
@@ -48,7 +42,7 @@ public class MetricsManagerServerTest {
   private static final String METRIC_NAME = "metric-name";
   private static final String METRIC_VALUE = "metric-value";
 
-  private static final int N = 20;
+  private static final int METRICS_COUNT = 20;
   private static final int MESSAGE_SIZE = 10;
   private static final String STACK_TRACE = "stackTrace";
   private static final String LAST_TIME = "lastTime";
@@ -56,58 +50,31 @@ public class MetricsManagerServerTest {
   private static final String LOGGING = "logging";
   private static final int EXCEPTION_COUNT = 20;
 
-  private static final String SERVER_HOST = "127.0.0.1";
-  private static final HeronSocketOptions TEST_SOCKET_OPTIONS = new HeronSocketOptions(
-      ByteAmount.fromMegabytes(100), Duration.ofMillis(100),
-      ByteAmount.fromMegabytes(100), Duration.ofMillis(100),
-      ByteAmount.fromMegabytes(5),
-      ByteAmount.fromMegabytes(5));
-
-  private static int serverPort;
-
   private MetricsManagerServer metricsManagerServer;
-  private SimpleMetricsClient simpleMetricsClient;
-  private NIOLooper serverLooper;
-
-  private ExecutorService threadsPool;
+  private HeronServerTester serverTester;
 
   @Before
-  public void before() throws Exception {
-    // Get an available port
-    serverPort = SysUtils.getFreePort();
+  public void before() throws IOException {
+    metricsManagerServer = new MetricsManagerServer(new NIOLooper(), HeronServerTester.SERVER_HOST,
+        SysUtils.getFreePort(), HeronServerTester.TEST_SOCKET_OPTIONS, new MultiCountMetric());
 
-    threadsPool = Executors.newFixedThreadPool(2);
-
-    serverLooper = new NIOLooper();
-    metricsManagerServer = new MetricsManagerServer(serverLooper, SERVER_HOST,
-        serverPort, TEST_SOCKET_OPTIONS, new MultiCountMetric());
+    serverTester = new HeronServerTester(metricsManagerServer,
+        new MetricsManagerClientRequestHandler(),
+        new HeronServerTester.SuccessResponseHandler(Metrics.MetricPublisherRegisterResponse.class,
+            new MetricsManagerClientResponseHandler(MESSAGE_SIZE)));
   }
 
   @After
-  public void after() throws Exception {
-    threadsPool.shutdownNow();
-
-    metricsManagerServer.stop();
-    metricsManagerServer = null;
-
-    if (simpleMetricsClient != null) {
-      simpleMetricsClient.stop();
-
-      simpleMetricsClient.getNIOLooper().exitLoop();
-    }
-
-    serverLooper.exitLoop();
-    serverLooper = null;
-
-    threadsPool = null;
+  public void after() {
+    serverTester.stop();
   }
 
   /**
    * Method: addSinkCommunicator(Communicator&lt;MetricsRecord&gt; communicator)
    */
   @Test
-  public void testAddSinkCommunicator() throws Exception {
-    Communicator<MetricsRecord> sinkCommunicator = new Communicator<MetricsRecord>();
+  public void testAddSinkCommunicator() {
+    Communicator<MetricsRecord> sinkCommunicator = new Communicator<>();
     metricsManagerServer.addSinkCommunicator(sinkCommunicator);
     Assert.assertTrue(metricsManagerServer.removeSinkCommunicator(sinkCommunicator));
   }
@@ -116,8 +83,8 @@ public class MetricsManagerServerTest {
    * Method: removeSinkCommunicator(Communicator&lt;MetricsRecord&gt; communicator)
    */
   @Test
-  public void testRemoveSinkCommunicator() throws Exception {
-    Communicator<MetricsRecord> sinkCommunicator = new Communicator<MetricsRecord>();
+  public void testRemoveSinkCommunicator() {
+    Communicator<MetricsRecord> sinkCommunicator = new Communicator<>();
     metricsManagerServer.addSinkCommunicator(sinkCommunicator);
     Assert.assertTrue(metricsManagerServer.removeSinkCommunicator(sinkCommunicator));
   }
@@ -126,22 +93,13 @@ public class MetricsManagerServerTest {
    * Method: addSinkCommunicator(Communicator&lt;MetricsRecord&gt; communicator)
    */
   @Test
-  public void testMetricsManagerServer() throws Exception {
-    final Communicator<MetricsRecord> sinkCommunicator = new Communicator<MetricsRecord>();
+  public void testMetricsManagerServer() throws InterruptedException {
+    HeronServerTester.TestCommunicator<MetricsRecord> sinkCommunicator =
+        new HeronServerTester.TestCommunicator<>(MESSAGE_SIZE);
     metricsManagerServer.addSinkCommunicator(sinkCommunicator);
 
-    // First run Server
-    runServer();
-
-    // Wait a while for server fully starting
-    Thread.sleep(3 * 1000);
-
-    // Then run Client
-    runClient();
-
-
-    // Wait some while to let message fully send out
-    Thread.sleep(10 * 1000);
+    serverTester.start();
+    sinkCommunicator.awaitOffers(HeronServerTester.RESPONSE_RECEIVED_WAIT_TIME);
 
     int messages = 0;
     while (!sinkCommunicator.isEmpty()) {
@@ -158,7 +116,7 @@ public class MetricsManagerServerTest {
         Assert.assertEquals(METRIC_VALUE, info.getValue());
         metrics++;
       }
-      Assert.assertEquals(N, metrics);
+      Assert.assertEquals(METRICS_COUNT, metrics);
 
       for (ExceptionInfo info : record.getExceptions()) {
         Assert.assertEquals(STACK_TRACE, info.getStackTrace());
@@ -168,75 +126,17 @@ public class MetricsManagerServerTest {
         Assert.assertEquals(EXCEPTION_COUNT, info.getCount());
         exceptions++;
       }
-      Assert.assertEquals(N, exceptions);
+      Assert.assertEquals(METRICS_COUNT, exceptions);
 
       messages++;
     }
     Assert.assertEquals(MESSAGE_SIZE, messages);
   }
 
-  private void runServer() {
-    Runnable runServer = new Runnable() {
-      @Override
-      public void run() {
-        metricsManagerServer.start();
-        metricsManagerServer.getNIOLooper().loop();
-      }
-    };
-    threadsPool.execute(runServer);
-  }
-
-  private void runClient() {
-
-    Runnable runClient = new Runnable() {
-      @Override
-      public void run() {
-        try {
-          NIOLooper looper = new NIOLooper();
-          simpleMetricsClient =
-              new SimpleMetricsClient(looper, SERVER_HOST, serverPort, MESSAGE_SIZE);
-          simpleMetricsClient.start();
-          looper.loop();
-        } catch (IOException e) {
-          throw new RuntimeException("Some error instantiating client");
-        } finally {
-          simpleMetricsClient.stop();
-        }
-      }
-    };
-    threadsPool.execute(runClient);
-  }
-
-  private static class SimpleMetricsClient extends HeronClient {
-    private static final Logger LOG = Logger.getLogger(SimpleMetricsClient.class.getName());
-    private int maxMessages;
-
-    SimpleMetricsClient(NIOLooper looper, String host, int port, int maxMessages) {
-      super(looper, host, port, TEST_SOCKET_OPTIONS);
-      this.maxMessages = maxMessages;
-    }
+  private class MetricsManagerClientRequestHandler implements HeronServerTester.TestRequestHandler {
 
     @Override
-    public void onConnect(StatusCode status) {
-      if (status != StatusCode.OK) {
-        org.junit.Assert.fail("Connection with server failed");
-      } else {
-        LOG.info("Connected with Metrics Manager Server");
-        sendRequest();
-      }
-    }
-
-    @Override
-    public void onError() {
-      org.junit.Assert.fail("Error in client while talking to server");
-    }
-
-    @Override
-    public void onClose() {
-
-    }
-
-    private void sendRequest() {
+    public Message getRequestMessage() {
       Metrics.MetricPublisher publisher = Metrics.MetricPublisher.newBuilder().
           setHostname("hostname").
           setPort(0).
@@ -244,50 +144,52 @@ public class MetricsManagerServerTest {
           setInstanceId("instance-id").
           setInstanceIndex(1).
           build();
-      Metrics.MetricPublisherRegisterRequest request =
-          Metrics.MetricPublisherRegisterRequest.newBuilder().setPublisher(publisher).build();
-
-      sendRequest(request, Metrics.MetricPublisherRegisterResponse.newBuilder());
-
+      return Metrics.MetricPublisherRegisterRequest.newBuilder().setPublisher(publisher).build();
     }
 
-    private void sendMessage() {
+    @Override
+    public Message.Builder getResponseBuilder() {
+      return Metrics.MetricPublisherRegisterResponse.newBuilder();
+    }
+  }
+
+  private class MetricsManagerClientResponseHandler
+      implements HeronServerTester.TestResponseHandler {
+    private int maxMessages;
+
+    MetricsManagerClientResponseHandler(int maxMessages) {
+      this.maxMessages = maxMessages;
+    }
+
+    @Override
+    public void handleResponse(HeronClient client, StatusCode status,
+                               Object ctx, Message response) {
+      for (int i = 0; i < maxMessages; i++) {
+        sendMessage(client);
+      }
+    }
+
+    private void sendMessage(HeronClient client) {
       Metrics.MetricPublisherPublishMessage.Builder builder =
           Metrics.MetricPublisherPublishMessage.newBuilder();
 
-      for (int j = 0; j < N; j++) {
-        Metrics.MetricDatum metricDatum =
-            Metrics.MetricDatum.newBuilder().setName(METRIC_NAME).setValue(METRIC_VALUE).build();
-        builder.addMetrics(metricDatum);
+      for (int j = 0; j < METRICS_COUNT; j++) {
+        builder.addMetrics(
+            Metrics.MetricDatum.newBuilder()
+                    .setName(METRIC_NAME)
+                    .setValue(METRIC_VALUE).build());
       }
 
-      for (int j = 0; j < N; j++) {
-        Metrics.ExceptionData exceptionData = Metrics.ExceptionData.newBuilder().
-            setStacktrace(STACK_TRACE).setLasttime(LAST_TIME).setFirsttime(FIRST_TIME).
-            setCount(EXCEPTION_COUNT).setLogging(LOGGING).build();
-        builder.addExceptions(exceptionData);
+      for (int j = 0; j < METRICS_COUNT; j++) {
+        builder.addExceptions(
+            Metrics.ExceptionData.newBuilder()
+                .setStacktrace(STACK_TRACE)
+                .setLasttime(LAST_TIME)
+                .setFirsttime(FIRST_TIME)
+                .setCount(EXCEPTION_COUNT)
+                .setLogging(LOGGING).build());
       }
-      sendMessage(builder.build());
-    }
-
-    @Override
-    public void onResponse(StatusCode status, Object ctx, Message response) {
-      if (response instanceof Metrics.MetricPublisherRegisterResponse) {
-        Assert.assertEquals(Common.StatusCode.OK,
-            ((Metrics.MetricPublisherRegisterResponse) response).getStatus().getStatus());
-
-        for (int i = 0; i < maxMessages; i++) {
-          sendMessage();
-        }
-
-      } else {
-        org.junit.Assert.fail("Unknown type of response received");
-      }
-    }
-
-    @Override
-    public void onIncomingMessage(Message request) {
-      org.junit.Assert.fail("Expected message from client");
+      client.sendMessage(builder.build());
     }
   }
 }


### PR DESCRIPTION
Adding `HeronServerTester` to simplify writing unit tests against Heron server. Much of what's in `HeronServerTester` is code that's copied in multiple tests.

Provides the following benefits:

- Consolidates common boilerplate client/server code that each unit test shouldn't have to deal with (loopers, threadpools, etc)
- Removes the use of timers and uses countdown latches instead. This reduces this test from 13 seconds to 1 second.
- Reduces possibility of flaky tests due to mis-implementation of sleep logic.
- Makes test logic easier to read and understand since other clutter is removed.

Review includes one test to show how `HeronServerTester` is used. I've upgraded one other that I'll do in a follow-up review. There will be a few more to upgrade after that.