### PR TITLE
add libtool-bin in doc compiling on linux

### DIFF
--- a/website/content/docs/developers/compiling/linux.md
+++ b/website/content/docs/developers/compiling/linux.md
@@ -21,7 +21,7 @@ $ sudo apt-get upgrade -y
 ### Step 2 --- Install required libraries
 
 ```bash
-$ sudo apt-get install git build-essential automake cmake libtool zip \
+$ sudo apt-get install git build-essential automake cmake libtool-bin zip \
   libunwind-setjmp0-dev zlib1g-dev unzip pkg-config -y
 ```
 

--- a/website/content/docs/developers/compiling/linux.md
+++ b/website/content/docs/developers/compiling/linux.md
@@ -22,7 +22,7 @@ $ sudo apt-get upgrade -y
 
 ```bash
 $ sudo apt-get install git build-essential automake cmake libtool-bin zip \
-  libunwind-setjmp0-dev zlib1g-dev unzip pkg-config -y
+  libunwind-setjmp0-dev zlib1g-dev unzip pkg-config python-setuptools -y
 ```
 
 #### Step 3 --- Set the following environment variables


### PR DESCRIPTION
./bazel_configure.py complains libtool not found in the path.
this pr fix it.

tested on ubuntu