### PR TITLE
Scripts to build docker artifacts

### DIFF
--- a/docker/Dockerfile.dist.centos7
+++ b/docker/Dockerfile.dist.centos7
@@ -3,20 +3,11 @@ FROM centos:centos7
 ARG heronVersion
 
 RUN yum -y upgrade
-RUN yum -y install \
-      curl \
-      git \
-      openssl-devel \
-      libtool \
-      python \
-      software-properties-common \
-      unzip \
-      wget \
-      which \
-      unzip \
-      zip
+RUN yum -y install python; yum clean all
+RUN yum -y install unzip; yum clean all 
+RUN yum -y install which; yum clean all
 
-RUN yum -y install java-1.8.0-openjdk java-1.8.0-openjdk-devel
+RUN yum -y install java-1.8.0-openjdk java-1.8.0-openjdk-devel; yum clean all
 
 ENV JAVA_HOME /usr/lib/jvm/java-1.8.0 
 
@@ -24,12 +15,14 @@ ADD artifacts /heron
 
 WORKDIR /heron
 
-#run heron installers
-RUN /heron/heron-client-install-$heronVersion-centos7.sh && \
-    /heron/heron-tools-install-$heronVersion-centos7.sh
+# run heron installers
+RUN /heron/heron-tools-install.sh
 
 RUN mkdir -p /opt/heron && \
-    tar --strip-components=1 -m -zxvf /usr/local/heron/dist/heron-core.tar.gz -C /opt/heron
+    tar --strip-components=1 -m -zxvf /heron/heron-core.tar.gz -C /opt/heron
+
+RUN rm -f /heron/heron-tools-install.sh
+RUN rm -f /heron/heron-core.tar.gz
 
 ENV HERON_HOME /opt/heron/heron-core/
 RUN export HERON_HOME

--- a/docker/Dockerfile.dist.ubuntu14.04
+++ b/docker/Dockerfile.dist.ubuntu14.04
@@ -2,19 +2,13 @@ FROM ubuntu:14.04
 
 ARG heronVersion
 
-RUN apt-get update && apt-get -y install \
-      curl \
-      git \
-      libssl-dev \
-      libtool \
-      python \
-      software-properties-common \
-      unzip \
-      wget \
-      zip
+RUN apt-get update 
+RUN apt-get -y install python ; apt-get clean all
+RUN apt-get -y install unzip ; apt-get clean all
+RUN apt-get -y install software-properties-common ; apt-get clean all
 
 RUN add-apt-repository ppa:openjdk-r/ppa && apt-get -y update
-RUN apt-get -y install openjdk-8-jdk
+RUN apt-get -y install openjdk-8-jdk; apt-get clean all
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
@@ -22,12 +16,14 @@ ADD artifacts /heron
 
 WORKDIR /heron
 
-#run heron installers
-RUN /heron/heron-tools-install-$heronVersion-ubuntu14.04.sh && \
-    /heron/heron-client-install-$heronVersion-ubuntu14.04.sh
+# run heron installers
+RUN /heron/heron-tools-install.sh
 
 RUN mkdir -p /opt/heron && \
-    tar --strip-components=1 -m -zxvf /usr/local/heron/dist/heron-core.tar.gz -C /opt/heron
+    tar --strip-components=1 -m -zxvf /heron/heron-core.tar.gz -C /opt/heron
+
+RUN rm -f /heron/heron-tools-install.sh
+RUN rm -f /heron/heron-core.tar.gz
 
 ENV HERON_HOME /opt/heron/heron-core/
 RUN export HERON_HOME

--- a/docker/Dockerfile.dist.ubuntu15.10
+++ b/docker/Dockerfile.dist.ubuntu15.10
@@ -2,18 +2,12 @@ FROM ubuntu:16.04
 
 ARG heronVersion
 
-RUN apt-get update && apt-get -y install \
-      curl \
-      git \
-      libssl-dev \
-      libtool \
-      python \
-      software-properties-common \
-      unzip \
-      wget \
-      zip
+RUN apt-get update
+RUN apt-get -y install python ; apt-get clean all
+RUN apt-get -y install unzip ; apt-get clean all
+RUN apt-get -y install software-properties-common ; apt-get clean all
 
