### PR TITLE
Refactored constants

### DIFF
--- a/heron/common/src/python/network/heron_client.py
+++ b/heron/common/src/python/network/heron_client.py
@@ -21,7 +21,7 @@ from abc import abstractmethod
 import time
 from heron.common.src.python.network import HeronProtocol, REQID, StatusCode, OutgoingPacket
 from heron.common.src.python.utils.log import Log
-import heron.common.src.python.constants as constants
+import heron.common.src.python.system_constants as constants
 
 # pylint: disable=too-many-instance-attributes
 # pylint: disable=fixme

--- a/heron/common/src/python/network/socket_options.py
+++ b/heron/common/src/python/network/socket_options.py
@@ -15,7 +15,7 @@
 
 from collections import namedtuple
 from heron.common.src.python.utils.log import Log
-import heron.common.src.python.constants as const
+import heron.common.src.python.system_constants as const
 from heron.common.src.python.config import system_config
 
 SocketOptions = namedtuple('Options', 'nw_write_batch_size_bytes, nw_write_batch_time_ms, '

--- a/heron/common/src/python/system_constants.py
+++ b/heron/common/src/python/system_constants.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-''' constants.py: defines constants for generic purposes and for topology and system config'''
+''' system_constants.py: defines constants for generic purposes and system config'''
 
 ##### Generic constants #####
 
@@ -26,66 +26,6 @@ NS_TO_MS = 0.000001
 RAM_FOR_STMGR = 1 * GB
 DEFAULT_RAM_FOR_INSTANCE = 1 * GB
 DEFAULT_DISK_PADDING_PER_CONTAINER = 12 * GB
-
-####################################################################################################
-###########################  Constants for topology configuration ##################################
-####################################################################################################
-
-# Topology-specific options for the worker child process.
-TOPOLOGY_WORKER_CHILDOPTS = "topology.worker.childopts"
-# Per component jvm options.
-TOPOLOGY_COMPONENT_JVMOPTS = "topology.component.jvmopts"
-# How often a tick tuple from the "__system" component and "__tick" stream should be sent to tasks.
-TOPOLOGY_TICK_TUPLE_FREQ_SECS = "topology.tick.tuple.freq.secs"
-# True if Heron should timeout messages or not. Default true. Meant to be used in unit tests.
-TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS = "topology.enable.message.timeouts"
-# When true, Heron will log every message that's emitted
-TOPOLOGY_DEBUG = "topology.debug"
-# The number of stmgr instances that should spin up to service this topology.
-TOPOLOGY_STMGRS = "topology.stmgrs"
-# The max amount of time given to the topology to fully process a message emitted by a spout.
-TOPOLOGY_MESSAGE_TIMEOUT_SECS = "topology.message.timeout.secs"
-# The per component parallelism for a component in this topology.
-TOPOLOGY_COMPONENT_PARALLELISM = "topology.component.parallelism"
-# The maximum number of tuples that can be pending on a spout task at any given time.
-TOPOLOGY_MAX_SPOUT_PENDING = "topology.max.spout.pending"
-# A list of task hooks that are automatically added to every spout and bolt in the topology.
-TOPOLOGY_AUTO_TASK_HOOKS = "topology.auto.task.hooks"
-# The serialization class that is used to serialize/deserialize tuples
-TOPOLOGY_SERIALIZER_CLASSNAME = "topology.serializer.classname"
-# How many executors to spawn for ackers.
-TOPOLOGY_ENABLE_ACKING = "topology.acking"
-
-# Number of cpu cores per container to be reserved for this topology.
-TOPOLOGY_CONTAINER_CPU_REQUESTED = "topology.container.cpu"
-# Amount of ram per container to be reserved for this topology, in bytes.
-TOPOLOGY_CONTAINER_RAM_REQUESTED = "topology.container.ram"
-# Amount of disk per container to be reserved for this topology, in bytes.
-TOPOLOGY_CONTAINER_DISK_REQUESTED = "topology.container.disk"
-# Hint for max amount of ram per container to be reserved for this topology, in bytes.
-TOPOLOGY_CONTAINER_MAX_CPU_HINT = "topology.container.max.cpu.hint"
-# Hint for max amount of disk per container to be reserved for this topology, in bytes.
-TOPOLOGY_CONTAINER_MAX_DISK_HINT = "topology.container.max.disk.hint"
-# Padding percentage for this container.
-TOPOLOGY_CONTAINER_PADDING_PERCENTAGE = "topology.container.padding.percentage"
-
-# Per component ram requirement.
-TOPOLOGY_COMPONENT_RAMMAP = "topology.component.rammap"
-# Name of the topology, automatically set by Heron when the topology is submitted.
-TOPOLOGY_NAME = "topology.name"
-# Name of the team which owns this topology.
-TOPOLOGY_TEAM_NAME = "topology.team.name"
-# Email of the team which owns this topology.
-TOPOLOGY_TEAM_EMAIL = "topology.team.email"
-# Cap ticket (if filed) for the topology. If the topology is in prod, this has to be set or it
-# cannot be deployed.
-TOPOLOGY_CAP_TICKET = "topology.cap.ticket"
-# Project name of the topology, to help us with tagging which topologies are part of which project.
-TOPOLOGY_PROJECT_NAME = "topology.project.name"
-# Any user defined classpath that needs to be passed to instances should be set in to config
-# through this key.
-TOPOLOGY_ADDITIONAL_CLASSPATH = "topology.additional.classpath"
-
 
 ####################################################################################################
 #############################  Constants for System configuration ##################################

--- a/heron/common/src/python/utils/metrics/metrics_helper.py
+++ b/heron/common/src/python/utils/metrics/metrics_helper.py
@@ -16,7 +16,7 @@
 from heron.common.src.python.utils.log import Log
 from heron.common.src.python.config import system_config
 from heron.proto import metrics_pb2
-import heron.common.src.python.constants as constants
+import heron.common.src.python.system_constants as constants
 
 from heron.api.src.python.metrics import (CountMetric, MultiCountMetric, MeanReducedMetric,
                                           ReducedMetric, MultiMeanReducedMetric, MultiReducedMetric)

--- a/heron/common/src/python/utils/metrics/py_metrics.py
+++ b/heron/common/src/python/utils/metrics/py_metrics.py
@@ -17,7 +17,7 @@ import psutil
 import traceback
 from heron.api.src.python.metrics import AssignableMetrics, MultiAssignableMetrics
 from .metrics_helper import BaseMetricsHelper
-import heron.common.src.python.constants as constants
+import heron.common.src.python.system_constants as constants
 from heron.common.src.python.config import system_config
 from heron.common.src.python.utils.log import Log
 

--- a/heron/common/src/python/utils/misc/outgoing_tuple_helper.py
+++ b/heron/common/src/python/utils/misc/outgoing_tuple_helper.py
@@ -18,7 +18,7 @@ from heron.common.src.python.config import system_config
 from heron.common.src.python.utils.log import Log
 from heron.proto import tuple_pb2, topology_pb2
 
-import heron.common.src.python.constants as constants
+import heron.common.src.python.system_constants as constants
 
 # pylint: disable=too-many-instance-attributes
 # pylint: disable=no-value-for-parameter

--- a/heron/common/src/python/utils/misc/serializer_helper.py
+++ b/heron/common/src/python/utils/misc/serializer_helper.py
@@ -15,7 +15,7 @@
 
 from heron.api.src.python.serializer import PythonSerializer
 
-import heron.common.src.python.constants as constants
+import heron.api.src.python.api_constants as constants
 import heron.common.src.python.pex_loader as pex_loader
 
 class SerializerHelper(object):

--- a/heron/common/src/python/utils/topology/topology_context.py
+++ b/heron/common/src/python/utils/topology/topology_context.py
@@ -19,9 +19,10 @@ from heron.api.src.python.task_hook import (ITaskHook, EmitInfo, SpoutAckInfo,
                                             SpoutFailInfo, BoltExecuteInfo,
                                             BoltAckInfo, BoltFailInfo)
 
+import heron.api.src.python.api_constants as api_constants
 from heron.common.src.python.utils.metrics import MetricsCollector
 
-import heron.common.src.python.constants as constants
+import heron.common.src.python.system_constants as system_constants
 import heron.common.src.python.pex_loader as pex_loader
 
 class TopologyContext(dict):
@@ -196,7 +197,8 @@ class TopologyContext(dict):
   ######### Task hook related ##########
 
   def _init_task_hooks(self):
-    task_hooks_cls_list = self.get_cluster_config().get(constants.TOPOLOGY_AUTO_TASK_HOOKS, None)
+    task_hooks_cls_list = self.get_cluster_config().get(api_constants.TOPOLOGY_AUTO_TASK_HOOKS,
+                                                        None)
     if task_hooks_cls_list is None:
       return
 
@@ -268,7 +270,8 @@ class TopologyContext(dict):
     if self.hook_exists:
       spout_ack_info = SpoutAckInfo(message_id=message_id,
                                     spout_task_id=self.task_id,
-                                    complete_latency_ms=complete_latency_ns * constants.NS_TO_MS)
+                                    complete_latency_ms=complete_latency_ns *
+                                    system_constants.NS_TO_MS)
       for task_hook in self[self.TASK_HOOKS]:
         task_hook.spout_ack(spout_ack_info)
 
