### PR TITLE
UpdateTopologyMaster using stale Topology from initial submission

### DIFF
--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
@@ -321,6 +321,11 @@ public class UpdateTopologyManager implements Closeable {
     return stateManager.getPackingPlan(topologyName);
   }
 
+  /**
+   * Returns the topology. It's key that we get the topology from the physical plan to reflect any
+   * state changes since launch. The stateManager.getTopology(name) method returns the topology from
+   * the time of submission. See additional commentary in topology.proto and physical_plan.proto.
+   */
   @VisibleForTesting
   TopologyAPI.Topology getTopology(SchedulerStateManagerAdaptor stateManager, String topologyName) {
     return stateManager.getPhysicalPlan(topologyName).getTopology();

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
@@ -142,7 +142,7 @@ public class UpdateTopologyManager implements Closeable {
     Preconditions.checkState(newContainerCount + removableContainerCount == 0
         || scalableScheduler.isPresent(), message);
 
-    TopologyAPI.Topology topology = stateManager.getTopology(topologyName);
+    TopologyAPI.Topology topology = getTopology(stateManager, topologyName);
     boolean initiallyRunning = topology.getState() == TopologyAPI.TopologyState.RUNNING;
 
     // fetch the topology, which will need to be updated
@@ -311,7 +311,7 @@ public class UpdateTopologyManager implements Closeable {
   TopologyAPI.Topology getUpdatedTopology(String topologyName,
                                           PackingPlan proposedPackingPlan,
                                           SchedulerStateManagerAdaptor stateManager) {
-    TopologyAPI.Topology updatedTopology = stateManager.getTopology(topologyName);
+    TopologyAPI.Topology updatedTopology = getTopology(stateManager, topologyName);
     Map<String, Integer> proposedComponentCounts = proposedPackingPlan.getComponentCounts();
     return mergeTopology(updatedTopology, proposedComponentCounts);
   }
@@ -320,6 +320,11 @@ public class UpdateTopologyManager implements Closeable {
   PackingPlans.PackingPlan getPackingPlan(SchedulerStateManagerAdaptor stateManager,
                                           String topologyName) {
     return stateManager.getPackingPlan(topologyName);
+  }
+
+  @VisibleForTesting
+  TopologyAPI.Topology getTopology(SchedulerStateManagerAdaptor stateManager, String topologyName) {
+    return stateManager.getPhysicalPlan(topologyName).getTopology();
   }
 
   /**

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
@@ -307,10 +307,9 @@ public class UpdateTopologyManager implements Closeable {
     }
   }
 
-  @VisibleForTesting
-  TopologyAPI.Topology getUpdatedTopology(String topologyName,
-                                          PackingPlan proposedPackingPlan,
-                                          SchedulerStateManagerAdaptor stateManager) {
+  private TopologyAPI.Topology getUpdatedTopology(String topologyName,
+                                                  PackingPlan proposedPackingPlan,
+                                                  SchedulerStateManagerAdaptor stateManager) {
     TopologyAPI.Topology updatedTopology = getTopology(stateManager, topologyName);
     Map<String, Integer> proposedComponentCounts = proposedPackingPlan.getComponentCounts();
     return mergeTopology(updatedTopology, proposedComponentCounts);

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/UpdateTopologyManagerTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/UpdateTopologyManagerTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -121,14 +122,13 @@ public class UpdateTopologyManagerTest {
 
   private UpdateTopologyManager spyUpdateManager(SchedulerStateManagerAdaptor stateManager,
                                                  IScalable scheduler,
-                                                 TopologyAPI.Topology updatedTopology) {
+                                                 TopologyAPI.Topology topology) {
     Config mockRuntime = mockRuntime(stateManager);
     UpdateTopologyManager spyUpdateManager = spy(new UpdateTopologyManager(
         mock(Config.class), mockRuntime, Optional.of(scheduler))
     );
 
-    when(spyUpdateManager.getUpdatedTopology(TOPOLOGY_NAME, this.proposedPacking, stateManager))
-        .thenReturn(updatedTopology);
+    doReturn(topology).when(spyUpdateManager).getTopology(stateManager, TOPOLOGY_NAME);
     return spyUpdateManager;
   }
 


### PR DESCRIPTION
Fixes #1922 by using `stateManager.getPhysicalPlan(name).getTopology()` instead of `stateManager.getTopology(name)`.