-RUN apt-get -y install openjdk-8-jdk
+RUN apt-get -y install openjdk-8-jdk; apt-get clean all
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
@@ -21,12 +15,14 @@ ADD artifacts /heron
 
 WORKDIR /heron
 
-#run heron installers
-RUN /heron/heron-client-install-$heronVersion-ubuntu15.10.sh && \
-    /heron/heron-tools-install-$heronVersion-ubuntu15.10.sh
+# run heron installers
+RUN /heron/heron-tools-install.sh
 
 RUN mkdir -p /opt/heron && \
-    tar --strip-components=1 -m -zxvf /usr/local/heron/dist/heron-core.tar.gz -C /opt/heron
+    tar --strip-components=1 -m -zxvf /heron/heron-core.tar.gz -C /opt/heron
+
+RUN rm -f /heron/heron-tools-install.sh
+RUN rm -f /heron/heron-core.tar.gz
 
 ENV HERON_HOME /opt/heron/heron-core/
 RUN export HERON_HOME

--- a/docker/Dockerfile.dist.ubuntu16.04
+++ b/docker/Dockerfile.dist.ubuntu16.04
@@ -2,18 +2,12 @@ FROM ubuntu:16.04
 
 ARG heronVersion
 
-RUN apt-get update && apt-get -y install \
-      curl \
-      git \
-      libssl-dev \
-      libtool \
-      python \
-      software-properties-common \
-      unzip \
-      wget \
-      zip
+RUN apt-get update
+RUN apt-get -y install python ; apt-get clean all
+RUN apt-get -y install unzip ; apt-get clean all
+RUN apt-get -y install software-properties-common ; apt-get clean all
 
-RUN apt-get -y install openjdk-8-jdk
+RUN apt-get -y install openjdk-8-jdk; apt-get clean all
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
@@ -21,12 +15,14 @@ ADD artifacts /heron
 
 WORKDIR /heron
 
-#run heron installers
-RUN /heron/heron-client-install-$heronVersion-ubuntu16.04.sh && \
-    /heron/heron-tools-install-$heronVersion-ubuntu16.04.sh
+# run heron installers
+RUN /heron/heron-tools-install.sh
 
 RUN mkdir -p /opt/heron && \
-    tar --strip-components=1 -m -zxvf /usr/local/heron/dist/heron-core.tar.gz -C /opt/heron
+    tar --strip-components=1 -m -zxvf /heron/heron-core.tar.gz -C /opt/heron
+
+RUN rm -f /heron/heron-tools-install.sh
+RUN rm -f /heron/heron-core.tar.gz
 
 ENV HERON_HOME /opt/heron/heron-core/
 RUN export HERON_HOME

--- a/docker/build-artifacts.sh
+++ b/docker/build-artifacts.sh
@@ -99,23 +99,6 @@ setup_output_dir() {
   mkdir -p $1
 }
 
