### PR TITLE
Another attempt to fix flakey HeronServerTest

### DIFF
--- a/heron/common/tests/java/com/twitter/heron/common/network/HeronServerTest.java
+++ b/heron/common/tests/java/com/twitter/heron/common/network/HeronServerTest.java
@@ -154,7 +154,6 @@ public class HeronServerTest {
   public void testHandleAccept() {
     runBase();
 
-    HeronServerTester.await(serverOnConnectSignal);
     Map<SocketChannel, SocketChannelHelper> activeConnections = heronServer.getActiveConnections();
     ServerSocketChannel acceptChannel = heronServer.getAcceptChannel();
 
@@ -362,6 +361,7 @@ public class HeronServerTest {
   private void runBase() {
     heronServerTester.start();
     HeronServerTester.await(clientOnConnectSignal);
+    HeronServerTester.await(serverOnConnectSignal);
   }
 
   private class SimpleHeronServer extends HeronServer {


### PR DESCRIPTION
Last night we saw the exception below. It's either because the server connection isn't established or because it was and it closed before the test ran for some reason. Adding this latch should prevent the first scenario.
```
1) testHandleWrite(com.twitter.heron.common.network.HeronServerTest)
java.util.NoSuchElementException
	at java.util.HashMap$HashIterator.nextNode(HashMap.java:1439)
	at java.util.HashMap$KeyIterator.next(HashMap.java:1461)
	at com.twitter.heron.common.network.HeronServerTest.testHandleWrite(HeronServerTest.java:191)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
```