### PR TITLE
set init value getTotalMemoryUsed

### DIFF
--- a/heron/common/src/cpp/basics/processutils.cpp
+++ b/heron/common/src/cpp/basics/processutils.cpp
@@ -24,7 +24,7 @@ pid_t ProcessUtils::getPid() { return ::getpid(); }
 int ProcessUtils::getResourceUsage(struct rusage *usage) { return ::getrusage(RUSAGE_SELF, usage); }
 
 size_t ProcessUtils::getTotalMemoryUsed() {
-  size_t total;
+  size_t total = 0;
   MallocExtension::instance()->GetNumericProperty("generic.heap_size", &total);
   return total;
 }


### PR DESCRIPTION
fix Valgrind Memcheck complaints
```
(1) ==27737== Conditional jump or move depends on uninitialised value(s)
(1) ==27737==    at 0x100C31E87: __ultoa (in /usr/lib/system/libsystem_c.dylib)
(1) ==27737==    by 0x100C57422: __v2printf (in /usr/lib/system/libsystem_c.dylib)
(1) ==27737==    by 0x100C3B929: _vsnprintf (in /usr/lib/system/libsystem_c.dylib)
(1) ==27737==    by 0x100C3B97C: vsnprintf_l (in /usr/lib/system/libsystem_c.dylib)
(1) ==27737==    by 0x100C2BD82: snprintf (in /usr/lib/system/libsystem_c.dylib)
(1) ==27737==    by 0x10098578C: std::__1::to_string(long long) (in /usr/lib/libc++.1.dylib)
(1) ==27737==    by 0x1000EAE73: heron::common::AssignableMetric::GetAndReset(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, heron::proto::system::MetricPublisherPublishMessage*) (assignable-metric.cpp:45)
(1) ==27737==    by 0x1000FA9BC: heron::common::MultiAssignableMetric::GetAndReset(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, heron::proto::system::MetricPublisherPublishMessage*) (multi-assignable-metric.cpp:57)
(1) ==27737==    by 0x1000EC7C9: heron::common::MetricsMgrSt::gather_metrics(EventLoop::Status) (metrics-mgr-st.cpp:82)
(1) ==27737==    by 0x1000EDFDD: heron::common::MetricsMgrSt::MetricsMgrSt(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, EventLoop*)::$_0::operator()(EventLoop::Status) const (metrics-mgr-st.cpp:45)
(1) ==27737==    by 0x1000EDFAE: void std::__1::__invoke_void_return_wrapper<void>::__call<heron::common::MetricsMgrSt::MetricsMgrSt(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, EventLoop*)::$_0&, EventLoop::Status>(heron::common::MetricsMgrSt::MetricsMgrSt(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, EventLoop*)::$_0&, EventLoop::Status&&) (__functional_base:416)
(1) ==27737==    by 0x1000EDEA8: std::__1::__function::__func<heron::common::MetricsMgrSt::MetricsMgrSt(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, EventLoop*)::$_0, std::__1::allocator<heron::common::MetricsMgrSt::MetricsMgrSt(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, EventLoop*)::$_0>, void (EventLoop::Status)>::operator()(EventLoop::Status&&) (functional:1437)
(1) ==27737==  Uninitialised value was created by a stack allocation
(1) ==27737==    at 0x1003116C0: ProcessUtils::getTotalMemoryUsed() (processutils.cpp:26)
(1) ==27737== 
(1) ==27737== Conditional jump or move depends on uninitialised value(s)
(1) ==27737==    at 0x100C31E98: __ultoa (in /usr/lib/system/libsystem_c.dylib)
(1) ==27737==    by 0x100C57422: __v2printf (in /usr/lib/system/libsystem_c.dylib)
(1) ==27737==    by 0x100C3B929: _vsnprintf (in /usr/lib/system/libsystem_c.dylib)
(1) ==27737==    by 0x100C3B97C: vsnprintf_l (in /usr/lib/system/libsystem_c.dylib)
(1) ==27737==    by 0x100C2BD82: snprintf (in /usr/lib/system/libsystem_c.dylib)
(1) ==27737==    by 0x10098578C: std::__1::to_string(long long) (in /usr/lib/libc++.1.dylib)
(1) ==27737==    by 0x1000EAE73: heron::common::AssignableMetric::GetAndReset(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, heron::proto::system::MetricPublisherPublishMessage*) (assignable-metric.cpp:45)
(1) ==27737==    by 0x1000FA9BC: heron::common::MultiAssignableMetric::GetAndReset(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, heron::proto::system::MetricPublisherPublishMessage*) (multi-assignable-metric.cpp:57)
(1) ==27737==    by 0x1000EC7C9: heron::common::MetricsMgrSt::gather_metrics(EventLoop::Status) (metrics-mgr-st.cpp:82)
(1) ==27737==    by 0x1000EDFDD: heron::common::MetricsMgrSt::MetricsMgrSt(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, EventLoop*)::$_0::operator()(EventLoop::Status) const (metrics-mgr-st.cpp:45)
(1) ==27737==    by 0x1000EDFAE: void std::__1::__invoke_void_return_wrapper<void>::__call<heron::common::MetricsMgrSt::MetricsMgrSt(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, EventLoop*)::$_0&, EventLoop::Status>(heron::common::MetricsMgrSt::MetricsMgrSt(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, EventLoop*)::$_0&, EventLoop::Status&&) (__functional_base:416)
(1) ==27737==    by 0x1000EDEA8: std::__1::__function::__func<heron::common::MetricsMgrSt::MetricsMgrSt(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, EventLoop*)::$_0, std::__1::allocator<heron::common::MetricsMgrSt::MetricsMgrSt(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, EventLoop*)::$_0>, void (EventLoop::Status)>::operator()(EventLoop::Status&&) (functional:1437)
(1) ==27737==  Uninitialised value was created by a stack allocation
(1) ==27737==    at 0x1003116C0: ProcessUtils::getTotalMemoryUsed() (processutils.cpp:26)
(1) ==27737== 
(1) ==27737== Conditional jump or move depends on uninitialised value(s)
(1) ==27737==    at 0x100C31F03: __ultoa (in /usr/lib/system/libsystem_c.dylib)
(1) ==27737==    by 0x100C57422: __v2printf (in /usr/lib/system/libsystem_c.dylib)
(1) ==27737==    by 0x100C3B929: _vsnprintf (in /usr/lib/system/libsystem_c.dylib)
(1) ==27737==    by 0x100C3B97C: vsnprintf_l (in /usr/lib/system/libsystem_c.dylib)
(1) ==27737==    by 0x100C2BD82: snprintf (in /usr/lib/system/libsystem_c.dylib)
(1) ==27737==    by 0x10098578C: std::__1::to_string(long long) (in /usr/lib/libc++.1.dylib)
(1) ==27737==    by 0x1000EAE73: heron::common::AssignableMetric::GetAndReset(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, heron::proto::system::MetricPublisherPublishMessage*) (assignable-metric.cpp:45)
(1) ==27737==    by 0x1000FA9BC: heron::common::MultiAssignableMetric::GetAndReset(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, heron::proto::system::MetricPublisherPublishMessage*) (multi-assignable-metric.cpp:57)
(1) ==27737==    by 0x1000EC7C9: heron::common::MetricsMgrSt::gather_metrics(EventLoop::Status) (metrics-mgr-st.cpp:82)
(1) ==27737==    by 0x1000EDFDD: heron::common::MetricsMgrSt::MetricsMgrSt(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, EventLoop*)::$_0::operator()(EventLoop::Status) const (metrics-mgr-st.cpp:45)
(1) ==27737==    by 0x1000EDFAE: void std::__1::__invoke_void_return_wrapper<void>::__call<heron::common::MetricsMgrSt::MetricsMgrSt(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, EventLoop*)::$_0&, EventLoop::Status>(heron::common::MetricsMgrSt::MetricsMgrSt(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, EventLoop*)::$_0&, EventLoop::Status&&) (__functional_base:416)
(1) ==27737==    by 0x1000EDEA8: std::__1::__function::__func<heron::common::MetricsMgrSt::MetricsMgrSt(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, EventLoop*)::$_0, std::__1::allocator<heron::common::MetricsMgrSt::MetricsMgrSt(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, EventLoop*)::$_0>, void (EventLoop::Status)>::operator()(EventLoop::Status&&) (functional:1437)
(1) ==27737==  Uninitialised value was created by a stack allocation
(1) ==27737==    at 0x1003116C0: ProcessUtils::getTotalMemoryUsed() (processutils.cpp:26)
(1) ==27737== 
(1) ==27737== Conditional jump or move depends on uninitialised value(s)
(1) ==27737==    at 0x100338315: google::protobuf::internal::UTF8GenericScanFastAscii(google::protobuf::internal::UTF8StateMachineObj const*, char const*, int, int*) (structurally_valid.cc:483)
(1) ==27737==    by 0x1003383C6: google::protobuf::internal::IsStructurallyValidUTF8(char const*, int) (structurally_valid.cc:529)
(1) ==27737==    by 0x10038BAF1: google::protobuf::internal::WireFormat::VerifyUTF8StringFallback(char const*, int, google::protobuf::internal::WireFormat::Operation) (wire_format.cc:1042)
(1) ==27737==    by 0x100248040: google::protobuf::internal::WireFormat::VerifyUTF8String(char const*, int, google::protobuf::internal::WireFormat::Operation) (wire_format.h:296)
(1) ==27737==    by 0x1001B3134: heron::proto::system::MetricDatum::SerializeWithCachedSizesToArray(unsigned char*) const (metrics.pb.cc:475)
(1) ==27737==    by 0x1001C106C: heron::proto::system::MetricPublisherPublishMessage::SerializeWithCachedSizesToArray(unsigned char*) const (wire_format_lite_inl.h:710)
(1) ==27737==    by 0x1002D026F: OutgoingPacket::PackProtocolBuffer(google::protobuf::Message const&, int) (packet.cpp:211)
(1) ==27737==    by 0x1002A43A9: Client::InternalSendMessage(google::protobuf::Message const&) (client.cpp:152)
(1) ==27737==    by 0x1002A3F2C: Client::SendMessage(google::protobuf::Message const&) (client.cpp:58)
(1) ==27737==    by 0x1000F3027: heron::common::MetricsMgrClient::SendMetrics(heron::proto::system::MetricPublisherPublishMessage*) (metricsmgr-client.cpp:137)
(1) ==27737==    by 0x1000EC91B: heron::common::MetricsMgrSt::gather_metrics(EventLoop::Status) (metrics-mgr-st.cpp:84)
(1) ==27737==    by 0x1000EDFDD: heron::common::MetricsMgrSt::MetricsMgrSt(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, EventLoop*)::$_0::operator()(EventLoop::Status) const (metrics-mgr-st.cpp:45)
(1) ==27737==  Uninitialised value was created by a stack allocation
(1) ==27737==    at 0x1003116C0: ProcessUtils::getTotalMemoryUsed() (processutils.cpp:26)
(1) ==27737== 
(1) ==27737== Conditional jump or move depends on uninitialised value(s)
(1) ==27737==    at 0x10033834B: google::protobuf::internal::UTF8GenericScanFastAscii(google::protobuf::internal::UTF8StateMachineObj const*, char const*, int, int*) (structurally_valid.cc:493)
(1) ==27737==    by 0x1003383C6: google::protobuf::internal::IsStructurallyValidUTF8(char const*, int) (structurally_valid.cc:529)
(1) ==27737==    by 0x10038BAF1: google::protobuf::internal::WireFormat::VerifyUTF8StringFallback(char const*, int, google::protobuf::internal::WireFormat::Operation) (wire_format.cc:1042)
(1) ==27737==    by 0x100248040: google::protobuf::internal::WireFormat::VerifyUTF8String(char const*, int, google::protobuf::internal::WireFormat::Operation) (wire_format.h:296)
(1) ==27737==    by 0x1001B3134: heron::proto::system::MetricDatum::SerializeWithCachedSizesToArray(unsigned char*) const (metrics.pb.cc:475)
(1) ==27737==    by 0x1001C106C: heron::proto::system::MetricPublisherPublishMessage::SerializeWithCachedSizesToArray(unsigned char*) const (wire_format_lite_inl.h:710)
(1) ==27737==    by 0x1002D026F: OutgoingPacket::PackProtocolBuffer(google::protobuf::Message const&, int) (packet.cpp:211)
(1) ==27737==    by 0x1002A43A9: Client::InternalSendMessage(google::protobuf::Message const&) (client.cpp:152)
(1) ==27737==    by 0x1002A3F2C: Client::SendMessage(google::protobuf::Message const&) (client.cpp:58)
(1) ==27737==    by 0x1000F3027: heron::common::MetricsMgrClient::SendMetrics(heron::proto::system::MetricPublisherPublishMessage*) (metricsmgr-client.cpp:137)
(1) ==27737==    by 0x1000EC91B: heron::common::MetricsMgrSt::gather_metrics(EventLoop::Status) (metrics-mgr-st.cpp:84)
(1) ==27737==    by 0x1000EDFDD: heron::common::MetricsMgrSt::MetricsMgrSt(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, EventLoop*)::$_0::operator()(EventLoop::Status) const (metrics-mgr-st.cpp:45)
(1) ==27737==  Uninitialised value was created by a stack allocation
(1) ==27737==    at 0x1003116C0: ProcessUtils::getTotalMemoryUsed() (processutils.cpp:26)
(1) ==27737== 
(1) ==27737== Syscall param writev(vector[...]) points to uninitialised byte(s)
(1) ==27737==    at 0x100D3A7FE: writev (in /usr/lib/system/libsystem_kernel.dylib)
(1) ==27737==    by 0x1002B34FF: Connection::writeIntoEndPoint(int) (connection.cpp:181)
(1) ==27737==    by 0x100295302: BaseConnection::handleWrite(EventLoop::Status) (baseconnection.cpp:126)
(1) ==27737==    by 0x100297F9D: BaseConnection::BaseConnection(ConnectionEndPoint*, ConnectionOptions*, EventLoop*)::$_1::operator()(EventLoop::Status) const (baseconnection.cpp:34)
(1) ==27737==    by 0x100297F6E: void std::__1::__invoke_void_return_wrapper<void>::__call<BaseConnection::BaseConnection(ConnectionEndPoint*, ConnectionOptions*, EventLoop*)::$_1&, EventLoop::Status>(BaseConnection::BaseConnection(ConnectionEndPoint*, ConnectionOptions*, EventLoop*)::$_1&, EventLoop::Status&&) (__functional_base:416)
(1) ==27737==    by 0x100297E68: std::__1::__function::__func<BaseConnection::BaseConnection(ConnectionEndPoint*, ConnectionOptions*, EventLoop*)::$_1, std::__1::allocator<BaseConnection::BaseConnection(ConnectionEndPoint*, ConnectionOptions*, EventLoop*)::$_1>, void (EventLoop::Status)>::operator()(EventLoop::Status&&) (functional:1437)
(1) ==27737==    by 0x1002C4E8A: std::__1::function<void (EventLoop::Status)>::operator()(EventLoop::Status) const (functional:1817)
(1) ==27737==    by 0x1002BCD08: EventLoopImpl::handleWriteCallback(int, short) (event_loop_impl.cpp:345)
(1) ==27737==    by 0x1002BC9FD: EventLoopImpl::eventLoopImplWriteCallback(int, short, void*) (event_loop_impl.cpp:34)
(1) ==27737==    by 0x1002E8328: event_base_loop (event.c:1350)
(1) ==27737==    by 0x1002BE5F8: EventLoopImpl::loop() (event_loop_impl.cpp:78)
(1) ==27737==    by 0x1000023F3: main (stmgr-main.cpp:84)
(1) ==27737==  Address 0x1018e2cef is 655 bytes inside a block of size 988 alloc'd
(1) ==27737==    at 0x100933586: malloc (in /opt/twitter/Cellar/valgrind/3.13.0/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
(1) ==27737==    by 0x100A1EE2D: operator new(unsigned long) (in /usr/lib/libc++abi.dylib)
(1) ==27737==    by 0x1002D0047: OutgoingPacket::OutgoingPacket(unsigned int) (packet.cpp:178)
(1) ==27737==    by 0x1002D008A: OutgoingPacket::OutgoingPacket(unsigned int) (packet.cpp:176)
(1) ==27737==    by 0x1002A40F1: Client::InternalSendMessage(google::protobuf::Message const&) (client.cpp:149)
(1) ==27737==    by 0x1002A3F2C: Client::SendMessage(google::protobuf::Message const&) (client.cpp:58)
(1) ==27737==    by 0x1000F3027: heron::common::MetricsMgrClient::SendMetrics(heron::proto::system::MetricPublisherPublishMessage*) (metricsmgr-client.cpp:137)
(1) ==27737==    by 0x1000EC91B: heron::common::MetricsMgrSt::gather_metrics(EventLoop::Status) (metrics-mgr-st.cpp:84)
(1) ==27737==    by 0x1000EDFDD: heron::common::MetricsMgrSt::MetricsMgrSt(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, EventLoop*)::$_0::operator()(EventLoop::Status) const (metrics-mgr-st.cpp:45)
(1) ==27737==    by 0x1000EDFAE: void std::__1::__invoke_void_return_wrapper<void>::__call<heron::common::MetricsMgrSt::MetricsMgrSt(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, EventLoop*)::$_0&, EventLoop::Status>(heron::common::MetricsMgrSt::MetricsMgrSt(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, EventLoop*)::$_0&, EventLoop::Status&&) (__functional_base:416)
(1) ==27737==    by 0x1000EDEA8: std::__1::__function::__func<heron::common::MetricsMgrSt::MetricsMgrSt(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, EventLoop*)::$_0, std::__1::allocator<heron::common::MetricsMgrSt::MetricsMgrSt(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, EventLoop*)::$_0>, void (EventLoop::Status)>::operator()(EventLoop::Status&&) (functional:1437)
(1) ==27737==    by 0x1002C4E8A: std::__1::function<void (EventLoop::Status)>::operator()(EventLoop::Status) const (functional:1817)
(1) ==27737==  Uninitialised value was created by a stack allocation
(1) ==27737==    at 0x1003116C0: ProcessUtils::getTotalMemoryUsed() (processutils.cpp:26)
```