-build_docker_image() {
-  DOCKER_FILE="$SCRATCH_DIR/Dockerfile.dist.$TARGET_PLATFORM"
-  DOCKER_TAG="heron:$HERON_VERSION-$TARGET_PLATFORM"
-
-  #need to copy artifacts locally
-  cp "$OUTPUT_DIRECTORY"/heron-tools-install*$HERON_VERSION*.sh "$SCRATCH_DIR/artifacts"
-  cp "$OUTPUT_DIRECTORY"/heron-client-install*$HERON_VERSION*.sh "$SCRATCH_DIR/artifacts"
-
-  echo "building docker image heron:$DOCKER_TAG"
-
-  docker build --build-arg heronVersion=$HERON_VERSION -t "$DOCKER_TAG" -f "$DOCKER_FILE" "$SCRATCH_DIR"
-
-  DOCKER_IMAGE_FILE="$OUTPUT_DIRECTORY/heron-docker-$HERON_VERSION-$TARGET_PLATFORM.tar"
-  echo "saving docker image to $DOCKER_IMAGE_FILE"
-  docker save -o $DOCKER_IMAGE_FILE $DOCKER_TAG
-}
-
 run_build() {
   TARGET_PLATFORM=$1
   HERON_VERSION=$2
@@ -150,7 +133,6 @@ run_build() {
     docker/compile-platform.sh
   else
     docker/compile-docker.sh
-    build_docker_image
   fi
 }
 

--- a/docker/build-exec-docker.sh
+++ b/docker/build-exec-docker.sh
@@ -28,34 +28,52 @@ setup_scratch_dir() {
   cp $DOCKER_DIR/* $1
 }
 
-run_build() {
+build_exec_image() {
   TARGET_PLATFORM=$1
   HERON_VERSION=$2
   OUTPUT_DIRECTORY=$(realpath $3)
+
   DOCKER_FILE="$SCRATCH_DIR/Dockerfile.dist.$TARGET_PLATFORM"
   DOCKER_TAG="heron:$HERON_VERSION-$TARGET_PLATFORM"
 
   setup_scratch_dir $SCRATCH_DIR
 
-  echo "Building docker image with tag:$DOCKER_TAG"
-  #need to copy artifacts locally
-  cp -pr "$OUTPUT_DIRECTORY"/*$HERON_VERSION* "$SCRATCH_DIR/artifacts"
-
+  # need to copy artifacts locally
+  TOOLS_FILE="$OUTPUT_DIRECTORY/heron-tools-install-$HERON_VERSION-$TARGET_PLATFORM.sh"
+  TOOLS_OUT_FILE="$SCRATCH_DIR/artifacts/heron-tools-install.sh"
+  
+  CORE_FILE="$OUTPUT_DIRECTORY/heron-core-$HERON_VERSION-$TARGET_PLATFORM.tar.gz"
+  CORE_OUT_FILE="$SCRATCH_DIR/artifacts/heron-core.tar.gz"
+ 
+  cp $TOOLS_FILE $TOOLS_OUT_FILE
+  cp $CORE_FILE $CORE_OUT_FILE
+ 
   export HERON_VERSION
+
+  # build the image
+  echo "Building docker image with tag:$DOCKER_TAG"
   docker build --build-arg heronVersion=$HERON_VERSION -t "$DOCKER_TAG" -f "$DOCKER_FILE" "$SCRATCH_DIR"
 
+  # save the image as a tar file
+  DOCKER_IMAGE_FILE="$OUTPUT_DIRECTORY/heron-docker-$HERON_VERSION-$TARGET_PLATFORM.tar"
+  
+  echo "Saving docker image to $DOCKER_IMAGE_FILE"
+  docker save -o $DOCKER_IMAGE_FILE $DOCKER_TAG
+  gzip $DOCKER_IMAGE_FILE
 }
 
 case $# in
   3)
-    run_build $1 $2 $3
+    build_exec_image $1 $2 $3
     ;;
 
   *)
     echo "Usage: $0 <platform> <version_string> <output-directory> "
     echo "  "
+    echo "Platforms Supported: ubuntu14.04, ubuntu15.10, ubuntu16.04 centos7"
+    echo "  "
     echo "Example:"
-    echo "  ./build-docker.sh ubuntu14.04 0.12.0 ."
+    echo "  ./build-exec-docker.sh ubuntu14.04 0.12.0 ."
     echo "  "
     exit 1
     ;;

--- a/scripts/packages/bin_common.sh
+++ b/scripts/packages/bin_common.sh
@@ -75,7 +75,7 @@ function check_java() {
   if [ -z "${JAVA_HOME-}" ]; then
     case "$(uname -s | tr 'A-Z' 'a-z')" in
       linux)
-        JAVA_HOME="$(readlink -f $(which javac) 2>/dev/null | sed 's_/bin/javac__')" || true
+        JAVA_HOME="$(readlink -f $(which java) 2>/dev/null | sed 's_/bin/java__')" || true
         BASHRC="~/.bashrc"
         ;;
       freebsd)
@@ -88,7 +88,7 @@ function check_java() {
         ;;
     esac
   fi
-  if [ ! -x "${JAVA_HOME}/bin/javac" ]; then
+  if [ ! -x "${JAVA_HOME}/bin/java" ]; then
     echo >&2
     echo "Java not found, please install the corresponding package" >&2
     echo "See $getting_started_url for more information on" >&2


### PR DESCRIPTION
Several scripts and docker files to build docker image artifacts for release. These docker scripts expect the artifacts already to be built and available in a directory before they can package them into docker. Docker images are saved as tar.gz files that are easy to publish. Once these files are published the user can download them, load them and push into private registry, if needed. Public docker images will be pushed into docker hub.