@@ -283,7 +286,7 @@ class TopologyContext(dict):
     if self.hook_exists:
       spout_fail_info = SpoutFailInfo(message_id=message_id,
                                       spout_task_id=self.task_id,
-                                      fail_latency_ms=fail_latency_ns * constants.NS_TO_MS)
+                                      fail_latency_ms=fail_latency_ns * system_constants.NS_TO_MS)
       for task_hook in self[self.TASK_HOOKS]:
         task_hook.spout_fail(spout_fail_info)
 
@@ -299,7 +302,7 @@ class TopologyContext(dict):
       bolt_execute_info = \
         BoltExecuteInfo(heron_tuple=heron_tuple,
                         executing_task_id=self.task_id,
-                        execute_latency_ms=execute_latency_ns * constants.NS_TO_MS)
+                        execute_latency_ms=execute_latency_ns * system_constants.NS_TO_MS)
       for task_hook in self[self.TASK_HOOKS]:
         task_hook.bolt_execute(bolt_execute_info)
 
@@ -314,7 +317,7 @@ class TopologyContext(dict):
     if self.hook_exists:
       bolt_ack_info = BoltAckInfo(heron_tuple=heron_tuple,
                                   acking_task_id=self.task_id,
-                                  process_latency_ms=process_latency_ns * constants.NS_TO_MS)
+                                  process_latency_ms=process_latency_ns * system_constants.NS_TO_MS)
       for task_hook in self[self.TASK_HOOKS]:
         task_hook.bolt_ack(bolt_ack_info)
 
