### PR TITLE
Moved the docker builds and docker images to use open-jdk-8

### DIFF
--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -28,15 +28,9 @@ RUN yum -y install \
       wget \
       which
 
-RUN wget --no-cookies --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" "http://download.oracle.com/otn-pub/java/jdk/$JAVA_VERSION-$BUILD_VERSION/jdk-$JAVA_VERSION-linux-x64.rpm" -O /tmp/jdk-8-linux-x64.rpm
+RUN yum -y install java-1.8.0-openjdk java-1.8.0-openjdk-devel
 
-RUN yum -y install /tmp/jdk-8-linux-x64.rpm
-
-RUN alternatives --install /usr/bin/java jar /usr/java/latest/bin/java 200000
-RUN alternatives --install /usr/bin/javaws javaws /usr/java/latest/bin/javaws 200000
-RUN alternatives --install /usr/bin/javac javac /usr/java/latest/bin/javac 200000
-
-ENV JAVA_HOME /usr/java/latest
+ENV JAVA_HOME /usr/lib/jvm/java-1.8.0
 
 RUN wget -O /tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/$bazelVersion/bazel-$bazelVersion-installer-linux-x86_64.sh \
       && chmod +x /tmp/bazel.sh \

--- a/docker/Dockerfile.dist.centos7
+++ b/docker/Dockerfile.dist.centos7
@@ -1,30 +1,32 @@
-FROM ubuntu:14.04
+FROM centos:centos7
 
 ARG heronVersion
 
-RUN apt-get update && apt-get -y install \
+RUN yum -y upgrade
+RUN yum -y install \
       curl \
       git \
-      libssl-dev \
+      openssl-devel \
       libtool \
       python \
       software-properties-common \
       unzip \
       wget \
+      which \
+      unzip \
       zip
 
-RUN add-apt-repository ppa:openjdk-r/ppa && apt-get -y update
-RUN apt-get -y install openjdk-8-jdk
+RUN yum -y install java-1.8.0-openjdk java-1.8.0-openjdk-devel
 
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+ENV JAVA_HOME /usr/lib/jvm/java-1.8.0 
 
 ADD artifacts /heron
 
 WORKDIR /heron
 
 #run heron installers
-RUN /heron/heron-tools-install-$heronVersion-ubuntu14.04.sh && \
-    /heron/heron-client-install-$heronVersion-ubuntu14.04.sh
+RUN /heron/heron-client-install-$heronVersion-centos7.sh && \
+    /heron/heron-tools-install-$heronVersion-centos7.sh
 
 RUN mkdir -p /opt/heron && \
     tar --strip-components=1 -m -zxvf /usr/local/heron/dist/heron-core.tar.gz -C /opt/heron

--- a/docker/Dockerfile.dist.ubuntu15.10
+++ b/docker/Dockerfile.dist.ubuntu15.10
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 
 ARG heronVersion
 
@@ -13,7 +13,6 @@ RUN apt-get update && apt-get -y install \
       wget \
       zip
 
-RUN add-apt-repository ppa:openjdk-r/ppa && apt-get -y update
 RUN apt-get -y install openjdk-8-jdk
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
@@ -23,8 +22,8 @@ ADD artifacts /heron
 WORKDIR /heron
 
 #run heron installers
-RUN /heron/heron-tools-install-$heronVersion-ubuntu14.04.sh && \
-    /heron/heron-client-install-$heronVersion-ubuntu14.04.sh
+RUN /heron/heron-client-install-$heronVersion-ubuntu15.10.sh && \
+    /heron/heron-tools-install-$heronVersion-ubuntu15.10.sh
 
 RUN mkdir -p /opt/heron && \
     tar --strip-components=1 -m -zxvf /usr/local/heron/dist/heron-core.tar.gz -C /opt/heron

--- a/docker/Dockerfile.dist.ubuntu16.04
+++ b/docker/Dockerfile.dist.ubuntu16.04
@@ -7,22 +7,15 @@ RUN apt-get update && apt-get -y install \
       git \
       libssl-dev \
       libtool \
