### PR TITLE
refactor metrics manager tests to not use Thread.sleep

### DIFF
--- a/heron/api/src/java/com/twitter/heron/api/metric/CountMetric.java
+++ b/heron/api/src/java/com/twitter/heron/api/metric/CountMetric.java
@@ -28,6 +28,10 @@ public class CountMetric implements IMetric<Long> {
     value += incrementBy;
   }
 
+  public Long getValue() {
+    return value;
+  }
+
   @Override
   public Long getValueAndReset() {
     long ret = value;

--- a/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/LatchedMultiCountMetric.java
+++ b/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/LatchedMultiCountMetric.java
@@ -1,0 +1,117 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.metricsmgr;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import com.twitter.heron.api.metric.CountMetric;
+import com.twitter.heron.api.metric.MultiCountMetric;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.spy;
+
+/**
+ * Test MultiCountMetric impl that lets the consumer await() for a metric to reach a certain
+ * value. Multiple expectedValues can be passed, in which case each call to await() will wait for
+ * the next value to be reached.
+ */
+public final class LatchedMultiCountMetric extends MultiCountMetric {
+  private final String expectedKey;
+  private final Long[] expectedValues;
+  private final CountDownLatch[] countDownLatches;
+  private CountMetric spiedMetric;
+  private int currentLatchIndex = 0;
+
+  public LatchedMultiCountMetric(String expectedKey, Long... expectedValues) {
+    this.expectedKey = expectedKey;
+    this.expectedValues = expectedValues;
+    this.countDownLatches = new CountDownLatch[expectedValues.length];
+    for (int i = 0; i < expectedValues.length; i++) {
+      this.countDownLatches[i] = new CountDownLatch(1);
+    }
+  }
+
+  public void await(Duration timeout) {
+    assertTrue(String.format(
+        "Invalid attempt made to call await() %s times, with only %d expectedValues passed",
+        currentLatchIndex + 1, countDownLatches.length),
+        currentLatchIndex < countDownLatches.length);
+    try {
+      if (!countDownLatches[currentLatchIndex].await(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+        if (spiedMetric != null) {
+          fail(String.format(
+              "After waiting for %s, the expected metric for key '%s' is %d, found %d",
+              timeout, expectedKey, expectedValues[currentLatchIndex], spiedMetric.getValue()));
+
+        } else {
+          fail(String.format(
+              "After waiting for %s, the expected metric for key '%s' is %d, "
+                  + "but the value was never incremented",
+              timeout, expectedKey, expectedValues[currentLatchIndex]));
+        }
+      }
+    } catch (InterruptedException e) {
+      fail(String.format(
+          "Await latch interrupted before timeout of %s was reached: %s",
+          timeout, e));
+    }
+    currentLatchIndex++;
+  }
+
+  @Override
+  public CountMetric scope(final String key) {
+    final CountMetric metric = super.scope(key);
+    if (!expectedKey.equals(key)) {
+      return metric;
+    } else if (spiedMetric == null) {
+      final CountMetric spy = spy(metric);
+
+      Mockito.doAnswer(new Answer<Void>() {
+        @Override
+        public Void answer(InvocationOnMock invocation) throws Throwable {
+          metric.incr();
+          countDown(metric);
+          return null;
+        }
+      }).when(spy).incr();
+
+      Mockito.doAnswer(new Answer<Void>() {
+        @Override
+        public Void answer(InvocationOnMock invocation) throws Throwable {
+          metric.incrBy((Long) invocation.getArguments()[0]);
+          countDown(metric);
+          return null;
+        }
+      }).when(spy).incrBy(anyLong());
+
+      this.spiedMetric = spy;
+    }
+
+    return spiedMetric;
+  }
+
+  private void countDown(CountMetric metric) {
+    if (metric.getValue().equals(expectedValues[currentLatchIndex])) {
+      countDownLatches[currentLatchIndex].countDown();
+    }
+  }
+}

--- a/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/metricscache/MetricsCacheSinkTest.java
+++ b/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/metricscache/MetricsCacheSinkTest.java
@@ -15,6 +15,7 @@
 package com.twitter.heron.metricsmgr.sink.metricscache;
 
 import java.lang.reflect.Field;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,11 +23,15 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.twitter.heron.api.metric.MultiCountMetric;
 import com.twitter.heron.common.basics.SingletonRegistry;
+import com.twitter.heron.metricsmgr.LatchedMultiCountMetric;
 import com.twitter.heron.metricsmgr.sink.SinkContextImpl;
 import com.twitter.heron.proto.tmaster.TopologyMaster;
 import com.twitter.heron.spi.metricsmgr.sink.SinkContext;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  * MetricsCacheSink Tester.
@@ -37,15 +42,14 @@ public class MetricsCacheSinkTest {
   private static final String METRICSCACHE_LOCATION_BEAN_NAME =
       TopologyMaster.MetricsCacheLocation.newBuilder().getDescriptorForType().getFullName();
 
-  private static final int RECONNECT_INTERVAL_SECONDS = 1;
-  private static final int RESTART_WAIT_INTERVAL_SECONDS = 5;
-  private static final int METRICSCACHE_LOCATION_CHECK_INTERVAL_SECONDS = 1;
-  private static final int WAIT_SECONDS = 10;
+  private static final Duration RECONNECT_INTERVAL = Duration.ofSeconds(1);
+  private static final Duration RESTART_WAIT_INTERVAL = Duration.ofSeconds(2);
+  private static final Duration METRICSCACHE_LOCATION_CHECK_INTERVAL = Duration.ofSeconds(1);
 
   private static Map<String, Object> buildServiceConfig() {
-    Map<String, Object> serviceConfig = new HashMap<String, Object>();
+    Map<String, Object> serviceConfig = new HashMap<>();
     // Fill with necessary config
-    serviceConfig.put("reconnect-interval-second", RECONNECT_INTERVAL_SECONDS);
+    serviceConfig.put("reconnect-interval-second", RECONNECT_INTERVAL.getSeconds());
     serviceConfig.put("network-write-batch-size-bytes", 1);
     serviceConfig.put("network-write-batch-time-ms", 1);
     serviceConfig.put("network-read-batch-size-bytes", 1);
@@ -53,6 +57,15 @@ public class MetricsCacheSinkTest {
     serviceConfig.put("socket-send-buffer-size-bytes", 1);
     serviceConfig.put("socket-received-buffer-size-bytes", 1);
     return serviceConfig;
+  }
+
+  private static TopologyMaster.MetricsCacheLocation getMetricsCacheLocation(int masterPort) {
+    // Notice here we set host and port as invalid values
+    // So MetricsCache would throw "java.nio.channels.UnresolvedAddressException" once it starts,
+    // and then dies
+    return TopologyMaster.MetricsCacheLocation.newBuilder().
+        setTopologyName("topology-name").setTopologyId("topology-id").setHost("host").
+        setControllerPort(0).setMasterPort(masterPort).setStatsPort(0).build();
   }
 
   @After
@@ -76,23 +89,16 @@ public class MetricsCacheSinkTest {
     Map<String, Object> serviceConfig = buildServiceConfig();
 
     metricsCacheSink.createSimpleMetricsCacheClientService(serviceConfig);
-
-    // Notice here we set host and port as invalid values
-    // So MetricsCache would throw "java.nio.channels.UnresolvedAddressException" once it starts,
-    // and then dies
-    TopologyMaster.MetricsCacheLocation location = TopologyMaster.MetricsCacheLocation.newBuilder().
-        setTopologyName("topology-name").setTopologyId("topology-id").setHost("host").
-        setControllerPort(0).setMasterPort(0).setStatsPort(0).build();
-    metricsCacheSink.startNewMetricsCacheClient(location);
+    metricsCacheSink.startNewMetricsCacheClient(getMetricsCacheLocation(0));
 
     // We wait for a while to let auto recover fully finish.
-    Thread.sleep(RESTART_WAIT_INTERVAL_SECONDS * 1000);
+    Thread.sleep(RESTART_WAIT_INTERVAL.toMillis());
 
     // Then we check whether the MetricsCacheService has restarted the MetricsCacheClient for
     // several times Take other factors into account, we would check whether the MetricsCacheClient
-    // has restarted at least half the RESTART_WAIT_INTERVAL_SECONDS/RECONNECT_INTERVAL_SECONDS
-    Assert.assertTrue(metricsCacheSink.getMetricsCacheStartedAttempts()
-        > (RESTART_WAIT_INTERVAL_SECONDS / RECONNECT_INTERVAL_SECONDS / 2));
+    // has restarted at least half the RESTART_WAIT_INTERVAL_SECONDS/RECONNECT_INTERVAL
+    assertTrue(metricsCacheSink.getMetricsCacheStartedAttempts()
+        > (RESTART_WAIT_INTERVAL.getSeconds() / RECONNECT_INTERVAL.getSeconds() / 2));
     metricsCacheSink.close();
   }
 
@@ -106,53 +112,48 @@ public class MetricsCacheSinkTest {
     Map<String, Object> sinkConfig = new HashMap<String, Object>();
 
     // Fill with necessary config
-    sinkConfig.put(
-        "metricscache-location-check-interval-sec", METRICSCACHE_LOCATION_CHECK_INTERVAL_SECONDS);
+    sinkConfig.put("metricscache-location-check-interval-sec",
+        METRICSCACHE_LOCATION_CHECK_INTERVAL.getSeconds());
 
-    // These are config for MetricsCacheClient
-    Map<String, Object> serviceConfig = buildServiceConfig();
-
-    sinkConfig.put("metricscache-client", serviceConfig);
+    sinkConfig.put("metricscache-client",  buildServiceConfig());
 
     // It is null since we have not set it
     Assert.assertNull(metricsCacheSink.getCurrentMetricsCacheLocation());
 
+    LatchedMultiCountMetric multiCountMetric =
+        new LatchedMultiCountMetric("tmaster-location-update-count", 1L, 2L);
     SinkContext sinkContext =
-        new SinkContextImpl("topology-name", "metricsmgr-id", "sink-id", new MultiCountMetric());
+        new SinkContextImpl("topology-name", "metricsmgr-id", "sink-id", multiCountMetric);
 
     // Start the MetricsCacheSink
     metricsCacheSink.init(sinkConfig, sinkContext);
 
     // Put the MetricsCacheLocation into SingletonRegistry
-    TopologyMaster.MetricsCacheLocation oldLoc = TopologyMaster.MetricsCacheLocation.newBuilder().
-        setTopologyName("topology-name").setTopologyId("topology-id").
-        setHost("host").setControllerPort(0).setMasterPort(0).build();
+    TopologyMaster.MetricsCacheLocation oldLoc = getMetricsCacheLocation(0);
     SingletonRegistry.INSTANCE.registerSingleton(METRICSCACHE_LOCATION_BEAN_NAME, oldLoc);
 
-    Thread.sleep(WAIT_SECONDS * 1000);
+    multiCountMetric.await(RESTART_WAIT_INTERVAL);
 
     // The MetricsCacheService should start
-    Assert.assertTrue(metricsCacheSink.getMetricsCacheStartedAttempts() > 0);
-    Assert.assertEquals(oldLoc, metricsCacheSink.getCurrentMetricsCacheLocation());
-    Assert.assertEquals(oldLoc, metricsCacheSink.getCurrentMetricsCacheLocationInService());
+    assertTrue(metricsCacheSink.getMetricsCacheStartedAttempts() > 0);
+    assertEquals(oldLoc, metricsCacheSink.getCurrentMetricsCacheLocation());
+    assertEquals(oldLoc, metricsCacheSink.getCurrentMetricsCacheLocationInService());
 
     // Update it, the MetricsCacheSink should pick up the new one.
-    TopologyMaster.MetricsCacheLocation newLoc = TopologyMaster.MetricsCacheLocation.newBuilder().
-        setTopologyName("topology-name").setTopologyId("topology-id").
-        setHost("host").setControllerPort(0).setMasterPort(1).build();
+    TopologyMaster.MetricsCacheLocation newLoc = getMetricsCacheLocation(1);
     SingletonRegistry.INSTANCE.updateSingleton(METRICSCACHE_LOCATION_BEAN_NAME, newLoc);
 
     int lastMetricsCacheStartedAttempts = metricsCacheSink.getMetricsCacheStartedAttempts();
 
-    Thread.sleep(WAIT_SECONDS * 1000);
+    multiCountMetric.await(RESTART_WAIT_INTERVAL);
 
     // The MetricsCacheService should use the new MetricsCacheLocation
-    Assert.assertTrue(
+    assertTrue(
         metricsCacheSink.getMetricsCacheStartedAttempts() > lastMetricsCacheStartedAttempts);
-    Assert.assertNotSame(oldLoc, metricsCacheSink.getCurrentMetricsCacheLocation());
-    Assert.assertNotSame(oldLoc, metricsCacheSink.getCurrentMetricsCacheLocationInService());
-    Assert.assertEquals(newLoc, metricsCacheSink.getCurrentMetricsCacheLocation());
-    Assert.assertEquals(newLoc, metricsCacheSink.getCurrentMetricsCacheLocationInService());
+    assertNotSame(oldLoc, metricsCacheSink.getCurrentMetricsCacheLocation());
+    assertNotSame(oldLoc, metricsCacheSink.getCurrentMetricsCacheLocationInService());
+    assertEquals(newLoc, metricsCacheSink.getCurrentMetricsCacheLocation());
+    assertEquals(newLoc, metricsCacheSink.getCurrentMetricsCacheLocationInService());
 
     metricsCacheSink.close();
   }


### PR DESCRIPTION
Refactors to introduce a new test class `LatchedMultiCountMetric` while provide the ability to wait for a metric to reach a value before proceeding. This eliminates a few `Thread.sleep` calls and speeds up tests by 35 seconds.

Changes `HandleTMasterLocationTest` to use `HeronServerTester`.

There is still one more stubborn sleep call in `TMasterSinkTest.testTMasterClientService` that I haven't yet found a way to refactor out.