### PR TITLE
Allow tracker to take command line args for a state manager.

### DIFF
--- a/heron/common/src/cpp/basics/processutils.cpp
+++ b/heron/common/src/cpp/basics/processutils.cpp
@@ -28,3 +28,10 @@ size_t ProcessUtils::getTotalMemoryUsed() {
   MallocExtension::instance()->GetNumericProperty("generic.heap_size", &total);
   return total;
 }
+
+sp_string ProcessUtils::getCurrentWorkingDirectory() {
+  char buff[FILENAME_MAX];
+  getcwd(buff, FILENAME_MAX);
+  sp_string current_working_dir(buff);
+  return current_working_dir;
+}

--- a/heron/common/src/cpp/basics/processutils.h
+++ b/heron/common/src/cpp/basics/processutils.h
@@ -20,10 +20,11 @@
 //
 /////////////////////////////////////////////////////////////////////
 
-#include <sys/types.h>
-
 #if !defined(__PROCESS_UTILS_H)
 #define __PROCESS_UTILS_H
+
+#include <sys/types.h>
+#include "basics/sptypes.h"
 
 struct rusage;
 
@@ -37,6 +38,9 @@ class ProcessUtils {
 
   // get the total amount of memory used by the process
   static size_t getTotalMemoryUsed();
+
+  // get working directory
+  static sp_string getCurrentWorkingDirectory();
 };
 
 #endif