-      libunwind8 \
-      libunwind-setjmp0-dev \
       python \
       software-properties-common \
       unzip \
       wget \
       zip
 
-RUN \
-  echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
-  add-apt-repository -y ppa:webupd8team/java && \
-  apt-get update && \
-  apt-get install -y oracle-java8-installer && \
-  rm -rf /var/lib/apt/lists/* && \
-  rm -rf /var/cache/oracle-jdk8-installer
-ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+RUN apt-get -y install openjdk-8-jdk
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
 ADD artifacts /heron
 
@@ -33,7 +26,7 @@ RUN /heron/heron-client-install-$heronVersion-ubuntu16.04.sh && \
     /heron/heron-tools-install-$heronVersion-ubuntu16.04.sh
 
 RUN mkdir -p /opt/heron && \
-    tar --strip-components=1 -zxvf /usr/local/heron/dist/heron-core.tar.gz -C /opt/heron
+    tar --strip-components=1 -m -zxvf /usr/local/heron/dist/heron-core.tar.gz -C /opt/heron
 
 ENV HERON_HOME /opt/heron/heron-core/
 RUN export HERON_HOME

--- a/docker/Dockerfile.ubuntu14.04
+++ b/docker/Dockerfile.ubuntu14.04
@@ -21,14 +21,11 @@ RUN apt-get update && apt-get -y install \
       unzip \
       wget
 
-RUN \
-  echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
-  add-apt-repository -y ppa:webupd8team/java && \
-  apt-get update && \
-  apt-get install -y oracle-java8-installer && \
-  rm -rf /var/lib/apt/lists/* && \
-  rm -rf /var/cache/oracle-jdk8-installer
-ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+
+RUN add-apt-repository ppa:openjdk-r/ppa && apt-get -y update
+RUN apt-get -y install openjdk-8-jdk
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
 RUN wget -O /tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/$bazelVersion/bazel-$bazelVersion-installer-linux-x86_64.sh \
       && chmod +x /tmp/bazel.sh \

--- a/docker/Dockerfile.ubuntu15.10
+++ b/docker/Dockerfile.ubuntu15.10
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get -y install \
       libssl-dev \
       git \
       libtool \
+      libtool-bin \
       python \
       python2.7-dev \
       python-software-properties \
@@ -21,14 +22,9 @@ RUN apt-get update && apt-get -y install \
       unzip \
       wget
 
-RUN \
-  echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
-  add-apt-repository -y ppa:webupd8team/java && \
-  apt-get update && \
-  apt-get install -y oracle-java8-installer && \
-  rm -rf /var/lib/apt/lists/* && \
-  rm -rf /var/cache/oracle-jdk8-installer
-ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+RUN apt-get -y install openjdk-8-jdk
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
 RUN wget -O /tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/$bazelVersion/bazel-$bazelVersion-installer-linux-x86_64.sh \
       && chmod +x /tmp/bazel.sh \

--- a/docker/Dockerfile.ubuntu16.04
+++ b/docker/Dockerfile.ubuntu16.04
@@ -23,14 +23,9 @@ RUN apt-get update && apt-get -y install \
       unzip \
       wget
 
-RUN \
-  echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
-  add-apt-repository -y ppa:webupd8team/java && \
-  apt-get update && \
-  apt-get install -y oracle-java8-installer && \
-  rm -rf /var/lib/apt/lists/* && \
-  rm -rf /var/cache/oracle-jdk8-installer
-ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+RUN apt-get -y install openjdk-8-jdk
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
 RUN wget -O /tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/$bazelVersion/bazel-$bazelVersion-installer-linux-x86_64.sh \
       && chmod +x /tmp/bazel.sh \


### PR DESCRIPTION
This is necessary since Oracle JDK licensing does not include shipping installed versions in the docker images. Hence we moved it to open jdk 8 consistently for compiling and also for publishing Docker images.