### PR TITLE
Asyncly handle subprocess stdout/stderr in client.

### DIFF
--- a/heron/common/src/python/utils/__init__.py
+++ b/heron/common/src/python/utils/__init__.py
@@ -1,3 +1,3 @@
 '''common utility modules'''
 __all__ = ['metrics', 'misc', 'topology', 'config', 'tracker_access',
-           'tuple', 'log']
+           'tuple', 'proc', 'log']

--- a/heron/common/src/python/utils/log.py
+++ b/heron/common/src/python/utils/log.py
@@ -15,7 +15,6 @@
 import logging
 from logging.handlers import RotatingFileHandler
 import colorlog
-from threading import Thread
 
 # Create the logger
 # pylint: disable=invalid-name
@@ -26,66 +25,6 @@ Log = logging.getLogger()
 # e.g. "08/16/1988 21:30:00 +1030"
 # see time formatter documentation for more
 date_format = "%Y-%m-%d %H:%M:%S %z"
-
-def _stream_process_fileno(fileno, handler):
-  """ Stream handling each line from fileno
-  :param filno: file object
-  :param handler: a function that will be called for each line from fileno
-  :return: None
-  """
-  while 1:
-    line = fileno.readline()
-    if not line:
-      break
-    handler(line)
-
-def stream_process_stdout(process, handler):
-  """ Stream the stdout for a process out to display
-  :param process: the process to stream the stdout for
-  :param handler: a function that will be called for each stdout line
-  :return: None
-  """
-  _stream_process_fileno(process.stdout, handler)
-
-def stream_process_stderr(process, handler):
-  """ Stream the stderr for a process out to display
-  :param process: the process to stream the stderr for
-  :param handler: a function that will be called for each stderr line
-  :return: None
-  """
-  _stream_process_fileno(process.stderr, handler)
-
-def _async_stream_process_output(process, stream_fn, handler):
-  """ Stream and handle the output of a process
-  :param process: the process to stream the output for
-  :param stream_fn: the function that applies handler to process
-  :param handler: a function that will be called for each log line
-  :return: None
-  """
-  logging_thread = Thread(target=stream_fn, args=(process, handler, ))
-
-  # Setting the logging thread as a daemon thread will allow it to exit with the program
-  # rather than blocking the exit waiting for it to be handled manually.
-  logging_thread.daemon = True
-  logging_thread.start()
-
-  return logging_thread
-
-def async_stream_process_stdout(process, handler):
-  """ Stream and handler the stdout of a process
-  :param process: the process to stream the stdout for
-  :param handler: a function that will be called to handle each line
-  :return: None
-  """
-  return _async_stream_process_output(process, stream_process_stdout, handler)
-
-def async_stream_process_stderr(process, handler):
-  """ Stream and handler the stderr of a process
-  :param process: the process to stream the stderr for
-  :param handler: a function that will be called to handle each line
-  :return: None
-  """
-  return _async_stream_process_output(process, stream_process_stderr, handler)
 
 def configure(level=logging.INFO, logfile=None):
   """ Configure logger which dumps log on terminal

--- a/heron/common/src/python/utils/proc.py
+++ b/heron/common/src/python/utils/proc.py
@@ -1,0 +1,110 @@
+# Copyright 2017 Twitter. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+''' proc.py: subprocess and subprocess's stdout/stderr management '''
+from threading import Thread
+
+def _stream_process_fileno(fileno, handler):
+  """ Stream handling each line from fileno
+  :param filno: file object
+  :param handler: a function that will be called for each line from fileno
+  :return: None
+  """
+  while 1:
+    line = fileno.readline()
+    if not line:
+      break
+    handler(line)
+
+def stream_process_stdout(process, handler):
+  """ Stream the stdout for a process out to display
+  :param process: the process to stream the stdout for
+  :param handler: a function that will be called for each stdout line
+  :return: None
+  """
+  _stream_process_fileno(process.stdout, handler)
+
+def stream_process_stderr(process, handler):
+  """ Stream the stderr for a process out to display
+  :param process: the process to stream the stderr for
+  :param handler: a function that will be called for each stderr line
+  :return: None
+  """
+  _stream_process_fileno(process.stderr, handler)
+
+def _async_stream_process_output(process, stream_fn, handler):
+  """ Stream and handle the output of a process
+  :param process: the process to stream the output for
+  :param stream_fn: the function that applies handler to process
+  :param handler: a function that will be called for each log line
+  :return: None
+  """
+  logging_thread = Thread(target=stream_fn, args=(process, handler, ))
+
+  # Setting the logging thread as a daemon thread will allow it to exit with the program
+  # rather than blocking the exit waiting for it to be handled manually.
+  logging_thread.daemon = True
+  logging_thread.start()
+
+  return logging_thread
+
+def async_stream_process_stdout(process, handler):
+  """ Stream and handler the stdout of a process
+  :param process: the process to stream the stdout for
+  :param handler: a function that will be called to handle each line
+  :return: None
+  """
+  return _async_stream_process_output(process, stream_process_stdout, handler)
+
+def async_stream_process_stderr(process, handler):
+  """ Stream and handler the stderr of a process
+  :param process: the process to stream the stderr for
+  :param handler: a function that will be called to handle each line
+  :return: None
+  """
+  return _async_stream_process_output(process, stream_process_stderr, handler)
+
+class StringBuilder(object):
+  def __init__(self):
+    self.str = ""
+
+  def add(self, line):
+    self.str += line
+
+  def result(self):
+    return self.str
+
+def async_stdout_builder(proc):
+  """ Save stdout into string builder
+  :param proc: the process to save stdout for
+  :return StringBuilder
+  """
+  stdout_builder = StringBuilder()
+  async_stream_process_stdout(proc, stdout_builder.add)
+  return stdout_builder
+
+def async_stderr_builder(proc):
+  """ Save stderr into string builder
+  :param proc: the process to save stderr for
+  :return StringBuilder
+  """
+  stderr_builder = StringBuilder()
+  async_stream_process_stderr(proc, stderr_builder.add)
+  return stderr_builder
+
+def async_stdout_stderr_builder(proc):
+  """ Save stdout and stderr into string builders
+  :param proc: the process to save stdout and stderr for
+  :return (StringBuilder, StringBuilder)
+  """
+  return async_stdout_builder(proc), async_stderr_builder(proc)

--- a/heron/common/tests/python/utils/log_unittest.py
+++ b/heron/common/tests/python/utils/log_unittest.py
@@ -18,7 +18,7 @@ import unittest
 from mock import patch, Mock, call
 from io import StringIO
 
-from heron.common.src.python.utils import log
+from heron.common.src.python.utils import proc
 
 class LogTest(unittest.TestCase):
   def setUp(self):
@@ -29,7 +29,7 @@ class LogTest(unittest.TestCase):
     log_fn = Mock()
     with patch("subprocess.Popen") as mock_process:
       mock_process.stdout = ret
-      log.stream_process_stdout(mock_process, log_fn)
+      proc.stream_process_stdout(mock_process, log_fn)
 
     log_fn.assert_has_calls([call(u'hello\n'), call(u'world\n')])
 
@@ -38,7 +38,7 @@ class LogTest(unittest.TestCase):
     log_fn = Mock()
     with patch("subprocess.Popen") as mock_process:
       mock_process.stdout = ret
-      thread = log.async_stream_process_stdout(mock_process, log_fn)
+      thread = proc.async_stream_process_stdout(mock_process, log_fn)
       thread.join()
 
     log_fn.assert_has_calls([call(u'hello\n'), call(u'world\n')])

--- a/heron/executor/src/python/BUILD
+++ b/heron/executor/src/python/BUILD
@@ -7,7 +7,7 @@ pex_library(
     srcs = ["heron_executor.py"],
     deps = [
         "//heron/statemgrs/src/python:statemgr-py",
-        "//heron/common/src/python:common-log-py",
+        "//heron/common/src/python:common-py",
     ],
     reqs = ["pyyaml==3.10"],
 )

--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -37,6 +37,7 @@ from functools import partial
 
 
 from heron.common.src.python.utils import log
+from heron.common.src.python.utils import proc
 # pylint: disable=unused-import
 from heron.proto.packing_plan_pb2 import PackingPlan
 from heron.statemgrs.src.python import statemanagerfactory
@@ -678,7 +679,7 @@ class HeronExecutor(object):
   # pylint: disable=no-self-use
   def _wait_process_std_out_err(self, name, process):
     ''' Wait for the termination of a process and log its stdout & stderr '''
-    log.stream_process_stdout(process, stdout_log_fn(name))
+    proc.stream_process_stdout(process, stdout_log_fn(name))
     process.wait()
 
   def _run_process(self, name, cmd, env_to_exec=None):
@@ -689,7 +690,7 @@ class HeronExecutor(object):
       process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                                  env=env_to_exec, bufsize=1)
 
-      log.async_stream_process_stdout(process, stdout_log_fn(name))
+      proc.async_stream_process_stdout(process, stdout_log_fn(name))
     except Exception:
       Log.info("Exception running command %:", cmd)
       traceback.print_exc()

--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -34,8 +34,6 @@ import traceback
 
 from functools import partial
 
-
-
 from heron.common.src.python.utils import log
 from heron.common.src.python.utils import proc
 # pylint: disable=unused-import

--- a/heron/shell/src/python/utils.py
+++ b/heron/shell/src/python/utils.py
@@ -22,7 +22,7 @@ import subprocess
 from datetime import datetime
 from xml.sax.saxutils import escape
 
-from heron.common.src.python.utils import log
+from heron.common.src.python.utils import proc
 
 def format_mode(sres):
   """
