### PR TITLE
Refactor network tests to use NIO selectors instead of sleep()

### DIFF
--- a/heron/common/src/java/com/twitter/heron/common/network/HeronServerTester.java
+++ b/heron/common/src/java/com/twitter/heron/common/network/HeronServerTester.java
@@ -51,7 +51,7 @@ public class HeronServerTester {
       ByteAmount.fromMegabytes(5));
   private static final Duration DEFAULT_LATCH_TIMEOUT = Duration.ofSeconds(2);
   private static final Duration SERVER_START_TIMEOUT = Duration.ofSeconds(2);
-  public static final Duration RESPONSE_RECEIVED_TIMEOUT = Duration.ofSeconds(10);
+  public static final Duration RESPONSE_RECEIVED_TIMEOUT = Duration.ofSeconds(4);
 
   private final HeronServer server;
   private final ExecutorService threadsPool;

--- a/heron/instance/tests/java/com/twitter/heron/network/AbstractNetworkTest.java
+++ b/heron/instance/tests/java/com/twitter/heron/network/AbstractNetworkTest.java
@@ -134,8 +134,7 @@ public abstract class AbstractNetworkTest {
     return inStreamQueueOfferLatch;
   }
 
-  @SuppressWarnings({"unchecked", "rawtypes"})
-  IncomingPacket blockForIncomingPacket(SocketChannel socketChannel) throws IOException {
+  IncomingPacket readIncomingPacket(SocketChannel socketChannel) throws IOException {
     // Receive request
     IncomingPacket incomingPacket = new IncomingPacket();
 

--- a/heron/instance/tests/java/com/twitter/heron/network/ConnectTest.java
+++ b/heron/instance/tests/java/com/twitter/heron/network/ConnectTest.java
@@ -60,7 +60,7 @@ public class ConnectTest extends AbstractNetworkTest {
       socketChannel = acceptSocketChannel(serverSocketChannel);
 
       // Receive request
-      REQID rid = blockForIncomingPacket(socketChannel).unpackREQID();
+      REQID rid = readIncomingPacket(socketChannel).unpackREQID();
 
       OutgoingPacket outgoingPacket
           = new OutgoingPacket(rid, UnitTestHelper.getRegisterInstanceResponse());

--- a/heron/instance/tests/java/com/twitter/heron/network/HandleReadTest.java
+++ b/heron/instance/tests/java/com/twitter/heron/network/HandleReadTest.java
@@ -58,7 +58,7 @@ public class HandleReadTest extends AbstractNetworkTest {
       socketChannel = acceptSocketChannel(serverSocketChannel);
 
       // Receive request
-      REQID rid = blockForIncomingPacket(socketChannel).unpackREQID();
+      REQID rid = readIncomingPacket(socketChannel).unpackREQID();
 
       OutgoingPacket outgoingPacket
           = new OutgoingPacket(rid, UnitTestHelper.getRegisterInstanceResponse());

--- a/heron/instance/tests/java/com/twitter/heron/network/HandleReadTest.java
+++ b/heron/instance/tests/java/com/twitter/heron/network/HandleReadTest.java
@@ -19,7 +19,6 @@ import java.net.InetSocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
-import java.time.Duration;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
@@ -28,14 +27,11 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.twitter.heron.api.generated.TopologyAPI;
-import com.twitter.heron.common.basics.SysUtils;
-import com.twitter.heron.common.network.IncomingPacket;
+import com.twitter.heron.common.network.HeronServerTester;
 import com.twitter.heron.common.network.OutgoingPacket;
 import com.twitter.heron.common.network.REQID;
-import com.twitter.heron.instance.InstanceControlMsg;
 import com.twitter.heron.proto.stmgr.StreamManager;
 import com.twitter.heron.proto.system.HeronTuples;
-import com.twitter.heron.resource.Constants;
 import com.twitter.heron.resource.UnitTestHelper;
 
 /**
@@ -53,58 +49,33 @@ public class HandleReadTest extends AbstractNetworkTest {
   @Test
   public void testHandleRead() throws IOException {
     ServerSocketChannel serverSocketChannel = ServerSocketChannel.open();
-    serverSocketChannel.socket().bind(new InetSocketAddress(HOST, serverPort));
+    serverSocketChannel.socket().bind(new InetSocketAddress(HOST, getServerPort()));
 
     SocketChannel socketChannel = null;
     try {
       runStreamManagerClient();
 
-      socketChannel = serverSocketChannel.accept();
-      configure(socketChannel);
-      socketChannel.configureBlocking(false);
-      close(serverSocketChannel);
+      socketChannel = acceptSocketChannel(serverSocketChannel);
 
       // Receive request
-      IncomingPacket incomingPacket = new IncomingPacket();
-      while (incomingPacket.readFromChannel(socketChannel) != 0) {
-        // 1ms sleep to mitigate busy looping
-        SysUtils.sleep(Duration.ofMillis(1));
-      }
-
-      // Send back response
-      // Though we do not use typeName, we need to unpack it first,
-      // since the order is required
-      String typeName = incomingPacket.unpackString();
-      REQID rid = incomingPacket.unpackREQID();
+      REQID rid = blockForIncomingPacket(socketChannel).unpackREQID();
 
       OutgoingPacket outgoingPacket
           = new OutgoingPacket(rid, UnitTestHelper.getRegisterInstanceResponse());
       outgoingPacket.writeToChannel(socketChannel);
 
-      for (int i = 0; i < Constants.RETRY_TIMES; i++) {
-        InstanceControlMsg instanceControlMsg = getInControlQueue().poll();
-        if (instanceControlMsg != null) {
-          break;
-        } else {
-          SysUtils.sleep(Constants.RETRY_INTERVAL);
-        }
-      }
+      HeronServerTester.await(getInControlQueueOfferLatch());
 
       outgoingPacket = new OutgoingPacket(REQID.zeroREQID, constructMockMessage());
       outgoingPacket.writeToChannel(socketChannel);
 
-      for (int i = 0; i < Constants.RETRY_TIMES; i++) {
-        if (!getInStreamQueue().isEmpty()) {
-          break;
-        }
-        SysUtils.sleep(Constants.RETRY_INTERVAL);
-      }
+      HeronServerTester.await(getInStreamQueueOfferLatch());
+
       getNIOLooper().exitLoop();
 
       Assert.assertEquals(1, getInStreamQueue().size());
-      HeronTuples.HeronTupleSet msg = getInStreamQueue().poll();
 
-      HeronTuples.HeronTupleSet heronTupleSet = msg;
+      HeronTuples.HeronTupleSet heronTupleSet = getInStreamQueue().poll();
 
       Assert.assertTrue(heronTupleSet.hasData());
       Assert.assertFalse(heronTupleSet.hasControl());
@@ -114,13 +85,13 @@ public class HandleReadTest extends AbstractNetworkTest {
       Assert.assertEquals("test-spout", heronDataTupleSet.getStream().getComponentName());
       Assert.assertEquals("default", heronDataTupleSet.getStream().getId());
 
-      String res = "";
+      StringBuilder response = new StringBuilder();
       for (HeronTuples.HeronDataTuple heronDataTuple : heronDataTupleSet.getTuplesList()) {
-        res += heronDataTuple.getValues(0).toStringUtf8();
+        response.append(heronDataTuple.getValues(0).toStringUtf8());
         Assert.assertEquals(1, heronDataTuple.getRootsCount());
       }
 
-      Assert.assertEquals("ABABABABAB", res);
+      Assert.assertEquals("ABABABABAB", response.toString());
     } catch (ClosedChannelException ignored) {
     } finally {
       close(socketChannel);

--- a/heron/instance/tests/java/com/twitter/heron/network/HandleWriteTest.java
+++ b/heron/instance/tests/java/com/twitter/heron/network/HandleWriteTest.java
@@ -56,7 +56,7 @@ public class HandleWriteTest extends AbstractNetworkTest {
       socketChannel = acceptSocketChannel(serverSocketChannel);
 
       // Receive request
-      REQID rid = blockForIncomingPacket(socketChannel).unpackREQID();
+      REQID rid = readIncomingPacket(socketChannel).unpackREQID();
 
       OutgoingPacket outgoingPacket
           = new OutgoingPacket(rid, UnitTestHelper.getRegisterInstanceResponse());
@@ -70,7 +70,7 @@ public class HandleWriteTest extends AbstractNetworkTest {
       }
 
       for (int i = 0; i < 10; i++) {
-        IncomingPacket incomingPacket = blockForIncomingPacket(socketChannel);
+        IncomingPacket incomingPacket = readIncomingPacket(socketChannel);
         incomingPacket.unpackREQID();
 
         StreamManager.RegisterInstanceResponse.Builder builder

--- a/heron/instance/tests/java/com/twitter/heron/network/HandleWriteTest.java
+++ b/heron/instance/tests/java/com/twitter/heron/network/HandleWriteTest.java
@@ -19,20 +19,17 @@ import java.net.InetSocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
-import java.time.Duration;
 
 import org.junit.Assert;
 import org.junit.Test;
 
 import com.twitter.heron.api.generated.TopologyAPI;
-import com.twitter.heron.common.basics.SysUtils;
+import com.twitter.heron.common.network.HeronServerTester;
 import com.twitter.heron.common.network.IncomingPacket;
 import com.twitter.heron.common.network.OutgoingPacket;
 import com.twitter.heron.common.network.REQID;
-import com.twitter.heron.instance.InstanceControlMsg;
 import com.twitter.heron.proto.stmgr.StreamManager;
 import com.twitter.heron.proto.system.Common;
-import com.twitter.heron.resource.Constants;
 import com.twitter.heron.resource.UnitTestHelper;
 
 /**
@@ -50,42 +47,22 @@ public class HandleWriteTest extends AbstractNetworkTest {
   @Test
   public void testHandleWrite() throws IOException {
     ServerSocketChannel serverSocketChannel = ServerSocketChannel.open();
-    serverSocketChannel.socket().bind(new InetSocketAddress(HOST, serverPort));
+    serverSocketChannel.socket().bind(new InetSocketAddress(HOST, getServerPort()));
 
     SocketChannel socketChannel = null;
     try {
       StreamManagerClient streamManagerClient = runStreamManagerClient();
 
-      socketChannel = serverSocketChannel.accept();
-      configure(socketChannel);
-      socketChannel.configureBlocking(false);
-      close(serverSocketChannel);
+      socketChannel = acceptSocketChannel(serverSocketChannel);
 
       // Receive request
-      IncomingPacket incomingPacket = new IncomingPacket();
-      while (incomingPacket.readFromChannel(socketChannel) != 0) {
-        // 1ms sleep to mitigate busy looping
-        SysUtils.sleep(Duration.ofMillis(1));
-      }
-
-      // Send back response
-      // Though we do not use typeName, we need to unpack it first,
-      // since the order is required
-      String typeName = incomingPacket.unpackString();
-      REQID rid = incomingPacket.unpackREQID();
+      REQID rid = blockForIncomingPacket(socketChannel).unpackREQID();
 
       OutgoingPacket outgoingPacket
           = new OutgoingPacket(rid, UnitTestHelper.getRegisterInstanceResponse());
       outgoingPacket.writeToChannel(socketChannel);
 
-      for (int i = 0; i < Constants.RETRY_TIMES; i++) {
-        InstanceControlMsg instanceControlMsg = getInControlQueue().poll();
-        if (instanceControlMsg != null) {
-          break;
-        } else {
-          SysUtils.sleep(Constants.RETRY_INTERVAL);
-        }
-      }
+      HeronServerTester.await(getInControlQueueOfferLatch());
 
       for (int i = 0; i < 10; i++) {
         // We randomly choose some messages writing to stream mgr
@@ -93,13 +70,9 @@ public class HandleWriteTest extends AbstractNetworkTest {
       }
 
       for (int i = 0; i < 10; i++) {
-        incomingPacket = new IncomingPacket();
-        while (incomingPacket.readFromChannel(socketChannel) != 0) {
-          // 1ms sleep to mitigate busy looping
-          SysUtils.sleep(Duration.ofMillis(1));
-        }
-        typeName = incomingPacket.unpackString();
-        rid = incomingPacket.unpackREQID();
+        IncomingPacket incomingPacket = blockForIncomingPacket(socketChannel);
+        incomingPacket.unpackREQID();
+
         StreamManager.RegisterInstanceResponse.Builder builder
             = StreamManager.RegisterInstanceResponse.newBuilder();
         incomingPacket.unpackMessage(builder);


### PR DESCRIPTION
The NIO package allows the ability to register a READ selector on a `SocketChannel` and receive a notification once there is data to read. This is a better approach that trying to read in a loop and sleeping in between.