### PR TITLE
Export heron-instances' streams-aggregated metrics

### DIFF
--- a/heron/common/src/java/com/twitter/heron/common/utils/metrics/BoltMetrics.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/metrics/BoltMetrics.java
@@ -32,7 +32,7 @@ import com.twitter.heron.common.utils.topology.TopologyContextImpl;
  * 4. Expose methods which could be called externally to change the value of metrics
  */
 
-public class BoltMetrics implements ComponentMetrics {
+public class BoltMetrics extends ComponentMetrics {
   private final CountMetric ackCount;
   private final ReducedMetric<MeanReducerState, Number, Double> processLatency;
   private final ReducedMetric<MeanReducerState, Number, Double> failLatency;

--- a/heron/common/src/java/com/twitter/heron/common/utils/metrics/ComponentMetrics.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/metrics/ComponentMetrics.java
@@ -13,16 +13,14 @@
 //  limitations under the License.
 package com.twitter.heron.common.utils.metrics;
 
-import com.twitter.heron.classification.InterfaceAudience;
-import com.twitter.heron.classification.InterfaceStability;
-
 /**
- * Interface for common metric actions that both spouts and bolts support
+ * Abstract Class for common metric actions that both spouts and bolts support
  */
-@InterfaceAudience.Private
-@InterfaceStability.Evolving
-public interface ComponentMetrics {
+public abstract class ComponentMetrics {
+  // Metric-name suffix reserved for value aggregating on all different streams
+  public static final String ALL_STREAMS_AGGREGATED = "__all-streams-aggregated";
 
-  void serializeDataTuple(String streamId, long latency);
-  void emittedTuple(String streamId);
+  public abstract void serializeDataTuple(String streamId, long latency);
+
+  public abstract void emittedTuple(String streamId);
 }

--- a/heron/common/src/java/com/twitter/heron/common/utils/metrics/FullBoltMetrics.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/metrics/FullBoltMetrics.java
@@ -54,7 +54,6 @@ public class FullBoltMetrics extends BoltMetrics {
   // so instance could not produce more tuples
   private final CountMetric outQueueFullCount;
 
-
   public FullBoltMetrics() {
     ackCount = new MultiCountMetric();
     processLatency = new MultiReducedMetric<>(new MeanReducer());
@@ -126,6 +125,8 @@ public class FullBoltMetrics extends BoltMetrics {
     ackCount.scope(streamId).incr();
     processLatency.scope(streamId).update(latency);
 
+    ackCount.scope(ALL_STREAMS_AGGREGATED).incr();
+
     // Consider there are cases that different streams with the same streamId,
     // but with different source component. We need to distinguish them too.
     String globalStreamId =
@@ -137,6 +138,8 @@ public class FullBoltMetrics extends BoltMetrics {
   public void failedTuple(String streamId, String sourceComponent, long latency) {
     failCount.scope(streamId).incr();
     failLatency.scope(streamId).update(latency);
+
+    failCount.scope(ALL_STREAMS_AGGREGATED).incr();
 
     // Consider there are cases that different streams with the same streamId,
     // but with different source component. We need to distinguish them too.
@@ -150,6 +153,9 @@ public class FullBoltMetrics extends BoltMetrics {
     executeCount.scope(streamId).incr();
     executeLatency.scope(streamId).update(latency);
     executeTimeNs.scope(streamId).incrBy(latency);
+
+    executeCount.scope(ALL_STREAMS_AGGREGATED).incr();
+    executeTimeNs.scope(ALL_STREAMS_AGGREGATED).incrBy(latency);
 
     // Consider there are cases that different streams with the same streamId,
     // but with different source component. We need to distinguish them too.
@@ -170,6 +176,7 @@ public class FullBoltMetrics extends BoltMetrics {
 
   public void deserializeDataTuple(String streamId, String sourceComponent, long latency) {
     deserializationTimeNs.scope(streamId).incrBy(latency);
+    deserializationTimeNs.scope(ALL_STREAMS_AGGREGATED).incrBy(latency);
 
     // Consider there are cases that different streams with the same streamId,
     // but with different source component. We need to distinguish them too.
@@ -180,6 +187,7 @@ public class FullBoltMetrics extends BoltMetrics {
 
   public void serializeDataTuple(String streamId, long latency) {
     serializationTimeNs.scope(streamId).incrBy(latency);
+    serializationTimeNs.scope(ALL_STREAMS_AGGREGATED).incrBy(latency);
   }
 }
 

--- a/heron/common/src/java/com/twitter/heron/common/utils/metrics/FullSpoutMetrics.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/metrics/FullSpoutMetrics.java
@@ -110,19 +110,25 @@ public class FullSpoutMetrics extends SpoutMetrics {
   public void ackedTuple(String streamId, long latency) {
     ackCount.scope(streamId).incr();
     completeLatency.scope(streamId).update(latency);
+
+    ackCount.scope(ALL_STREAMS_AGGREGATED).incr();
   }
 
   public void failedTuple(String streamId, long latency) {
     failCount.scope(streamId).incr();
     failLatency.scope(streamId).update(latency);
+
+    failCount.scope(ALL_STREAMS_AGGREGATED).incr();
   }
 
   public void timeoutTuple(String streamId) {
     timeoutCount.scope(streamId).incr();
+    timeoutCount.scope(ALL_STREAMS_AGGREGATED).incr();
   }
 
   public void emittedTuple(String streamId) {
     emitCount.scope(streamId).incr();
+    emitCount.scope(ALL_STREAMS_AGGREGATED).incr();
   }
 
   public void nextTuple(long latency) {
@@ -140,6 +146,7 @@ public class FullSpoutMetrics extends SpoutMetrics {
 
   public void serializeDataTuple(String streamId, long latency) {
     serializationTimeNs.scope(streamId).incrBy(latency);
+    serializationTimeNs.scope(ALL_STREAMS_AGGREGATED).incrBy(latency);
   }
 }
 

--- a/heron/common/src/java/com/twitter/heron/common/utils/metrics/SpoutMetrics.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/metrics/SpoutMetrics.java
@@ -33,7 +33,7 @@ import com.twitter.heron.common.utils.topology.TopologyContextImpl;
  * 4. Expose methods which could be called externally to change the value of metrics
  */
 
-public class SpoutMetrics implements ComponentMetrics {
+public class SpoutMetrics extends ComponentMetrics {
   private final CountMetric ackCount;
   private final ReducedMetric<MeanReducerState, Number, Double> completeLatency;
   private final ReducedMetric<MeanReducerState, Number, Double> failLatency;


### PR DESCRIPTION
Currently heron-instances exports most of metrics scoped by different streams.

But a lot of customers expressed their interest on the value of all streams aggregated and for now they have to sum them up by themselves.
This pull request exports metrics aggregated on different streams too.
Tested with LocalScheduler.