### PR TITLE
cleanup stateful configs and statefulstorage package

### DIFF
--- a/heron/api/src/java/com/twitter/heron/api/Config.java
+++ b/heron/api/src/java/com/twitter/heron/api/Config.java
@@ -165,16 +165,6 @@ public class Config extends HashMap<String, Object> {
   public static final String TOPOLOGY_STATEFUL_CHECKPOINT_INTERVAL_SECONDS =
                              "topology.stateful.checkpoint.interval.seconds";
   /**
-   * What's the provider for state? i.e. one where state is stored
-   */
-  public static final String TOPOLOGY_STATEFUL_PROVIDER_CLASS =
-                             "topology.stateful.provider.class";
-  /**
-   * What's the config for state provider?
-   */
-  public static final String TOPOLOGY_STATEFUL_PROVIDER_CONFIG_FILE =
-                             "topology.stateful.provider.config.file";
-  /**
    * Boolean flag that says that the stateful topology should start from
    * clean state, i.e. ignore any checkpoint state
    */
@@ -265,8 +255,6 @@ public class Config extends HashMap<String, Object> {
     apiVars.add(TOPOLOGY_COMPONENT_RAMMAP);
     apiVars.add(TOPOLOGY_STATEFUL_START_CLEAN);
     apiVars.add(TOPOLOGY_STATEFUL_CHECKPOINT_INTERVAL_SECONDS);
-    apiVars.add(TOPOLOGY_STATEFUL_PROVIDER_CLASS);
-    apiVars.add(TOPOLOGY_STATEFUL_PROVIDER_CONFIG_FILE);
     apiVars.add(TOPOLOGY_STATEFUL_ENABLED);
     apiVars.add(TOPOLOGY_EXACTLYONCE_ENABLED);
     apiVars.add(TOPOLOGY_NAME);
@@ -456,15 +444,6 @@ public class Config extends HashMap<String, Object> {
     conf.put(Config.TOPOLOGY_STATEFUL_CHECKPOINT_INTERVAL_SECONDS, Integer.toString(secs));
   }
 
-  public static void setTopologyStatefulProviderClass(Map<String, Object> conf, String provider) {
-    conf.put(Config.TOPOLOGY_STATEFUL_PROVIDER_CLASS, provider);
-  }
-
-  public static void setTopologyStatefulProviderConfigFile(Map<String, Object> conf,
-                                                           String config) {
-    conf.put(Config.TOPOLOGY_STATEFUL_PROVIDER_CONFIG_FILE, config);
-  }
-
   public static void setTopologyStatefulStartClean(Map<String, Object> conf, boolean clean) {
     conf.put(Config.TOPOLOGY_STATEFUL_START_CLEAN, String.valueOf(clean));
   }
@@ -601,14 +580,6 @@ public class Config extends HashMap<String, Object> {
 
   public void setTopologyStatefulCheckpointIntervalSecs(int secs) {
     setTopologyStatefulCheckpointIntervalSecs(this, secs);
-  }
-
-  public void setTopologyStatefulProviderClass(String provider) {
-    setTopologyStatefulProviderClass(this, provider);
-  }
-
-  public void setTopologyStatefulProviderConfigFile(String config) {
-    setTopologyStatefulProviderConfigFile(this, config);
   }
 
   public void setTopologyStatefulStartClean(boolean clean) {

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Context.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Context.java
@@ -250,11 +250,7 @@ public class Context {
   }
 
   public static String statefulStoragesClassPath(Config cfg) {
-    return cfg.getStringValue(Key.STATEFULSTORAGES_CLASSPATH);
-  }
-
-  public static Boolean isStateful(Config cfg) {
-    return cfg.getBooleanValue(Key.IS_STATEFUL_ENABLED);
+    return cfg.getStringValue(Key.STATEFULSTORAGE_CLASSPATH);
   }
 
   public static String stateManagerClassPath(Config cfg) {
@@ -295,10 +291,6 @@ public class Context {
 
   public static String pythonInstanceBinary(Config cfg) {
     return cfg.getStringValue(Key.PYTHON_INSTANCE_BINARY);
-  }
-
-  public static final Boolean isCleanStateCheckpoints(Config cfg) {
-    return cfg.getBooleanValue(Key.IS_CLEAN_STATEFUL_CHECKPOINTS);
   }
 
   @SuppressWarnings("unchecked")

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Key.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Key.java
@@ -109,8 +109,6 @@ public enum Key {
   INSTANCE_DISK             ("heron.resources.instance.disk", ByteAmount.fromBytes(1073741824)),
 
   //keys for checkpoint management
-  IS_STATEFUL_ENABLED                      ("heron.is.stateful.enabled", Boolean.FALSE),
-  IS_CLEAN_STATEFUL_CHECKPOINTS            ("heron.is.clean.stateful.checkpoints", Boolean.FALSE),
   STATEFUL_STORAGE_CLASSNAME               ("heron.statefulstorage.classname", Type.STRING),
   STATEFUL_STORAGE_CONF                    ("heron.statefulstorage.config", Type.MAP),
   STATEFUL_STORAGE_CUSTOM_CLASSPATH        ("heron.statefulstorage.custom.classpath", Type.STRING),
@@ -124,7 +122,7 @@ public enum Key {
   STATEMGR_CLASSPATH         ("heron.classpath.statemgr",             "${HERON_LIB}/statemgr/*"),
   UPLOADER_CLASSPATH         ("heron.classpath.uploader",             "${HERON_LIB}/uploader/*"),
   CKPTMGR_CLASSPATH          ("heron.classpath.ckptmgr",              "${HERON_LIB}/ckptmgr/*"),
-  STATEFULSTORAGES_CLASSPATH ("heron.classpath.statefulstorage",      "${HERON_LIB}/statefulstorages/*"),
+  STATEFULSTORAGE_CLASSPATH  ("heron.classpath.statefulstorage",      "${HERON_LIB}/statefulstorage/*"),
 
   //keys for run time config
   TOPOLOGY_CLASSPATH             ("heron.runtime.topology.class.path",             Type.STRING),

--- a/scripts/packages/BUILD
+++ b/scripts/packages/BUILD
@@ -22,7 +22,7 @@ load("/tools/rules/heron_core", "heron_core_lib_metricscachemgr_files")
 load("/tools/rules/heron_core", "heron_core_lib_packing_files")
 load("/tools/rules/heron_core", "heron_core_lib_statemgr_files")
 load("/tools/rules/heron_core", "heron_core_lib_ckptmgr_files")
-load("/tools/rules/heron_core", "heron_core_lib_statefulstorages_files")
+load("/tools/rules/heron_core", "heron_core_lib_statefulstorage_files")
 
 load("/tools/rules/heron_tools", "heron_tools_files")
 load("/tools/rules/heron_tools", "heron_tools_bin_files")
@@ -74,7 +74,7 @@ pkg_tar(
         ":heron-core-lib-statemgr",
         ":heron-core-lib-instance",
         ":heron-core-lib-ckptmgr",
-        ":heron-core-lib-statefulstorages",
+        ":heron-core-lib-statefulstorage",
     ],
 )
 
@@ -127,9 +127,9 @@ pkg_tar(
 )
 
 pkg_tar(
-    name = "heron-core-lib-statefulstorages",
-    package_dir = "heron-core/lib/statefulstorages",
-    files = heron_core_lib_statefulstorages_files(),
+    name = "heron-core-lib-statefulstorage",
+    package_dir = "heron-core/lib/statefulstorage",
+    files = heron_core_lib_statefulstorage_files(),
 )
 
 ################################################################################

--- a/tools/rules/heron_core.bzl
+++ b/tools/rules/heron_core.bzl
@@ -27,7 +27,7 @@ def heron_core_lib_files():
         heron_core_lib_statemgr_files() + \
         heron_core_lib_instance_files() + \
         heron_core_lib_ckptmgr_files() + \
-        heron_core_lib_statefulstorages_files()
+        heron_core_lib_statefulstorage_files()
 
 def heron_core_lib_scheduler_files():
     return [
@@ -70,7 +70,7 @@ def heron_core_lib_ckptmgr_files():
         "//heron/ckptmgr/src/java:heron-ckptmgr",
     ]
 
-def heron_core_lib_statefulstorages_files():
+def heron_core_lib_statefulstorage_files():
     return [
         "//heron/statefulstorages/src/java:heron-localfs-statefulstorage",
         "//heron/statefulstorages/src/java:heron-hdfs-statefulstorage",


### PR DESCRIPTION
This PR separates stateful configs into topology-set part and heron-set part. Make sure `IS_STATEFUL_ENABLED` and `TOPOLOGY_STATEFUL_START_CLEAN ` are set in topology conf. And `STORAGE_CLASS` and `STORAGE_CONF` are set in `stateful.yaml`.

It also updates how the stateful storage implementations are packaged in consistency with other components like `uploader`, `scheduler`.