@@ -329,6 +332,6 @@ class TopologyContext(dict):
     if self.hook_exists:
       bolt_fail_info = BoltFailInfo(heron_tuple=heron_tuple,
                                     failing_task_id=self.task_id,
-                                    fail_latency_ms=fail_latency_ns * constants.NS_TO_MS)
+                                    fail_latency_ms=fail_latency_ns * system_constants.NS_TO_MS)
       for task_hook in self[self.TASK_HOOKS]:
         task_hook.bolt_fail(bolt_fail_info)

--- a/heron/common/tests/python/utils/mock_generator.py
+++ b/heron/common/tests/python/utils/mock_generator.py
@@ -27,7 +27,7 @@ from heron.common.src.python.utils.misc import (OutgoingTupleHelper, PhysicalPla
                                                 HeronCommunicator)
 from heron.proto import tuple_pb2
 
-import heron.common.src.python.constants as constants
+import heron.common.src.python.system_constants as constants
 import heron.common.tests.python.mock_protobuf as mock_protobuf
 
 prim_list = [1000, -234, 0.00023, "string",

--- a/heron/common/tests/python/utils/py_metrics_unittest.py
+++ b/heron/common/tests/python/utils/py_metrics_unittest.py
@@ -19,7 +19,7 @@ import unittest
 import threading
 
 from heron.common.src.python.utils.metrics.py_metrics import PyMetrics
-import heron.common.src.python.constants as constants
+import heron.common.src.python.system_constants as constants
 import heron.common.tests.python.utils.mock_generator as mock_generator
 
 Mem = namedtuple('Mem', ['rss', 'vms'])

--- a/heron/examples/src/python/custom_grouping_topology.py
+++ b/heron/examples/src/python/custom_grouping_topology.py
@@ -15,7 +15,8 @@
 
 from heron.common.src.python.utils.log import Log
 from heron.api.src.python.custom_grouping import ICustomGrouping
-from heron.pyheron.src.python import Topology, Grouping, constants
+import heron.api.src.python.constants as constants
+from heron.pyheron.src.python import Topology, Grouping
 
 from heron.examples.src.python.spout import WordSpout
 from heron.examples.src.python.bolt import ConsumeBolt

--- a/heron/examples/src/python/half_acking_topology.py
+++ b/heron/examples/src/python/half_acking_topology.py
@@ -14,7 +14,8 @@
 '''Example HalfAckingTopology'''
 import sys
 
-from heron.pyheron.src.python import Grouping, TopologyBuilder, constants
+import heron.api.src.python.api_constants as constants
+from heron.pyheron.src.python import Grouping, TopologyBuilder
 
 from heron.examples.src.python.spout import WordSpout
 from heron.examples.src.python.bolt import HalfAckBolt

--- a/heron/examples/src/python/multi_stream_topology.py
+++ b/heron/examples/src/python/multi_stream_topology.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 '''module for example topology: CustomGroupingTopology'''
 
-from heron.pyheron.src.python import Topology, Grouping, constants
+import heron.api.src.python.api_constants as constants
+from heron.pyheron.src.python import Topology, Grouping
 
 from heron.examples.src.python.spout import MultiStreamSpout
 from heron.examples.src.python.bolt import CountBolt, StreamAggregateBolt

--- a/heron/examples/src/python/word_count_topology.py
+++ b/heron/examples/src/python/word_count_topology.py
@@ -14,7 +14,8 @@
 '''Example WordCountTopology'''
 import sys
 
-from heron.pyheron.src.python import Grouping, TopologyBuilder, constants
+import heron.api.src.python.api_constants as constants
+from heron.pyheron.src.python import Grouping, TopologyBuilder
 from heron.examples.src.python.spout import WordSpout
 from heron.examples.src.python.bolt import CountBolt
 

--- a/heron/instance/src/python/basics/bolt_instance.py
+++ b/heron/instance/src/python/basics/bolt_instance.py
@@ -16,15 +16,16 @@
 import time
 import Queue
 
+from heron.api.src.python import global_metrics
+from heron.api.src.python import api_constants
 from heron.common.src.python.utils.log import Log
 from heron.common.src.python.utils.tuple import TupleHelper, HeronTuple
 from heron.common.src.python.utils.metrics import BoltMetrics
-from heron.api.src.python import global_metrics
 from heron.common.src.python.utils.misc import SerializerHelper
 from heron.proto import tuple_pb2
 from heron.pyheron.src.python import Stream
 
-import heron.common.src.python.constants as constants
+import heron.common.src.python.system_constants as system_constants
 
 from .base_instance import BaseInstance
 
@@ -43,7 +44,8 @@ class BoltInstance(BaseInstance):
     self.serializer = SerializerHelper.get_serializer(context)
 
     # acking related
-    self.acking_enabled = context.get_cluster_config().get(constants.TOPOLOGY_ENABLE_ACKING, False)
+    self.acking_enabled = context.get_cluster_config().get(api_constants.TOPOLOGY_ENABLE_ACKING,
+                                                           False)
     Log.info("Enable ACK: %s" % str(self.acking_enabled))
 
     # load user's bolt class
@@ -57,7 +59,7 @@ class BoltInstance(BaseInstance):
     context.invoke_hook_prepare()
 
     # prepare global metrics
-    interval = float(self.sys_config[constants.HERON_METRICS_EXPORT_INTERVAL_SEC])
+    interval = float(self.sys_config[system_constants.HERON_METRICS_EXPORT_INTERVAL_SEC])
     collector = context.get_metrics_collector()
     global_metrics.init(collector, interval)
 
@@ -136,7 +138,7 @@ class BoltInstance(BaseInstance):
       serialized = self.serializer.serialize(obj)
       data_tuple.values.append(serialized)
       tuple_size_in_bytes += len(serialized)
-    serialize_latency_ns = (time.time() - start_time) * constants.SEC_TO_NS
+    serialize_latency_ns = (time.time() - start_time) * system_constants.SEC_TO_NS
     self.bolt_metrics.serialize_data_tuple(stream, serialize_latency_ns)
 
     super(BoltInstance, self).admit_data_tuple(stream_id=stream, data_tuple=data_tuple,
@@ -167,8 +169,8 @@ class BoltInstance(BaseInstance):
     start_cycle_time = time.time()
     total_data_emitted_bytes_before = self.get_total_data_emitted_in_bytes()
     exec_batch_time = \
-      self.sys_config[constants.INSTANCE_EXECUTE_BATCH_TIME_MS] * constants.MS_TO_SEC
-    exec_batch_size = self.sys_config[constants.INSTANCE_EXECUTE_BATCH_SIZE_BYTES]
+      self.sys_config[system_constants.INSTANCE_EXECUTE_BATCH_TIME_MS] * system_constants.MS_TO_SEC
+    exec_batch_size = self.sys_config[system_constants.INSTANCE_EXECUTE_BATCH_SIZE_BYTES]
     while not self.in_stream.is_empty():
       try:
         tuples = self.in_stream.poll()
@@ -206,8 +208,8 @@ class BoltInstance(BaseInstance):
 
     deserialized_time = time.time()
     self.bolt_impl.process(tup)
-    execute_latency_ns = (time.time() - deserialized_time) * constants.SEC_TO_NS
-    deserialize_latency_ns = (deserialized_time - start_time) * constants.SEC_TO_NS
+    execute_latency_ns = (time.time() - deserialized_time) * system_constants.SEC_TO_NS
+    deserialize_latency_ns = (deserialized_time - start_time) * system_constants.SEC_TO_NS
 
     self.pplan_helper.context.invoke_hook_bolt_execute(tup, execute_latency_ns)
 
@@ -217,15 +219,15 @@ class BoltInstance(BaseInstance):
 
   def _prepare_tick_tup_timer(self):
     cluster_config = self.pplan_helper.context.get_cluster_config()
-    if constants.TOPOLOGY_TICK_TUPLE_FREQ_SECS in cluster_config:
-      tick_freq_sec = cluster_config[constants.TOPOLOGY_TICK_TUPLE_FREQ_SECS]
+    if api_constants.TOPOLOGY_TICK_TUPLE_FREQ_SECS in cluster_config:
+      tick_freq_sec = cluster_config[api_constants.TOPOLOGY_TICK_TUPLE_FREQ_SECS]
       Log.debug("Tick Tuple Frequency: %s sec." % str(tick_freq_sec))
 
       def send_tick():
         tick = TupleHelper.make_tick_tuple()
         start_time = time.time()
         self.bolt_impl.process_tick(tick)
-        tick_execute_latency_ns = (time.time() - start_time) * constants.SEC_TO_NS
+        tick_execute_latency_ns = (time.time() - start_time) * system_constants.SEC_TO_NS
         self.bolt_metrics.execute_tuple(tick.id, tick.component, tick_execute_latency_ns)
         self.output_helper.send_out_tuples()
         self.looper.wake_up() # so emitted tuples would be added to buffer now
@@ -253,7 +255,7 @@ class BoltInstance(BaseInstance):
         tuple_size_in_bytes += rt.ByteSize()
       super(BoltInstance, self).admit_control_tuple(ack_tuple, tuple_size_in_bytes, True)
 
-    process_latency_ns = (time.time() - tup.creation_time) * constants.SEC_TO_NS
+    process_latency_ns = (time.time() - tup.creation_time) * system_constants.SEC_TO_NS
     self.pplan_helper.context.invoke_hook_bolt_ack(tup, process_latency_ns)
     self.bolt_metrics.acked_tuple(tup.stream, tup.component, process_latency_ns)
 
@@ -277,7 +279,7 @@ class BoltInstance(BaseInstance):
         tuple_size_in_bytes += rt.ByteSize()
       super(BoltInstance, self).admit_control_tuple(fail_tuple, tuple_size_in_bytes, False)
 
-    fail_latency_ns = (time.time() - tup.creation_time) * constants.SEC_TO_NS
+    fail_latency_ns = (time.time() - tup.creation_time) * system_constants.SEC_TO_NS
     self.pplan_helper.context.invoke_hook_bolt_fail(tup, fail_latency_ns)
     self.bolt_metrics.failed_tuple(tup.stream, tup.component, fail_latency_ns)
 

--- a/heron/instance/src/python/instance/st_heron_instance.py
+++ b/heron/instance/src/python/instance/st_heron_instance.py
@@ -31,7 +31,7 @@ from heron.proto import physical_plan_pb2, tuple_pb2
 from heron.instance.src.python.network import MetricsManagerClient, SingleThreadStmgrClient
 from heron.instance.src.python.basics import SpoutInstance, BoltInstance
 
-import heron.common.src.python.constants as constants
+import heron.common.src.python.system_constants as constants
 
 Log = log.Log
 AssignedInstance = collections.namedtuple('AssignedInstance', 'is_spout, protobuf, py_class')

--- a/heron/instance/src/python/network/metricsmgr_client.py
+++ b/heron/instance/src/python/network/metricsmgr_client.py
@@ -19,7 +19,7 @@ from heron.common.src.python.utils.log import Log
 from heron.common.src.python.network import HeronClient, StatusCode
 from heron.proto import metrics_pb2, common_pb2
 
-import heron.common.src.python.constants as constants
+import heron.common.src.python.system_constants as constants
 
 class MetricsManagerClient(HeronClient):
   """MetricsManagerClient, responsible for communicating with Metrics Manager"""

--- a/heron/instance/src/python/network/st_stmgr_client.py
+++ b/heron/instance/src/python/network/st_stmgr_client.py
@@ -18,7 +18,7 @@ from heron.common.src.python.utils.misc import PhysicalPlanHelper
 from heron.common.src.python.network import HeronClient, StatusCode
 from heron.proto import common_pb2, stmgr_pb2, tuple_pb2
 
-import heron.common.src.python.constants as constants
+import heron.common.src.python.system_constants as constants
 
 # pylint: disable=too-many-arguments
 class SingleThreadStmgrClient(HeronClient):

--- a/heron/instance/tests/python/network/mock_generator.py
+++ b/heron/instance/tests/python/network/mock_generator.py
@@ -17,7 +17,7 @@ from heron.common.src.python.basics import EventLooper
 from heron.common.src.python.network import SocketOptions
 from heron.common.src.python.utils.misc import HeronCommunicator
 from heron.instance.src.python.network import SingleThreadStmgrClient, MetricsManagerClient
-import heron.common.src.python.constants as constants
+import heron.common.src.python.system_constants as constants
 import heron.common.tests.python.mock_protobuf as mock_protobuf
 from mock import Mock
 

--- a/heron/pyheron/src/python/__init__.py
+++ b/heron/pyheron/src/python/__init__.py
@@ -12,8 +12,6 @@ from heron.api.src.python.custom_grouping import ICustomGrouping
 from heron.common.src.python.utils.tuple import HeronTuple
 from heron.common.src.python.utils.topology import TopologyContext
 
-import heron.common.src.python.constants as constants
-
 # Load basic topology modules
 from .stream import Stream, Grouping
 from .topology import Topology, TopologyBuilder

--- a/heron/pyheron/src/python/component/component_spec.py
+++ b/heron/pyheron/src/python/component/component_spec.py
@@ -15,7 +15,7 @@
 import uuid
 
 from heron.api.src.python.serializer import default_serializer
-import heron.common.src.python.constants as constants
+import heron.api.src.python.api_constants as constants
 from heron.proto import topology_pb2
 
 from ..stream import Stream, Grouping

--- a/heron/pyheron/src/python/topology.py
+++ b/heron/pyheron/src/python/topology.py
@@ -16,7 +16,7 @@ import os
 import uuid
 
 from heron.api.src.python.serializer import default_serializer
-import heron.common.src.python.constants as constants
+import heron.api.src.python.api_constants as constants
 from heron.proto import topology_pb2
 
 from .component import HeronComponentSpec

--- a/heron/tools/tracker/src/python/BUILD
+++ b/heron/tools/tracker/src/python/BUILD
@@ -10,6 +10,7 @@ pex_library(
     ),
     deps = [
         "//heron/common/src/python:common-py",
+        "//heron/api/src/python:heron-python-py",
         "//heron/tools/common/src/python:common-py",
         "//heron/statemgrs/src/python:statemgr-py",
         "//heron/proto:proto-py",

--- a/heron/tools/tracker/src/python/topology.py
+++ b/heron/tools/tracker/src/python/topology.py
@@ -15,7 +15,7 @@
 import traceback
 import uuid
 
-from heron.common.src.python import constants
+from heron.api.src.python import api_constants
 from heron.common.src.python.utils.log import Log
 
 # pylint: disable=too-many-instance-attributes
@@ -166,7 +166,7 @@ class Topology(object):
     for component in components:
       config = component.comp.config
       for kvs in config.kvs:
-        if kvs.key == constants.TOPOLOGY_COMPONENT_PARALLELISM:
+        if kvs.key == api_constants.TOPOLOGY_COMPONENT_PARALLELISM:
           num += int(kvs.value)
           break
 

--- a/heron/tools/tracker/tests/python/BUILD
+++ b/heron/tools/tracker/tests/python/BUILD
@@ -6,6 +6,7 @@ pex_library(
   srcs = ["mock_proto.py"],
   deps = [
     '//heron/proto:proto-py',
+    '//heron/api/src/python:heron-python-py',
   ],
 )
 
@@ -14,6 +15,7 @@ pex_test(
     srcs = ["topology_helpers_unittest.py"],
     deps = [
         "//heron/tools/tracker/src/python:tracker-py",
+        "//heron/api/src/python:heron-python-py",
     ],
     reqs = [
         "mock==1.0.1",

--- a/heron/tools/tracker/tests/python/mock_proto.py
+++ b/heron/tools/tracker/tests/python/mock_proto.py
@@ -1,5 +1,5 @@
 ''' mock_proto.py '''
-from heron.common.src.python import constants
+from heron.api.src.python import api_constants
 import heron.proto.execution_state_pb2 as protoEState
 import heron.proto.physical_plan_pb2 as protoPPlan
 import heron.proto.tmaster_pb2 as protoTmaster
@@ -20,7 +20,7 @@ class MockProto(object):
     spout = protoTopology.Spout()
     spout.comp.name = spout_name
     kv = spout.comp.config.kvs.add()
-    kv.key = constants.TOPOLOGY_COMPONENT_PARALLELISM
+    kv.key = api_constants.TOPOLOGY_COMPONENT_PARALLELISM
     kv.type = protoTopology.ConfigValueType.Value('STRING_VALUE')
     kv.value = str(spout_parallelism)
     for stream in output_streams:
@@ -35,7 +35,7 @@ class MockProto(object):
     bolt = protoTopology.Bolt()
     bolt.comp.name = bolt_name
     kv = bolt.comp.config.kvs.add()
-    kv.key = constants.TOPOLOGY_COMPONENT_PARALLELISM
+    kv.key = api_constants.TOPOLOGY_COMPONENT_PARALLELISM
     kv.type = protoTopology.ConfigValueType.Value('STRING_VALUE')
     kv.value = str(bolt_parallelism)
     for stream in input_streams:

--- a/heron/tools/tracker/tests/python/topology_helpers_unittest.py
+++ b/heron/tools/tracker/tests/python/topology_helpers_unittest.py
@@ -2,7 +2,8 @@
 # pylint: disable=missing-docstring
 import unittest2 as unittest
 
-from heron.common.src.python import constants
+from heron.api.src.python import api_constants
+from heron.common.src.python import system_constants
 from heron.tools.tracker.src.python import topology_helpers
 from mock_proto import MockProto
 
@@ -26,16 +27,16 @@ class TopologyHelpersTest(unittest.TestCase):
     # First try with 1 container, so the disk request should be:
     # 10 * GB + Padding_Disk (12GB) = 22GB
     default_disk = topology_helpers.get_disk_per_container(topology)
-    self.assertEqual(22 * constants.GB, default_disk)
+    self.assertEqual(22 * system_constants.GB, default_disk)
 
     # Then try with 4 container, so the disk request should be:
     # 10/4 = 2.5 -> 3 (round to ceiling) + 12 = 15GB
-    self.mock_proto.add_topology_config(topology, constants.TOPOLOGY_STMGRS, 4)
-    self.assertEqual(15 * constants.GB, topology_helpers.get_disk_per_container(topology))
+    self.mock_proto.add_topology_config(topology, api_constants.TOPOLOGY_STMGRS, 4)
+    self.assertEqual(15 * system_constants.GB, topology_helpers.get_disk_per_container(topology))
 
     # Then let's set the disk_per_container explicitly
     self.mock_proto.add_topology_config(
-        topology, constants.TOPOLOGY_CONTAINER_DISK_REQUESTED, 950109)
+        topology, api_constants.TOPOLOGY_CONTAINER_DISK_REQUESTED, 950109)
     # The add_topology_config will convert config into string
     self.assertEqual(str(950109), topology_helpers.get_disk_per_container(topology))
 
@@ -71,51 +72,51 @@ class TopologyHelpersTest(unittest.TestCase):
 
     # If num containers are greater than num instances
     topology = self.mock_proto.create_mock_simple_topology(1, 1)
-    self.mock_proto.add_topology_config(topology, constants.TOPOLOGY_STMGRS, 4)
+    self.mock_proto.add_topology_config(topology, api_constants.TOPOLOGY_STMGRS, 4)
     self.assertFalse(topology_helpers.sane(topology))
 
     # If rammap is partial with less componenets
     topology = self.mock_proto.create_mock_simple_topology()
     self.mock_proto.add_topology_config(
-        topology, constants.TOPOLOGY_COMPONENT_RAMMAP, "mock_spout:1")
+        topology, api_constants.TOPOLOGY_COMPONENT_RAMMAP, "mock_spout:1")
     self.assertTrue(topology_helpers.sane(topology))
 
     # If rammap is not well formatted
     topology = self.mock_proto.create_mock_simple_topology()
     self.mock_proto.add_topology_config(
-        topology, constants.TOPOLOGY_COMPONENT_RAMMAP, "mock_spout:1:2,mock_bolt:2:3")
+        topology, api_constants.TOPOLOGY_COMPONENT_RAMMAP, "mock_spout:1:2,mock_bolt:2:3")
     self.assertFalse(topology_helpers.sane(topology))
 
     # If rammap has wrong component name
     topology = self.mock_proto.create_mock_simple_topology()
     self.mock_proto.add_topology_config(
-        topology, constants.TOPOLOGY_COMPONENT_RAMMAP, "wrong_mock_spout:1,mock_bolt:2")
+        topology, api_constants.TOPOLOGY_COMPONENT_RAMMAP, "wrong_mock_spout:1,mock_bolt:2")
     self.assertFalse(topology_helpers.sane(topology))
 
     # If everything is right
     topology = self.mock_proto.create_mock_simple_topology()
     self.mock_proto.add_topology_config(
-        topology, constants.TOPOLOGY_COMPONENT_RAMMAP, "mock_spout:1,mock_bolt:2")
+        topology, api_constants.TOPOLOGY_COMPONENT_RAMMAP, "mock_spout:1,mock_bolt:2")
     self.assertTrue(topology_helpers.sane(topology))
 
   def test_num_cpus_per_container(self):
     topology = self.mock_proto.create_mock_simple_topology(2, 2)