--- a/heron/common/src/cpp/zookeeper/zkclient.h
+++ b/heron/common/src/cpp/zookeeper/zkclient.h
@@ -66,7 +66,7 @@ class ZKClient {
   virtual void Exists(const std::string& _node, VCallback<sp_int32> _cb);
 
   // creates a node. The node is created at _node. If _is_ephemeral is set,
-  // then the node is created as a ephimeral node. _cb is called with
+  // then the node is created as a ephemeral node. _cb is called with
   // the status code after the Create completes.
   virtual void CreateNode(const std::string& _node, const std::string& _value, bool _is_ephimeral,
                           VCallback<sp_int32> _cb);

--- a/heron/common/tests/python/basics/event_looper_unittest.py
+++ b/heron/common/tests/python/basics/event_looper_unittest.py
@@ -57,7 +57,7 @@ class EventLooperTest(unittest.TestCase):
     self.looper.register_timer_task_in_sec(to_run, interval)
     self.looper.loop()
     end_time = time.time()
-    self.assertAlmostEqual(start_time + interval, end_time, delta=0.01)
+    self.assertAlmostEqual(start_time + interval, end_time, delta=0.05)
     self.assertEqual(10, self.global_value)
 
   def test_exit_loop(self):

--- a/heron/common/tests/python/basics/gateway_looper_unittest.py
+++ b/heron/common/tests/python/basics/gateway_looper_unittest.py
@@ -34,7 +34,7 @@ class GatewayLooperTest(unittest.TestCase):
     sleep_times = [0.1, 0.3, 0.5, 1.0, 3.0, 5.0]
     for sleep in sleep_times:
       start, end = self.prepare_wakeup_test(sleep)
-      self.assertAlmostEqual(start + sleep, end, delta=0.02)
+      self.assertAlmostEqual(start + sleep, end, delta=0.05)
 
   def prepare_wakeup_test(self, sleep, poll_timeout=30.0):
     looper = GatewayLooper(socket_map={})

--- a/heron/shell/src/python/handlers/downloadhandler.py
+++ b/heron/shell/src/python/handlers/downloadhandler.py
@@ -13,12 +13,56 @@
 # limitations under the License.
 
 ''' downloadhandler.py '''
+import os
+import logging
 import tornado.web
 
-class DownloadHandler(tornado.web.StaticFileHandler):
+from heron.shell.src.python import utils
+
+class DownloadHandler(tornado.web.RequestHandler):
   """
   Responsible for downloading the files.
   """
-  def set_headers(self):
-    """ set headers """
+  @tornado.web.asynchronous
+  def get(self, path):
+    """ get method """
+
+    logging.debug("request to download: %s", path)
+    # If the file is large, we want to abandon downloading
+    # if user cancels the requests.
+    # pylint: disable=attribute-defined-outside-init
+    self.connection_closed = False
+
     self.set_header("Content-Disposition", "attachment")
+    if path.startswith("/"):
+      self.write("Only relative paths are allowed")
+      self.set_status(403)
+      self.finish()
+      return
+
+    if path is None or not os.path.isfile(path):
+      self.write("File %s  not found" % path)
+      self.set_status(404)
+      self.finish()
+      return
+
+    length = long(4 * 1024 * 1024)
+    offset = long(0)
+    while True:
+      data = utils.read_chunk(path, offset=offset, length=length, escape_data=False)
+      if self.connection_closed or 'data' not in data or len(data['data']) < length:
+        break
+      offset += length
+      self.write(data['data'])
+      self.flush()
+
+    if 'data' in data:
+      self.write(data['data'])
+    self.finish()
+
+def on_connection_close(self):
+  '''
+  :return:
+  '''
+  # pylint: disable=attribute-defined-outside-init
+  self.connection_closed = True

--- a/heron/shell/src/python/handlers/filedatahandler.py
+++ b/heron/shell/src/python/handlers/filedatahandler.py
@@ -38,6 +38,6 @@ class FileDataHandler(tornado.web.RequestHandler):
     length = self.get_argument("length", default=-1)
     if not os.path.isfile(path):
       return {}
-    data = utils.read_chunk(path, offset, length)
+    data = utils.read_chunk(path, offset=offset, length=length, escape_data=True)
     self.write(json.dumps(data))
     self.finish()

--- a/heron/shell/src/python/main.py
+++ b/heron/shell/src/python/main.py
@@ -33,7 +33,7 @@ app = tornado.web.Application([
     (r"^/file/(.*)", handlers.FileHandler),
     (r"^/filedata/(.*)", handlers.FileDataHandler),
     (r"^/filestats/(.*)", handlers.FileStatsHandler),
-    (r"^/download/(.*)", handlers.DownloadHandler, {"path":"."}),
+    (r"^/download/(.*)", handlers.DownloadHandler),
 ])
 
 

--- a/heron/shell/src/python/utils.py
+++ b/heron/shell/src/python/utils.py
@@ -104,13 +104,10 @@ def get_stat(path, filename):
   ''' get stat '''
   return os.stat(os.path.join(path, filename))
 
-def read_chunk(filename, offset=None, length=None):
+def read_chunk(filename, offset=-1, length=-1, escape_data=False):
   """
   Read a chunk of a file from an offset upto the length.
   """
-  offset = offset or -1
-  length = length or -1
-
   try:
     length = long(length)
     offset = long(offset)
@@ -139,10 +136,13 @@ def read_chunk(filename, offset=None, length=None):
       return {}
 
   if data:
-    return dict(offset=offset, length=len(data), data=escape(data.decode('utf8', 'replace')))
+    data = _escape_data(data) if escape_data else data
+    return dict(offset=offset, length=len(data), data=data)
 
   return dict(offset=offset, length=0)
 
+def _escape_data(data):
+  return escape(data.decode('utf8', 'replace'))
 
 def pipe(prev_proc, to_cmd):
   """

--- a/heron/statemgrs/src/cpp/statemgr/heron-localfilestatemgr.cpp
+++ b/heron/statemgrs/src/cpp/statemgr/heron-localfilestatemgr.cpp
@@ -53,6 +53,9 @@ void HeronLocalFileStateMgr::InitTree() {
   path += "/pplans";
   FileUtils::makeDirectory(path);
   path = dpath;
+  path += "/packingplans";
+  FileUtils::makeDirectory(path);
+  path = dpath;
   path += "/executionstate";
   FileUtils::makeDirectory(path);
   path = dpath;
@@ -82,6 +85,19 @@ void HeronLocalFileStateMgr::SetMetricsCacheLocationWatch(const std::string& top
 
   auto cb = [topology_name, tmaster_last_change, watcher, this](EventLoop::Status status) {
     this->CheckMetricsCacheLocation(topology_name, tmaster_last_change, std::move(watcher), status);
+  };
+
+  CHECK_GT(eventLoop_->registerTimer(std::move(cb), false, 1000000), 0);
+}
+
+void HeronLocalFileStateMgr::SetPackingPlanWatch(const std::string& topology_name,
+                                                 VCallback<> watcher) {
+  CHECK(watcher);
+  // We kind of cheat here. We check periodically
+  time_t packingplan_last_change = FileUtils::getModifiedTime(GetPackingPlanPath(topology_name));
+
+  auto cb = [topology_name, packingplan_last_change, watcher, this](EventLoop::Status status) {
+    this->CheckPackingPlan(topology_name, packingplan_last_change, std::move(watcher), status);
   };
 
   CHECK_GT(eventLoop_->registerTimer(std::move(cb), false, 1000000), 0);
@@ -234,6 +250,31 @@ void HeronLocalFileStateMgr::GetPhysicalPlan(const std::string& _topology_name,
   std::string contents;
   proto::system::StatusCode status =
       ReadAllFileContents(GetPhysicalPlanPath(_topology_name), contents);
+  if (status == proto::system::OK) {
+    if (!_return->ParseFromString(contents)) {
+      status = proto::system::STATE_CORRUPTED;
+    }
+  }
+  auto wCb = [cb, status](EventLoop::Status) { cb(status); };
+  CHECK_GT(eventLoop_->registerTimer(std::move(wCb), false, 0), 0);
+}
+
+void HeronLocalFileStateMgr::CreatePackingPlan(const std::string& _topology_name,
+                                               const proto::system::PackingPlan& _packingPlan,
+                                               VCallback<proto::system::StatusCode> _cb) {
+  std::string fname = GetPackingPlanPath(_topology_name);
+  std::string contents;
+  _packingPlan.SerializeToString(&contents);
+
+  WriteToFile(fname, contents);
+}
+
+void HeronLocalFileStateMgr::GetPackingPlan(const std::string& _topology_name,
+                                             proto::system::PackingPlan* _return,
+                                             VCallback<proto::system::StatusCode> cb) {
+  std::string contents;
+  proto::system::StatusCode status =
+      ReadAllFileContents(GetPackingPlanPath(_topology_name), contents);
   if (status == proto::system::OK) {
     if (!_return->ParseFromString(contents)) {
       status = proto::system::STATE_CORRUPTED;
@@ -448,6 +489,22 @@ void HeronLocalFileStateMgr::CheckMetricsCacheLocation(
 
   auto cb = [topology_name, nlast_change, watcher, this](EventLoop::Status status) {
     this->CheckMetricsCacheLocation(topology_name, nlast_change, std::move(watcher), status);
+  };
+
+  CHECK_GT(eventLoop_->registerTimer(std::move(cb), false, 1000000), 0);
+}
+
+void HeronLocalFileStateMgr::CheckPackingPlan(std::string topology_name, time_t last_change,
+                                              VCallback<> watcher, EventLoop::Status) {
+  time_t nlast_change = FileUtils::getModifiedTime(GetPackingPlanPath(topology_name));
+  if (nlast_change > last_change) {
+    watcher();
+  } else {
+    nlast_change = last_change;
+  }
+
+  auto cb = [topology_name, nlast_change, watcher, this](EventLoop::Status status) {
+    this->CheckPackingPlan(topology_name, nlast_change, std::move(watcher), status);
   };
 
   CHECK_GT(eventLoop_->registerTimer(std::move(cb), false, 1000000), 0);

--- a/heron/statemgrs/src/cpp/statemgr/heron-localfilestatemgr.h
+++ b/heron/statemgrs/src/cpp/statemgr/heron-localfilestatemgr.h
@@ -47,6 +47,7 @@ class HeronLocalFileStateMgr : public HeronStateMgr {
 
   void SetTMasterLocationWatch(const std::string& _topology_name, VCallback<> _watcher);
   void SetMetricsCacheLocationWatch(const std::string& _topology_name, VCallback<> _watcher);
+  void SetPackingPlanWatch(const std::string& _topology_name, VCallback<> _watcher);
 
   // implement the functions
   void GetTMasterLocation(const std::string& _topology_name,
@@ -74,6 +75,12 @@ class HeronLocalFileStateMgr : public HeronStateMgr {
                        VCallback<proto::system::StatusCode> _cb);
   void GetPhysicalPlan(const std::string& _topology_name, proto::system::PhysicalPlan* _return,
                        VCallback<proto::system::StatusCode> _cb);
+
+  void CreatePackingPlan(const std::string& _topology_name,
+                         const proto::system::PackingPlan& _packingPlan,
+                         VCallback<proto::system::StatusCode> _cb);
+  void GetPackingPlan(const std::string& _topology_name, proto::system::PackingPlan* _return,
+                      VCallback<proto::system::StatusCode> _cb);
 
   void CreateExecutionState(const proto::system::ExecutionState& _pplan,
                             VCallback<proto::system::StatusCode> _cb);
@@ -121,6 +128,8 @@ class HeronLocalFileStateMgr : public HeronStateMgr {
                             EventLoop::Status);
   void CheckMetricsCacheLocation(std::string _topology_name, time_t _last_change,
                                  VCallback<> _watcher, EventLoop::Status);
+  void CheckPackingPlan(std::string _topology_name, time_t _last_change,
+                        VCallback<> _watcher, EventLoop::Status);
 
   // Hold the EventLoop for scheduling callbacks
   EventLoop* eventLoop_;

--- a/heron/statemgrs/src/cpp/statemgr/heron-statemgr.cpp
+++ b/heron/statemgrs/src/cpp/statemgr/heron-statemgr.cpp
@@ -99,6 +99,8 @@ std::string HeronStateMgr::GetTopologyDir() { return topleveldir_ + "/topologies
 
 std::string HeronStateMgr::GetPhysicalPlanDir() { return topleveldir_ + "/pplans"; }
 
+std::string HeronStateMgr::GetPackingPlanDir() { return topleveldir_ + "/packingplans"; }
+
 std::string HeronStateMgr::GetExecutionStateDir() { return topleveldir_ + "/executionstate"; }
 
 std::string HeronStateMgr::GetStatefulCheckpointsDir() {
@@ -118,6 +120,10 @@ std::string HeronStateMgr::GetTopologyPath(const std::string& _topname) {
 
 std::string HeronStateMgr::GetPhysicalPlanPath(const std::string& _topname) {
   return GetPhysicalPlanDir() + "/" + _topname;
+}
+
+std::string HeronStateMgr::GetPackingPlanPath(const std::string& _topname) {
+  return GetPackingPlanDir() + "/" + _topname;
 }
 
 std::string HeronStateMgr::GetExecutionStatePath(const std::string& _topname) {

--- a/heron/statemgrs/src/cpp/statemgr/heron-statemgr.h
+++ b/heron/statemgrs/src/cpp/statemgr/heron-statemgr.h
@@ -76,6 +76,7 @@ class HeronStateMgr {
   virtual void SetTMasterLocationWatch(const std::string& _topology_name, VCallback<> _watcher) = 0;
   virtual void SetMetricsCacheLocationWatch(
                const std::string& _topology_name, VCallback<> _watcher) = 0;
+  virtual void SetPackingPlanWatch(const std::string& _topology_name, VCallback<> _watcher) = 0;
 
   // Sets/Gets the Tmaster
   virtual void GetTMasterLocation(const std::string& _topology_name,
@@ -109,6 +110,11 @@ class HeronStateMgr {
   virtual void GetPhysicalPlan(const std::string& _topology_name,
                                proto::system::PhysicalPlan* _return,
                                VCallback<proto::system::StatusCode> _cb) = 0;
+
+  // Gets PackingPlan
+  virtual void GetPackingPlan(const std::string& _topology_name,
+                              proto::system::PackingPlan* _return,
+                              VCallback<proto::system::StatusCode> _cb) = 0;
 
   // Gets/Sets ExecutionState
   virtual void CreateExecutionState(const proto::system::ExecutionState& _st,
@@ -155,6 +161,7 @@ class HeronStateMgr {
   std::string GetMetricsCacheLocationPath(const std::string& _topology_name);
   std::string GetTopologyPath(const std::string& _topology_name);
   std::string GetPhysicalPlanPath(const std::string& _topology_name);
+  std::string GetPackingPlanPath(const std::string& _topology_name);
   std::string GetExecutionStatePath(const std::string& _topology_name);
   std::string GetStatefulCheckpointsPath(const std::string& _topology_name);
 
@@ -162,6 +169,7 @@ class HeronStateMgr {
   std::string GetMetricsCacheLocationDir();
   std::string GetTopologyDir();
   std::string GetPhysicalPlanDir();
+  std::string GetPackingPlanDir();
   std::string GetExecutionStateDir();
   std::string GetStatefulCheckpointsDir();
 

--- a/heron/statemgrs/src/cpp/statemgr/heron-zkstatemgr.cpp
+++ b/heron/statemgrs/src/cpp/statemgr/heron-zkstatemgr.cpp
@@ -96,6 +96,14 @@ void HeronZKStateMgr::SetMetricsCacheLocationWatch(const std::string& topology_n
   SetMetricsCacheLocationWatchInternal();
 }
 
+void HeronZKStateMgr::SetPackingPlanWatch(const std::string& topology_name, VCallback<> watcher) {
+  CHECK(watcher);
+  CHECK(!topology_name.empty());
+
+  packing_plan_watcher_info_ = new TMasterLocationWatchInfo(std::move(watcher), topology_name);
+  SetPackingPlanWatchInternal();
+}
+
 void HeronZKStateMgr::SetTMasterLocation(const proto::tmaster::TMasterLocation& _location,
                                          VCallback<proto::system::StatusCode> cb) {
   // Just try to create an ephimeral node
@@ -216,6 +224,18 @@ void HeronZKStateMgr::GetPhysicalPlan(const std::string& _topology_name,
   std::string* contents = new std::string();
   auto wCb = [contents, _return, cb, this](sp_int32 rc) {
     this->GetPhysicalPlanDone(contents, _return, std::move(cb), rc);
+  };
+
+  zkclient_->Get(path, contents, std::move(wCb));
+}
+
+void HeronZKStateMgr::GetPackingPlan(const std::string& _topology_name,
+                                      proto::system::PackingPlan* _return,
+                                      VCallback<proto::system::StatusCode> cb) {
+  std::string path = GetPackingPlanPath(_topology_name);
+  std::string* contents = new std::string();
+  auto wCb = [contents, _return, cb, this](sp_int32 rc) {
+    this->GetPackingPlanDone(contents, _return, std::move(cb), rc);
   };
 
   zkclient_->Get(path, contents, std::move(wCb));
@@ -535,6 +555,24 @@ void HeronZKStateMgr::GetPhysicalPlanDone(std::string* _contents,
   cb(code);
 }
 
+void HeronZKStateMgr::GetPackingPlanDone(std::string* _contents,
+                                          proto::system::PackingPlan* _return,
+                                          VCallback<proto::system::StatusCode> cb, sp_int32 _rc) {
+  proto::system::StatusCode code = proto::system::OK;
+  if (_rc == ZOK) {
+    if (!_return->ParseFromString(*_contents)) {
+      code = proto::system::STATE_CORRUPTED;
+    }
+  } else if (_rc == ZNONODE) {
+    code = proto::system::PATH_DOES_NOT_EXIST;
+  } else {
+    LOG(ERROR) << "Getting PackingPlan failed with error " << _rc << std::endl;
+    code = proto::system::STATE_READ_ERROR;
+  }
+  delete _contents;
+  cb(code);
+}
+
 void HeronZKStateMgr::CreateExecutionStateDone(VCallback<proto::system::StatusCode> cb,
                                                sp_int32 _rc) {
   proto::system::StatusCode code = proto::system::OK;
@@ -682,6 +720,12 @@ bool HeronZKStateMgr::IsMetricsCacheWatchDefined() {
           !metricscache_location_watcher_info_->topology_name.empty());
 }
 
+bool HeronZKStateMgr::IsPackingPlanWatchDefined() {
+  return (packing_plan_watcher_info_ != NULL &&
+          packing_plan_watcher_info_->watcher_cb &&
+          !packing_plan_watcher_info_->topology_name.empty());
+}
+
 // 2 seconds
 const int HeronZKStateMgr::SET_WATCH_RETRY_INTERVAL_S = 2;
 
@@ -734,12 +778,35 @@ void HeronZKStateMgr::SetMetricsCacheWatchCompletionHandler(sp_int32 rc) {
   }
 }
 
+void HeronZKStateMgr::SetPackingPlanWatchCompletionHandler(sp_int32 rc) {
+  if (rc == ZOK || rc == ZNONODE) {
+    // NoNode is when there is no packingplan up yet, but the watch is set.
+    LOG(INFO) << "Setting watch on packing plan succeeded: " << zerror(rc) << std::endl;
+  } else {
+    // Any other return code should be treated as warning, since ideally
+    // we shouldn't be in this state.
+    LOG(WARNING) << "Setting watch on packing plan returned: " << zerror(rc) << std::endl;
+
+    if (ShouldRetrySetWatch(rc)) {
+      LOG(INFO) << "Retrying after " << SET_WATCH_RETRY_INTERVAL_S << " seconds" << std::endl;
+
+      auto cb = [this](EventLoop::Status status) { this->CallSetPackingPlanWatch(status);};
+
+      eventLoop_->registerTimer(std::move(cb), false, SET_WATCH_RETRY_INTERVAL_S * 1000 * 1000);
+    }
+  }
+}
+
 void HeronZKStateMgr::CallSetTMasterLocationWatch(EventLoop::Status) {
   SetTMasterLocationWatchInternal();
 }
 
 void HeronZKStateMgr::CallSetMetricsCacheLocationWatch(EventLoop::Status) {
   SetMetricsCacheLocationWatchInternal();
+}
+
+void HeronZKStateMgr::CallSetPackingPlanWatch(EventLoop::Status) {
+  SetPackingPlanWatchInternal();
 }
 
 void HeronZKStateMgr::SetTMasterLocationWatchInternal() {
@@ -763,6 +830,16 @@ void HeronZKStateMgr::SetMetricsCacheLocationWatchInternal() {
                     [this](sp_int32 rc) { this->SetMetricsCacheWatchCompletionHandler(rc); });
 }
 
+void HeronZKStateMgr::SetPackingPlanWatchInternal() {
+  CHECK(IsPackingPlanWatchDefined());
+
+  LOG(INFO) << "Setting watch on packing plan " << std::endl;
+  std::string path = GetPackingPlanPath(packing_plan_watcher_info_->topology_name);
+
+  zkclient_->Exists(path, [this]() { this->PackingPlanWatch(); },
+                    [this](sp_int32 rc) { this->SetPackingPlanWatchCompletionHandler(rc); });
+}
+
 void HeronZKStateMgr::TMasterLocationWatch() {
   // First setup watch again
   SetTMasterLocationWatchInternal();
@@ -775,6 +852,13 @@ void HeronZKStateMgr::MetricsCacheLocationWatch() {
   SetMetricsCacheLocationWatchInternal();
   // Then run the watcher
   metricscache_location_watcher_info_->watcher_cb();
+}
+
+void HeronZKStateMgr::PackingPlanWatch() {
+  // First setup watch again
+  SetPackingPlanWatchInternal();
+  // Then run the watcher
+  packing_plan_watcher_info_->watcher_cb();
 }
 }  // namespace common
 }  // namespace heron

--- a/heron/statemgrs/src/cpp/statemgr/heron-zkstatemgr.h
+++ b/heron/statemgrs/src/cpp/statemgr/heron-zkstatemgr.h
@@ -66,6 +66,7 @@ class HeronZKStateMgr : public HeronStateMgr {
   // Sets up a watch on tmaster location change
   void SetTMasterLocationWatch(const std::string& _topology_name, VCallback<> _watcher);
   void SetMetricsCacheLocationWatch(const std::string& _topology_name, VCallback<> _watcher);
+  void SetPackingPlanWatch(const std::string& _topology_name, VCallback<> _watcher);
 
   // Sets the Tmaster
   void SetTMasterLocation(const proto::tmaster::TMasterLocation& _location,
@@ -95,6 +96,9 @@ class HeronZKStateMgr : public HeronStateMgr {
                        VCallback<proto::system::StatusCode> _cb);
   void GetPhysicalPlan(const std::string& _topology_name, proto::system::PhysicalPlan* _return,
                        VCallback<proto::system::StatusCode> _cb);
+
+  void GetPackingPlan(const std::string& _topology_name, proto::system::PackingPlan* _return,
+                      VCallback<proto::system::StatusCode> _cb);
 
   // Gets/Sets execution state
   void CreateExecutionState(const proto::system::ExecutionState& _state,
@@ -154,6 +158,8 @@ class HeronZKStateMgr : public HeronStateMgr {
   void SetPhysicalPlanDone(VCallback<proto::system::StatusCode> _cb, sp_int32 _rc);
   void GetPhysicalPlanDone(std::string* _contents, proto::system::PhysicalPlan* _return,
                            VCallback<proto::system::StatusCode> _cb, sp_int32 _rc);
+  void GetPackingPlanDone(std::string* _contents, proto::system::PackingPlan* _return,
+                          VCallback<proto::system::StatusCode> _cb, sp_int32 _rc);
 
   void CreateExecutionStateDone(VCallback<proto::system::StatusCode> _cb, sp_int32 _rc);
   void DeleteExecutionStateDone(VCallback<proto::system::StatusCode> _cb, sp_int32 _rc);
@@ -176,6 +182,7 @@ class HeronZKStateMgr : public HeronStateMgr {
   // clients about the change.
   void TMasterLocationWatch();
   void MetricsCacheLocationWatch();
+  void PackingPlanWatch();
   // Handles global events from ZKClient. For now, it handles the session
   // expired event, by deleting the current client, creating a new one,
   // setting the tmaster location watch, and notifying the client of a
@@ -184,20 +191,24 @@ class HeronZKStateMgr : public HeronStateMgr {
   // Sets a tmaster location watch through the ZKClient Exists method.
   void SetTMasterLocationWatchInternal();
   void SetMetricsCacheLocationWatchInternal();
+  void SetPackingPlanWatchInternal();
   // A wrapper to be passed to select server registerTimer call.
   // Ignores the status and call SetTMasterLocationWatchInternal
   void CallSetTMasterLocationWatch(EventLoop::Status status);
   void CallSetMetricsCacheLocationWatch(EventLoop::Status status);
+  void CallSetPackingPlanWatch(EventLoop::Status status);
   // A handler callback that gets called by ZkClient upon completion of
   // setting Tmaster watch. If the return code indicates failure, we
   // retry after SET_WATCH_RETRY_INTERVAL_S seconds.
   void SetTMasterWatchCompletionHandler(sp_int32 rc);
   void SetMetricsCacheWatchCompletionHandler(sp_int32 rc);
+  void SetPackingPlanWatchCompletionHandler(sp_int32 rc);
   // Essentially tells you whether SetTmasterLocationWatch has been
   // called by the client or not. It gets this info through
   // tmaster_location_watcher_info_
   bool IsTmasterWatchDefined();
   bool IsMetricsCacheWatchDefined();
+  bool IsPackingPlanWatchDefined();
   // Common functionality for c`tors. Should be called only once from c`tor
   void Init();
 
@@ -229,6 +240,7 @@ class HeronZKStateMgr : public HeronStateMgr {
 
   const TMasterLocationWatchInfo* tmaster_location_watcher_info_;
   const TMasterLocationWatchInfo* metricscache_location_watcher_info_;
+  const TMasterLocationWatchInfo* packing_plan_watcher_info_;
   // If true, we exit on zookeeper session expired event
   const bool exitOnSessionExpiry_;
   // Retry interval if setting a watch on zk node fails.

--- a/heron/statemgrs/tests/cpp/statetest.cpp
+++ b/heron/statemgrs/tests/cpp/statetest.cpp
@@ -53,6 +53,7 @@ int main(int argc, char* argv[]) {
 
   HeronStateMgr* state_mgr = HeronStateMgr::MakeStateMgr(host_port, top_level_dir, &ss);
   state_mgr->SetTMasterLocationWatch(topology_name, []() { TMasterLocationWatchHandler(); });
+  state_mgr->SetPackingPlanWatch(topology_name, []() { PackingPlanWatchHandler(); });
   ss.loop();
   return 0;
 }

--- a/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
@@ -1707,6 +1707,8 @@ TEST(StMgr, test_metricsmgr_reconnect) {
 
 int main(int argc, char** argv) {
   heron::common::Initialize(argv[0]);
+  std::cout << "Current working directory (to find stmgr logs) "
+      << ProcessUtils::getCurrentWorkingDirectory() << std::endl;
   testing::InitGoogleTest(&argc, argv);
   if (argc > 1) {
     std::cerr << "Using config file " << argv[1] << std::endl;

--- a/heron/tmaster/src/cpp/manager/tmaster.cpp
+++ b/heron/tmaster/src/cpp/manager/tmaster.cpp
@@ -211,7 +211,7 @@ void TMaster::SetTMasterLocationDone(proto::system::StatusCode _code) {
     }
     // There was an error setting our location
     LOG(ERROR) << "For topology " << tmaster_location_->topology_name()
-               << " Error setting ourselves as TMaster. Errorcode is " << _code << std::endl;
+               << " Error setting ourselves as TMaster. Error code is " << _code << std::endl;
     ::exit(1);
   }
 
@@ -230,7 +230,7 @@ void TMaster::GetTopologyDone(proto::system::StatusCode _code) {
   if (_code != proto::system::OK) {
     // Without Topology we can't do much
     LOG(ERROR) << "For topology " << tmaster_location_->topology_name()
-               << " Error getting topology Errsettingorcode is " << _code << std::endl;
+               << " Error getting topology. Error code is " << _code << std::endl;
     ::exit(1);
   }
   // Ok things are fine. topology_ contains the result
@@ -241,7 +241,7 @@ void TMaster::GetTopologyDone(proto::system::StatusCode _code) {
     LOG(ERROR) << "Topology invalid" << std::endl;
     ::exit(1);
   }
-  LOG(INFO) << "Topology Read and Validated\n";
+  LOG(INFO) << "Topology read and validated\n";
   // Now see if there is already a pplan
   proto::system::PhysicalPlan* pplan = new proto::system::PhysicalPlan();
   auto cb = [pplan, this](proto::system::StatusCode code) {
@@ -253,23 +253,22 @@ void TMaster::GetTopologyDone(proto::system::StatusCode _code) {
 
 void TMaster::GetPhysicalPlanDone(proto::system::PhysicalPlan* _pplan,
                                   proto::system::StatusCode _code) {
-  // Assignment need not exist. First check if some other
-  // error occured.
+  // Physical plan need not exist. First check if some other error occurred.
   if (_code != proto::system::OK && _code != proto::system::PATH_DOES_NOT_EXIST) {
     // Something bad happened. Bail out!
     // TODO(kramasamy): This is not as bad as it seems. Maybe we can delete this assignment
     // and have a new assignment instead.
     LOG(ERROR) << "For topology " << tmaster_location_->topology_name()
-               << " Error getting assignment Errsettingorcode is " << _code << std::endl;
+               << " Error getting assignment. Error code is " << _code << std::endl;
     ::exit(1);
   }
 
   if (_code == proto::system::PATH_DOES_NOT_EXIST) {
-    LOG(ERROR) << "There was no existing assignment\n";
+    LOG(ERROR) << "There was no existing physical plan\n";
     // We never did assignment in the first place
     delete _pplan;
   } else {
-    LOG(INFO) << "There was an existing assignment\n";
+    LOG(INFO) << "There was an existing physical plan\n";
     CHECK_EQ(_code, proto::system::OK);
     current_pplan_ = _pplan;
     absent_stmgrs_.clear();
@@ -466,7 +465,7 @@ void TMaster::DoPhysicalPlan(EventLoop::Status) {
 void TMaster::SetPhysicalPlanDone(proto::system::PhysicalPlan* _pplan,
                                   proto::system::StatusCode _code) {
   if (_code != proto::system::OK) {
-    LOG(ERROR) << "Error writing assignment to statemgr. Errocode is " << _code << std::endl;
+    LOG(ERROR) << "Error writing assignment to statemgr. Error code is " << _code << std::endl;
     ::exit(1);
   }
 
@@ -491,7 +490,7 @@ void TMaster::SetPhysicalPlanDone(proto::system::PhysicalPlan* _pplan,
 bool TMaster::DistributePhysicalPlan() {
   if (current_pplan_) {
     // First valid the physical plan to distribute
-    LOG(INFO) << "To distribute new pplan:" << std::endl;
+    LOG(INFO) << "To distribute new physical plan:" << std::endl;
     config::PhysicalPlanHelper::LogPhysicalPlan(*current_pplan_);
 
     // Distribute physical plan to all active stmgrs
@@ -502,7 +501,7 @@ bool TMaster::DistributePhysicalPlan() {
     return true;
   }
 
-  LOG(ERROR) << "No valid assignment yet" << std::endl;
+  LOG(ERROR) << "No valid physical plan yet" << std::endl;
   return false;
 }
 
@@ -541,7 +540,7 @@ proto::system::PhysicalPlan* TMaster::MakePhysicalPlan() {
 
   // TMaster does not really have any control over who does what.
   // That has already been decided while launching the jobs.
-  // TMaster just stiches the info together to pass to everyone
+  // TMaster just stitches the info together to pass to everyone
 
   // Build the PhysicalPlan structure
   proto::system::PhysicalPlan* new_pplan = new proto::system::PhysicalPlan();
@@ -564,7 +563,7 @@ proto::system::Status* TMaster::UpdateStMgrHeartbeat(Connection* _conn, sp_int64
   proto::system::Status* retval = new proto::system::Status();
   if (connection_to_stmgr_id_.find(_conn) == connection_to_stmgr_id_.end()) {
     retval->set_status(proto::system::INVALID_STMGR);
-    retval->set_message("Uknown connection doing stmgr heartbeat");
+    retval->set_message("Unknown connection doing stmgr heartbeat");
     return retval;
   }
   const sp_string& stmgr = connection_to_stmgr_id_[_conn];
@@ -640,7 +639,7 @@ bool TMaster::ValidateTopology(proto::api::Topology _topology) {
 
 bool TMaster::ValidateStMgrsWithTopology(proto::api::Topology _topology) {
   // here we check to see if the total number of instances
-  // accross all stmgrs match up to all the spout/bolt
+  // across all stmgrs match up to all the spout/bolt
   // parallelism the topology has specified
   sp_int32 ntasks = 0;
   for (sp_int32 i = 0; i < _topology.spouts_size(); ++i) {

--- a/heron/tmaster/tests/cpp/server/tmaster_unittest.cpp
+++ b/heron/tmaster/tests/cpp/server/tmaster_unittest.cpp
@@ -542,6 +542,8 @@ TEST(StMgr, test_activate_deactivate) {
 
 int main(int argc, char** argv) {
   heron::common::Initialize(argv[0]);
+  std::cout << "Current working directory (to find tmaster logs) "
+      << ProcessUtils::getCurrentWorkingDirectory() << std::endl;
   testing::InitGoogleTest(&argc, argv);
   if (argc > 1) {
     std::cerr << "Using config file " << argv[1] << std::endl;

--- a/heron/tools/common/src/python/access/heron_api.py
+++ b/heron/tools/common/src/python/access/heron_api.py
@@ -43,6 +43,7 @@ JMAP_URL_FMT                = "%s/jmap"               % TOPOLOGIES_URL_FMT
 HISTOGRAM_URL_FMT           = "%s/histo"              % TOPOLOGIES_URL_FMT
 
 FILE_DATA_URL_FMT           = "%s/containerfiledata"  % TOPOLOGIES_URL_FMT
+FILE_DOWNLOAD_URL_FMT       = "%s/containerfiledownload"  % TOPOLOGIES_URL_FMT
 FILESTATS_URL_FMT           = "%s/containerfilestats" % TOPOLOGIES_URL_FMT
 
 capacity = "DIVIDE(" \
@@ -635,6 +636,33 @@ def run_instance_jmap(cluster, environ, topology, instance, role=None):
 
   raise tornado.gen.Return((yield fetch_url_as_json(request_url)))
 
+# Get a url to download a file from the container
+def get_container_file_download_url(cluster, environ, topology, container,
+                                    path, role=None):
+  '''
+  :param cluster:
+  :param environ:
+  :param topology:
+  :param container:
+  :param path:
+  :param role:
+  :return:
+  '''
+  params = dict(
+      cluster=cluster,
+      environ=environ,
+      topology=topology,
+      container=container,
+      path=path)
+  if role is not None:
+    params['role'] = role
+
+  request_url = tornado.httputil.url_concat(
+      create_url(FILE_DOWNLOAD_URL_FMT), params)
+
+  if role is not None:
+    request_url = tornado.httputil.url_concat(request_url, dict(role=role))
+  return request_url
 
 # Get file data from the container
 @tornado.gen.coroutine

--- a/heron/tools/tracker/src/python/config.py
+++ b/heron/tools/tracker/src/python/config.py
@@ -93,6 +93,3 @@ class Config(object):
   def config_str(self, config):
     keys = ("type", "name", "hostport", "rootpath", "tunnelhost")
     return "".join("\t{}: {}\n".format(k, config[k]) for k in keys if k in config).rstrip()
-
-
-

--- a/heron/tools/tracker/src/python/config.py
+++ b/heron/tools/tracker/src/python/config.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ''' config.py '''
-#import os
-#import yaml
 
 from heron.statemgrs.src.python.config import Config as StateMgrConfig
 
@@ -34,17 +32,6 @@ class Config(object):
     self.configs = config
 
     self.load_configs()
-
-#  def parse_config_file(self, conf_file):
-#    """parse config files"""
-#    expanded_conf_file_path = os.path.expanduser(conf_file)
-# assert os.path.lexists(expanded_conf_file_path), "Config file does not exists: %s" % (conf_file)
-#
-#    # Read the configuration file
-#    with open(expanded_conf_file_path, 'r') as f:
-#      self.configs = yaml.load(f)
-#
-#    self.load_configs()
 
   def load_configs(self):
     """load config files"""

--- a/heron/tools/tracker/src/python/config.py
+++ b/heron/tools/tracker/src/python/config.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ''' config.py '''
-import os
-import yaml
+#import os
+#import yaml
 
 from heron.statemgrs.src.python.config import Config as StateMgrConfig
 
@@ -27,23 +27,24 @@ class Config(object):
   exposing various tracker configs.
   """
 
-  def __init__(self, conf_file):
+  def __init__(self, config):
     self.configs = None
     self.statemgr_config = StateMgrConfig()
     self.viz_url_format = None
-
-    self.parse_config_file(conf_file)
-
-  def parse_config_file(self, conf_file):
-    """parse config files"""
-    expanded_conf_file_path = os.path.expanduser(conf_file)
-    assert os.path.lexists(expanded_conf_file_path), "Config file does not exists: %s" % (conf_file)
-
-    # Read the configuration file
-    with open(expanded_conf_file_path, 'r') as f:
-      self.configs = yaml.load(f)
+    self.configs = config
 
     self.load_configs()
+
+#  def parse_config_file(self, conf_file):
+#    """parse config files"""
+#    expanded_conf_file_path = os.path.expanduser(conf_file)
+# assert os.path.lexists(expanded_conf_file_path), "Config file does not exists: %s" % (conf_file)
+#
+#    # Read the configuration file
+#    with open(expanded_conf_file_path, 'r') as f:
+#      self.configs = yaml.load(f)
+#
+#    self.load_configs()
 
   def load_configs(self):
     """load config files"""
@@ -98,3 +99,13 @@ class Config(object):
       formatted_viz_url = formatted_viz_url.replace(key, value)
 
     return formatted_viz_url
+
+  def __str__(self):
+    return "".join((self.config_str(c) for c in self.configs[STATEMGRS_KEY]))
+
+  def config_str(self, config):
+    keys = ("type", "name", "hostport", "rootpath", "tunnelhost")
+    return "".join("\t{}: {}\n".format(k, config[k]) for k in keys if k in config).rstrip()
+
+
+

--- a/heron/tools/tracker/src/python/constants.py
+++ b/heron/tools/tracker/src/python/constants.py
@@ -20,7 +20,10 @@ import heron.tools.common.src.python.utils.config as common_config
 
 # Version Information
 
-API_VERSION = common_config.get_version_number()
+try:
+  API_VERSION = common_config.get_version_number()
+except:
+  API_VERSION = ""
 
 
 # Handler Constants
@@ -64,6 +67,9 @@ HTTP_TIMEOUT = 5 #seconds
 
 # default parameter - port for the tracker to listen on
 DEFAULT_PORT = 8888
+
+# default config file to read
+DEFAULT_CONFIG_FILE = "heron_tracker.yaml"
 
 # default paramater - type of state manaager
 DEFAULT_STATE_MANAGER_TYPE = "file"

--- a/heron/tools/tracker/src/python/constants.py
+++ b/heron/tools/tracker/src/python/constants.py
@@ -65,5 +65,17 @@ HTTP_TIMEOUT = 5 #seconds
 # default parameter - port for the tracker to listen on
 DEFAULT_PORT = 8888
 
-# default config file to read
-DEFAULT_CONFIG_FILE = "heron_tracker.yaml"
+# default paramater - type of state manaager
+DEFAULT_STATE_MANAGER_TYPE = "file"
+
+# default parameter - name to be used for the state manager
+DEFAULT_STATE_MANAGER_NAME = "local"
+
+# default parameter - where all the states are stored
+DEFAULT_STATE_MANAGER_ROOTPATH = "~/.herondata/repository/state/local"
+
+# default parameter - if ssh tunneling needs to be established to connect to it
+DEFAULT_STATE_MANAGER_TUNNELHOST = "localhost"
+
+# default parameter - only used to connect to zk, must be of the form host:port
+DEFAULT_STATE_MANAGER_HOSTPORT = "localhost:2181"

--- a/heron/tools/tracker/src/python/handlers/__init__.py
+++ b/heron/tools/tracker/src/python/handlers/__init__.py
@@ -2,6 +2,7 @@
 from basehandler import BaseHandler
 from clustershandler import ClustersHandler
 from containerfilehandler import ContainerFileDataHandler
+from containerfilehandler import ContainerFileDownloadHandler
 from containerfilehandler import ContainerFileStatsHandler
 from defaulthandler import DefaultHandler
 from exceptionhandler import ExceptionHandler

--- a/heron/tools/tracker/src/python/main.py
+++ b/heron/tools/tracker/src/python/main.py
@@ -21,7 +21,7 @@ import sys
 import tornado.httpserver
 import tornado.ioloop
 import tornado.web
-from tornado.options import define, options
+from tornado.options import define
 from tornado.httpclient import AsyncHTTPClient
 
 import heron.tools.common.src.python.utils.config as common_config
@@ -36,10 +36,9 @@ Log = log.Log
 
 class Application(tornado.web.Application):
   """ Tornado server application """
-  def __init__(self):
+  def __init__(self, config):
 
     AsyncHTTPClient.configure(None, defaults=dict(request_timeout=120.0))
-    config = Config(options.config_file)
     self.tracker = Tracker(config)
     self.tracker.synch_topologies()
     tornadoHandlers = [
@@ -127,13 +126,43 @@ def add_titles(parser):
 
 def add_arguments(parser):
   """ add arguments """
-  default_config_file = os.path.join(
-      utils.get_heron_tracker_conf_dir(), constants.DEFAULT_CONFIG_FILE)
 
   parser.add_argument(
       '--config-file',
-      metavar='(a string; path to config file; default: "' + default_config_file + '")',
-      default=default_config_file)
+      metavar="""(a string; path to config file;)
+      if a config file is provided the following args are ignored:
+      [--type, --name, --rootpath, --tunnelhost, --hostport]
+      """)
+
+  parser.add_argument(
+      '--type',
+      metavar='(an string; type of state manager (zookeeper or file, etc.); default: ' \
+        + str(constants.DEFAULT_STATE_MANAGER_TYPE) + ')',
+      default=constants.DEFAULT_STATE_MANAGER_TYPE,
+      choices=["file", "zookeeper"])
+
+  parser.add_argument(
+      '--name',
+      metavar='(an string; name to be used for the state manager; default: ' \
+        + str(constants.DEFAULT_STATE_MANAGER_NAME) + ')',
+      default=constants.DEFAULT_STATE_MANAGER_NAME)
+
+  parser.add_argument(
+      '--rootpath',
+      metavar='(an string; where all the states are stored; default: ' \
+        + str(constants.DEFAULT_STATE_MANAGER_ROOTPATH) + ')',
+      default=constants.DEFAULT_STATE_MANAGER_ROOTPATH)
+
+  parser.add_argument(
+      '--tunnelhost',
+      metavar='(an string; if ssh tunneling needs to be established to connect to it; default: ' \
+        + str(constants.DEFAULT_STATE_MANAGER_TUNNELHOST) + ')',
+      default=constants.DEFAULT_STATE_MANAGER_TUNNELHOST)
+
+  parser.add_argument(
+      '--hostport',
+      metavar='(an string; only used to connect to zk, must be of the form \'host:port\';'\
+      ' default: ' + str(constants.DEFAULT_STATE_MANAGER_HOSTPORT) + ')')
 
   parser.add_argument(
       '--port',
@@ -184,6 +213,23 @@ def define_options(port, config_file):
   define("port", default=port)
   define("config_file", default=config_file)
 
+
+def create_tracker_config(namespace):
+  if namespace["config_file"]:
+    config = utils.parse_config_file(namespace["config_file"])
+    Log.info("Parsed config: %s", str(config))
+    return config
+  else:
+    config = dict(
+        type=namespace["type"],
+        name=namespace["name"],
+        rootpath=namespace["rootpath"],
+        tunnelhost=namespace["tunnelhost"])
+    if namespace["hostport"]:
+      config["hostport"] = namespace["hostport"]
+
+    return dict(statemgrs=[config])
+
 def main():
   """ main """
   # create the parser and parse the arguments
@@ -209,8 +255,10 @@ def main():
   # set Tornado global option
   define_options(namespace['port'], namespace['config_file'])
 
+  config = Config(create_tracker_config(namespace))
+
   # create Tornado application
-  application = Application()
+  application = Application(config)
 
   # pylint: disable=unused-argument
   # SIGINT handler:
@@ -227,7 +275,9 @@ def main():
   signal.signal(signal.SIGTERM, signal_handler)
 
   Log.info("Running on port: %d", namespace['port'])
-  Log.info("Using config file: %s", namespace['config_file'])
+  if namespace["config_file"]:
+    Log.info("Using config file: %s", namespace['config_file'])
+  Log.info("Using state manager:\n" + str(config))
 
   http_server = tornado.httpserver.HTTPServer(application)
   http_server.listen(namespace['port'])

--- a/heron/tools/tracker/src/python/main.py
+++ b/heron/tools/tracker/src/python/main.py
@@ -217,7 +217,6 @@ def define_options(port, config_file):
 def create_tracker_config(namespace):
   if namespace["config_file"]:
     config = utils.parse_config_file(namespace["config_file"])
-    Log.info("Parsed config: %s", str(config))
     return config
   else:
     config = dict(

--- a/heron/tools/tracker/src/python/main.py
+++ b/heron/tools/tracker/src/python/main.py
@@ -51,6 +51,8 @@ class Application(tornado.web.Application):
         (r"/topologies/logicalplan", handlers.LogicalPlanHandler, {"tracker":self.tracker}),
         (r"/topologies/containerfiledata", handlers.ContainerFileDataHandler,
          {"tracker":self.tracker}),
+        (r"/topologies/containerfiledownload", handlers.ContainerFileDownloadHandler,
+         {"tracker":self.tracker}),
         (r"/topologies/containerfilestats",
          handlers.ContainerFileStatsHandler, {"tracker":self.tracker}),
         (r"/topologies/physicalplan", handlers.PhysicalPlanHandler, {"tracker":self.tracker}),

--- a/heron/tools/tracker/src/python/utils.py
+++ b/heron/tools/tracker/src/python/utils.py
@@ -20,6 +20,7 @@ import os
 import string
 import sys
 import subprocess
+import yaml
 
 # directories for heron tools distribution
 BIN_DIR = "bin"
@@ -150,10 +151,15 @@ def get_heron_tracker_conf_dir():
   conf_path = os.path.join(get_heron_tracker_dir(), CONF_DIR)
   return conf_path
 
-# def get_heron_tracker_lib_dir():
-#   """
-#   This will provide heron tracker lib directory from .pex file.
-#   :return: absolute path of heron lib directory
-#   """
-#   lib_path = os.path.join(get_heron_tools_dir(), LIB_DIR)
-#   return lib_path
+
+def parse_config_file(config_file):
+  expanded_config_file_path = os.path.expanduser(config_file)
+  assert os.path.lexists(expanded_config_file_path), \
+    "Config file does not exists: %s" % (config_file)
+
+  configs = {}
+  # Read the configuration file
+  with open(expanded_config_file_path, 'r') as f:
+    configs = yaml.load(f)
+
+  return configs

--- a/heron/tools/tracker/src/python/utils.py
+++ b/heron/tools/tracker/src/python/utils.py
@@ -151,11 +151,14 @@ def get_heron_tracker_conf_dir():
   conf_path = os.path.join(get_heron_tracker_dir(), CONF_DIR)
   return conf_path
 
-
 def parse_config_file(config_file):
+  """
+  This will parse the config file for the tracker
+  :return: the config or None if the file is not found
+  """
   expanded_config_file_path = os.path.expanduser(config_file)
-  assert os.path.lexists(expanded_config_file_path), \
-    "Config file does not exists: %s" % (config_file)
+  if not os.path.lexists(expanded_config_file_path):
+    return None
 
   configs = {}
   # Read the configuration file

--- a/heron/tools/ui/src/python/handlers/topology.py
+++ b/heron/tools/ui/src/python/handlers/topology.py
@@ -254,6 +254,8 @@ class ContainerFileDownloadHandler(base.BaseHandler):
   """
   Responsible for downloading the file from a container.
   """
+  def initialize(self, baseUrl):
+    self.baseUrl = baseUrl
 
   @tornado.gen.coroutine
   def get(self, cluster, environ, topology, container):

--- a/heron/tools/ui/src/python/handlers/topology.py
+++ b/heron/tools/ui/src/python/handlers/topology.py
@@ -260,9 +260,6 @@ class ContainerFileDownloadHandler(base.BaseHandler):
   def initialize(self, baseUrl):
     self.baseUrl = baseUrl
 
-  def initialize(self, baseUrl):
-    self.baseUrl = baseUrl
-
   @tornado.gen.coroutine
   def get(self, cluster, environ, topology, container):
     '''

--- a/website/content/docs/operators/heron-tracker.md
+++ b/website/content/docs/operators/heron-tracker.md
@@ -100,11 +100,17 @@ dashboards with topology UI page.
 ### Heron Tracker Args
 
 * `--port` - Port to run the heron-tracker on. Default port is `8888`.
-* `--config-file` - The location of the config file for tracker. Default config
-  file is `~/.herontools/conf/heron_tracker.yaml`.
+* `--config-file` - The location of the config file for tracker.  
+* `--type` (an string; type of state manager (zookeeper or file, etc.); default: file)
+* `--name` (an string; name to be used for the state manager; default: local)
+* `--rootpath` (an string; where all the states are stored; default: ~/.herondata/repository/state/local)
+* `--tunnelhost` (an string; if ssh tunneling needs to be established to connect to it; default: localhost)
+* `--hostport` (an string; only used to connect to zk, must be of the form 'host:port'; default: localhost:2181)
+
+**Note:** If a config file is provided the following args are ignored; --type, --name, --rootpath, --tunnelhost, --hostport
 
 ```bash
 $ heron-tracker
 # is equivalent to
-$ heron-ui --port=8888 --config-file=~/.herontools/conf/heron_tracker.yaml
+$ heron-ui --port=8888 --type=file --name=local --rootpath=~/.herondata/repository/state/local
 ```


### PR DESCRIPTION
To make deploying easier in a container environment make the config file
optional and allow the traker to be started with command line args.

Args added:
--type; state manager type
--name; state manager name
--rootpath; where state manager data is stored
--hostport; for zookeeper state managers
--tunnelhost; if ssh tunneling is needed