### PR TITLE
add a readme file for pyheron

### DIFF
--- a/scripts/packages/BUILD
+++ b/scripts/packages/BUILD
@@ -322,6 +322,7 @@ genrule(
     srcs = [
         "pyheron/requirements.txt", 
         "pyheron/setup.py.template",
+        "pyheron/README.txt",
     ] + generated_release_files,
     outs = generated_pyheron_egg_file,
     stamp = 1,

--- a/scripts/packages/pyheron/README.txt
+++ b/scripts/packages/pyheron/README.txt
@@ -1,0 +1,2 @@
+PyHeron is the python API for Heron, the distributed streaming engine. The API is
+based on the Storm python API provided by Parsely.

--- a/scripts/packages/pyheron/README.txt
+++ b/scripts/packages/pyheron/README.txt
@@ -1,2 +1,3 @@
-PyHeron is the python API for Heron, the distributed streaming engine. The API is
-based on the Storm python API provided by Parsely.
+PyHeron is the python API for Heron, the distributed streaming engine.
+The API is based on the streamparse Storm python API from Parsely. More
+details can be found at https://github.com/Parsely/streamparse


### PR DESCRIPTION
When we package pyheron for publishing to pypi, it expects a readme file. This readme file should be either README or README.txt or README.rst