### PR TITLE
Refactor ActivateDeactivateTest to not use Thread.sleep()

### DIFF
--- a/heron/instance/tests/java/com/twitter/heron/resource/Constants.java
+++ b/heron/instance/tests/java/com/twitter/heron/resource/Constants.java
@@ -31,8 +31,8 @@ public final class Constants {
 
   public static final String FAIL_COUNT = "fail-count";
   public static final String ACK_COUNT = "ack-count";
-  public static final String ACTIVATE_COUNT = "activate-count";
-  public static final String DEACTIVATE_COUNT = "deactivate-count";
+  public static final String ACTIVATE_COUNT_LATCH = "activate-count-latch";
+  public static final String DEACTIVATE_COUNT_LATCH = "deactivate-count-latch";
 
   public static final String GATEWAY_METRICS = "com.twitter.heron.metrics.GatewayMetrics";
 

--- a/heron/instance/tests/java/com/twitter/heron/resource/TestSpout.java
+++ b/heron/instance/tests/java/com/twitter/heron/resource/TestSpout.java
@@ -17,6 +17,7 @@ package com.twitter.heron.resource;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Ignore;
@@ -72,20 +73,16 @@ public class TestSpout implements IRichSpout {
 
   @Override
   public void activate() {
-    AtomicInteger activateCount =
-        (AtomicInteger) SingletonRegistry.INSTANCE.getSingleton(Constants.ACTIVATE_COUNT);
-    if (activateCount != null) {
-      activateCount.getAndIncrement();
-    }
+    CountDownLatch latch =
+        (CountDownLatch) SingletonRegistry.INSTANCE.getSingleton(Constants.ACTIVATE_COUNT_LATCH);
+    latch.countDown();
   }
 
   @Override
   public void deactivate() {
-    AtomicInteger deactivateCount =
-        (AtomicInteger) SingletonRegistry.INSTANCE.getSingleton(Constants.DEACTIVATE_COUNT);
-    if (deactivateCount != null) {
-      deactivateCount.getAndIncrement();
-    }
+    CountDownLatch latch =
+        (CountDownLatch) SingletonRegistry.INSTANCE.getSingleton(Constants.DEACTIVATE_COUNT_LATCH);
+    latch.countDown();
   }
 
   @Override


### PR DESCRIPTION
Basically, instead of sleeping and checking `AtomicInteger` we can use `CountDownLatch` instead.