### PR TITLE
Add SlaveTester to centralize duplicate slave, looper, communicator test logic

### DIFF
--- a/heron/instance/tests/java/com/twitter/heron/grouping/AbstractTupleRoutingTest.java
+++ b/heron/instance/tests/java/com/twitter/heron/grouping/AbstractTupleRoutingTest.java
@@ -15,8 +15,6 @@
 package com.twitter.heron.grouping;
 
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import org.junit.After;
 import org.junit.Before;
@@ -25,21 +23,16 @@ import org.junit.Test;
 import com.twitter.heron.api.Config;
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.api.topology.TopologyBuilder;
-import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.basics.SingletonRegistry;
-import com.twitter.heron.common.basics.SlaveLooper;
 import com.twitter.heron.common.basics.SysUtils;
-import com.twitter.heron.common.basics.WakeableLooper;
 import com.twitter.heron.common.utils.misc.PhysicalPlanHelper;
 import com.twitter.heron.instance.InstanceControlMsg;
-import com.twitter.heron.instance.Slave;
+import com.twitter.heron.instance.SlaveTester;
 import com.twitter.heron.proto.system.HeronTuples;
-import com.twitter.heron.proto.system.Metrics;
 import com.twitter.heron.proto.system.PhysicalPlans;
 import com.twitter.heron.resource.Constants;
 import com.twitter.heron.resource.TestBolt;
 import com.twitter.heron.resource.TestSpout;
