### PR TITLE
UpdateTopologyManager using stale topology

### DIFF
--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
@@ -151,10 +151,8 @@ public class UpdateTopologyManager implements Closeable {
 
     // deactivate and sleep
     if (initiallyRunning) {
-      deactivateTopology(stateManager, updatedTopology);
       // Update the topology since the state should have changed from RUNNING to PAUSED
-      updatedTopology =
-        getUpdatedTopology(topologyName, proposedPackingPlan, stateManager);
+      updatedTopology = deactivateTopology(stateManager, updatedTopology, proposedPackingPlan);
     }
 
     // request new resources if necessary. Once containers are allocated we should make the changes
@@ -185,8 +183,9 @@ public class UpdateTopologyManager implements Closeable {
   }
 
   @VisibleForTesting
-  void deactivateTopology(SchedulerStateManagerAdaptor stateManager,
-                          final TopologyAPI.Topology topology)
+  TopologyAPI.Topology deactivateTopology(SchedulerStateManagerAdaptor stateManager,
+                          final TopologyAPI.Topology topology,
+                          PackingPlan proposedPackingPlan)
       throws InterruptedException, TMasterException {
 
     List<TopologyAPI.Config.KeyValue> topologyConfig = topology.getTopologyConfig().getKvsList();
@@ -206,6 +205,8 @@ public class UpdateTopologyManager implements Closeable {
     } else {
       logInfo("Deactivated topology %s.", topology.getName());
     }
+
+    return getUpdatedTopology(topology.getName(), proposedPackingPlan, stateManager);
   }
 
   @VisibleForTesting

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
@@ -152,6 +152,9 @@ public class UpdateTopologyManager implements Closeable {
     // deactivate and sleep
     if (initiallyRunning) {
       deactivateTopology(stateManager, updatedTopology);
+      // Update the topology since the state should have changed from RUNNING to PAUSED
+      updatedTopology =
+        getUpdatedTopology(topologyName, proposedPackingPlan, stateManager);
     }
 
     // request new resources if necessary. Once containers are allocated we should make the changes

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/UpdateTopologyManagerTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/UpdateTopologyManagerTest.java
@@ -166,7 +166,8 @@ public class UpdateTopologyManagerTest {
 
     spyUpdateManager.updateTopology(currentProtoPlan, proposedProtoPlan);
 
-    verify(spyUpdateManager).deactivateTopology(eq(mockStateMgr), eq(testTopology));
+    verify(spyUpdateManager).deactivateTopology(eq(mockStateMgr), eq(testTopology),
+        eq(proposedPacking));
     verify(spyUpdateManager).reactivateTopology(eq(mockStateMgr), eq(testTopology), eq(2));
     verify(mockScheduler).addContainers(expectedContainersToAdd);
     verify(mockScheduler).removeContainers(expectedContainersToRemove);


### PR DESCRIPTION
Hi all, not sure if I'm doing this right, but open for comments/improvements. 

#1924 fixes the Update mechanism using a stale copy of the Topology for determining whether to deactivate the topology before scaling.

This fixes another similar issue. It looks like the UpdateTopologyManager pulls the Topology before deactivating the running topology. UpdateTopologyManager then updates this stale copy (that still shows the topology as running) and pushes it to the state manager.

This fix just pulls an updated Topology from the state manager after deactivating.