### PR TITLE
Remove unused heron.instance.state.check.interval.sec config

### DIFF
--- a/heron/common/src/java/com/twitter/heron/common/config/SystemConfig.java
+++ b/heron/common/src/java/com/twitter/heron/common/config/SystemConfig.java
@@ -67,10 +67,6 @@ public final class SystemConfig {
     return getDuration(SystemConfigKey.INSTANCE_FORCE_EXIT_TIMEOUT);
   }
 
-  public Duration getInstanceStateCheckInterval() {
-    return getDuration(SystemConfigKey.INSTANCE_STATE_CHECK_INTERVAL);
-  }
-
   public int getInstanceInternalBoltReadQueueCapacity() {
     return getInteger(SystemConfigKey.INSTANCE_INTERNAL_BOLT_READ_QUEUE_CAPACITY);
   }

--- a/heron/common/src/java/com/twitter/heron/common/config/SystemConfigKey.java
+++ b/heron/common/src/java/com/twitter/heron/common/config/SystemConfigKey.java
@@ -176,13 +176,6 @@ public enum SystemConfigKey {
   INSTANCE_EXECUTE_BATCH_SIZE("heron.instance.execute.batch.size.bytes", Type.BYTE_AMOUNT),
 
   /**
-   * The time interval for an instance to check the state change, for instance,
-   * the interval a spout using to check whether activate/deactivate is invoked
-   * Slated for removal, see https://github.com/twitter/heron/issues/1712
-   */
-  INSTANCE_STATE_CHECK_INTERVAL("heron.instance.state.check.interval.sec", ChronoUnit.SECONDS),
-
-  /**
    * The time to wait before the instance exits forcibly when uncaught exception happens
    */
   INSTANCE_FORCE_EXIT_TIMEOUT("heron.instance.force.exit.timeout.ms", ChronoUnit.MILLIS),

--- a/heron/common/src/python/constants.py
+++ b/heron/common/src/python/constants.py
@@ -151,9 +151,6 @@ INSTANCE_EXECUTE_BATCH_TIME_MS = "heron.instance.execute.batch.time.ms"
 # The maximum batch size in bytes for an bolt instance to execute tuples per attempt
 INSTANCE_EXECUTE_BATCH_SIZE_BYTES = "heron.instance.execute.batch.size.bytes"
 
-# The time interval for an instance to check the state change, for instance,
-# the interval a spout using to check whether activate/deactivate is invoked
-INSTANCE_STATE_CHECK_INTERVAL_SEC = "heron.instance.state.check.interval.sec"
 # The time to wait before the instance exits forcibly when uncaught exception happens
 INSTANCE_FORCE_EXIT_TIMEOUT_MS = "heron.instance.force.exit.timeout.ms"
 # Interval in seconds to reconnect to the stream manager

--- a/heron/config/src/yaml/conf/aurora/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/aurora/heron_internals.yaml
@@ -227,10 +227,6 @@ heron.instance.execute.batch.time.ms: 16
 # The maximum batch size in bytes for an bolt instance to execute tuples per attempt
 heron.instance.execute.batch.size.bytes: 32768
 
-# The time interval for an instance to check the state change,
-# for example, the interval a spout uses to check whether activate/deactivate is invoked
-heron.instance.state.check.interval.sec: 5
-
 # The time to wait before the instance exits forcibly when uncaught exception happens
 heron.instance.force.exit.timeout.ms: 2000
 

--- a/heron/config/src/yaml/conf/examples/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/examples/heron_internals.yaml
@@ -227,10 +227,6 @@ heron.instance.execute.batch.time.ms: 16
 # The maximum batch size in bytes for an bolt instance to execute tuples per attempt
 heron.instance.execute.batch.size.bytes: 32768
 
-# The time interval for an instance to check the state change,
-# for example, the interval a spout uses to check whether activate/deactivate is invoked
-heron.instance.state.check.interval.sec: 5
-
 # The time to wait before the instance exits forcibly when uncaught exception happens
 heron.instance.force.exit.timeout.ms: 2000
 

--- a/heron/config/src/yaml/conf/local/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/local/heron_internals.yaml
@@ -227,10 +227,6 @@ heron.instance.execute.batch.time.ms: 16
 # The maximum batch size in bytes for an bolt instance to execute tuples per attempt
 heron.instance.execute.batch.size.bytes: 32768
 
-# The time interval for an instance to check the state change,
-# for example, the interval a spout uses to check whether activate/deactivate is invoked
-heron.instance.state.check.interval.sec: 5
-
 # The time to wait before the instance exits forcibly when uncaught exception happens
 heron.instance.force.exit.timeout.ms: 2000
 

--- a/heron/config/src/yaml/conf/localzk/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/localzk/heron_internals.yaml
@@ -227,10 +227,6 @@ heron.instance.execute.batch.time.ms: 16
 # The maximum batch size in bytes for an bolt instance to execute tuples per attempt
 heron.instance.execute.batch.size.bytes: 32768
 
-# The time interval for an instance to check the state change,
-# for example, the interval a spout uses to check whether activate/deactivate is invoked
-heron.instance.state.check.interval.sec: 5
-
 # The time to wait before the instance exits forcibly when uncaught exception happens
 heron.instance.force.exit.timeout.ms: 2000
 

--- a/heron/config/src/yaml/conf/marathon/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/marathon/heron_internals.yaml
@@ -227,10 +227,6 @@ heron.instance.execute.batch.time.ms: 16
 # The maximum batch size in bytes for an bolt instance to execute tuples per attempt
 heron.instance.execute.batch.size.bytes: 32768
 
-# The time interval for an instance to check the state change,
-# for example, the interval a spout uses to check whether activate/deactivate is invoked
-heron.instance.state.check.interval.sec: 5
-
 # The time to wait before the instance exits forcibly when uncaught exception happens
 heron.instance.force.exit.timeout.ms: 2000
 

--- a/heron/config/src/yaml/conf/mesos/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/mesos/heron_internals.yaml
@@ -227,10 +227,6 @@ heron.instance.execute.batch.time.ms: 16
 # The maximum batch size in bytes for an bolt instance to execute tuples per attempt
 heron.instance.execute.batch.size.bytes: 32768
 
-# The time interval for an instance to check the state change,
-# for example, the interval a spout uses to check whether activate/deactivate is invoked
-heron.instance.state.check.interval.sec: 5
-
 # The time to wait before the instance exits forcibly when uncaught exception happens
 heron.instance.force.exit.timeout.ms: 2000
 

--- a/heron/config/src/yaml/conf/slurm/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/slurm/heron_internals.yaml
@@ -227,10 +227,6 @@ heron.instance.execute.batch.time.ms: 16
 # The maximum batch size in bytes for an bolt instance to execute tuples per attempt
 heron.instance.execute.batch.size.bytes: 32768 
 
-# The time interval for an instance to check the state change, 
-# for example, the interval a spout uses to check whether activate/deactivate is invoked
-heron.instance.state.check.interval.sec: 5 
-
 # The time to wait before the instance exits forcibly when uncaught exception happens
 heron.instance.force.exit.timeout.ms: 2000 
 

--- a/heron/config/src/yaml/conf/test/test_heron_internals.yaml
+++ b/heron/config/src/yaml/conf/test/test_heron_internals.yaml
@@ -208,9 +208,6 @@ heron.instance.execute.batch.time.ms: 16
 # The maximum batch size in bytes for an bolt instance to execute tuples per attempt
 heron.instance.execute.batch.size.bytes: 32768
 
-# The time interval for an instance to check the state change, for instance, the interval a spout using to check whether activate/deactivate is invoked
-heron.instance.state.check.interval.sec: 5
-
 # The time to wait before the instance exits forcibly when uncaught exception happens
 heron.instance.force.exit.timeout.ms: 2000
 

--- a/heron/config/src/yaml/conf/yarn/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/yarn/heron_internals.yaml
@@ -227,10 +227,6 @@ heron.instance.execute.batch.time.ms: 16
 # The maximum batch size in bytes for an bolt instance to execute tuples per attempt
 heron.instance.execute.batch.size.bytes: 32768
 
-# The time interval for an instance to check the state change,
-# for example, the interval a spout uses to check whether activate/deactivate is invoked
-heron.instance.state.check.interval.sec: 5
-
 # The time to wait before the instance exits forcibly when uncaught exception happens
 heron.instance.force.exit.timeout.ms: 2000
 


### PR DESCRIPTION
Fixed issue #1712. This config is not used in the codebase so removing it.