### PR TITLE
update stmgr max packet size

### DIFF
--- a/heron/stmgr/src/cpp/dummy/stmgr-main.cpp
+++ b/heron/stmgr/src/cpp/dummy/stmgr-main.cpp
@@ -72,7 +72,10 @@ int main(int argc, char* argv[]) {
   sops.set_host("localhost");  // this is mostly ignored
   sops.set_port(myport);
   sops.set_socket_family(PF_INET);
-  sops.set_max_packet_size(std::numeric_limits<sp_uint32>::max() - 1);
+  sops.set_max_packet_size(
+      config::HeronInternalsConfigReader::Instance()
+          ->GetHeronStreammgrNetworkOptionsMaximumPacketMb() *
+      1_MB);
 
   heron::stmgr::StMgr mgr(&ss, sops, topology_name, myid, spout_workers, bolt_workers,
                           zkhostportlist, topdir);

--- a/heron/stmgr/src/cpp/manager/stmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr.cpp
@@ -228,7 +228,10 @@ void StMgr::CreateTMasterClient(proto::tmaster::TMasterLocation* tmasterLocation
   master_options.set_host(tmasterLocation->host());
   master_options.set_port(tmasterLocation->master_port());
   master_options.set_socket_family(PF_INET);
-  master_options.set_max_packet_size(std::numeric_limits<sp_uint32>::max() - 1);
+  master_options.set_max_packet_size(
+      config::HeronInternalsConfigReader::Instance()
+          ->GetHeronTmasterNetworkMasterOptionsMaximumPacketMb() *
+      1_MB);
   master_options.set_high_watermark(high_watermark_);
   master_options.set_low_watermark(low_watermark_);
   auto pplan_watch = [this](proto::system::PhysicalPlan* pplan) { this->NewPhysicalPlan(pplan); };

--- a/heron/stmgr/src/cpp/manager/stmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr.cpp
@@ -207,7 +207,10 @@ void StMgr::StartStmgrServer() {
   sops.set_host(IpUtils::getHostName());
   sops.set_port(stmgr_port_);
   sops.set_socket_family(PF_INET);
-  sops.set_max_packet_size(std::numeric_limits<sp_uint32>::max() - 1);
+  sops.set_max_packet_size(
+      config::HeronInternalsConfigReader::Instance()
+          ->GetHeronStreammgrNetworkOptionsMaximumPacketMb() *
+      1_MB);
   sops.set_high_watermark(high_watermark_);
   sops.set_low_watermark(low_watermark_);
   server_ = new StMgrServer(eventLoop_, sops, topology_name_, topology_id_, stmgr_id_, instances_,


### PR DESCRIPTION
When the stmgr receives a packet with large size but less than max()-1, the memory alloc get stuck in the `IncomingPacket::Read(int)`

```
(gdb) bt
#0  0x00007f239971443d in write () from /lib64/libpthread.so.0
#1  0x0000000000408867 in (anonymous namespace)::ReportLargeAlloc (num_pages=num_pages@entry=145963, result=result@entry=0x7a9a000) at src/tcmalloc.cc:1023
#2  0x00000000004089b0 in (anonymous namespace)::do_malloc_pages (heap=<optimized out>, size=1195728896, size@entry=1195725856) at src/tcmalloc.cc:1083
#3  0x000000000058b3da in do_malloc_no_errno (size=1195725856) at src/tcmalloc.cc:1110
#4  cpp_alloc (nothrow=false, size=1195725856) at src/tcmalloc.cc:1434
#5  tc_newarray (size=1195725856) at src/tcmalloc.cc:1642
#6  0x000000000049aa58 in IncomingPacket::Read(int) ()
#7  0x000000000049783e in Connection::readFromEndPoint(int) ()
#8  0x0000000000492e99 in BaseConnection::handleRead(EventLoop::Status) ()
#9  0x00000000004992dd in EventLoopImpl::handleReadCallback(int, short) ()
#10 0x00000000004a2f4c in event_process_active_single_queue (activeq=0x1af0020, base=0x1b08000) at event.c:1350
#11 event_process_active (base=<optimized out>) at event.c:1420
#12 event_base_loop (base=0x1b08000, flags=0) at event.c:1621
#13 0x00000000004090eb in main ()
```

The fix is to set max packet size according to config