@@ -143,15 +143,6 @@ def read_chunk(filename, offset=None, length=None):
 
   return dict(offset=offset, length=0)
 
-class StringBuilder(object):
-  def __init__(self):
-    self.str = ""
-
-  def add(self, line):
-    self.str += line
-
-  def result(self):
-    return self.str
 
 def pipe(prev_proc, to_cmd):
   """
@@ -159,23 +150,21 @@ def pipe(prev_proc, to_cmd):
   Returns piped process
   """
   stdin = None if prev_proc is None else prev_proc.stdout
-  proc = subprocess.Popen(to_cmd,
-                          stdout=subprocess.PIPE,
-                          stdin=stdin)
+  process = subprocess.Popen(to_cmd,
+                             stdout=subprocess.PIPE,
+                             stdin=stdin)
   if prev_proc is not None:
     prev_proc.stdout.close() # Allow prev_proc to receive a SIGPIPE
-  return proc
+  return process
 
 def str_cmd(cmd, cwd, env):
   """
   Runs the command and returns its stdout and stderr.
   """
-  proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                          stderr=subprocess.PIPE, cwd=cwd, env=env)
-  stdout_builder, stderr_builder = StringBuilder(), StringBuilder()
-  log.async_stream_process_stdout(proc, stdout_builder.add)
-  log.async_stream_process_stderr(proc, stderr_builder.add)
-  proc.wait()
+  process = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE, cwd=cwd, env=env)
+  stdout_builder, stderr_builder = proc.async_stdout_stderr_builder(process)
+  process.wait()
   stdout, stderr = stdout_builder.result(), stderr_builder.result()
   return {'command': ' '.join(cmd), 'stderr': stderr, 'stdout': stdout}
 