-import com.twitter.heron.resource.UnitTestHelper;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -51,16 +44,9 @@ import static org.junit.Assert.assertTrue;
  * necessary to achieve the desired routing logic.
  */
 public abstract class AbstractTupleRoutingTest {
-  private WakeableLooper testLooper;
-  private SlaveLooper slaveLooper;
-  private PhysicalPlans.PhysicalPlan physicalPlan;
-  private Communicator<HeronTuples.HeronTupleSet> outStreamQueue;
-  private Communicator<HeronTuples.HeronTupleSet> inStreamQueue;
-  private Communicator<InstanceControlMsg> inControlQueue;
-  private ExecutorService threadsPool;
   private volatile int tupleReceived;
   private volatile StringBuilder groupingInitInfo;
-  private Slave slave;
+  private SlaveTester slaveTester;
 
   // Test component info. Topology is SPOUT -> BOLT_A -> BOLT_B
   protected enum Component {
@@ -68,8 +54,8 @@ public abstract class AbstractTupleRoutingTest {
     BOLT_A("test-bolt-a", "bolt-a-id"),
     BOLT_B("test-bolt-b", "bolt-b-id");
 
-    private String name;
-    private String id;
+    private final String name;
+    private final String id;
 
     Component(String name, String instanceId) {
       this.name = name;
@@ -86,57 +72,20 @@ public abstract class AbstractTupleRoutingTest {
   }
 
   @Before
-  public void before() throws Exception {
-    UnitTestHelper.addSystemConfigToSingleton();
-
+  public void before() {
     tupleReceived = 0;
     groupingInitInfo = new StringBuilder();
 
-    testLooper = new SlaveLooper();
-    slaveLooper = new SlaveLooper();
-    outStreamQueue = new Communicator<>(slaveLooper, testLooper);
-    outStreamQueue.init(Constants.QUEUE_BUFFER_SIZE, Constants.QUEUE_BUFFER_SIZE, 0.5);
-    inStreamQueue = new Communicator<>(testLooper, slaveLooper);
-    inStreamQueue.init(Constants.QUEUE_BUFFER_SIZE, Constants.QUEUE_BUFFER_SIZE, 0.5);
-    inControlQueue = new Communicator<>(testLooper, slaveLooper);
-
-    Communicator<Metrics.MetricPublisherPublishMessage> slaveMetricsOut =
-        new Communicator<>(slaveLooper, testLooper);
-    slaveMetricsOut.init(Constants.QUEUE_BUFFER_SIZE, Constants.QUEUE_BUFFER_SIZE, 0.5);
-
-    slave = new Slave(slaveLooper, inStreamQueue, outStreamQueue, inControlQueue, slaveMetricsOut);
-    threadsPool = Executors.newSingleThreadExecutor();
-
-    threadsPool.execute(slave);
+    slaveTester = new SlaveTester();
+    slaveTester.start();
   }
 
   @After
-  public void after() throws Exception {
-    UnitTestHelper.clearSingletonRegistry();
-
-    tupleReceived = 0;
-    groupingInitInfo = null;
-
-    if (testLooper != null) {
-      testLooper.exitLoop();
-    }
-    if (slaveLooper != null) {
-      slaveLooper.exitLoop();
-    }
-    if (threadsPool != null) {
-      threadsPool.shutdownNow();
-    }
-    physicalPlan = null;
-    testLooper = null;
-    slaveLooper = null;
-    outStreamQueue = null;
-    inStreamQueue = null;
-
-    slave = null;
-    threadsPool = null;
+  public void after() throws NoSuchFieldException, IllegalAccessException {
+    slaveTester.stop();
   }
 
-  protected String getInitInfoKey(String componentName) {
+  String getInitInfoKey(String componentName) {
     return "routing-init-info+" + componentName;
   }
 
@@ -145,15 +94,13 @@ public abstract class AbstractTupleRoutingTest {
    */
   @Test
   public void testRoundRobinRouting() throws Exception {
-    physicalPlan = constructPhysicalPlan();
-
     PhysicalPlanHelper physicalPlanHelper =
-        new PhysicalPlanHelper(physicalPlan, getComponentToVerify().getInstanceId());
+        new PhysicalPlanHelper(constructPhysicalPlan(), getComponentToVerify().getInstanceId());
     InstanceControlMsg instanceControlMsg = InstanceControlMsg.newBuilder()
         .setNewPhysicalPlanHelper(physicalPlanHelper)
         .build();
 
-    inControlQueue.offer(instanceControlMsg);
+    slaveTester.getInControlQueue().offer(instanceControlMsg);
 
     SingletonRegistry.INSTANCE.registerSingleton(
         getInitInfoKey(getComponentToVerify().getName()), groupingInitInfo);
@@ -163,8 +110,8 @@ public abstract class AbstractTupleRoutingTest {
       @Override
       public void run() {
         for (int i = 0; i < Constants.RETRY_TIMES; i++) {
-          if (outStreamQueue.size() != 0) {
-            HeronTuples.HeronTupleSet set = outStreamQueue.poll();
+          if (slaveTester.getOutStreamQueue().size() != 0) {
+            HeronTuples.HeronTupleSet set = slaveTester.getOutStreamQueue().poll();
 
             assertTrue(set.isInitialized());
             assertFalse(set.hasControl());
@@ -184,7 +131,7 @@ public abstract class AbstractTupleRoutingTest {
           }
           if (tupleReceived == expectedTuplesValidated) {
             assertEquals(getExpectedComponentInitInfo(), groupingInitInfo.toString());
-            testLooper.exitLoop();
+            slaveTester.getTestLooper().exitLoop();
             break;
           }
           SysUtils.sleep(Constants.RETRY_INTERVAL);
@@ -192,8 +139,8 @@ public abstract class AbstractTupleRoutingTest {
       }
     };
 
-    testLooper.addTasksOnWakeup(task);
-    testLooper.loop();
+    slaveTester.getTestLooper().addTasksOnWakeup(task);
+    slaveTester.getTestLooper().loop();
     assertEquals(expectedTuplesValidated, tupleReceived);
   }
 

--- a/heron/instance/tests/java/com/twitter/heron/instance/CommunicatorTester.java
+++ b/heron/instance/tests/java/com/twitter/heron/instance/CommunicatorTester.java
@@ -1,0 +1,95 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.instance;
+
+import java.io.IOException;
+
+import com.twitter.heron.common.basics.Communicator;
+import com.twitter.heron.common.basics.NIOLooper;
+import com.twitter.heron.common.basics.SlaveLooper;
+import com.twitter.heron.common.basics.WakeableLooper;
+import com.twitter.heron.proto.system.HeronTuples;
+import com.twitter.heron.proto.system.Metrics;
+import com.twitter.heron.resource.Constants;
+import com.twitter.heron.resource.UnitTestHelper;
+
+/**
+ * Class to help write tests that require loopers and communicators
+ */
+public class CommunicatorTester {
+  private final WakeableLooper testLooper;
+  private final SlaveLooper slaveLooper;
+
+  // Only one outStreamQueue, which is responsible for both control tuples and data tuples
+  private final Communicator<HeronTuples.HeronTupleSet> outStreamQueue;
+
+  // This blocking queue is used to buffer tuples read from socket and ready to be used by instance
+  // For spout, it will buffer Control tuple, while for bolt, it will buffer data tuple.
+  private final Communicator<HeronTuples.HeronTupleSet> inStreamQueue;
+  private final Communicator<InstanceControlMsg> inControlQueue;
+  private final Communicator<Metrics.MetricPublisherPublishMessage> slaveMetricsOut;
+
+  public CommunicatorTester() throws IOException {
+    this(new NIOLooper());
+  }
+
+  protected CommunicatorTester(WakeableLooper testLooper) {
+    UnitTestHelper.addSystemConfigToSingleton();
+    this.testLooper = testLooper;
+    slaveLooper = new SlaveLooper();
+    outStreamQueue = new Communicator<>(slaveLooper, testLooper);
+    outStreamQueue.init(Constants.QUEUE_BUFFER_SIZE, Constants.QUEUE_BUFFER_SIZE, 0.5);
+    inStreamQueue = new Communicator<>(testLooper, slaveLooper);
+    inStreamQueue.init(Constants.QUEUE_BUFFER_SIZE, Constants.QUEUE_BUFFER_SIZE, 0.5);
+    inControlQueue = new Communicator<>(testLooper, slaveLooper);
+
+    slaveMetricsOut = new Communicator<>(slaveLooper, testLooper);
+    slaveMetricsOut.init(Constants.QUEUE_BUFFER_SIZE, Constants.QUEUE_BUFFER_SIZE, 0.5);
+  }
+
+  public void stop() throws NoSuchFieldException, IllegalAccessException {
+    UnitTestHelper.clearSingletonRegistry();
+
+    if (testLooper != null) {
+      testLooper.exitLoop();
+    }
+    if (slaveLooper != null) {
+      slaveLooper.exitLoop();
+    }
+  }
+
+  public Communicator<Metrics.MetricPublisherPublishMessage> getSlaveMetricsOut() {
+    return slaveMetricsOut;
+  }
+
+  public WakeableLooper getTestLooper() {
+    return testLooper;
+  }
+
+  public SlaveLooper getSlaveLooper() {
+    return slaveLooper;
+  }
+
+  public Communicator<InstanceControlMsg> getInControlQueue() {
+    return inControlQueue;
+  }
+
+  public Communicator<HeronTuples.HeronTupleSet> getInStreamQueue() {
+    return inStreamQueue;
+  }
+
+  public Communicator<HeronTuples.HeronTupleSet> getOutStreamQueue() {
+    return outStreamQueue;
+  }
+}

--- a/heron/instance/tests/java/com/twitter/heron/instance/SlaveTester.java
+++ b/heron/instance/tests/java/com/twitter/heron/instance/SlaveTester.java
@@ -1,0 +1,103 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.instance;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import com.twitter.heron.common.basics.Communicator;
+import com.twitter.heron.common.basics.SlaveLooper;
+import com.twitter.heron.common.basics.WakeableLooper;
+import com.twitter.heron.proto.system.HeronTuples;
+import com.twitter.heron.proto.system.Metrics;
+import com.twitter.heron.resource.Constants;
+import com.twitter.heron.resource.UnitTestHelper;
+
+/**
+ * Class to help write tests that require Slave instances, loopers and communicators
+ */
+public class SlaveTester {
+  private final WakeableLooper testLooper;
+  private final SlaveLooper slaveLooper;
+
+  // Only one outStreamQueue, which is responsible for both control tuples and data tuples
+  private final Communicator<HeronTuples.HeronTupleSet> outStreamQueue;
+
+  // This blocking queue is used to buffer tuples read from socket and ready to be used by instance
+  // For spout, it will buffer Control tuple, while for bolt, it will buffer data tuple.
+  private final Communicator<HeronTuples.HeronTupleSet> inStreamQueue;
+  private final Communicator<InstanceControlMsg> inControlQueue;
+  private final ExecutorService threadsPool;
+  private final Communicator<Metrics.MetricPublisherPublishMessage> slaveMetricsOut;
+  private final Slave slave;
+
+  public SlaveTester() {
+    UnitTestHelper.addSystemConfigToSingleton();
+    testLooper = new SlaveLooper();
+    slaveLooper = new SlaveLooper();
+    outStreamQueue = new Communicator<>(slaveLooper, testLooper);
+    outStreamQueue.init(Constants.QUEUE_BUFFER_SIZE, Constants.QUEUE_BUFFER_SIZE, 0.5);
+    inStreamQueue = new Communicator<>(testLooper, slaveLooper);
+    inStreamQueue.init(Constants.QUEUE_BUFFER_SIZE, Constants.QUEUE_BUFFER_SIZE, 0.5);
+    inControlQueue = new Communicator<>(testLooper, slaveLooper);
+
+    slaveMetricsOut = new Communicator<>(slaveLooper, testLooper);
+    slaveMetricsOut.init(Constants.QUEUE_BUFFER_SIZE, Constants.QUEUE_BUFFER_SIZE, 0.5);
+
+    slave = new Slave(slaveLooper, inStreamQueue, outStreamQueue, inControlQueue, slaveMetricsOut);
+    threadsPool = Executors.newSingleThreadExecutor();
+  }
+
+  public void start() {
+    threadsPool.execute(slave);
+  }
+
+  public void stop() throws NoSuchFieldException, IllegalAccessException {
+    UnitTestHelper.clearSingletonRegistry();
+
+    if (testLooper != null) {
+      testLooper.exitLoop();
+    }
+    if (slaveLooper != null) {
+      slaveLooper.exitLoop();
+    }
+    if (threadsPool != null) {
+      threadsPool.shutdownNow();
+    }
+  }
+
+  public Communicator<Metrics.MetricPublisherPublishMessage> getSlaveMetricsOut() {
+    return slaveMetricsOut;
+  }
+
+  public WakeableLooper getTestLooper() {
+    return testLooper;
+  }
+
+  public SlaveLooper getSlaveLooper() {
+    return slaveLooper;
+  }
+
+  public Communicator<InstanceControlMsg> getInControlQueue() {
+    return inControlQueue;
+  }
+
+  public Communicator<HeronTuples.HeronTupleSet> getInStreamQueue() {
+    return inStreamQueue;
+  }
+
+  public Communicator<HeronTuples.HeronTupleSet> getOutStreamQueue() {
+    return outStreamQueue;
+  }
+}

--- a/heron/instance/tests/java/com/twitter/heron/instance/bolt/BoltInstanceTest.java
+++ b/heron/instance/tests/java/com/twitter/heron/instance/bolt/BoltInstanceTest.java
@@ -15,32 +15,24 @@
 package com.twitter.heron.instance.bolt;
 
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.protobuf.ByteString;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.api.serializer.IPluggableSerializer;
 import com.twitter.heron.api.serializer.JavaSerializer;
-import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.basics.SingletonRegistry;
-import com.twitter.heron.common.basics.SlaveLooper;
 import com.twitter.heron.common.basics.SysUtils;
-import com.twitter.heron.common.basics.WakeableLooper;
 import com.twitter.heron.common.utils.misc.PhysicalPlanHelper;
 import com.twitter.heron.instance.InstanceControlMsg;
-import com.twitter.heron.instance.Slave;
+import com.twitter.heron.instance.SlaveTester;
 import com.twitter.heron.proto.system.HeronTuples;
-import com.twitter.heron.proto.system.Metrics;
 import com.twitter.heron.proto.system.PhysicalPlans;
 import com.twitter.heron.resource.Constants;
 import com.twitter.heron.resource.UnitTestHelper;
@@ -56,108 +48,49 @@ import com.twitter.heron.resource.UnitTestHelper;
  */
 public class BoltInstanceTest {
   private static final String BOLT_INSTANCE_ID = "bolt-id";
-  private static IPluggableSerializer serializer;
-
-  private WakeableLooper testLooper;
-  private SlaveLooper slaveLooper;
+  private static IPluggableSerializer serializer = new JavaSerializer();
 
   // Singleton to be changed globally for testing
   private AtomicInteger ackCount;
   private AtomicInteger failCount;
   private AtomicInteger tupleExecutedCount;
   private volatile StringBuilder receivedStrings;
-  private PhysicalPlans.PhysicalPlan physicalPlan;
 
-  // Only one outStreamQueue, which is responsible for both control tuples and data tuples
-  private Communicator<HeronTuples.HeronTupleSet> outStreamQueue;
+  private SlaveTester slaveTester;
 
-  // This blocking queue is used to buffer tuples read from socket and ready to be used by instance
-  // For spout, it will buffer Control tuple, while for bolt, it will buffer data tuple.
-  private Communicator<HeronTuples.HeronTupleSet> inStreamQueue;
-  private Communicator<InstanceControlMsg> inControlQueue;
-  private ExecutorService threadsPool;
-  private Communicator<Metrics.MetricPublisherPublishMessage> slaveMetricsOut;
-  private Slave slave;
-
-  @BeforeClass
-  public static void beforeClass() throws Exception {
-    serializer = new JavaSerializer();
+  static {
     serializer.initialize(null);
   }
 
-  @AfterClass
-  public static void afterClass() throws Exception {
-    serializer = null;
-  }
-
   @Before
-  public void before() throws Exception {
-    UnitTestHelper.addSystemConfigToSingleton();
-
+  public void before() {
     ackCount = new AtomicInteger(0);
     failCount = new AtomicInteger(0);
     tupleExecutedCount = new AtomicInteger(0);
     receivedStrings = new StringBuilder();
 
-    testLooper = new SlaveLooper();
-    slaveLooper = new SlaveLooper();
-    outStreamQueue = new Communicator<HeronTuples.HeronTupleSet>(slaveLooper, testLooper);
-    outStreamQueue.init(Constants.QUEUE_BUFFER_SIZE, Constants.QUEUE_BUFFER_SIZE, 0.5);
-    inStreamQueue = new Communicator<HeronTuples.HeronTupleSet>(testLooper, slaveLooper);
-    inStreamQueue.init(Constants.QUEUE_BUFFER_SIZE, Constants.QUEUE_BUFFER_SIZE, 0.5);
-    inControlQueue = new Communicator<InstanceControlMsg>(testLooper, slaveLooper);
-
-    slaveMetricsOut =
-        new Communicator<Metrics.MetricPublisherPublishMessage>(slaveLooper, testLooper);
-    slaveMetricsOut.init(Constants.QUEUE_BUFFER_SIZE, Constants.QUEUE_BUFFER_SIZE, 0.5);
-
-    slave = new Slave(slaveLooper, inStreamQueue, outStreamQueue, inControlQueue, slaveMetricsOut);
-    threadsPool = Executors.newSingleThreadExecutor();
-
-    threadsPool.execute(slave);
+    slaveTester = new SlaveTester();
+    slaveTester.start();
   }
 
   @After
-  public void after() throws Exception {
-    UnitTestHelper.clearSingletonRegistry();
-
-    ackCount = new AtomicInteger(0);
-    failCount = new AtomicInteger(0);
-    tupleExecutedCount = new AtomicInteger(0);
-    receivedStrings = null;
-
-    if (testLooper != null) {
-      testLooper.exitLoop();
-    }
-    if (slaveLooper != null) {
-      slaveLooper.exitLoop();
-    }
-    if (threadsPool != null) {
-      threadsPool.shutdownNow();
-    }
-    physicalPlan = null;
-    testLooper = null;
-    slaveLooper = null;
-    outStreamQueue = null;
-    inStreamQueue = null;
-
-    slave = null;
-    threadsPool = null;
+  public void after() throws NoSuchFieldException, IllegalAccessException {
+    slaveTester.stop();
   }
 
   /**
    * Test the reading of a tuple and apply execute on that tuple
    */
   @Test
-  public void testReadTupleAndExecute() throws Exception {
-    physicalPlan = UnitTestHelper.getPhysicalPlan(false, -1);
+  public void testReadTupleAndExecute() {
+    PhysicalPlans.PhysicalPlan physicalPlan = UnitTestHelper.getPhysicalPlan(false, -1);
 
     PhysicalPlanHelper physicalPlanHelper = new PhysicalPlanHelper(physicalPlan, BOLT_INSTANCE_ID);
     InstanceControlMsg instanceControlMsg = InstanceControlMsg.newBuilder().
         setNewPhysicalPlanHelper(physicalPlanHelper).
         build();
 
-    inControlQueue.offer(instanceControlMsg);
+    slaveTester.getInControlQueue().offer(instanceControlMsg);
 
     SingletonRegistry.INSTANCE.registerSingleton(Constants.ACK_COUNT, ackCount);
     SingletonRegistry.INSTANCE.registerSingleton(Constants.FAIL_COUNT, failCount);
@@ -182,7 +115,7 @@ public class BoltInstanceTest {
       rootId.setTaskid(0);
       dataTuple.addRoots(rootId);
 
-      String s = "";
+      String s;
       if ((i & 1) == 0) {
         s = "A";
       } else {
@@ -195,7 +128,7 @@ public class BoltInstanceTest {
     }
 
     heronTupleSet.setData(dataTupleSet);
-    inStreamQueue.offer(heronTupleSet.build());
+    slaveTester.getInStreamQueue().offer(heronTupleSet.build());
 
     for (int i = 0; i < Constants.RETRY_TIMES; i++) {
       if (tupleExecutedCount.intValue() == 10) {

--- a/heron/instance/tests/java/com/twitter/heron/instance/spout/ActivateDeactivateTest.java
+++ b/heron/instance/tests/java/com/twitter/heron/instance/spout/ActivateDeactivateTest.java
@@ -15,8 +15,6 @@
 package com.twitter.heron.instance.spout;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
@@ -24,14 +22,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.twitter.heron.api.generated.TopologyAPI;
-import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.basics.SingletonRegistry;
-import com.twitter.heron.common.basics.SlaveLooper;
 import com.twitter.heron.common.utils.misc.PhysicalPlanHelper;
 import com.twitter.heron.instance.InstanceControlMsg;
-import com.twitter.heron.instance.Slave;
-import com.twitter.heron.proto.system.HeronTuples;
-import com.twitter.heron.proto.system.Metrics;
+import com.twitter.heron.instance.SlaveTester;
 import com.twitter.heron.proto.system.PhysicalPlans;
 import com.twitter.heron.resource.Constants;
 import com.twitter.heron.resource.UnitTestHelper;
@@ -41,62 +35,23 @@ import static org.junit.Assert.assertTrue;
 
 public class ActivateDeactivateTest {
   private static final String SPOUT_INSTANCE_ID = "spout-id";
-  private SlaveLooper slaveLooper;
-
-  // Only one outStreamQueue, which is responsible for both control tuples and data tuples
-  private Communicator<HeronTuples.HeronTupleSet> outStreamQueue;
-
-  // This blocking queue is used to buffer tuples read from socket and ready to be used by instance
-  // For spout, it will buffer Control tuple, while for bolt, it will buffer data tuple.
-  private Communicator<HeronTuples.HeronTupleSet> inStreamQueue;
-  private Communicator<InstanceControlMsg> inControlQueue;
-  private ExecutorService threadsPool;
-  private Communicator<Metrics.MetricPublisherPublishMessage> slaveMetricsOut;
-  private Slave slave;
+  private SlaveTester slaveTester;
 
   @Before
-  public void before() throws Exception {
-    UnitTestHelper.addSystemConfigToSingleton();
-
-    slaveLooper = new SlaveLooper();
-    outStreamQueue = new Communicator<HeronTuples.HeronTupleSet>(slaveLooper, null);
-    outStreamQueue.init(Constants.QUEUE_BUFFER_SIZE, Constants.QUEUE_BUFFER_SIZE, 0.5);
-    inStreamQueue = new Communicator<HeronTuples.HeronTupleSet>(null, slaveLooper);
-    inStreamQueue.init(Constants.QUEUE_BUFFER_SIZE, Constants.QUEUE_BUFFER_SIZE, 0.5);
-    slaveMetricsOut = new Communicator<Metrics.MetricPublisherPublishMessage>(slaveLooper, null);
-    slaveMetricsOut.init(Constants.QUEUE_BUFFER_SIZE, Constants.QUEUE_BUFFER_SIZE, 0.5);
-    inControlQueue = new Communicator<InstanceControlMsg>(null, slaveLooper);
-
-    slave = new Slave(slaveLooper, inStreamQueue, outStreamQueue, inControlQueue, slaveMetricsOut);
-    threadsPool = Executors.newSingleThreadExecutor();
-
-    threadsPool.execute(slave);
+  public void before() {
+    slaveTester = new SlaveTester();
+    slaveTester.start();
   }
 
   @After
-  public void after() throws Exception {
-    UnitTestHelper.clearSingletonRegistry();
-    if (slaveLooper != null) {
-      slaveLooper.exitLoop();
-    }
-    if (threadsPool != null) {
-      threadsPool.shutdownNow();
-    }
-
-    slaveLooper = null;
-    outStreamQueue = null;
-    inStreamQueue = null;
-
-    slave = null;
-    threadsPool = null;
+  public void after() throws NoSuchFieldException, IllegalAccessException {
+    slaveTester.stop();
   }
-
 
   /**
    * We will test whether spout would pull activate/deactivate state change and
    * invoke activate()/deactivate()
    */
-
   @Test
   public void testActivateAndDeactivate() throws Exception {
     CountDownLatch activateLatch = new CountDownLatch(1);
@@ -104,20 +59,20 @@ public class ActivateDeactivateTest {
     SingletonRegistry.INSTANCE.registerSingleton(Constants.ACTIVATE_COUNT_LATCH, activateLatch);
     SingletonRegistry.INSTANCE.registerSingleton(Constants.DEACTIVATE_COUNT_LATCH, deactivateLatch);
 
-    inControlQueue.offer(buildMessage(TopologyAPI.TopologyState.RUNNING));
+    slaveTester.getInControlQueue().offer(buildMessage(TopologyAPI.TopologyState.RUNNING));
 
     // Now the activateLatch and deactivateLatch should be 1
     assertEquals(1, activateLatch.getCount());
     assertEquals(1, deactivateLatch.getCount());
 
     // And we start the test
-    inControlQueue.offer(buildMessage(TopologyAPI.TopologyState.PAUSED));
+    slaveTester.getInControlQueue().offer(buildMessage(TopologyAPI.TopologyState.PAUSED));
     assertTrue(deactivateLatch.await(Constants.TEST_WAIT_TIME.toMillis(), TimeUnit.MILLISECONDS));
 
     assertEquals(1, activateLatch.getCount());
     assertEquals(0, deactivateLatch.getCount());
 
-    inControlQueue.offer(buildMessage(TopologyAPI.TopologyState.RUNNING));
+    slaveTester.getInControlQueue().offer(buildMessage(TopologyAPI.TopologyState.RUNNING));
     assertTrue(activateLatch.await(Constants.TEST_WAIT_TIME.toMillis(), TimeUnit.MILLISECONDS));
 
     assertEquals(0, activateLatch.getCount());

--- a/heron/instance/tests/java/com/twitter/heron/resource/UnitTestHelper.java
+++ b/heron/instance/tests/java/com/twitter/heron/resource/UnitTestHelper.java
@@ -141,7 +141,7 @@ public final class UnitTestHelper {
   }
 
   @SuppressWarnings("unchecked")
-  public static void clearSingletonRegistry() throws Exception {
+  public static void clearSingletonRegistry() throws IllegalAccessException, NoSuchFieldException {
     // Remove the Singleton by Reflection
     Field field = SingletonRegistry.INSTANCE.getClass().getDeclaredField("singletonObjects");
     field.setAccessible(true);


### PR DESCRIPTION
These tests all have to duplicate the same verbose boilerplate. Centralizing that in `SlaveTester`.