-    self.mock_proto.add_topology_config(topology, constants.TOPOLOGY_STMGRS, 4)
+    self.mock_proto.add_topology_config(topology, api_constants.TOPOLOGY_STMGRS, 4)
     self.assertEqual(2, topology_helpers.get_cpus_per_container(topology))
 
     topology = self.mock_proto.create_mock_simple_topology(2, 2)
-    self.mock_proto.add_topology_config(topology, constants.TOPOLOGY_CONTAINER_CPU_REQUESTED, 42)
+    self.mock_proto.add_topology_config(topology, api_constants.TOPOLOGY_CONTAINER_CPU_REQUESTED, 42)
     self.assertEqual(42, topology_helpers.get_cpus_per_container(topology))
 
   def test_get_user_rammap(self):
     topology = self.mock_proto.create_mock_simple_topology()
     self.mock_proto.add_topology_config(
-        topology, constants.TOPOLOGY_COMPONENT_RAMMAP, "mock_spout:2,mock_bolt:3")
+        topology, api_constants.TOPOLOGY_COMPONENT_RAMMAP, "mock_spout:2,mock_bolt:3")
     self.assertEqual({"mock_spout":2, "mock_bolt":3}, topology_helpers.get_user_rammap(topology))
 
   def test_get_component_distribution(self):
     topology = self.mock_proto.create_mock_simple_topology(4, 8)