@@ -187,8 +176,7 @@ def chain(cmd_list):
   """
   command = ' | '.join(map(lambda x: ' '.join(x), cmd_list))
   chained_proc = reduce(pipe, [None] + cmd_list)
-  stdout_builder = StringBuilder()
-  log.async_stream_process_stdout(chained_proc, stdout_builder.add)
+  stdout_builder = proc.async_stdout_builder(chained_proc)
   chained_proc.wait()
   return {
       'command': command,

--- a/heron/tools/cli/src/python/cli_helper.py
+++ b/heron/tools/cli/src/python/cli_helper.py
@@ -84,7 +84,7 @@ def run(command, cl_args, action, extra_args=[], extra_lib_jars=[]):
       args=new_args
   )
 
-  err_msg = "Failed to %s %s" % (action, topology_name)
-  succ_msg = "Successfully %s %s" % (action, topology_name)
+  err_msg = "Failed to %s: %s" % (action, topology_name)
+  succ_msg = "Successfully %s: %s" % (action, topology_name)
   result.add_context(err_msg, succ_msg)
   return result

--- a/heron/tools/cli/src/python/execute.py
+++ b/heron/tools/cli/src/python/execute.py
@@ -67,11 +67,11 @@ def heron_class(class_name, lib_jars, extra_jars=None, args=None, java_defines=N
   Log.debug("Heron options: {%s}", str(heron_env["HERON_OPTIONS"]))
 
   # invoke the command with subprocess and print error message, if any
-  proc = subprocess.Popen(all_args, env=heron_env, stdout=subprocess.PIPE,
-                          stderr=subprocess.PIPE, bufsize=1)
+  process = subprocess.Popen(all_args, env=heron_env, stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE, bufsize=1)
   # stdout message has the information Java program sends back
   # stderr message has extra information, such as debugging message
-  return ProcessResult(proc)
+  return ProcessResult(process)
 
 def heron_tar(class_name, topology_tar, arguments, tmpdir_root, java_defines):
   '''
@@ -118,10 +118,10 @@ def heron_pex(topology_pex, topology_class_name, args=None):
     Log.debug("Invoking class using command: ``%s''", ' '.join(cmd))
     Log.debug('Heron options: {%s}', str(heron_env['HERON_OPTIONS']))
     # invoke the command with subprocess and print error message, if any
-    proc = subprocess.Popen(cmd, env=heron_env, stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE, bufsize=1)
+    process = subprocess.Popen(cmd, env=heron_env, stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE, bufsize=1)
     # todo(rli): improve python topology submission workflow
-    return ProcessResult(proc)
+    return ProcessResult(process)
   else:
     try:
       # loading topology from Topology's subclass (no main method)

--- a/heron/tools/cli/src/python/result.py
+++ b/heron/tools/cli/src/python/result.py
@@ -16,6 +16,7 @@ import abc
 import sys
 from enum import Enum
 
+from heron.common.src.python.utils import proc
 from heron.common.src.python.utils.log import Log
 
 # Meaning of exit status code:
@@ -111,9 +112,12 @@ class SimpleResult(Result):
 
 class ProcessResult(Result):
   """Process result: a wrapper of result class"""
-  def __init__(self, proc):
+  def __init__(self, process):
     super(ProcessResult, self).__init__()
-    self.proc = proc
+    self.process = process
+    self.stdout_builder = proc.async_stdout_builder(process)
+    # start redirect stderr in initialization, before render() gets called
+    proc.async_stream_process_stderr(self.process, self.renderProcessStdErr)
 
   def renderProcessStdErr(self, stderr_line):
     """ render stderr of shelled-out process
