### PR TITLE
Fix flakey HeronServerTest test

### DIFF
--- a/heron/common/src/java/com/twitter/heron/common/network/HeronServerTester.java
+++ b/heron/common/src/java/com/twitter/heron/common/network/HeronServerTester.java
@@ -176,13 +176,9 @@ public class HeronServerTester {
     Runnable runClient = new Runnable() {
       @Override
       public void run() {
-        try {
-          await(serverStartedSignal, SERVER_START_TIMEOUT);
-          client.start();
-          client.getNIOLooper().loop();
-        } finally {
-          client.stop();
-        }
+        await(serverStartedSignal, SERVER_START_TIMEOUT);
+        client.start();
+        client.getNIOLooper().loop();
       }
     };
     threadsPool.execute(runClient);


### PR DESCRIPTION
I saw a test failure of `testHandleAccept` and `testSendMessage`. I think the first was because the test didn't wait for connect to happen, so there's a race. I've added a `CountDownLatch` for server connect to fix this. For the other issue the error was during `after()` when the server was being shutdown. It seems that the `client.stop()` method was being executed twice and the `OutputPacket` size went to zero after it was checked but before processing was attempted. Removing the extra `stop()` call.

These are the stack traces from the failures:
```
There were 2 failures:
1) testHandleAccept(com.twitter.heron.common.network.HeronServerTest)
java.lang.AssertionError: expected:<1> but was:<0>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:743)
	at org.junit.Assert.assertEquals(Assert.java:118)
	at org.junit.Assert.assertEquals(Assert.java:555)
	at org.junit.Assert.assertEquals(Assert.java:542)
	at com.twitter.heron.common.network.HeronServerTest.testHandleAccept(HeronServerTest.java:161)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.rules.ExpectedException$ExpectedExceptionStatement.evaluate(ExpectedException.java:168)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at com.google.testing.junit.runner.junit4.CancellableRequestFactory$CancellableRunner.run(CancellableRequestFactory.java:89)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:160)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:138)
	at com.google.testing.junit.runner.junit4.JUnit4Runner.run(JUnit4Runner.java:114)
	at com.google.testing.junit.runner.BazelTestRunner.runTestsInSuite(BazelTestRunner.java:152)
	at com.google.testing.junit.runner.BazelTestRunner.main(BazelTestRunner.java:91)
2) testSendMessage(com.twitter.heron.common.network.HeronServerTest)
java.lang.AssertionError
	at com.twitter.heron.common.network.OutgoingPacket.writeToChannel(OutgoingPacket.java:93)
	at com.twitter.heron.common.network.SocketChannelHelper.forceFlushWithBestEffort(SocketChannelHelper.java:215)
	at com.twitter.heron.common.network.HeronClient.forceFlushWithBestEffort(HeronClient.java:371)
	at com.twitter.heron.common.network.HeronClient.stop(HeronClient.java:145)
	at com.twitter.heron.common.network.HeronServerTester.stop(HeronServerTester.java:129)
	at com.twitter.heron.common.network.HeronServerTest.after(HeronServerTest.java:93)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:33)
	at org.junit.rules.ExpectedException$ExpectedExceptionStatement.evaluate(ExpectedException.java:168)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at com.google.testing.junit.runner.junit4.CancellableRequestFactory$CancellableRunner.run(CancellableRequestFactory.java:89)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:160)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:138)
	at com.google.testing.junit.runner.junit4.JUnit4Runner.run(JUnit4Runner.java:114)
	at com.google.testing.junit.runner.BazelTestRunner.runTestsInSuite(BazelTestRunner.java:152)
	at com.google.testing.junit.runner.BazelTestRunner.main(BazelTestRunner.java:91)
```