### PR TITLE
Allow the tracker to take command line args for a state manager.

### DIFF
--- a/heron/tools/tracker/src/python/config.py
+++ b/heron/tools/tracker/src/python/config.py
@@ -98,3 +98,10 @@ class Config(object):
       formatted_viz_url = formatted_viz_url.replace(key, value)
 
     return formatted_viz_url
+
+  def __str__(self):
+    return "".join((self.config_str(c) for c in self.configs[STATEMGRS_KEY]))
+
+  def config_str(self, config):
+    keys = ("type", "name", "hostport", "rootpath", "tunnelhost")
+    return "".join("\t{}: {}\n".format(k, config[k]) for k in keys if k in config).rstrip()

--- a/heron/tools/tracker/src/python/config.py
+++ b/heron/tools/tracker/src/python/config.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ''' config.py '''
-import os
-import yaml
 
 from heron.statemgrs.src.python.config import Config as StateMgrConfig
 
@@ -27,21 +25,10 @@ class Config(object):
   exposing various tracker configs.
   """
 
-  def __init__(self, conf_file):
-    self.configs = None
+  def __init__(self, configs):
+    self.configs = configs
     self.statemgr_config = StateMgrConfig()
     self.viz_url_format = None
-
-    self.parse_config_file(conf_file)
-
-  def parse_config_file(self, conf_file):
-    """parse config files"""
-    expanded_conf_file_path = os.path.expanduser(conf_file)
-    assert os.path.lexists(expanded_conf_file_path), "Config file does not exists: %s" % (conf_file)
-
-    # Read the configuration file
-    with open(expanded_conf_file_path, 'r') as f:
-      self.configs = yaml.load(f)
 
     self.load_configs()
 

--- a/heron/tools/tracker/src/python/constants.py
+++ b/heron/tools/tracker/src/python/constants.py
@@ -23,6 +23,7 @@ import heron.tools.common.src.python.utils.config as common_config
 API_VERSION = common_config.get_version_number()
 
 
+
 # Handler Constants
 
 # Parameter Names
@@ -67,3 +68,18 @@ DEFAULT_PORT = 8888
 
 # default config file to read
 DEFAULT_CONFIG_FILE = "heron_tracker.yaml"
+
+# default paramater - type of state manaager
+DEFAULT_STATE_MANAGER_TYPE = "file"
+
+# default parameter - name to be used for the state manager
+DEFAULT_STATE_MANAGER_NAME = "local"
+
+# default parameter - where all the states are stored
+DEFAULT_STATE_MANAGER_ROOTPATH = "~/.herondata/repository/state/local"
+
+# default parameter - if ssh tunneling needs to be established to connect to it
+DEFAULT_STATE_MANAGER_TUNNELHOST = "localhost"
+
+# default parameter - only used to connect to zk, must be of the form host:port
+DEFAULT_STATE_MANAGER_HOSTPORT = "localhost:2181"

--- a/heron/tools/tracker/src/python/constants.py
+++ b/heron/tools/tracker/src/python/constants.py
@@ -20,7 +20,10 @@ import heron.tools.common.src.python.utils.config as common_config
 
 # Version Information
 
-API_VERSION = common_config.get_version_number()
+try:
+  API_VERSION = common_config.get_version_number()
+except:
+  API_VERSION = ""
 
 
 

--- a/heron/tools/tracker/src/python/main.py
+++ b/heron/tools/tracker/src/python/main.py
@@ -29,7 +29,7 @@ import heron.common.src.python.utils.log as log
 from heron.tools.tracker.src.python import constants
 from heron.tools.tracker.src.python import handlers
 from heron.tools.tracker.src.python import utils
-from heron.tools.tracker.src.python.config import Config
+from heron.tools.tracker.src.python.config import Config, STATEMGRS_KEY
 from heron.tools.tracker.src.python.tracker import Tracker
 
 Log = log.Log
@@ -136,6 +136,32 @@ def add_arguments(parser):
       default=default_config_file)
 
   parser.add_argument(
+      '--type',
+      metavar='(an string; type of state manager (zookeeper or file, etc.); example: ' \
+        + str(constants.DEFAULT_STATE_MANAGER_TYPE) + ')',
+      choices=["file", "zookeeper"])
+
+  parser.add_argument(
+      '--name',
+      metavar='(an string; name to be used for the state manager; example: ' \
+        + str(constants.DEFAULT_STATE_MANAGER_NAME) + ')')
+
+  parser.add_argument(
+      '--rootpath',
+      metavar='(an string; where all the states are stored; example: ' \
+        + str(constants.DEFAULT_STATE_MANAGER_ROOTPATH) + ')')
+
+  parser.add_argument(
+      '--tunnelhost',
+      metavar='(an string; if ssh tunneling needs to be established to connect to it; example: ' \
+        + str(constants.DEFAULT_STATE_MANAGER_TUNNELHOST) + ')')
+
+  parser.add_argument(
+      '--hostport',
+      metavar='(an string; only used to connect to zk, must be of the form \'host:port\';'\
+      ' example: ' + str(constants.DEFAULT_STATE_MANAGER_HOSTPORT) + ')')
+
+  parser.add_argument(
       '--port',
       metavar='(an integer; port to listen; default: ' + str(constants.DEFAULT_PORT) + ')',
       type=int,
@@ -184,6 +210,27 @@ def define_options(port, config_file):
   define("port", default=port)
   define("config_file", default=config_file)
 
+<<<<<<< HEAD
+=======
+def create_tracker_config(namespace):
+  # try to parse the config file if we find one
+  config_file = namespace["config_file"]
+  config = utils.parse_config_file(config_file)
+  if config is None:
+    Log.debug("Config file does not exists: %s" % config_file)
+    config = {STATEMGRS_KEY:[{}]}
+
+  # update the config if we have any flags
+  config_flags = ["type", "name", "rootpath", "tunnelhost", "hostport"]
+  config_to_update = config[STATEMGRS_KEY][0]
+  for flag in config_flags:
+    value = namespace.get(flag, None)
+    if value is not None:
+      config_to_update[flag] = value
+
+  return config
+
+>>>>>>> c2369777a... Try to read the config first before setting command line args.
 def main():
   """ main """
   # create the parser and parse the arguments

--- a/heron/tools/tracker/src/python/utils.py
+++ b/heron/tools/tracker/src/python/utils.py
@@ -150,10 +150,18 @@ def get_heron_tracker_conf_dir():
   conf_path = os.path.join(get_heron_tracker_dir(), CONF_DIR)
   return conf_path
 
-# def get_heron_tracker_lib_dir():
-#   """
-#   This will provide heron tracker lib directory from .pex file.
-#   :return: absolute path of heron lib directory
-#   """
-#   lib_path = os.path.join(get_heron_tools_dir(), LIB_DIR)
-#   return lib_path
+def parse_config_file(config_file):
+  """
+  This will parse the config file for the tracker
+  :return: the config or None if the file is not found
+  """
+  expanded_config_file_path = os.path.expanduser(config_file)
+  if not os.path.lexists(expanded_config_file_path):
+    return None
+
+  configs = {}
+  # Read the configuration file
+  with open(expanded_config_file_path, 'r') as f:
+    configs = yaml.load(f)
+
+  return configs

--- a/heron/tools/tracker/src/python/utils.py
+++ b/heron/tools/tracker/src/python/utils.py
@@ -20,6 +20,7 @@ import os
 import string
 import sys
 import subprocess
+import yaml
 
 # directories for heron tools distribution
 BIN_DIR = "bin"


### PR DESCRIPTION
To make deploying easier in a container environment make the config file
optional and allow the traker to be started with command line args.

Args added:
--type; state manager type
--name; state manager name
--rootpath; where state manager data is stored
--hostport; for zookeeper state managers
--tunnelhost; if ssh tunneling is needed