### PR TITLE
add tmaster zk watch on tmaster location

### DIFF
--- a/heron/tmaster/src/cpp/manager/tmaster.cpp
+++ b/heron/tmaster/src/cpp/manager/tmaster.cpp
@@ -142,6 +142,14 @@ void TMaster::EstablishTMaster(EventLoop::Status) {
   auto cb = [this](proto::system::StatusCode code) { this->SetTMasterLocationDone(code); };
 
   state_mgr_->SetTMasterLocation(*tmaster_location_, std::move(cb));
+
+  // if zk lost the tmaster location, tmaster quits to bail out and re-establish its location
+  auto cb2 = [this]() {
+    LOG(ERROR) << " lost tmaster location in zk state manager. Bailing out..." << std::endl;
+    ::exit(1);
+  };
+  state_mgr_->SetTMasterLocationWatch(tmaster_location_->topology_name(), std::move(cb2));
+
   master_establish_attempts_++;
 }
 


### PR DESCRIPTION
Fix the issue that tmaster keeps running after zk state manager lost the tmaster location.

The fix is: add a watch, which triggers tmaster to quit immediately, in tmaster.

Tested with local scheduler and zk statemanager.