### PR TITLE
Added Checkpoint Gateway

### DIFF
--- a/heron/stmgr/src/cpp/BUILD
+++ b/heron/stmgr/src/cpp/BUILD
@@ -76,6 +76,7 @@ cc_library(
         "manager/stream-consumers.cpp",
         "manager/tmaster-client.cpp",
         "manager/ckptmgr-client.cpp",
+        "manager/checkpoint-gateway.cpp",
 
         "manager/stmgr-client.h",
         "manager/stmgr-clientmgr.h",
@@ -84,6 +85,7 @@ cc_library(
         "manager/stream-consumers.h",
         "manager/tmaster-client.h",
         "manager/ckptmgr-client.h",
+        "manager/checkpoint-gateway.h",
     ],
     copts = [
         "-Iheron",

--- a/heron/stmgr/src/cpp/manager/checkpoint-gateway.cpp
+++ b/heron/stmgr/src/cpp/manager/checkpoint-gateway.cpp
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2015 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "manager/checkpoint-gateway.h"
+#include <functional>
+#include <iostream>
+#include <deque>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+#include "util/neighbour-calculator.h"
+#include "metrics/metrics.h"
+#include "proto/messages.h"
+#include "basics/basics.h"
+#include "errors/errors.h"
+#include "threads/threads.h"
+#include "network/network.h"
+
+namespace heron {
+namespace stmgr {
+
+CheckpointGateway::CheckpointGateway(sp_uint64 _drain_threshold,
+             NeighbourCalculator* _neighbour_calculator,
+             common::MetricsMgrSt* _metrics_manager_client,
+             std::function<void(sp_int32, proto::system::HeronTupleSet2*)> _drainer1,
+             std::function<void(proto::stmgr::TupleStreamMessage2*)> _drainer2,
+             std::function<void(sp_int32, proto::ckptmgr::InitiateStatefulCheckpoint*)> _drainer3) {
+  drain_threshold_ = _drain_threshold;
+  current_size_ = 0;
+  neighbour_calculator_ = _neighbour_calculator;
+  drainer1_ = _drainer1;
+  drainer2_ = _drainer2;
+  drainer3_ = _drainer3;
+  metrics_manager_client_ = _metrics_manager_client;
+  size_metric_ = new common::AssignableMetric(current_size_);
+  metrics_manager_client_->register_metric("__stateful_gateway_size", size_metric_);
+}
+
+CheckpointGateway::~CheckpointGateway() {
+  for (auto kv : pending_tuples_) {
+    delete kv.second;
+  }
+  metrics_manager_client_->unregister_metric("__stateful_gateway_size");
+  delete size_metric_;
+}
+
+void CheckpointGateway::SendToInstance(sp_int32 _task_id,
+                                       proto::system::HeronTupleSet2* _message) {
+  if (current_size_ > drain_threshold_) {
+    ForceDrain();
+  }
+  CheckpointInfo* info = get_info(_task_id);
+  sp_uint64 size = _message->GetCachedSize();
+  _message = info->SendToInstance(_message, size);
+  if (!_message) {
+    current_size_ += size;
+  } else {
+    drainer1_(_task_id, _message);
+  }
+  size_metric_->SetValue(current_size_);
+}
+
+void CheckpointGateway::SendToInstance(proto::stmgr::TupleStreamMessage2* _message) {
+  if (current_size_ > drain_threshold_) {
+    ForceDrain();
+  }
+  sp_int32 task_id = _message->task_id();
+  sp_uint64 size = _message->set().size();
+  CheckpointInfo* info = get_info(task_id);
+  _message = info->SendToInstance(_message, size);
+  if (!_message) {
+    current_size_ += size;
+  } else {
+    drainer2_(_message);
+  }
+  size_metric_->SetValue(current_size_);
+}
+
+void CheckpointGateway::HandleUpstreamMarker(sp_int32 _src_task_id, sp_int32 _destination_task_id,
+                                             const sp_string& _checkpoint_id) {
+  LOG(INFO) << "Got checkpoint marker for triplet "
+            << _checkpoint_id << " " << _src_task_id << " " << _destination_task_id;
+  CheckpointInfo* info = get_info(_destination_task_id);
+  sp_uint64 size = 0;
+  std::deque<Tuple> tuples = info->HandleUpstreamMarker(_src_task_id, _checkpoint_id, &size);
+  for (auto tupl : tuples) {
+    DrainTuple(_destination_task_id, tupl);
+  }
+  current_size_ -= size;
+  size_metric_->SetValue(current_size_);
+}
+
+void CheckpointGateway::DrainTuple(sp_int32 _dest, Tuple& _tuple) {
+  if (std::get<0>(_tuple)) {
+    drainer1_(_dest, std::get<0>(_tuple));
+  } else if (std::get<1>(_tuple)) {
+    drainer2_(std::get<1>(_tuple));
+  } else {
+    drainer3_(_dest, std::get<2>(_tuple));
+  }
+}
+
+void CheckpointGateway::ForceDrain() {
+  for (auto kv : pending_tuples_) {
+    std::deque<Tuple> tuples = kv.second->ForceDrain();
+    for (auto tupl : tuples) {
+      DrainTuple(kv.first, tupl);
+    }
+  }
+  current_size_ = 0;
+  size_metric_->SetValue(current_size_);
+}
+
+CheckpointGateway::CheckpointInfo*
+CheckpointGateway::get_info(sp_int32 _task_id) {
+  auto iter = pending_tuples_.find(_task_id);
+  if (iter == pending_tuples_.end()) {
+    CheckpointInfo* info =
+         new CheckpointInfo(_task_id, neighbour_calculator_->get_upstreamers(_task_id));
+    pending_tuples_[_task_id] = info;
+    return info;
+  } else {
+    return iter->second;
+  }
+}
+
+void CheckpointGateway::Clear() {
+  for (auto kv : pending_tuples_) {
+    kv.second->Clear();
+    delete kv.second;
+  }
+  pending_tuples_.clear();
+  current_size_ = 0;
+  size_metric_->SetValue(current_size_);
+}
+
+CheckpointGateway::CheckpointInfo::CheckpointInfo(sp_int32 _this_task_id,
+               const std::unordered_set<sp_int32>& _all_upstream_dependencies) {
+  checkpoint_id_ = "";
+  all_upstream_dependencies_ = _all_upstream_dependencies;
+  pending_upstream_dependencies_ = all_upstream_dependencies_;
+  current_size_ = 0;
+  this_task_id_ = _this_task_id;
+}
+
+CheckpointGateway::CheckpointInfo::~CheckpointInfo() {
+  CHECK(pending_tuples_.empty());
+  CHECK_EQ(current_size_, 0);
+}
+
+proto::system::HeronTupleSet2*
+CheckpointGateway::CheckpointInfo::SendToInstance(proto::system::HeronTupleSet2* _tuple,
+                                                  sp_uint64 _size) {
+  if (checkpoint_id_.empty()) {
+    return _tuple;
+  } else {
+    if (pending_upstream_dependencies_.find(_tuple->src_task_id()) !=
+        pending_upstream_dependencies_.end()) {
+      // This means that we still are expecting a checkpoint marker from this src task id
+      return _tuple;
+    } else {
+      add(std::make_tuple(_tuple, (proto::stmgr::TupleStreamMessage2*)NULL,
+                         (proto::ckptmgr::InitiateStatefulCheckpoint*)NULL), _size);
+      return NULL;
+    }
+  }
+}
+
+proto::stmgr::TupleStreamMessage2*
+CheckpointGateway::CheckpointInfo::SendToInstance(proto::stmgr::TupleStreamMessage2* _tuple,
+                                                  sp_uint64 _size) {
+  if (checkpoint_id_.empty()) {
+    return _tuple;
+  } else {
+    if (pending_upstream_dependencies_.find(_tuple->src_task_id()) !=
+        pending_upstream_dependencies_.end()) {
+      // This means that we still are expecting a checkpoint marker from this src task id
+      return _tuple;
+    } else {
+      add(std::make_tuple((proto::system::HeronTupleSet2*)NULL, _tuple,
+                         (proto::ckptmgr::InitiateStatefulCheckpoint*)NULL), _size);
+      return NULL;
+    }
+  }
+}
+
+std::deque<CheckpointGateway::Tuple>
+CheckpointGateway::CheckpointInfo::HandleUpstreamMarker(sp_int32 _src_task_id,
+                                                        const sp_string& _checkpoint_id,
+                                                        sp_uint64* _size) {
+  if (_checkpoint_id == checkpoint_id_) {
+    pending_upstream_dependencies_.erase(_src_task_id);
+  } else if (checkpoint_id_.empty()) {
+    LOG(INFO) << "TaskId: " << this_task_id_
+              << " Seeing the checkpoint marker " << _checkpoint_id
+              << " for the first time";
+    checkpoint_id_ = _checkpoint_id;
+    pending_upstream_dependencies_.erase(_src_task_id);
+  } else if (_checkpoint_id > checkpoint_id_) {
+    LOG(INFO) << "TaskId: " << this_task_id_
+              << " Seeing the checkpoint marker " << _checkpoint_id
+              << " while we were already amidst " << checkpoint_id_
+              << " ..resetting";
+    checkpoint_id_ = _checkpoint_id;
+    pending_upstream_dependencies_ = all_upstream_dependencies_;
+    pending_upstream_dependencies_.erase(_src_task_id);
+  } else {
+    LOG(WARNING) << "TaskId: " << this_task_id_
+                 << " Discarding older checkpoint_id message "
+                 << _checkpoint_id << " from upstream task "
+                 << _src_task_id;
+  }
+  if (pending_upstream_dependencies_.empty()) {
+    LOG(INFO) << "TaskId: " << this_task_id_
+              << " All checkpoint markers received for checkpoint "
+                 << _checkpoint_id;
+    // We need to add Initiate Checkpoint message before the current set
+    auto message = new proto::ckptmgr::InitiateStatefulCheckpoint();
+    message->set_checkpoint_id(_checkpoint_id);
+    add_front(std::make_tuple((proto::system::HeronTupleSet2*)NULL,
+                              (proto::stmgr::TupleStreamMessage2*)NULL, message),
+                              message->GetCachedSize());
+    return ForceDrain();
+  } else {
+    std::deque<Tuple> dummy;
+    return dummy;
+  }
+}
+
+std::deque<CheckpointGateway::Tuple>
+CheckpointGateway::CheckpointInfo::ForceDrain() {
+  checkpoint_id_ = "";
+  current_size_ = 0;
+  std::deque<Tuple> tmp = pending_tuples_;
+  pending_tuples_.clear();
+  pending_upstream_dependencies_ = all_upstream_dependencies_;
+  return tmp;
+}
+
+void CheckpointGateway::CheckpointInfo::add(Tuple _tuple, sp_uint64 _size) {
+  pending_tuples_.push_back(_tuple);
+  current_size_ += _size;
+}
+
+void CheckpointGateway::CheckpointInfo::add_front(Tuple _tuple, sp_uint64 _size) {
+  pending_tuples_.push_front(_tuple);
+  current_size_ += _size;
+}
+
+void CheckpointGateway::CheckpointInfo::Clear() {
+  for (auto tupl : pending_tuples_) {
+    if (std::get<0>(tupl)) {
+      __global_protobuf_pool_release__(std::get<0>(tupl));
+    } else if (std::get<1>(tupl)) {
+      __global_protobuf_pool_release__(std::get<1>(tupl));
+    } else {
+      __global_protobuf_pool_release__(std::get<2>(tupl));
+    }
+  }
+  pending_tuples_.clear();
+  current_size_ = 0;
+  checkpoint_id_ = "";
+}
+}  // namespace stmgr
+}  // namespace heron

--- a/heron/stmgr/src/cpp/manager/checkpoint-gateway.h
+++ b/heron/stmgr/src/cpp/manager/checkpoint-gateway.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2015 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_CPP_SVCS_STMGR_SRC_MANAGER_CHECKPOINT_GATEWAY_H_
+#define SRC_CPP_SVCS_STMGR_SRC_MANAGER_CHECKPOINT_GATEWAY_H_
+
+#include <unordered_map>
+#include <unordered_set>
+#include <deque>
+#include <tuple>
+#include <utility>
+#include "proto/messages.h"
+#include "network/network.h"
+#include "basics/basics.h"
+
+namespace heron {
+namespace common {
+class MetricsMgrSt;
+class AssignableMetric;
+}
+}  // namespace heron
+
+namespace heron {
+namespace stmgr {
+
+class NeighbourCalculator;
+
+// The CheckpointGateway class defines the buffer inside the stmgr
+// that exists to buffer tuples to all the local instances until
+// all upstream checkpoint markers are received. The gateway
+// buffers the tuples uptil a certain threshold after which the
+// markers are discarded
+class CheckpointGateway {
+ public:
+  explicit CheckpointGateway(sp_uint64 _drain_threshold,
+        NeighbourCalculator* _neighbour_calculator,
+        common::MetricsMgrSt* _metrics_manager_client,
+        std::function<void(sp_int32, proto::system::HeronTupleSet2*)> drainer1,
+        std::function<void(proto::stmgr::TupleStreamMessage2*)> drainer2,
+        std::function<void(sp_int32, proto::ckptmgr::InitiateStatefulCheckpoint*)> drainer3);
+  virtual ~CheckpointGateway();
+  void SendToInstance(sp_int32 _task_id, proto::system::HeronTupleSet2* _message);
+  void SendToInstance(proto::stmgr::TupleStreamMessage2* _message);
+  void HandleUpstreamMarker(sp_int32 _src_task_id, sp_int32 _destination_task_id,
+                            const sp_string& _checkpoint_id);
+
+  // Clears all tuples
+  void Clear();
+
+ private:
+  typedef std::tuple<proto::system::HeronTupleSet2*,
+                     proto::stmgr::TupleStreamMessage2*,
+                     proto::ckptmgr::InitiateStatefulCheckpoint*>
+          Tuple;
+
+  // This helper class defines the current state of affairs
+  // for a particular local instance(this_task_id_)
+  class CheckpointInfo {
+   public:
+    explicit CheckpointInfo(sp_int32 _this_task_id,
+                            const std::unordered_set<sp_int32>& _all_upstream_dependencies);
+    ~CheckpointInfo();
+    proto::system::HeronTupleSet2*  SendToInstance(proto::system::HeronTupleSet2* _tuple,
+                                                   sp_uint64 _size);
+    proto::stmgr::TupleStreamMessage2* SendToInstance(proto::stmgr::TupleStreamMessage2* _tuple,
+                                                      sp_uint64 _size);
+    std::deque<Tuple> HandleUpstreamMarker(sp_int32 _src_task_id,
+                                             const sp_string& _checkpoint_id, sp_uint64* _size);
+    std::deque<Tuple> ForceDrain();
+    void Clear();
+   private:
+    void add(Tuple _tuple, sp_uint64 _size);
+    void add_front(Tuple _tuple, sp_uint64 _size);
+    sp_string checkpoint_id_;
+    std::unordered_set<sp_int32> all_upstream_dependencies_;
+    std::unordered_set<sp_int32> pending_upstream_dependencies_;
+    std::deque<Tuple> pending_tuples_;
+    sp_uint64 current_size_;
+    sp_int32 this_task_id_;
+  };
+  void ForceDrain();
+  void DrainTuple(sp_int32 _dest, Tuple& _tuple);
+  CheckpointInfo* get_info(sp_int32 _task_id);
+  // The maximum buffering that we can do before we discard the marker
+  sp_uint64 drain_threshold_;
+  sp_uint64 current_size_;
+  NeighbourCalculator* neighbour_calculator_;
+  common::MetricsMgrSt* metrics_manager_client_;
+  common::AssignableMetric* size_metric_;
+  std::unordered_map<sp_int32, CheckpointInfo*> pending_tuples_;
+  std::function<void(sp_int32, proto::system::HeronTupleSet2*)> drainer1_;
+  std::function<void(proto::stmgr::TupleStreamMessage2*)> drainer2_;
+  std::function<void(sp_int32, proto::ckptmgr::InitiateStatefulCheckpoint*)> drainer3_;
+};
+
+}  // namespace stmgr
+}  // namespace heron
+
+#endif  // SRC_CPP_SVCS_STMGR_SRC_MANAGER_CHECKPOINT_GATEWAY_H_

--- a/heron/stmgr/src/cpp/manager/checkpoint-gateway.h
+++ b/heron/stmgr/src/cpp/manager/checkpoint-gateway.h
@@ -30,7 +30,7 @@ namespace heron {
 namespace common {
 class MetricsMgrSt;
 class AssignableMetric;
-}
+}  // namespace common
 }  // namespace heron
 
 namespace heron {
@@ -48,9 +48,9 @@ class CheckpointGateway {
   explicit CheckpointGateway(sp_uint64 _drain_threshold,
         NeighbourCalculator* _neighbour_calculator,
         common::MetricsMgrSt* _metrics_manager_client,
-        std::function<void(sp_int32, proto::system::HeronTupleSet2*)> drainer1,
-        std::function<void(proto::stmgr::TupleStreamMessage2*)> drainer2,
-        std::function<void(sp_int32, proto::ckptmgr::InitiateStatefulCheckpoint*)> drainer3);
+        std::function<void(sp_int32, proto::system::HeronTupleSet2*)> tupleset_drainer,
+        std::function<void(proto::stmgr::TupleStreamMessage2*)> tuplestream_drainer,
+        std::function<void(sp_int32, proto::ckptmgr::InitiateStatefulCheckpoint*)> ckpt_drainer);
   virtual ~CheckpointGateway();
   void SendToInstance(sp_int32 _task_id, proto::system::HeronTupleSet2* _message);
   void SendToInstance(proto::stmgr::TupleStreamMessage2* _message);
@@ -101,9 +101,9 @@ class CheckpointGateway {
   common::MetricsMgrSt* metrics_manager_client_;
   common::AssignableMetric* size_metric_;
   std::unordered_map<sp_int32, CheckpointInfo*> pending_tuples_;
-  std::function<void(sp_int32, proto::system::HeronTupleSet2*)> drainer1_;
-  std::function<void(proto::stmgr::TupleStreamMessage2*)> drainer2_;
-  std::function<void(sp_int32, proto::ckptmgr::InitiateStatefulCheckpoint*)> drainer3_;
+  std::function<void(sp_int32, proto::system::HeronTupleSet2*)> tupleset_drainer_;
+  std::function<void(proto::stmgr::TupleStreamMessage2*)> tuplestream_drainer_;
+  std::function<void(sp_int32, proto::ckptmgr::InitiateStatefulCheckpoint*)> ckpt_drainer_;
 };
 
 }  // namespace stmgr

--- a/heron/stmgr/tests/cpp/server/BUILD
+++ b/heron/stmgr/tests/cpp/server/BUILD
@@ -35,3 +35,26 @@ cc_test(
     linkstatic = 1,
     flaky = 1,
 )
+
+cc_test(
+    name = "checkpoint-gateway_unittest",
+    srcs = [
+        "checkpoint-gateway_unittest.cpp",
+    ],
+    deps = [
+        "//heron/stmgr/src/cpp:manager-cxx",
+        "//heron/stmgr/src/cpp:grouping-cxx",
+        "//heron/stmgr/src/cpp:util-cxx",
+        "//third_party/gtest:gtest-cxx",
+    ],
+    copts = [
+        "-Iheron",
+        "-Iheron/common/src/cpp",
+        "-Iheron/statemgrs/src/cpp",
+        "-Iheron/stmgr/src/cpp",
+        "-Iheron/stmgr/tests/cpp",
+        "-I$(GENDIR)/heron",
+        "-I$(GENDIR)/heron/common/src/cpp",
+    ],
+    linkstatic = 1,
+)

--- a/heron/stmgr/tests/cpp/server/checkpoint-gateway_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/checkpoint-gateway_unittest.cpp
@@ -1,0 +1,467 @@
+/*
+ * Copyright 2015 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <limits>
+#include <map>
+#include <vector>
+#include <sstream>
+#include <thread>
+#include <string>
+#include <unordered_set>
+#include <unordered_map>
+#include "gtest/gtest.h"
+#include "glog/logging.h"
+#include "proto/messages.h"
+#include "basics/basics.h"
+#include "errors/errors.h"
+#include "threads/threads.h"
+#include "network/network.h"
+#include "basics/modinit.h"
+#include "errors/modinit.h"
+#include "threads/modinit.h"
+#include "network/modinit.h"
+#include "config/topology-config-vars.h"
+#include "config/topology-config-helper.h"
+#include "config/physical-plan-helper.h"
+#include "metrics/metrics-mgr-st.h"
+#include "util/neighbour-calculator.h"
+#include "manager/checkpoint-gateway.h"
+
+const sp_string SPOUT_NAME = "spout";
+const sp_string BOLT_NAME = "bolt";
+const sp_string STREAM_NAME = "stream";
+const sp_string CONTAINER_INDEX = "0";
+const sp_string STMGR_NAME = "stmgr";
+const sp_string LOCALHOST = "127.0.0.1";
+
+// Generate a dummy topology
+static heron::proto::api::Topology* GenerateDummyTopology(
+    const sp_string& topology_name, const sp_string& topology_id, int num_spouts,
+    int num_spout_instances, int num_bolts, int num_bolt_instances,
+    const heron::proto::api::Grouping& grouping) {
+  heron::proto::api::Topology* topology = new heron::proto::api::Topology();
+  topology->set_id(topology_id);
+  topology->set_name(topology_name);
+  size_t spouts_size = num_spouts;
+  size_t bolts_size = num_bolts;
+  // Set spouts
+  for (size_t i = 0; i < spouts_size; ++i) {
+    heron::proto::api::Spout* spout = topology->add_spouts();
+    // Set the component information
+    heron::proto::api::Component* component = spout->mutable_comp();
+    sp_string compname = SPOUT_NAME;
+    compname += std::to_string(i);
+    component->set_name(compname);
+    heron::proto::api::ComponentObjectSpec compspec = heron::proto::api::JAVA_CLASS_NAME;
+    component->set_spec(compspec);
+    // Set the stream information
+    heron::proto::api::OutputStream* ostream = spout->add_outputs();
+    heron::proto::api::StreamId* tstream = ostream->mutable_stream();
+    sp_string streamid = STREAM_NAME;
+    streamid += std::to_string(i);
+    tstream->set_id(streamid);
+    tstream->set_component_name(compname);
+    heron::proto::api::StreamSchema* schema = ostream->mutable_schema();
+    heron::proto::api::StreamSchema::KeyType* key_type = schema->add_keys();
+    key_type->set_key("dummy");
+    key_type->set_type(heron::proto::api::OBJECT);
+    // Set the config
+    heron::proto::api::Config* config = component->mutable_config();
+    heron::proto::api::Config::KeyValue* kv = config->add_kvs();
+    kv->set_key(heron::config::TopologyConfigVars::TOPOLOGY_COMPONENT_PARALLELISM);
+    kv->set_value(std::to_string(num_spout_instances));
+  }
+  // Set bolts
+  for (size_t i = 0; i < bolts_size; ++i) {
+    heron::proto::api::Bolt* bolt = topology->add_bolts();
+    // Set the component information
+    heron::proto::api::Component* component = bolt->mutable_comp();
+    sp_string compname = BOLT_NAME;
+    compname += std::to_string(i);
+    component->set_name(compname);
+    heron::proto::api::ComponentObjectSpec compspec = heron::proto::api::JAVA_CLASS_NAME;
+    component->set_spec(compspec);
+    // Set the stream information
+    heron::proto::api::InputStream* istream = bolt->add_inputs();
+    heron::proto::api::StreamId* tstream = istream->mutable_stream();
+    sp_string streamid = STREAM_NAME;
+    streamid += std::to_string(i);
+    tstream->set_id(streamid);
+    sp_string input_compname = SPOUT_NAME;
+    input_compname += std::to_string(i);
+    tstream->set_component_name(input_compname);
+    istream->set_gtype(grouping);
+    // Set the config
+    heron::proto::api::Config* config = component->mutable_config();
+    heron::proto::api::Config::KeyValue* kv = config->add_kvs();
+    kv->set_key(heron::config::TopologyConfigVars::TOPOLOGY_COMPONENT_PARALLELISM);
+    kv->set_value(std::to_string(num_bolt_instances));
+  }
+  // Set message timeout
+  heron::proto::api::Config* topology_config = topology->mutable_topology_config();
+  heron::proto::api::Config::KeyValue* kv = topology_config->add_kvs();
+  kv->set_key(heron::config::TopologyConfigVars::TOPOLOGY_STATEFUL_ENABLED);
+  kv->set_value("true");
+
+  // Set state
+  topology->set_state(heron::proto::api::RUNNING);
+
+  return topology;
+}
+
+const sp_string CreateInstanceId(int32_t _global_index) {
+  std::ostringstream instanceid_stream;
+  instanceid_stream << "instance-" << _global_index;
+  return instanceid_stream.str();
+}
+
+std::string GenerateStMgrId(int32_t _index) {
+  std::ostringstream ostr;
+  ostr << "stmgr-" << _index;
+  return ostr.str();
+}
+
+heron::proto::system::Instance* CreateInstance(int32_t _comp, int32_t _comp_instance,
+                                               int32_t _stmgr_id,
+                                               int32_t _global_index, bool _is_spout) {
+  heron::proto::system::Instance* imap = new heron::proto::system::Instance();
+  imap->set_instance_id(CreateInstanceId(_global_index));
+  imap->set_stmgr_id(GenerateStMgrId(_stmgr_id));
+  heron::proto::system::InstanceInfo* inst = imap->mutable_info();
+  inst->set_task_id(_global_index);
+  inst->set_component_index(_comp_instance);
+  if (_is_spout) {
+    inst->set_component_name("spout" + std::to_string(_comp));
+  } else {
+    inst->set_component_name("bolt" + std::to_string(_comp));
+  }
+  return imap;
+}
+
+heron::proto::system::PhysicalPlan* CreatePplan(int32_t _ncontainers,
+                                                int32_t _nsbcomp, int32_t _ninstances) {
+  int32_t nContainers = _ncontainers;
+  int32_t nSpouts = _nsbcomp;
+  int32_t nSpoutInstances = _ninstances;
+  int32_t nBolts = _nsbcomp;
+  int32_t nBoltInstances = _ninstances;
+  auto topology = GenerateDummyTopology("TestTopology", "TestTopology-12345",
+                                        nSpouts, nSpoutInstances, nBolts, nBoltInstances,
+                                        heron::proto::api::SHUFFLE);
+  auto pplan = new heron::proto::system::PhysicalPlan();
+  pplan->mutable_topology()->CopyFrom(*topology);
+  delete topology;
+  for (int32_t i = 0; i < nContainers; ++i) {
+    auto stmgr = pplan->add_stmgrs();
+    stmgr->set_id(GenerateStMgrId(i));
+    stmgr->set_host_name("127.0.0.1");
+    stmgr->set_data_port(100);
+    stmgr->set_local_endpoint("101");
+  }
+  int32_t stmgr_assignment = 0;
+  int32_t global_index = 1;
+  for (int spout = 0; spout < nSpouts; ++spout) {
+    for (int spout_instance = 0; spout_instance < nSpoutInstances; ++spout_instance) {
+      heron::proto::system::Instance* instance =
+          CreateInstance(spout, spout_instance, stmgr_assignment, global_index++, true);
+      if (++stmgr_assignment >= nContainers) {
+        stmgr_assignment = 0;
+      }
+      pplan->add_instances()->CopyFrom(*instance);
+      delete instance;
+    }
+  }
+  for (int bolt = 0; bolt < nBolts; ++bolt) {
+    for (int bolt_instance = 0; bolt_instance < nBoltInstances; ++bolt_instance) {
+      heron::proto::system::Instance* instance =
+          CreateInstance(bolt, bolt_instance, stmgr_assignment, global_index++, false);
+      if (++stmgr_assignment >= nContainers) {
+        stmgr_assignment = 0;
+      }
+      pplan->add_instances()->CopyFrom(*instance);
+      delete instance;
+    }
+  }
+  return pplan;
+}
+
+static std::vector<sp_int32> drainer1_tuples;
+static std::vector<sp_int32> drainer2_tuples;
+static std::vector<sp_int32> drainer3_markers;
+void drainer1(sp_int32 _task_id, heron::proto::system::HeronTupleSet2* _tup) {
+  drainer1_tuples.push_back(_task_id);
+  delete _tup;
+}
+
+void drainer2(heron::proto::stmgr::TupleStreamMessage2* _tup) {
+  drainer2_tuples.push_back(_tup->task_id());
+  delete _tup;
+}
+
+void drainer3(sp_int32 _task_id, heron::proto::ckptmgr::InitiateStatefulCheckpoint* _ckpt) {
+  drainer3_markers.push_back(_task_id);
+  delete _ckpt;
+}
+
+// Test to make sure that without any checkpoint business, things work smoothly
+TEST(CheckpointGateway, emptyckptid) {
+  for (int i = 1; i < 4; ++i) {
+    for (int j = 1; j < 4; ++j) {
+      auto pplan = CreatePplan(2, i, j);
+      auto neighbour_calculator = new heron::stmgr::NeighbourCalculator();
+      neighbour_calculator->Reconstruct(*pplan);
+      EventLoop* dummyLoop = new EventLoopImpl();
+      auto dummy_metrics_client_ = new heron::common::MetricsMgrSt("localhost", 11000, 11001,
+                                                                   "_stmgr", "_stmgr", 100,
+                                                                   dummyLoop);
+      auto gateway = new heron::stmgr::CheckpointGateway(1024 * 1024, neighbour_calculator,
+                                                         dummy_metrics_client_,
+                                                         drainer1, drainer2, drainer3);
+      int nTuples = 100;
+      for (auto i = 0; i < nTuples; ++i) {
+        auto tup = new heron::proto::system::HeronTupleSet2();
+        gateway->SendToInstance(i, tup);
+      }
+      EXPECT_EQ(nTuples, drainer1_tuples.size());
+      for (auto i = 0; i < nTuples; ++i) {
+        EXPECT_EQ(i, drainer1_tuples[i]);
+      }
+      EXPECT_EQ(0, drainer2_tuples.size());
+      EXPECT_EQ(0, drainer3_markers.size());
+
+      drainer1_tuples.clear();
+      drainer2_tuples.clear();
+      drainer3_markers.clear();
+      delete pplan;
+      delete neighbour_calculator;
+      delete gateway;
+      delete dummy_metrics_client_;
+      delete dummyLoop;
+    }
+  }
+}
+
+void computeTasks(const heron::proto::system::PhysicalPlan& _pplan,
+                  heron::stmgr::NeighbourCalculator* _neighbour_calculator,
+                  std::unordered_set<sp_int32>& _local_tasks,
+                  std::unordered_set<sp_int32>& _local_spouts,
+                  std::unordered_set<sp_int32>& _local_bolts,
+                  std::unordered_map<sp_int32, std::unordered_set<sp_int32>>& _upstream_map) {
+  const std::string& stmgr = _pplan.stmgrs(0).id();
+  heron::config::PhysicalPlanHelper::GetTasks(_pplan, stmgr, _local_tasks);
+  heron::config::PhysicalPlanHelper::GetLocalSpouts(_pplan, stmgr, _local_spouts);
+  for (auto task : _local_tasks) {
+    if (_local_spouts.find(task) == _local_spouts.end()) {
+      _local_bolts.insert(task);
+    }
+  }
+  for (auto local_bolt : _local_bolts) {
+    _upstream_map[local_bolt] = _neighbour_calculator->get_upstreamers(local_bolt);
+  }
+}
+
+// Test to check if tuple draining and buffering happens properly
+TEST(CheckpointGateway, normaloperation) {
+  for (int i = 1; i < 4; ++i) {
+    for (int j = 1; j < 4; ++j) {
+      auto pplan = CreatePplan(2, i, j);
+      auto neighbour_calculator = new heron::stmgr::NeighbourCalculator();
+      neighbour_calculator->Reconstruct(*pplan);
+      EventLoop* dummyLoop = new EventLoopImpl();
+      auto dummy_metrics_client_ = new heron::common::MetricsMgrSt("localhost", 11000, 11001,
+                                                                   "_stmgr", "_stmgr", 100,
+                                                                   dummyLoop);
+      auto gateway = new heron::stmgr::CheckpointGateway(1024 * 1024, neighbour_calculator,
+                                                         dummy_metrics_client_,
+                                                         drainer1, drainer2, drainer3);
+      // We will pretend to be one of the stmgrs
+      std::unordered_set<sp_int32> local_tasks;
+      std::unordered_set<sp_int32> local_spouts;
+      std::unordered_set<sp_int32> local_bolts;
+      std::unordered_map<sp_int32, std::unordered_set<sp_int32>> upstream_map;
+      computeTasks(*pplan, neighbour_calculator, local_tasks, local_spouts,
+                   local_bolts, upstream_map);
+
+      // Let's make sure that at first, things just pass thru
+      for (auto local_bolt : local_bolts) {
+        EXPECT_EQ(0, drainer1_tuples.size());
+        EXPECT_EQ(0, drainer2_tuples.size());
+        EXPECT_EQ(0, drainer3_markers.size());
+        auto tup = new heron::proto::system::HeronTupleSet2();
+        gateway->SendToInstance(local_bolt, tup);
+        EXPECT_EQ(1, drainer1_tuples.size());
+        EXPECT_EQ(0, drainer2_tuples.size());
+        EXPECT_EQ(0, drainer3_markers.size());
+        drainer1_tuples.clear();
+      }
+
+      // Now let;s issue a ckpt marker
+      std::string ckpt = "0";
+      for (auto local_bolt : local_bolts) {
+        sp_int32 upstreamer = *(upstream_map[local_bolt].begin());
+        upstream_map[local_bolt].erase(upstreamer);
+        gateway->HandleUpstreamMarker(upstreamer, local_bolt, ckpt);
+        // Now send another tuple from the upstreamer.
+        auto tup = new heron::proto::system::HeronTupleSet2();
+        tup->set_src_task_id(upstreamer);
+        gateway->SendToInstance(local_bolt, tup);
+        if (upstream_map[local_bolt].empty()) {
+          // They only have one upstreamer, so the tuple is passed thru
+          EXPECT_EQ(1, drainer1_tuples.size());
+          EXPECT_EQ(0, drainer2_tuples.size());
+          EXPECT_EQ(1, drainer3_markers.size());
+        } else {
+          // These should be buffered
+          EXPECT_EQ(0, drainer1_tuples.size());
+          EXPECT_EQ(0, drainer2_tuples.size());
+          EXPECT_EQ(0, drainer3_markers.size());
+        }
+        // Send the rest of the checkpoint markers
+        for (auto src : upstream_map[local_bolt]) {
+          gateway->HandleUpstreamMarker(src, local_bolt, ckpt);
+        }
+        // Things should have been drained
+        EXPECT_EQ(1, drainer1_tuples.size());
+        EXPECT_EQ(0, drainer2_tuples.size());
+        EXPECT_EQ(1, drainer3_markers.size());
+
+        // Next tuples should be passed thru without blocking
+        tup = new heron::proto::system::HeronTupleSet2();
+        tup->set_src_task_id(upstreamer);
+        gateway->SendToInstance(local_bolt, tup);
+        EXPECT_EQ(2, drainer1_tuples.size());
+        EXPECT_EQ(0, drainer2_tuples.size());
+        EXPECT_EQ(1, drainer3_markers.size());
+        drainer1_tuples.clear();
+        drainer2_tuples.clear();
+        drainer3_markers.clear();
+      }
+
+      // clean things up
+      drainer1_tuples.clear();
+      drainer2_tuples.clear();
+      drainer3_markers.clear();
+      delete pplan;
+      delete neighbour_calculator;
+      delete gateway;
+      delete dummy_metrics_client_;
+      delete dummyLoop;
+    }
+  }
+}
+
+// Test to check if overflow works
+TEST(CheckpointGateway, overflow) {
+  for (int i = 1; i < 4; ++i) {
+    for (int j = 1; j < 4; ++j) {
+      auto pplan = CreatePplan(2, i, j);
+      auto neighbour_calculator = new heron::stmgr::NeighbourCalculator();
+      neighbour_calculator->Reconstruct(*pplan);
+      EventLoop* dummyLoop = new EventLoopImpl();
+      auto dummy_metrics_client_ = new heron::common::MetricsMgrSt("localhost", 11000, 11001,
+                                                                   "_stmgr", "_stmgr", 100,
+                                                                   dummyLoop);
+      auto gateway = new heron::stmgr::CheckpointGateway(1024 * 1024, neighbour_calculator,
+                                                         dummy_metrics_client_,
+                                                         drainer1, drainer2, drainer3);
+      // We will pretend to be one of the stmgrs
+      std::unordered_set<sp_int32> local_tasks;
+      std::unordered_set<sp_int32> local_spouts;
+      std::unordered_set<sp_int32> local_bolts;
+      std::unordered_map<sp_int32, std::unordered_set<sp_int32>> upstream_map;
+      computeTasks(*pplan, neighbour_calculator, local_tasks, local_spouts,
+                   local_bolts, upstream_map);
+
+      // Let's make sure that at first, things just pass thru
+      for (auto local_bolt : local_bolts) {
+        EXPECT_EQ(0, drainer1_tuples.size());
+        EXPECT_EQ(0, drainer2_tuples.size());
+        EXPECT_EQ(0, drainer3_markers.size());
+        auto tup = new heron::proto::system::HeronTupleSet2();
+        gateway->SendToInstance(local_bolt, tup);
+        EXPECT_EQ(1, drainer1_tuples.size());
+        EXPECT_EQ(0, drainer2_tuples.size());
+        EXPECT_EQ(0, drainer3_markers.size());
+        drainer1_tuples.clear();
+      }
+
+      // Now let;s issue a ckpt marker
+      std::string ckpt = "0";
+      for (auto local_bolt : local_bolts) {
+        sp_int32 upstreamer = *(upstream_map[local_bolt].begin());
+        upstream_map[local_bolt].erase(upstreamer);
+        gateway->HandleUpstreamMarker(upstreamer, local_bolt, ckpt);
+        // Now send another tuple from the upstreamer.
+        auto tup = new heron::proto::system::HeronTupleSet2();
+        tup->set_src_task_id(upstreamer);
+        sp_uint32 cached_size = tup->ByteSize();
+        gateway->SendToInstance(local_bolt, tup);
+        if (upstream_map[local_bolt].empty()) {
+          // They only have one upstreamer, so the tuple is passed thru
+          EXPECT_EQ(1, drainer1_tuples.size());
+          EXPECT_EQ(0, drainer2_tuples.size());
+          EXPECT_EQ(1, drainer3_markers.size());
+        } else {
+          // These should be buffered
+          EXPECT_EQ(0, drainer1_tuples.size());
+          EXPECT_EQ(0, drainer2_tuples.size());
+          EXPECT_EQ(0, drainer3_markers.size());
+          // Bombard lots of tuples from upstreamer
+          sp_uint32 total_sent = 1;
+          while (cached_size <= 1024 * 1024) {
+            EXPECT_EQ(0, drainer1_tuples.size());
+            EXPECT_EQ(0, drainer2_tuples.size());
+            EXPECT_EQ(0, drainer3_markers.size());
+            tup = new heron::proto::system::HeronTupleSet2();
+            tup->set_src_task_id(upstreamer);
+            cached_size += tup->ByteSize();
+            total_sent++;
+            gateway->SendToInstance(local_bolt, tup);
+          }
+          // Send one more to tip over
+          tup = new heron::proto::system::HeronTupleSet2();
+          tup->set_src_task_id(upstreamer);
+          cached_size += tup->ByteSize();
+          total_sent++;
+          gateway->SendToInstance(local_bolt, tup);
+          EXPECT_EQ(total_sent, drainer1_tuples.size());
+          EXPECT_EQ(0, drainer2_tuples.size());
+          EXPECT_EQ(0, drainer3_markers.size());
+        }
+
+        drainer1_tuples.clear();
+        drainer2_tuples.clear();
+        drainer3_markers.clear();
+      }
+
+      // clean things up
+      drainer1_tuples.clear();
+      drainer2_tuples.clear();
+      drainer3_markers.clear();
+      delete pplan;
+      delete neighbour_calculator;
+      delete gateway;
+      delete dummy_metrics_client_;
+      delete dummyLoop;
+    }
+  }
+}
+
+int main(int argc, char** argv) {
+  heron::common::Initialize(argv[0]);
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
In Stateful processing, once we receive a checkpoint marker from an upstream task, we need to buffer further tuples from that task until the marker for the same checkpoint id has been received from all upstream task_ids. We should buffer this, until a certain threshold is reached. The added class encapsulates the logic of doing this.