### PR TITLE
Decode serialized value in heron-tracker

### DIFF
--- a/heron/tools/tracker/src/python/tracker.py
+++ b/heron/tools/tracker/src/python/tracker.py
@@ -302,11 +302,11 @@ class Tracker(object):
       spoutConfigs = spout.comp.config.kvs
       for kvs in spoutConfigs:
         if kvs.key == "spout.type":
-          spoutType = kvs.value
+          spoutType = javaobj.loads(kvs.serialized_value)
         elif kvs.key == "spout.source":
-          spoutSource = kvs.value
+          spoutSource = javaobj.loads(kvs.serialized_value)
         elif kvs.key == "spout.version":
-          spoutVersion = kvs.value
+          spoutVersion = javaobj.loads(kvs.serialized_value)
       spoutPlan = {
           "type": spoutType,
           "source": spoutSource,


### PR DESCRIPTION
#1808 makes values of `spout.type`, `spout.source`, and `spout.version` into [serialized value](https://github.com/twitter/heron/blob/master/heron/proto/topology.proto#L86). We need to propagate this change into tracker.

Tested locally.