### PR TITLE
Fix inaccurate execute-latency metric

### DIFF
--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
@@ -192,9 +192,8 @@ public class BoltInstance implements IInstance {
       int nValues = topologyContext.getComponentOutputFields(
           stream.getComponentName(), stream.getId()).size();
 
-      // Record current time at the start of processing a set of tuples
-      long currentTime = System.nanoTime();
       for (HeronTuples.HeronDataTuple dataTuple : tuples.getData().getTuplesList()) {
+        long startExecuteTuple = System.nanoTime();
         // Create the value list and fill the value
         List<Object> values = new ArrayList<>(nValues);
         for (int i = 0; i < nValues; i++) {
@@ -203,16 +202,15 @@ public class BoltInstance implements IInstance {
 
         // Decode the tuple
         TupleImpl t = new TupleImpl(topologyContext, stream, dataTuple.getKey(),
-            dataTuple.getRootsList(), values, currentTime, false);
+            dataTuple.getRootsList(), values, startExecuteTuple, false);
 
         // Delegate to the use defined bolt
         bolt.execute(t);
 
-        // Swap
-        long startTime = currentTime;
-        currentTime = System.nanoTime();
+        // record the end of a tuple execution
+        long endExecuteTuple = System.nanoTime();
 
-        long executeLatency = currentTime - startTime;
+        long executeLatency = endExecuteTuple - startExecuteTuple;
 
         // Invoke user-defined execute task hook
         topologyContext.invokeHookBoltExecute(t, Duration.ofNanos(executeLatency));
@@ -222,6 +220,7 @@ public class BoltInstance implements IInstance {
       }
 
       // To avoid spending too much time
+      long currentTime = System.nanoTime();
       if (currentTime - startOfCycle - instanceExecuteBatchTime.toNanos() > 0) {
         break;
       }

--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
@@ -177,7 +177,6 @@ public class BoltInstance implements IInstance {
     TopologyContextImpl topologyContext = helper.getTopologyContext();
     Duration instanceExecuteBatchTime = systemConfig.getInstanceExecuteBatchTime();
 
-    long startOfCycle = System.nanoTime();
     // Read data from in Queues
     while (!inQueue.isEmpty()) {
       HeronTuples.HeronTupleSet tuples = inQueue.poll();
@@ -193,6 +192,8 @@ public class BoltInstance implements IInstance {
           stream.getComponentName(), stream.getId()).size();
 
       // We would reuse the System.nanoTime()
+      long startOfCycle = System.nanoTime();
+
       long currentTime = startOfCycle;
       for (HeronTuples.HeronDataTuple dataTuple : tuples.getData().getTuplesList()) {
         // Create the value list and fill the value

--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
@@ -177,6 +177,7 @@ public class BoltInstance implements IInstance {
     TopologyContextImpl topologyContext = helper.getTopologyContext();
     Duration instanceExecuteBatchTime = systemConfig.getInstanceExecuteBatchTime();
 
+    long startOfCycle = System.nanoTime();
     // Read data from in Queues
     while (!inQueue.isEmpty()) {
       HeronTuples.HeronTupleSet tuples = inQueue.poll();
@@ -191,10 +192,8 @@ public class BoltInstance implements IInstance {
       int nValues = topologyContext.getComponentOutputFields(
           stream.getComponentName(), stream.getId()).size();
 
-      // We would reuse the System.nanoTime()
-      long startOfCycle = System.nanoTime();
-
-      long currentTime = startOfCycle;
+      // Record current time at the start of processing a set of tuples
+      long currentTime = System.nanoTime();
       for (HeronTuples.HeronDataTuple dataTuple : tuples.getData().getTuplesList()) {
         // Create the value list and fill the value
         List<Object> values = new ArrayList<>(nValues);


### PR DESCRIPTION
Currently in bolt instance, we would use an inaccurate start of time, causing the execute-latency higher than expected, especially when the actual execute-latency is small. For instance, the time spent in execute() could be 200+s in a minute. This is also an issue reported from Twitter internally.

This pull request fixes this issue by recording a more accurate start of time.