### PR TITLE
When the python pex file is copied over to the container, only base name should be refered

### DIFF
--- a/heron/tools/cli/src/python/submit.py
+++ b/heron/tools/cli/src/python/submit.py
@@ -94,7 +94,7 @@ def launch_a_topology(cl_args, tmp_dir, topology_file, topology_defn_file, topol
       "--release_file", release_yaml_file,
       "--topology_package", topology_pkg_path,
       "--topology_defn", topology_defn_file,
-      "--topology_bin", topology_file   # pex file if pex specified
+      "--topology_bin", os.path.basename(topology_file)   # pex file if pex specified
   ]
 
   if Log.getEffectiveLevel() == logging.DEBUG:


### PR DESCRIPTION
We copy the pex file into the ./ directory of the container. Thus if I do
heron submit ... <path/to/my/pex/topology.pex> only topology.pex should be referenced as the topology bin