### PR TITLE
Update documentation regarding topology_bin in the SubmitterMain

### DIFF
--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
@@ -189,10 +189,10 @@ public class SubmitterMain {
         .build();
 
     Option topologyJar = Option.builder("j")
-        .desc("user heron topology jar/tar/pex file")
+        .desc("The filename of the heron topology jar/tar/pex file to be run by the executor")
         .longOpt("topology_bin")
         .hasArgs()
-        .argName("topology binary file")
+        .argName("topology binary filename on the cluster")
         .required()
         .build();
 

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
@@ -189,7 +189,7 @@ public class SubmitterMain {
         .build();
 
     Option topologyJar = Option.builder("j")
-        .desc("user heron topology jar/pex file path")
+        .desc("user heron topology jar/tar/pex file")
         .longOpt("topology_bin")
         .hasArgs()
         .argName("topology binary file")

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
@@ -200,7 +200,7 @@ public class AuroraScheduler implements IScheduler, IScalable {
     auroraProperties.put(AuroraField.TOPOLOGY_PACKAGE_TYPE,
         Context.topologyPackageType(config).name().toLowerCase());
     auroraProperties.put(AuroraField.TOPOLOGY_BINARY_FILE,
-        FileUtils.getBaseName(Context.topologyBinaryFile(config)));
+        Context.topologyBinaryFile(config));
     auroraProperties.put(AuroraField.JAVA_HOME, Context.clusterJavaHome(config));
 
     auroraProperties.put(AuroraField.SHELL_BINARY, Context.shellBinary(config));

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/marathon/MarathonScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/marathon/MarathonScheduler.java
@@ -108,7 +108,7 @@ public class MarathonScheduler implements IScheduler {
     config = Config.newBuilder()
         .putAll(config)
         .put(Key.TOPOLOGY_BINARY_FILE,
-            FileUtils.getBaseName(Context.topologyBinaryFile(config)))
+            Context.topologyBinaryFile(config))
         .build();
 
     ObjectMapper mapper = new ObjectMapper();

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/marathon/MarathonScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/marathon/MarathonScheduler.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Joiner;
 
-import com.twitter.heron.common.basics.FileUtils;
 import com.twitter.heron.proto.scheduler.Scheduler;
 import com.twitter.heron.scheduler.utils.Runtime;
 import com.twitter.heron.scheduler.utils.SchedulerUtils;

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraSchedulerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraSchedulerTest.java
@@ -245,7 +245,7 @@ public class AuroraSchedulerTest {
     when(commandLine.getOptionValue("config_path")).thenReturn("/some/config/path");
     when(commandLine.getOptionValue("topology_package")).thenReturn("jar");
     when(commandLine.getOptionValue("topology_defn")).thenReturn("/mock/defnFile.defn");
-    when(commandLine.getOptionValue("topology_bin")).thenReturn("/mock/binaryFile.jar");
+    when(commandLine.getOptionValue("topology_bin")).thenReturn("binaryFile.jar");
     Config config = Mockito.spy(SubmitterMain.loadConfig(commandLine, topology));
 
     AuroraScheduler testScheduler = new AuroraScheduler();


### PR DESCRIPTION
 Cli passes only the file name of the topology_bin.
Thus it's not necessary for the schedulers to get the basename.