-    self.mock_proto.add_topology_config(topology, constants.TOPOLOGY_STMGRS, 4)
+    self.mock_proto.add_topology_config(topology, api_constants.TOPOLOGY_STMGRS, 4)
     component_distribution = topology_helpers.get_component_distribution(topology)
 
     expected_component_distribution = {
@@ -147,30 +148,30 @@ class TopologyHelpersTest(unittest.TestCase):
     # This is not a good way since this shows the internals
     # of the method. These methods need to be changed.
     # For example, ram_per_contaner could be taken as an argument.
-    original_ram_for_stmgr = constants.RAM_FOR_STMGR
-    constants.RAM_FOR_STMGR = 2
+    original_ram_for_stmgr = system_constants.RAM_FOR_STMGR
+    system_constants.RAM_FOR_STMGR = 2
 
     # When rammap is specified, it should be used.
     topology = self.mock_proto.create_mock_simple_topology(4, 8)
     self.mock_proto.add_topology_config(
-        topology, constants.TOPOLOGY_COMPONENT_RAMMAP, "mock_spout:2,mock_bolt:3")
+        topology, api_constants.TOPOLOGY_COMPONENT_RAMMAP, "mock_spout:2,mock_bolt:3")
     self.assertEqual(
         {"mock_spout":2, "mock_bolt":3}, topology_helpers.get_component_rammap(topology))
 
     # When partial rammap is specified, rest of the components should get default
     topology = self.mock_proto.create_mock_simple_topology(4, 8)
     self.mock_proto.add_topology_config(
-        topology, constants.TOPOLOGY_COMPONENT_RAMMAP, "mock_spout:2")
+        topology, api_constants.TOPOLOGY_COMPONENT_RAMMAP, "mock_spout:2")
     expected_component_rammap = {
         "mock_spout": 2,
-        "mock_bolt": constants.DEFAULT_RAM_FOR_INSTANCE
+        "mock_bolt": system_constants.DEFAULT_RAM_FOR_INSTANCE
     }
     self.assertEqual(expected_component_rammap, topology_helpers.get_component_rammap(topology))
 
     # When container ram is specified.
     topology = self.mock_proto.create_mock_simple_topology(4, 8)
