### PR TITLE
Add GcsUploader for uploading topologies to Google Cloud Storage.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -336,3 +336,30 @@ maven_jar(
   name = "com_101tec_zkclient",
   artifact = "com.101tec:zkclient:0.3"
 )
+
+# Google Cloud
+maven_jar(
+  name = "google_api_services_storage",
+  artifact = "com.google.apis:google-api-services-storage:v1-rev108-1.22.0"
+)
+
+maven_jar(
+  name = "google_api_client",
+  artifact = "com.google.api-client:google-api-client:1.22.0"
+)
+
+maven_jar(
+  name = "google_http_client",
+  artifact = "com.google.http-client:google-http-client:1.22.0"
+)
+
+maven_jar(
+  name = "google_http_client_jackson2",
+  artifact = "com.google.http-client:google-http-client-jackson2:1.22.0"
+)
+
+maven_jar(
+  name = "google_oauth_client",
+  artifact = "com.google.oauth-client:google-oauth-client:1.22.0"
+)
+# end Google Cloud

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,7 @@
 # versions shared across artifacts that should be upgraded together
 aws_version = "1.11.58"
 curator_version = "2.9.0"
+google_client_version = "1.22.0"
 jackson_version = "2.6.6"
 powermock_version = "1.6.2"
 reef_version = "0.14.0"
@@ -340,26 +341,26 @@ maven_jar(
 # Google Cloud
 maven_jar(
   name = "google_api_services_storage",
-  artifact = "com.google.apis:google-api-services-storage:v1-rev108-1.22.0"
+  artifact = "com.google.apis:google-api-services-storage:v1-rev108-" + google_client_version
 )
 
 maven_jar(
   name = "google_api_client",
-  artifact = "com.google.api-client:google-api-client:1.22.0"
+  artifact = "com.google.api-client:google-api-client:" + google_client_version
 )
 
 maven_jar(
   name = "google_http_client",
-  artifact = "com.google.http-client:google-http-client:1.22.0"
+  artifact = "com.google.http-client:google-http-client:" + google_client_version
 )
 
 maven_jar(
   name = "google_http_client_jackson2",
-  artifact = "com.google.http-client:google-http-client-jackson2:1.22.0"
+  artifact = "com.google.http-client:google-http-client-jackson2:" + google_client_version
 )
 
 maven_jar(
   name = "google_oauth_client",
-  artifact = "com.google.oauth-client:google-oauth-client:1.22.0"
+  artifact = "com.google.oauth-client:google-oauth-client:" + google_client_version
 )
 # end Google Cloud

--- a/heron/uploaders/src/java/BUILD
+++ b/heron/uploaders/src/java/BUILD
@@ -14,6 +14,12 @@ s3_deps_files = \
         "//third_party/java:guava",
     ]
 
