### PR TITLE
print bazel log directory for apps

### DIFF
--- a/heron/common/src/cpp/basics/processutils.cpp
+++ b/heron/common/src/cpp/basics/processutils.cpp
@@ -28,3 +28,10 @@ size_t ProcessUtils::getTotalMemoryUsed() {
   MallocExtension::instance()->GetNumericProperty("generic.heap_size", &total);
   return total;
 }
+
+sp_string ProcessUtils::getCurrentWorkingDirectory() {
+  char buff[FILENAME_MAX];
+  getcwd(buff, FILENAME_MAX);
+  sp_string current_working_dir(buff);
+  return current_working_dir;
+}

--- a/heron/common/src/cpp/basics/processutils.h
+++ b/heron/common/src/cpp/basics/processutils.h
@@ -20,11 +20,11 @@
 //
 /////////////////////////////////////////////////////////////////////
 
-#include <sys/types.h>
-#include "sptypes.h"
-
 #if !defined(__PROCESS_UTILS_H)
 #define __PROCESS_UTILS_H
+
+#include <sys/types.h>
+#include "basics/sptypes.h"
 
 struct rusage;
 

--- a/heron/common/src/cpp/basics/processutils.h
+++ b/heron/common/src/cpp/basics/processutils.h
@@ -21,6 +21,7 @@
 /////////////////////////////////////////////////////////////////////
 
 #include <sys/types.h>
+#include "sptypes.h"
 
 #if !defined(__PROCESS_UTILS_H)
 #define __PROCESS_UTILS_H
@@ -37,6 +38,9 @@ class ProcessUtils {
 
   // get the total amount of memory used by the process
   static size_t getTotalMemoryUsed();
+
+  // get working directory
+  static sp_string getCurrentWorkingDirectory();
 };
 
 #endif

--- a/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
@@ -1707,7 +1707,7 @@ TEST(StMgr, test_metricsmgr_reconnect) {
 
 int main(int argc, char** argv) {
   heron::common::Initialize(argv[0]);
-  std::cerr << "Current working directory (to find stmgr logs) "
+  std::cout << "Current working directory (to find stmgr logs) "
       << ProcessUtils::getCurrentWorkingDirectory() << std::endl;
   testing::InitGoogleTest(&argc, argv);
   if (argc > 1) {

--- a/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
@@ -1707,6 +1707,8 @@ TEST(StMgr, test_metricsmgr_reconnect) {
 
 int main(int argc, char** argv) {
   heron::common::Initialize(argv[0]);
+  std::cerr << "Current working directory (to find stmgr logs) "
+      << ProcessUtils::getCurrentWorkingDirectory() << std::endl;
   testing::InitGoogleTest(&argc, argv);
   if (argc > 1) {
     std::cerr << "Using config file " << argv[1] << std::endl;

--- a/heron/tmaster/tests/cpp/server/tmaster_unittest.cpp
+++ b/heron/tmaster/tests/cpp/server/tmaster_unittest.cpp
@@ -542,7 +542,7 @@ TEST(StMgr, test_activate_deactivate) {
 
 int main(int argc, char** argv) {
   heron::common::Initialize(argv[0]);
-  std::cerr << "Current working directory (to find tmaster logs) "
+  std::cout << "Current working directory (to find tmaster logs) "
       << ProcessUtils::getCurrentWorkingDirectory() << std::endl;
   testing::InitGoogleTest(&argc, argv);
   if (argc > 1) {

--- a/heron/tmaster/tests/cpp/server/tmaster_unittest.cpp
+++ b/heron/tmaster/tests/cpp/server/tmaster_unittest.cpp
@@ -542,6 +542,8 @@ TEST(StMgr, test_activate_deactivate) {
 
 int main(int argc, char** argv) {
   heron::common::Initialize(argv[0]);
+  std::cerr << "Current working directory (to find tmaster logs) "
+      << ProcessUtils::getCurrentWorkingDirectory() << std::endl;
   testing::InitGoogleTest(&argc, argv);
   if (argc > 1) {
     std::cerr << "Using config file " << argv[1] << std::endl;


### PR DESCRIPTION
The apps in unit-test write the logs into bazel directory, which is hard to find out.
This PR prints out the log directory.