### PR TITLE
start ckptmgr if topology is stateful-enabled

### DIFF
--- a/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/CheckpointManagerConfig.java
+++ b/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/CheckpointManagerConfig.java
@@ -166,6 +166,9 @@ public final class CheckpointManagerConfig {
           case BYTE_AMOUNT:
             config.put(key.value(), TypeUtils.getByteAmount(value));
             break;
+          case DURATION:
+            config.put(key.value(), TypeUtils.getDuration(value, key.getTemporalUnit()));
+            break;
           case INTEGER:
             config.put(key.value(), TypeUtils.getInteger(value));
             break;

--- a/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/CheckpointManagerConfigKey.java
+++ b/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/CheckpointManagerConfigKey.java
@@ -31,7 +31,7 @@ public enum CheckpointManagerConfigKey {
   /**
    * The class name of the stateful storage
    */
-  STORAGE_CLASSNAME("heron.class.statefulstorage", Type.STRING),
+  STORAGE_CLASSNAME("heron.statefulstorage.classname", Type.STRING),
 
   /**
    * The batch size in bytes for write operation

--- a/heron/config/src/yaml/conf/aurora/stateful.yaml
+++ b/heron/config/src/yaml/conf/aurora/stateful.yaml
@@ -1,7 +1,19 @@
 # indicate the type of storage for checkpoint is hdfs
-heron.statefulstorage.type: "HDFSStorage"
+heron.statefulstorage.classname:         "com.twitter.heron.statefulstorage.hdfs.HDFSStorage"
 
 heron.statefulstorage.config:
-  heron.statefulstorage.classname:         "com.twitter.heron.statefulstorage.hdfs.HDFSStorage"
-  heron.statefulstorage.classpath:         "$(hadoop --config /path/to/configs classpath)"
+  heron.statefulstorage.classpath:        "$(hadoop --config /path/to/configs classpath)"
   heron.statefulstorage.hdfs.root.path:   "/user/heron/checkpoints"
+
+# Following are configs for socket between ckptmgr and stateful storage
+heron.ckptmgr.network.write.batch.size.bytes: 32768
+
+heron.ckptmgr.network.write.batch.time.ms: 16
+
+heron.ckptmgr.network.read.batch.size.bytes: 32768
+
+heron.ckptmgr.network.read.batch.time.ms: 16
+
+heron.ckptmgr.network.options.socket.send.buffer.size.bytes: 655360
+
+heron.ckptmgr.network.options.socket.receive.buffer.size.bytes: 655360

--- a/heron/config/src/yaml/conf/local/stateful.yaml
+++ b/heron/config/src/yaml/conf/local/stateful.yaml
@@ -1,7 +1,19 @@
 # indicate the type of storage for checkpoint is local file system
-heron.statefulstorage.type:    "LocalFileSystemStorage"
+heron.statefulstorage.classname:            "com.twitter.heron.statefulstorage.localfs.LocalFileSystemStorage"
 
 heron.statefulstorage.config:
-  heron.statefulstorage.classname:            "com.twitter.heron.statefulstorage.localfs.LocalFileSystemStorage"
-  heron.statefulstorage.classpath:            ""
+  heron.statefulstorage.classpath:           ""
   heron.statefulstorage.localfs.root.path:   "./checkpoints"
+
+# Following are configs for socket between ckptmgr and stateful storage
+heron.ckptmgr.network.write.batch.size.bytes: 32768
+
+heron.ckptmgr.network.write.batch.time.ms: 16
+
+heron.ckptmgr.network.read.batch.size.bytes: 32768
+
+heron.ckptmgr.network.read.batch.time.ms: 16
+
+heron.ckptmgr.network.options.socket.send.buffer.size.bytes: 655360
+
+heron.ckptmgr.network.options.socket.receive.buffer.size.bytes: 655360

--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -55,7 +55,8 @@ def print_usage():
       " <heron_java_home> <shell-port> <heron_shell_binary> <metricsmgr_port>"
       " <cluster> <role> <environ> <instance_classpath> <metrics_sinks_config_file>"
       " <scheduler_classpath> <scheduler_port> <python_instance_binary>"
-      " <metricscachemgr_classpath> <metricscachemgr_masterport> <metricscachemgr_statsport>")
+      " <metricscachemgr_classpath> <metricscachemgr_masterport> <metricscachemgr_statsport>"
+      " <is_stateful> <ckptmgr_classpath> <ckptmgr_port> <stateful_config_file>")
 
 def id_map(prefix, container_plans, add_zero_id=False):
   ids = {}
@@ -71,6 +72,9 @@ def stmgr_map(container_plans):
 
 def metricsmgr_map(container_plans):
   return id_map("metricsmgr", container_plans, True)
+
+def ckptmgr_map(container_plans):
+  return id_map("ckptmgr", container_plans, True)
 
 def heron_shell_map(container_plans):
   return id_map("heron-shell", container_plans, True)
@@ -207,6 +211,11 @@ class HeronExecutor(object):
     self.scheduler_port = parsed_args.scheduler_port
     self.python_instance_binary = parsed_args.python_instance_binary
 
+    self.is_stateful_topology = (parsed_args.is_stateful.lower() == 'true')
+    self.ckptmgr_classpath = parsed_args.ckptmgr_classpath
+    self.ckptmgr_port = parsed_args.ckptmgr_port
+    self.stateful_config_file = parsed_args.stateful_config_file
+
   def __init__(self, args, shell_env):
     self.init_parsed_args(args)
 
@@ -222,6 +231,7 @@ class HeronExecutor(object):
     self.stmgr_ids = {}
     self.metricsmgr_ids = {}
     self.heron_shell_ids = {}
+    self.ckptmgr_ids = {}
 
     # processes_to_monitor gets set once processes are launched. we need to synchronize rw to this
     # dict since is used by multiple threads
@@ -270,6 +280,10 @@ class HeronExecutor(object):
     parser.add_argument("metricscachemgr_classpath")
     parser.add_argument("metricscachemgr_masterport")
     parser.add_argument("metricscachemgr_statsport")
+    parser.add_argument("is_stateful")
+    parser.add_argument("ckptmgr_classpath")
+    parser.add_argument("ckptmgr_port")
+    parser.add_argument("stateful_config_file")
 
     parsed_args, unknown_args = parser.parse_known_args(args[1:])
 
@@ -312,6 +326,7 @@ class HeronExecutor(object):
   def update_packing_plan(self, new_packing_plan):
     self.packing_plan = new_packing_plan
     self.stmgr_ids = stmgr_map(self.packing_plan.container_plans)
+    self.ckptmgr_ids = ckptmgr_map(self.packing_plan.container_plans)
     self.metricsmgr_ids = metricsmgr_map(self.packing_plan.container_plans)
     self.heron_shell_ids = heron_shell_map(self.packing_plan.container_plans)
 
@@ -426,6 +441,9 @@ class HeronExecutor(object):
         self.metricsmgr_ids[0],
         self.metrics_sinks_config_file,
         self.metricsmgr_port)
+
+    if self.is_stateful_topology:
+      retval.update(self._get_ckptmgr_process())
 
     return retval
 
@@ -576,12 +594,53 @@ class HeronExecutor(object):
         self.metricsmgr_port
     )
 
+    if self.is_stateful_topology:
+      retval.update(self._get_ckptmgr_process())
+
     if self.pkg_type == 'jar' or self.pkg_type == 'tar':
       retval.update(self._get_java_instance_cmd(instance_info))
     elif self.pkg_type == 'pex':
       retval.update(self._get_python_instance_cmd(instance_info))
     else:
       raise ValueError("Unrecognized package type: %s" % self.pkg_type)
+
+    return retval
+
+  def _get_ckptmgr_process(self):
+    ''' Get the command to start the checkpoint manager process'''
+
+    ckptmgr_main_class = 'com.twitter.heron.ckptmgr.CheckpointManager'
+
+    ckptmgr_cmd = [os.path.join(self.heron_java_home, "bin/java"),
+                   '-Xmx512M',
+                   '-XX:+PrintCommandLineFlags',
+                   '-verbosegc',
+                   '-XX:+PrintGCDetails',
+                   '-XX:+PrintGCTimeStamps',
+                   '-XX:+PrintGCDateStamps',
+                   '-XX:+PrintGCCause',
+                   '-XX:+UseGCLogFileRotation',
+                   '-XX:NumberOfGCLogFiles=5',
+                   '-XX:GCLogFileSize=100M',
+                   '-XX:+PrintPromotionFailure',
+                   '-XX:+PrintTenuringDistribution',
+                   '-XX:+PrintHeapAtGC',
+                   '-XX:+HeapDumpOnOutOfMemoryError',
+                   '-XX:+UseConcMarkSweepGC',
+                   '-XX:+UseConcMarkSweepGC',
+                   '-Xloggc:log-files/gc.metricsmgr.log',
+                   '-Djava.net.preferIPv4Stack=true',
+                   '-cp',
+                   self.ckptmgr_classpath,
+                   ckptmgr_main_class,
+                   '-t' + self.topology_name,
+                   '-i' + self.topology_id,
+                   '-c' + self.ckptmgr_ids[self.shard],
+                   '-p' + self.ckptmgr_port,
+                   '-f' + self.stateful_config_file,
+                   '-g' + self.heron_internals_config_file]
+    retval = {}
+    retval[self.ckptmgr_ids[self.shard]] = ckptmgr_cmd
 
     return retval
 

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/SchedulerUtils.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/SchedulerUtils.java
@@ -38,7 +38,7 @@ import com.twitter.heron.spi.utils.ShellUtils;
 import com.twitter.heron.spi.utils.TopologyUtils;
 
 public final class SchedulerUtils {
-  public static final int PORTS_REQUIRED_FOR_EXECUTOR = 8;
+  public static final int PORTS_REQUIRED_FOR_EXECUTOR = 9;
   public static final int PORTS_REQUIRED_FOR_SCHEDULER = 1;
   public static final String SCHEDULER_COMMAND_LINE_PROPERTIES_OVERRIDE_OPTION = "P";
 
@@ -198,6 +198,7 @@ public final class SchedulerUtils {
     String schedulerPort = freePorts.get(5);
     String metricsCacheMasterPort = freePorts.get(6);
     String metricsCacheStatsPort = freePorts.get(7);
+    String ckptmgrPort = freePorts.get(8);
 
     List<String> commands = new ArrayList<>();
     commands.add(topology.getName());
@@ -239,6 +240,18 @@ public final class SchedulerUtils {
     commands.add(Context.metricsCacheManagerClassPath(config));
     commands.add(metricsCacheMasterPort);
     commands.add(metricsCacheStatsPort);
+
+    Boolean isStatefulEnabled = TopologyUtils.getConfigWithDefault(
+        topology.getTopologyConfig().getKvsList(),
+        com.twitter.heron.api.Config.TOPOLOGY_STATEFUL_ENABLED, false);
+    commands.add(Boolean.toString(isStatefulEnabled));
+    String completeCkptmgrProcessClassPath = String.format("%s:%s:%s",
+        Context.ckptmgrClassPath(config),
+        Context.statefulStoragesClassPath(config),
+        Context.statefulStorageCustomClassPath(config));
+    commands.add(completeCkptmgrProcessClassPath);
+    commands.add(ckptmgrPort);
+    commands.add(Context.statefulFile(config));
 
     return commands.toArray(new String[commands.size()]);
   }

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Context.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Context.java
@@ -249,8 +249,12 @@ public class Context {
     return cfg.getStringValue(Key.CKPTMGR_CLASSPATH);
   }
 
+  public static String statefulStoragesClassPath(Config cfg) {
+    return cfg.getStringValue(Key.STATEFULSTORAGES_CLASSPATH);
+  }
+
   public static Boolean isStateful(Config cfg) {
-    return cfg.getBooleanValue(Key.IS_STATEFUL);
+    return cfg.getBooleanValue(Key.IS_STATEFUL_ENABLED);
   }
 
   public static String stateManagerClassPath(Config cfg) {
@@ -298,10 +302,10 @@ public class Context {
   }
 
   @SuppressWarnings("unchecked")
-  public static final String statefulStorageClassPath(Config cfg) {
+  public static final String statefulStorageCustomClassPath(Config cfg) {
     Map<String, Object> statefulStorageConfig =
         (Map<String, Object>) cfg.get(Key.STATEFUL_STORAGE_CONF);
-    Object o = statefulStorageConfig.get(Key.STATEFUL_STORAGE_CLASSPATH.value());
+    Object o = statefulStorageConfig.get(Key.STATEFUL_STORAGE_CUSTOM_CLASSPATH.value());
     return o == null ? "" : (String) o;
   }
 }

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Key.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Key.java
@@ -109,21 +109,22 @@ public enum Key {
   INSTANCE_DISK             ("heron.resources.instance.disk", ByteAmount.fromBytes(1073741824)),
 
   //keys for checkpoint management
-  IS_STATEFUL                       ("heron.is.stateful", Boolean.FALSE),
-  IS_CLEAN_STATEFUL_CHECKPOINTS     ("heron.is.clean.stateful.checkpoints", Boolean.FALSE),
-  CKPTMGR_STATEFUL_STORAGE          ("heron.statefulstorage.type", Type.STRING),
-  STATEFUL_STORAGE_CONF             ("heron.statefulstorage.config", Type.MAP),
-  STATEFUL_STORAGE_CLASSPATH        ("heron.statefulstorage.classpath", Type.STRING),
+  IS_STATEFUL_ENABLED                      ("heron.is.stateful.enabled", Boolean.FALSE),
+  IS_CLEAN_STATEFUL_CHECKPOINTS            ("heron.is.clean.stateful.checkpoints", Boolean.FALSE),
+  STATEFUL_STORAGE_CLASSNAME               ("heron.statefulstorage.classname", Type.STRING),
+  STATEFUL_STORAGE_CONF                    ("heron.statefulstorage.config", Type.MAP),
+  STATEFUL_STORAGE_CUSTOM_CLASSPATH        ("heron.statefulstorage.custom.classpath", Type.STRING),
 
   //keys for config provided paths
-  INSTANCE_CLASSPATH        ("heron.classpath.instance",             "${HERON_LIB}/instance/*"),
-  METRICSMGR_CLASSPATH      ("heron.classpath.metrics.manager",      "${HERON_LIB}/metricsmgr/*"),
-  METRICSCACHEMGR_CLASSPATH ("heron.classpath.metricscache.manager", "${HERON_LIB}/metricscachemgr/*"),
-  PACKING_CLASSPATH         ("heron.classpath.packing",              "${HERON_LIB}/packing/*"),
-  SCHEDULER_CLASSPATH       ("heron.classpath.scheduler",            "${HERON_LIB}/scheduler/*"),
-  STATEMGR_CLASSPATH        ("heron.classpath.statemgr",             "${HERON_LIB}/statemgr/*"),
-  UPLOADER_CLASSPATH        ("heron.classpath.uploader",             "${HERON_LIB}/uploader/*"),
-  CKPTMGR_CLASSPATH         ("heron.classpath.ckptmgr",              "${HERON_LIB}/ckptmgr/*"),
+  INSTANCE_CLASSPATH         ("heron.classpath.instance",             "${HERON_LIB}/instance/*"),
+  METRICSMGR_CLASSPATH       ("heron.classpath.metrics.manager",      "${HERON_LIB}/metricsmgr/*"),
+  METRICSCACHEMGR_CLASSPATH  ("heron.classpath.metricscache.manager", "${HERON_LIB}/metricscachemgr/*"),
+  PACKING_CLASSPATH          ("heron.classpath.packing",              "${HERON_LIB}/packing/*"),
+  SCHEDULER_CLASSPATH        ("heron.classpath.scheduler",            "${HERON_LIB}/scheduler/*"),
+  STATEMGR_CLASSPATH         ("heron.classpath.statemgr",             "${HERON_LIB}/statemgr/*"),
+  UPLOADER_CLASSPATH         ("heron.classpath.uploader",             "${HERON_LIB}/uploader/*"),
+  CKPTMGR_CLASSPATH          ("heron.classpath.ckptmgr",              "${HERON_LIB}/ckptmgr/*"),
+  STATEFULSTORAGES_CLASSPATH ("heron.classpath.statefulstorage",      "${HERON_LIB}/statefulstorages/*"),
 
   //keys for run time config
   TOPOLOGY_CLASSPATH             ("heron.runtime.topology.class.path",             Type.STRING),

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/TopologyUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/TopologyUtils.java
@@ -85,6 +85,11 @@ public final class TopologyUtils {
     return ByteAmount.fromBytes(getConfigWithDefault(config, key, defaultBytes));
   }
 
+  public static Boolean getConfigWithDefault(
+      List<TopologyAPI.Config.KeyValue> config, String key, boolean defaultValue) {
+    return Boolean.parseBoolean(getConfigWithDefault(config, key, Boolean.toString(defaultValue)));
+  }
+
   public static String getConfigWithException(
       List<TopologyAPI.Config.KeyValue> config, String key) {
     for (TopologyAPI.Config.KeyValue kv : config) {


### PR DESCRIPTION
This PR finishes the following tasks:
1. update config file for stateful processing according to the current Config design
2. start ckptmgr process if the topology is stateful-enabled; won't start it if unspecified or disabled
3. add necessary Key and util methods

Tested with local scheduler. Ckptmgr is started correctly if stateful enabled; no ckptmgr is started otherwise