### PR TITLE
Add back missing arguments in URL of heron-ui config request

### DIFF
--- a/heron/tools/ui/resources/static/js/config.js
+++ b/heron/tools/ui/resources/static/js/config.js
@@ -7,6 +7,8 @@ var ConfigTable = React.createClass({
   getTopologyConfig: function() {
     urlTokens = [  this.props.baseUrl,
                    'topologies',
+                   this.props.cluster,
+                   this.props.environ,
                    this.props.topology,
                    'physicalplan.json'];
     fetchUrl = urlTokens.join('/');


### PR DESCRIPTION
Bug introduced [here](https://github.com/twitter/heron/commit/bc0a6c4e76e3f4b0a9c16228e5385cbfac3eceef#diff-2b270b96c5301bb9f687d62d63b5dce3).

Tested in internal environment.