-    self.mock_proto.add_topology_config(topology, constants.TOPOLOGY_STMGRS, 4)
-    self.mock_proto.add_topology_config(topology, constants.TOPOLOGY_CONTAINER_RAM_REQUESTED, 8)
+    self.mock_proto.add_topology_config(topology, api_constants.TOPOLOGY_STMGRS, 4)
+    self.mock_proto.add_topology_config(topology, api_constants.TOPOLOGY_CONTAINER_RAM_REQUESTED, 8)
 
     expected_component_rammap = {
         "mock_spout": 2,
@@ -183,33 +184,33 @@ class TopologyHelpersTest(unittest.TestCase):
     topology = self.mock_proto.create_mock_simple_topology(4, 8)
     component_rammap = topology_helpers.get_component_rammap(topology)
     expected_component_rammap = {
-        "mock_spout": constants.DEFAULT_RAM_FOR_INSTANCE,
-        "mock_bolt": constants.DEFAULT_RAM_FOR_INSTANCE
+        "mock_spout": system_constants.DEFAULT_RAM_FOR_INSTANCE,
+        "mock_bolt": system_constants.DEFAULT_RAM_FOR_INSTANCE
     }
     self.assertEqual(expected_component_rammap, component_rammap)
 
     # Unmock the things that we mocked.
-    constants.RAM_FOR_STMGR = original_ram_for_stmgr
+    system_constants.RAM_FOR_STMGR = original_ram_for_stmgr
 
   def test_get_ram_per_container(self):
     # Mock a few things
-    original_ram_for_stmgr = constants.RAM_FOR_STMGR
-    constants.RAM_FOR_STMGR = 2
-    original_default_ram_for_instance = constants.DEFAULT_RAM_FOR_INSTANCE
-    constants.DEFAULT_RAM_FOR_INSTANCE = 1
+    original_ram_for_stmgr = system_constants.RAM_FOR_STMGR
+    system_constants.RAM_FOR_STMGR = 2
+    original_default_ram_for_instance = system_constants.DEFAULT_RAM_FOR_INSTANCE
+    system_constants.DEFAULT_RAM_FOR_INSTANCE = 1
 
     # When rammap is specified
     topology = self.mock_proto.create_mock_simple_topology(4, 8)
     self.mock_proto.add_topology_config(
-        topology, constants.TOPOLOGY_COMPONENT_RAMMAP, "mock_spout:2,mock_bolt:3")
-    self.mock_proto.add_topology_config(topology, constants.TOPOLOGY_STMGRS, 4)
+        topology, api_constants.TOPOLOGY_COMPONENT_RAMMAP, "mock_spout:2,mock_bolt:3")
+    self.mock_proto.add_topology_config(topology, api_constants.TOPOLOGY_STMGRS, 4)
     self.assertEqual(10, topology_helpers.get_ram_per_container(topology))
 
     # When partial rammap is specified, rest of the components should get default
     topology = self.mock_proto.create_mock_simple_topology(4, 8)
     self.mock_proto.add_topology_config(
-        topology, constants.TOPOLOGY_COMPONENT_RAMMAP, "mock_spout:2")
-    self.mock_proto.add_topology_config(topology, constants.TOPOLOGY_STMGRS, 4)
+        topology, api_constants.TOPOLOGY_COMPONENT_RAMMAP, "mock_spout:2")
+    self.mock_proto.add_topology_config(topology, api_constants.TOPOLOGY_STMGRS, 4)
     expected_ram_per_container = 6
     self.assertEqual(expected_ram_per_container, topology_helpers.get_ram_per_container(topology))
 