@@ -127,7 +131,7 @@ class ProcessResult(Result):
     :param stderr_line: one line from shelled-out process
     :return:
     """
-    retcode = self.proc.poll()
+    retcode = self.process.poll()
     if retcode is not None and status_type(retcode) == Status.InvocationError:
       self._do_log(Log.error, stderr_line)
     else:
@@ -160,21 +164,10 @@ class ProcessResult(Result):
           (self.status.value, list(Status)))
 
   def render(self):
-    while True:
-      stderr_line = self.proc.stderr.readline()
-      if not stderr_line:
-        if self.proc.poll() is None:
-          continue
-        else:
-          break
-      else:
-        self.renderProcessStdErr(stderr_line)
-    self.proc.wait()
-    self.status = status_type(self.proc.returncode)
-    stdout = "".join(self.proc.stdout.readlines())
-    self.renderProcessStdOut(stdout)
+    self.process.wait()
+    self.status = status_type(self.process.returncode)
+    self.renderProcessStdOut(self.stdout_builder.result())
     self._log_context()
-
 
 def render(results):
   if isinstance(results, Result):

--- a/heron/tools/cli/src/python/submit.py
+++ b/heron/tools/cli/src/python/submit.py
@@ -154,7 +154,8 @@ def launch_topologies(cl_args, topology_file, tmp_dir):
       err_context = "Cannot load topology definition '%s': %s" % (defn_file, e)
       return SimpleResult(Status.HeronError, err_context)
     # launch the topology
-    Log.info("Launching topology: \'%s\'", topology_defn.name)
+    mode = " in dry-run mode" if cl_args['dry_run'] else ''
+    Log.info("Launching topology: \'%s\'%s", topology_defn.name, mode)
     res = launch_a_topology(
         cl_args, tmp_dir, topology_file, defn_file, topology_defn.name)
     results.append(res)

--- a/heron/tools/cli/src/python/update.py
+++ b/heron/tools/cli/src/python/update.py
@@ -60,9 +60,10 @@ def run(command, parser, cl_args, unknown_args):
   """ run the update command """
   extra_args = ["--component_parallelism", ','.join(cl_args['component_parallelism'])]
   extra_lib_jars = jars.packing_jars()
+  action = "update topology%s" % (' in dry-run mode' if cl_args["dry_run"] else '')
   if cl_args["dry_run"]:
     extra_args.append('--dry_run')
     if "dry_run_format" in cl_args:
       extra_args += ["--dry_run_format", cl_args["dry_run_format"]]
 
-  return cli_helper.run(command, cl_args, "update topology", extra_args, extra_lib_jars)
+  return cli_helper.run(command, cl_args, action, extra_args, extra_lib_jars)


### PR DESCRIPTION
Asyncly handle subprocess stdout/stderr in client so that rendering large dry-run output will not deadlock.

Also move the utilities of handling stdout/stderr of subprocess to `proc.py`.