### PR TITLE
Update grouping tests to not use Thread.sleep()

### DIFF
--- a/heron/instance/tests/java/com/twitter/heron/grouping/AbstractTupleRoutingTest.java
+++ b/heron/instance/tests/java/com/twitter/heron/grouping/AbstractTupleRoutingTest.java
@@ -113,7 +113,7 @@ public abstract class AbstractTupleRoutingTest {
     Runnable task = new Runnable() {
       @Override
       public void run() {
-        HeronServerTester.await(outStreamQueueOfferLatch, Duration.ofSeconds(10));
+        HeronServerTester.await(outStreamQueueOfferLatch, Duration.ofSeconds(3));
         assertNotEquals(0, slaveTester.getOutStreamQueue().size());
 
         while (tupleReceived < expectedTuplesValidated) {

--- a/heron/instance/tests/java/com/twitter/heron/grouping/AbstractTupleRoutingTest.java
+++ b/heron/instance/tests/java/com/twitter/heron/grouping/AbstractTupleRoutingTest.java
@@ -14,7 +14,6 @@
 
 package com.twitter.heron.grouping;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
@@ -113,7 +112,7 @@ public abstract class AbstractTupleRoutingTest {
     Runnable task = new Runnable() {
       @Override
       public void run() {
-        HeronServerTester.await(outStreamQueueOfferLatch, Duration.ofSeconds(3));
+        HeronServerTester.await(outStreamQueueOfferLatch);
         assertNotEquals(0, slaveTester.getOutStreamQueue().size());
 
         while (tupleReceived < expectedTuplesValidated) {


### PR DESCRIPTION
The diff looks larger than it is because I removed a loop, but the validation logic is all the same, just indented differently. Where we used to have this:
```
for (int i = 0; i < Constants.RETRY_TIMES; i++) {
  if (slaveTester.getOutStreamQueue().size() != 0) {
```
we now have this:
```
HeronServerTester.await(outStreamQueueOfferLatch);
assertNotEquals(0, slaveTester.getOutStreamQueue().size());
```