@@ -217,16 +218,16 @@ class TopologyHelpersTest(unittest.TestCase):
     topology = self.mock_proto.create_mock_simple_topology(4, 8)
     requested_ram = 15000
     self.mock_proto.add_topology_config(
-        topology, constants.TOPOLOGY_CONTAINER_RAM_REQUESTED, str(requested_ram))
+        topology, api_constants.TOPOLOGY_CONTAINER_RAM_REQUESTED, str(requested_ram))
     # Difference should be less than the total instances
     self.assertLess(abs(topology_helpers.get_ram_per_container(topology) - requested_ram), 12)
 
     # When nothing is specified
     topology = self.mock_proto.create_mock_simple_topology(4, 8)
-    self.mock_proto.add_topology_config(topology, constants.TOPOLOGY_STMGRS, 4)
+    self.mock_proto.add_topology_config(topology, api_constants.TOPOLOGY_STMGRS, 4)
     expected_ram_per_container = 5
     self.assertEqual(expected_ram_per_container, topology_helpers.get_ram_per_container(topology))
 
     # Unmock the things that we mocked.
-    constants.RAM_FOR_STMGR = original_ram_for_stmgr
-    constants.DEFAULT_RAM_FOR_INSTANCE = original_default_ram_for_instance
+    system_constants.RAM_FOR_STMGR = original_ram_for_stmgr
+    system_constants.DEFAULT_RAM_FOR_INSTANCE = original_default_ram_for_instance