+gcs_deps_files = \
+    uploader_spi_files + [
+        "//third_party/java:google-api-services-storage",
+        "//third_party/java:guava",
+    ]
+
 java_library(
     name = 'null-uploader-java',
     srcs = glob(["**/NullUploader.java"]),
@@ -104,5 +110,23 @@ genrule(
     name = "heron-scp-uploader",
     srcs = [":scp-uploader-unshaded_deploy.jar"],
     outs = ["heron-scp-uploader.jar"],
+    cmd  = "cp $< $@",
+)
+
+java_library(
+    name = 'gcs-uploader-java',
+    srcs = glob(["**/gcs/**/*.java"]),
+    deps = gcs_deps_files,
+)
+
+java_binary(
+    name = 'gcs-uploader-unshaded',
+    srcs = glob(["**/gcs/**/*.java"]),
+    deps = gcs_deps_files)
+
+genrule(
+    name = "heron-gcs-uploader",
+    srcs = [":gcs-uploader-unshaded_deploy.jar"],
+    outs = ["heron-gcs-uploader.jar"],
     cmd  = "cp $< $@",
 )

--- a/heron/uploaders/src/java/com/twitter/heron/uploader/gcs/GcsContext.java
+++ b/heron/uploaders/src/java/com/twitter/heron/uploader/gcs/GcsContext.java
@@ -1,0 +1,33 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.uploader.gcs;
+
+import com.twitter.heron.spi.common.Config;
+import com.twitter.heron.spi.common.Context;
+
+public class GcsContext extends Context {
+
+  static final String HERON_UPLOADER_GCS_CREDENTIALS_PATH =
+      "heron.uploader.gcs.credentials_path";
+
+  static final String HERON_UPLOADER_GCS_BUCKET = "heron.uploader.gcs.bucket";
+
+  static String getBucket(Config configuration) {
+    return configuration.getStringValue(HERON_UPLOADER_GCS_BUCKET);
+  }
+
+  static String getCredentialsPath(Config configuration) {
+    return configuration.getStringValue(HERON_UPLOADER_GCS_CREDENTIALS_PATH);
+  }
+}

--- a/heron/uploaders/src/java/com/twitter/heron/uploader/gcs/GcsContext.java
+++ b/heron/uploaders/src/java/com/twitter/heron/uploader/gcs/GcsContext.java
@@ -17,10 +17,8 @@ import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Context;
 
 public class GcsContext extends Context {
-
   static final String HERON_UPLOADER_GCS_CREDENTIALS_PATH =
       "heron.uploader.gcs.credentials_path";
-
   static final String HERON_UPLOADER_GCS_BUCKET = "heron.uploader.gcs.bucket";
 
   static String getBucket(Config configuration) {

--- a/heron/uploaders/src/java/com/twitter/heron/uploader/gcs/GcsController.java
+++ b/heron/uploaders/src/java/com/twitter/heron/uploader/gcs/GcsController.java
@@ -1,0 +1,76 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.uploader.gcs;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import com.google.api.client.http.InputStreamContent;
+import com.google.api.services.storage.Storage;
+import com.google.api.services.storage.model.StorageObject;
+
+
+public class GcsController {
+
+  private static final String MIME_TYPE = "application/x-gzip";
+
+  private static final String DEFAULT_PREDEFINED_ACL = "publicRead";
+
+  private final Storage storage;
+  private final String bucket;
+
+  GcsController(Storage storage, String bucket) {
+    this.storage = storage;
+    this.bucket = bucket;
+  }
+
+  StorageObject createObject(String objectName, File file) throws IOException {
+    final InputStreamContent content =
+        new InputStreamContent(MIME_TYPE, new FileInputStream(file));
+    final Storage.Objects.Insert insertObject =
+        storage.objects()
+            .insert(bucket, null, content)
+            .setName(objectName)
+            .setPredefinedAcl(DEFAULT_PREDEFINED_ACL);
+
+    // The media uploader gzips content by default, and alters the Content-Encoding accordingly.
+    // GCS dutifully stores content as-uploaded. This line disables the media uploader behavior,
+    // so the service stores exactly what is in the InputStream, without transformation.
+    insertObject.getMediaHttpUploader().setDisableGZipContent(true);
+    return insertObject.execute();
+  }
+
+  StorageObject getObject(String name) {
+    try {
+      return storage.objects().get(bucket, name).execute();
+    } catch (IOException e) {
+      // ignored
+    }
+    return null;
+  }
+
+  void copyObject(String sourceObject, String destinationObject,
+                  StorageObject content) throws IOException {
+    storage.objects().copy(bucket, sourceObject, bucket, destinationObject, content).execute();
+  }
+
+  void deleteObject(String objectName) throws IOException {
+    storage.objects().delete(bucket, objectName).execute();
+  }
+
+  static GcsController create(Storage storage, String bucket) {
+    return new GcsController(storage, bucket);
+  }
+}

--- a/heron/uploaders/src/java/com/twitter/heron/uploader/gcs/GcsController.java
+++ b/heron/uploaders/src/java/com/twitter/heron/uploader/gcs/GcsController.java
@@ -21,11 +21,8 @@ import com.google.api.client.http.InputStreamContent;
 import com.google.api.services.storage.Storage;
 import com.google.api.services.storage.model.StorageObject;
 
-
 public class GcsController {
-
   private static final String MIME_TYPE = "application/x-gzip";
-
   private static final String DEFAULT_PREDEFINED_ACL = "publicRead";
 
   private final Storage storage;
@@ -36,38 +33,40 @@ public class GcsController {
     this.bucket = bucket;
   }
 
-  StorageObject createObject(String objectName, File file) throws IOException {
+  StorageObject createStorageObject(String storageObjectName, File file) throws IOException {
     final InputStreamContent content =
         new InputStreamContent(MIME_TYPE, new FileInputStream(file));
-    final Storage.Objects.Insert insertObject =
+    final Storage.Objects.Insert insertStorageObject =
         storage.objects()
             .insert(bucket, null, content)
-            .setName(objectName)
+            .setName(storageObjectName)
             .setPredefinedAcl(DEFAULT_PREDEFINED_ACL);
 
     // The media uploader gzips content by default, and alters the Content-Encoding accordingly.
     // GCS dutifully stores content as-uploaded. This line disables the media uploader behavior,
     // so the service stores exactly what is in the InputStream, without transformation.
-    insertObject.getMediaHttpUploader().setDisableGZipContent(true);
-    return insertObject.execute();
+    insertStorageObject.getMediaHttpUploader().setDisableGZipContent(true);
+    return insertStorageObject.execute();
   }
 
-  StorageObject getObject(String name) {
+  StorageObject getStorageObject(String storageObjectName) {
     try {
-      return storage.objects().get(bucket, name).execute();
+      return storage.objects().get(bucket, storageObjectName).execute();
     } catch (IOException e) {
       // ignored
     }
     return null;
   }
 
-  void copyObject(String sourceObject, String destinationObject,
-                  StorageObject content) throws IOException {
-    storage.objects().copy(bucket, sourceObject, bucket, destinationObject, content).execute();
+  void copyStorageObject(String sourceStorageObjectName, String destinationStorageObjectName,
+                  StorageObject storageObject) throws IOException {
+    storage.objects()
+        .copy(bucket, sourceStorageObjectName, bucket, destinationStorageObjectName, storageObject)
+        .execute();
   }
 
-  void deleteObject(String objectName) throws IOException {
-    storage.objects().delete(bucket, objectName).execute();
+  void deleteStorageObject(String storageObjectName) throws IOException {
+    storage.objects().delete(bucket, storageObjectName).execute();
   }
 
   static GcsController create(Storage storage, String bucket) {

--- a/heron/uploaders/src/java/com/twitter/heron/uploader/gcs/GcsUploader.java
+++ b/heron/uploaders/src/java/com/twitter/heron/uploader/gcs/GcsUploader.java
@@ -1,0 +1,225 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.uploader.gcs;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.GeneralSecurityException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.storage.Storage;
+import com.google.api.services.storage.StorageScopes;
+import com.google.api.services.storage.model.StorageObject;
+import com.google.common.base.Strings;
+
+import com.twitter.heron.spi.common.Config;
+import com.twitter.heron.spi.common.Context;
+import com.twitter.heron.spi.uploader.IUploader;
+import com.twitter.heron.spi.uploader.UploaderException;
+
+/**
+ * Provides a basic uploader class for uploading topology packages to Google Cloud Storage (gcs).
+ * <p>
+ * This uploader will write topology packages to
+ * https://storage.googleapis.com/<bucket>/<topologyName>/topology.tar.gz
+ * This provides a known package destination location which can be used to download
+ * the topology package in order to run the topology.
+ *
+ * Clients must have write access to the bucket in order to upload topologies. Authentication
+ * can be provided by providing a path the service credentials files or logging in
+ * through the gcloud client.
+ * https://cloud.google.com/storage/docs/authentication
+ *
+ * <p>
+ * This class also handles the undo action by copying any existing topology.tar.gz package found
+ * in the folder to previous-topology.tar.gz. In the event that the deploy fails and
+ * the undo action is triggered the previous-topology.tar.gz file will be renamed
+ * to topology.tar.gz effectively rolling back the live code. In the event that the deploy is
+ * successful the previous-topology.tar.gz package will be deleted as it is no longer needed.
+ * <p>
+ * The config values for this uploader are:
+ * heron.class.uploader (required) com.twitter.heron.uploader.gcs.GcsUploader
+ * heron.uploader.gcs.bucket (required) The bucket that you have write access to where you want the topology packages to be stored
+ * heron.uploader.gcs.credentials_path (optional) Google Services Account Credentials to use
+ */
+public class GcsUploader implements IUploader {
+  private static final Logger LOG = Logger.getLogger(GcsUploader.class.getName());
+
+  private static final String BACKUP_PREFIX = "previous-";
+
+  private static final String GCS_URL_FORMAT = "https://storage.googleapis.com/%s/%s";
+
+  private GcsController gcsController;
+  private String bucket;
+  private File topologyPackageFile;
+  private String topologyObjectName;
+
+  // Stores the path to the backup version of the topology in case the deploy fails and
+  // it needs to be undone. This is the same as the existing path but prepended with `previous-`.
+  // This serves as a simple backup incase we need to revert.
+  private String previousTopologyObjectName;
+
+  @Override
+  public void initialize(Config config) {
+    bucket = GcsContext.getBucket(config);
+
+    if (Strings.isNullOrEmpty(bucket)) {
+      throw new RuntimeException("Missing heron.uploader.gcs.bucket config value");
+    }
+
+    // get the topology package location
+    final String topologyPackageLocation = Context.topologyPackageFile(config);
+    final String topologyName = Context.topologyName(config);
+
+    topologyPackageFile = new File(topologyPackageLocation);
+    final String topologyFilename = topologyPackageFile.getName();
+    topologyObjectName = generateStorageObjectName(topologyName, topologyFilename);
+    previousTopologyObjectName =
+        generateStorageObjectName(topologyName, BACKUP_PREFIX + topologyFilename);
+
+    gcsController = createGcsController(config, bucket);
+  }
+
+  @Override
+  public URI uploadPackage() throws UploaderException {
+    // Backup any existing files incase we need to undo this action
+    final StorageObject previousStorageObject = gcsController.getObject(topologyObjectName);
+    if (previousStorageObject != null) {
+      try {
+        gcsController.copyObject(topologyObjectName, previousTopologyObjectName,
+            previousStorageObject);
+      } catch (IOException ioe) {
+        throw new UploaderException("Failed to back up previous topology version", ioe);
+      }
+    }
+
+    final StorageObject storageObject;
+    try {
+      storageObject = gcsController.createObject(topologyObjectName, topologyPackageFile);
+    } catch (IOException ioe) {
+      throw new UploaderException(
+          String.format("Error writing topology package to %s %s",
+              bucket, topologyObjectName), ioe);
+    }
+
+    final String downloadUrl = getDownloadUrl(bucket, storageObject.getName());
+    LOG.info("Package URL: " + downloadUrl);
+    try {
+      return new URI(downloadUrl);
+    } catch (URISyntaxException e) {
+      throw new UploaderException(
+          String.format("Could not convert URL %s to URI", downloadUrl), e);
+    }
+  }
+
+  @Override
+  public boolean undo() {
+    // Try to get the previous version. This will be null on the first deploy.
+    final StorageObject previousObject = gcsController.getObject(previousTopologyObjectName);
+    if (previousObject != null) {
+      try {
+        gcsController.copyObject(previousTopologyObjectName, topologyObjectName, previousObject);
+      } catch (IOException ioe) {
+        LOG.log(Level.SEVERE, "Reverting to previous topology version failed", ioe);
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @Override
+  public void close() {
+    if (!Strings.isNullOrEmpty(previousTopologyObjectName)) {
+      try {
+        gcsController.deleteObject(previousTopologyObjectName);
+      } catch (IOException ioe) {
+        LOG.info("Failed to delete previous topology " + previousTopologyObjectName);
+      }
+    }
+  }
+
+  GcsController createGcsController(Config configuration, String storageBucket) {
+    final Credential credential;
+    try {
+      credential = createCredentials(configuration);
+    } catch (IOException ioe) {
+      throw new RuntimeException("Unable to create credentials", ioe);
+    }
+
+    final Storage storage;
+    try {
+      storage = createStorage(credential);
+    } catch (IOException ioe) {
+      throw new RuntimeException("Unable to create google cloud storage client", ioe);
+    } catch (GeneralSecurityException gse) {
+      throw new RuntimeException("Unable to create google cloud storage client", gse);
+    }
+
+    return GcsController.create(storage, storageBucket);
+  }
+
+  private Credential createCredentials(Config configuration) throws IOException {
+    final String credentialsPath = GcsContext.getCredentialsPath(configuration);
+    if (!Strings.isNullOrEmpty(credentialsPath)) {
+      LOG.info("Using credentials from file: " + credentialsPath);
+      return GoogleCredential
+          .fromStream(new FileInputStream(credentialsPath))
+          .createScoped(StorageScopes.all());
+    }
+
+    // if a credentials path is not provided try using the application default one.
+    LOG.info("Using default application credentials");
+    return GoogleCredential.getApplicationDefault().createScoped(StorageScopes.all());
+  }
+
+  private Storage createStorage(Credential credential)
+      throws GeneralSecurityException, IOException {
+    final HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
+    final JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
+    return new Storage.Builder(httpTransport, jsonFactory, credential).build();
+  }
+
+  /**
+   * Generate the storage object name in gcs given the topologyName and filename.
+   *
+   * @param topologyName the name of the topology
+   * @param filename the name of the file to upload to gcs
+   * @return the name of the object.
+   */
+  private static String generateStorageObjectName(String topologyName, String filename) {
+    return String.format("%s/%s", topologyName, filename);
+  }
+
+  /**
+   * Returns a url to download an gcs object the given bucket and object name
+   *
+   * @param bucket the name of the bucket
+   * @param objectName the name of the object
+   * @return a url to download the object
+   */
+  static String getDownloadUrl(String bucket, String objectName) {
+    return String.format(GCS_URL_FORMAT, bucket, objectName);
+  }
+}

--- a/heron/uploaders/src/java/com/twitter/heron/uploader/gcs/GcsUploader.java
+++ b/heron/uploaders/src/java/com/twitter/heron/uploader/gcs/GcsUploader.java
@@ -42,7 +42,7 @@ import com.twitter.heron.spi.uploader.UploaderException;
  * Provides a basic uploader class for uploading topology packages to Google Cloud Storage (gcs).
  * <p>
  * This uploader will write topology packages to
- * https://storage.googleapis.com/<bucket>/<topologyName>/topology.tar.gz
+ * https://storage.googleapis.com/bucket-name/topology-name/topology.tar.gz
  * This provides a known package destination location which can be used to download
  * the topology package in order to run the topology.
  *

--- a/heron/uploaders/tests/java/BUILD
+++ b/heron/uploaders/tests/java/BUILD
@@ -73,3 +73,13 @@ java_test(
     deps = scp_deps_files,
     size = "small",
 )
+
+java_test(
+    name = "GcsUploaderTests",
+    srcs = glob(["**/gcs/GcsUploaderTests.java"]),
+    size = "small",
+    deps = common_deps_files + spi_deps_files + [
+        "//heron/uploaders/src/java:gcs-uploader-java",
+        "//third_party/java:google-api-services-storage"
+    ],
+)

--- a/heron/uploaders/tests/java/com/twitter/heron/uploader/gcs/GcsUploaderTests.java
+++ b/heron/uploaders/tests/java/com/twitter/heron/uploader/gcs/GcsUploaderTests.java
@@ -1,0 +1,136 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.uploader.gcs;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import com.google.api.services.storage.model.StorageObject;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.twitter.heron.spi.common.Config;
+import com.twitter.heron.spi.common.Key;
+
+import static org.junit.Assert.assertEquals;
+
+public class GcsUploaderTests {
+
+  private final String topologyName = "test-topology";
+
+  private final String topologyPackageName = "topology.tar.gz";
+
+  private final String bucket = "topologies-bucket";
+
+  private final String topologyObjectName =
+      String.format("%s/%s", topologyName, topologyPackageName);
+
+  private final String previousTopologyObjectName =
+      String.format("%s/previous-%s", topologyName, topologyPackageName);
+
+  private GcsUploader uploader;
+
+  private GcsController mockGcsController = Mockito.mock(GcsController.class);
+
+  @Before
+  public void before() throws Exception {
+    uploader = createUploaderWithMockController();
+  }
+
+  @Test
+  public void uploadTopology() throws IOException, URISyntaxException {
+    Mockito.when(mockGcsController
+        .createObject(Mockito.matches(topologyObjectName), Mockito.any(File.class)))
+        .thenReturn(createObject(topologyObjectName));
+
+    uploader.initialize(createDefaultBuilder().build());
+
+    String expectedUri =
+        String.format("https://storage.googleapis.com/%s/%s/%s",
+            bucket, topologyName, topologyPackageName);
+    assertEquals(new URI(expectedUri), uploader.uploadPackage());
+  }
+
+  @Test
+  public void verifyObjectBackedUpIfExists() throws IOException {
+    final StorageObject currentObject = createObject(topologyObjectName);
+    Mockito.when(mockGcsController
+        .getObject(Mockito.matches(topologyObjectName)))
+        .thenReturn(currentObject);
+
+    uploader.initialize(createDefaultBuilder().build());
+
+    uploader.uploadPackage();
+
+    // verify that we copied the old topology before uploading the new one
+    Mockito.verify(mockGcsController)
+        .copyObject(topologyObjectName, previousTopologyObjectName, currentObject);
+  }
+
+  @Test
+  public void restorePreviousVersionOnUndo() throws IOException {
+    final StorageObject previousObject = createObject(previousTopologyObjectName);
+    Mockito.when(mockGcsController
+        .getObject(Mockito.matches(previousTopologyObjectName)))
+        .thenReturn(previousObject);
+
+    uploader.initialize(createDefaultBuilder().build());
+
+    uploader.undo();
+
+    // verify that we restored the previous topology
+    Mockito.verify(mockGcsController)
+        .copyObject(previousTopologyObjectName, topologyObjectName, previousObject);
+  }
+
+  @Test
+  public void doNotRestorePreviousVersionIfItDoesNotExist() throws IOException {
+    Mockito.when(mockGcsController
+        .getObject(Mockito.matches(previousTopologyObjectName)))
+        .thenReturn(null);
+
+    uploader.initialize(createDefaultBuilder().build());
+
+    uploader.undo();
+
+    Mockito.verify(mockGcsController, Mockito.never())
+        .copyObject(Mockito.anyString(), Mockito.anyString(), Mockito.any(StorageObject.class));
+  }
+
+  private StorageObject createObject(String name) {
+    final StorageObject storageObject = new StorageObject();
+    storageObject.setName(name);
+    return storageObject;
+  }
+
+  private Config.Builder createDefaultBuilder() {
+    return Config.newBuilder()
+        .put(GcsContext.HERON_UPLOADER_GCS_BUCKET, bucket)
+        .put(Key.TOPOLOGY_NAME, topologyName)
+        .put(Key.TOPOLOGY_PACKAGE_FILE, topologyPackageName);
+  }
+
+  private GcsUploader createUploaderWithMockController() {
+    return new GcsUploader() {
+      @Override
+      GcsController createGcsController(Config configuration, String storageBucket) {
+        return mockGcsController;
+      }
+    };
+  }
+}

--- a/heron/uploaders/tests/java/com/twitter/heron/uploader/gcs/GcsUploaderTests.java
+++ b/heron/uploaders/tests/java/com/twitter/heron/uploader/gcs/GcsUploaderTests.java
@@ -68,10 +68,16 @@ public class GcsUploaderTests {
 
   @Test
   public void verifyObjectBackedUpIfExists() throws IOException {
+    // return an object to simulate that the topology has been uploaded before
     final StorageObject currentObject = createObject(topologyObjectName);
     Mockito.when(mockGcsController
         .getObject(Mockito.matches(topologyObjectName)))
         .thenReturn(currentObject);
+
+    // return an object when we try to create one
+    Mockito.when(mockGcsController
+        .createObject(Mockito.matches(topologyObjectName), Mockito.any(File.class)))
+        .thenReturn(createObject(topologyObjectName));
 
     uploader.initialize(createDefaultBuilder().build());
 

--- a/third_party/java/BUILD
+++ b/third_party/java/BUILD
@@ -196,3 +196,26 @@ java_library(
     exports = [ "@org_mockito_mockito_all//jar" ],
     deps = [ "@org_mockito_mockito_all//jar" ],
 )
+
+java_library(
+    name = "google-api-services-storage",
+    srcs = [ "Empty.java" ],
+    exports = [ 
+        "@google_api_services_storage//jar",
+        "@google_api_client//jar",
+        "@google_http_client//jar",
+        "@google_http_client_jackson2//jar",
+        "@google_oauth_client//jar",
+    ],
+    deps = [ 
+        "@google_api_client//jar",
+        "@google_http_client//jar",
+        "@google_http_client_jackson2//jar",
+        "@google_oauth_client//jar",
+        "@com_fasterxml_jackson_core_jackson_core//jar",
+        "@commons_codec//jar",
+        "@commons_logging_commons_logging//jar",
+        "@org_apache_httpcomponents_http_client//jar",
+        "@org_apache_httpcomponents_http_core//jar",
+    ],
+)

--- a/tools/rules/heron_client.bzl
+++ b/tools/rules/heron_client.bzl
@@ -61,6 +61,7 @@ def heron_client_lib_uploader_files():
         "//heron/uploaders/src/java:heron-s3-uploader",
         "//heron/uploaders/src/java:heron-hdfs-uploader",
         "//heron/uploaders/src/java:heron-scp-uploader",
+        "//heron/uploaders/src/java:heron-gcs-uploader",
     ]
 
 def heron_client_lib_third_party_files():


### PR DESCRIPTION
What?
An uploader for using google cloud storage (similar to s3).

Will add docs in another patch.

Why?
Make it easier for users to deploy in google cloud.