--- a/integration-test/src/python/integration_test/core/BUILD
+++ b/integration-test/src/python/integration_test/core/BUILD
@@ -6,6 +6,7 @@ pex_library(
     name = "pyheron-integration-core-py",
     srcs = glob(["**/*.py"]),
     deps = [
+        "//heron/api/src/python:heron-python-py"
         "//heron/pyheron/src/python:pyheron-py"
     ],
 )

--- a/integration-test/src/python/integration_test/core/BUILD
+++ b/integration-test/src/python/integration_test/core/BUILD
@@ -6,7 +6,7 @@ pex_library(
     name = "pyheron-integration-core-py",
     srcs = glob(["**/*.py"]),
     deps = [
-        "//heron/api/src/python:heron-python-py"
+        "//heron/api/src/python:heron-python-py",
         "//heron/pyheron/src/python:pyheron-py"
     ],
 )

--- a/integration-test/src/python/integration_test/core/test_topology_builder.py
+++ b/integration-test/src/python/integration_test/core/test_topology_builder.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 '''integration test topology builder'''
 import copy
-from heron.pyheron.src.python import Stream, Grouping, constants
+from heron.api.src.python import api_constants
+from heron.pyheron.src.python import Stream, Grouping
 from heron.pyheron.src.python.topology import TopologyBuilder, Topology, TopologyType
 from ..core import constants as integ_const
 from .aggregator_bolt import AggregatorBolt
@@ -28,9 +29,9 @@ class TestTopologyBuilder(TopologyBuilder):
   """
   TERMINAL_BOLT_NAME = '__integration_test_aggregator_bolt'
   TERMINAL_BOLT_CLASS = AggregatorBolt
-  DEFAULT_CONFIG = {constants.TOPOLOGY_DEBUG: True,
-                    constants.TOPOLOGY_ENABLE_ACKING: True,
-                    constants.TOPOLOGY_PROJECT_NAME: "pyheron-integration-test"}
+  DEFAULT_CONFIG = {api_constants.TOPOLOGY_DEBUG: True,
+                    api_constants.TOPOLOGY_ENABLE_ACKING: True,
+                    api_constants.TOPOLOGY_PROJECT_NAME: "pyheron-integration-test"}
   def __init__(self, name, http_server_url):
     super(TestTopologyBuilder, self).__init__(name)
     self.output_location = "%s/%s" % (http_server_url, self.topology_name)


### PR DESCRIPTION
Removed api part of constants since they are already part of heron.api.src.python.api_constants.
Renamed constants to system_constants since thats what they represent