### PR TITLE
Changed custom grouping api for python

### DIFF
--- a/heron/api/src/python/stream.py
+++ b/heron/api/src/python/stream.py
@@ -16,6 +16,7 @@
 import collections
 
 from .serializer import default_serializer
+from .custom_grouping import ICustomGrouping
 from heron.proto import topology_pb2
 
 class Stream(object):
@@ -114,17 +115,14 @@ class Grouping(object):
                       fields=fields)
 
   @classmethod
-  def custom(cls, classpath):
-    """Custom grouping from a given classpath to an implementation of ICustomGrouping
+  def custom(cls, customgrouper):
+    """Custom grouping from a given implementation of ICustomGrouping
 
-    This method does not exist in the Streamparse API.
-
-    :param classpath: classpath to the ICustomGrouping class to use
+    :param customgrouper: The ICustomGrouping implemention to use
     """
-    if classpath is None or not isinstance(classpath, str):
-      raise TypeError("Argument to custom() must be classpath string to custom grouping, given: "
-                      "%s" % str(classpath))
-    serialized = default_serializer.serialize(classpath)
+    if customgrouper is None or not isinstance(customgrouper, ICustomGrouping):
+      raise TypeError("Argument to custom() must be ICustomGrouping instance")
+    serialized = default_serializer.serialize(customgrouper)
     return cls.custom_serialized(serialized, is_java=False)
 
   @classmethod

--- a/heron/api/tests/python/stream_unittest.py
+++ b/heron/api/tests/python/stream_unittest.py
@@ -17,7 +17,14 @@
 import unittest
 
 from heron.api.src.python.stream import Stream, Grouping
+from heron.api.src.python.custom_grouping import ICustomGrouping
 from heron.proto import topology_pb2
+
+class DummyCustomGrouping(ICustomGrouping):
+  def prepare(self, context, component, stream, target_tasks):
+    pass
+  def choose_tasks(self, values):
+    pass
 
 class StreamTest(unittest.TestCase):
   def test_default_stream_id(self):
@@ -63,7 +70,7 @@ class GroupingTest(unittest.TestCase):
     self.assertTrue(Grouping.is_grouping_sane(sane_fields))
 
     self.assertFalse(Grouping.is_grouping_sane(Grouping.CUSTOM))
-    sane_custom = Grouping.custom("class.path")
+    sane_custom = Grouping.custom(DummyCustomGrouping())
     self.assertTrue(Grouping.is_grouping_sane(sane_custom))
 
   def test_sparse_compatibility(self):
@@ -94,7 +101,7 @@ class GroupingTest(unittest.TestCase):
 
   def test_custom(self):
     # sane
-    sane = Grouping.custom("class.path")
+    sane = Grouping.custom(DummyCustomGrouping())
     self.assertEqual(sane.gtype, topology_pb2.Grouping.Value("CUSTOM"))
     self.assertTrue(isinstance(sane.python_serialized, bytes))
 

--- a/heron/common/src/python/utils/misc/pplan_helper.py
+++ b/heron/common/src/python/utils/misc/pplan_helper.py
@@ -20,8 +20,6 @@ from heron.proto import topology_pb2
 from heron.common.src.python.utils.log import Log
 from heron.common.src.python.utils.topology import TopologyContextImpl
 
-import heron.common.src.python.pex_loader as pex_loader
-
 from .custom_grouping_helper import CustomGroupingHelper
 
 # pylint: disable=too-many-instance-attributes
@@ -223,11 +221,7 @@ class PhysicalPlanHelper(object):
           in_stream.gtype == topology_pb2.Grouping.Value("CUSTOM"):
           # this bolt takes my output in custom grouping manner
           if in_stream.type == topology_pb2.CustomGroupingObjectType.Value("PYTHON_OBJECT"):
-            grouping_class_path = default_serializer.deserialize(in_stream.custom_grouping_object)
-            pex_loader.load_pex(self.topology_pex_abs_path)
-            grouping_cls = \
-              pex_loader.import_and_get_class(self.topology_pex_abs_path, grouping_class_path)
-            custom_grouping_obj = grouping_cls()
+            custom_grouping_obj = default_serializer.deserialize(in_stream.custom_grouping_object)
             assert isinstance(custom_grouping_obj, ICustomGrouping)
             self.custom_grouper.add(in_stream.stream.id,
                                     self._get_taskids_for_component(topology.bolts[i].comp.name),

--- a/heron/examples/src/python/custom_grouping_topology.py
+++ b/heron/examples/src/python/custom_grouping_topology.py
@@ -16,7 +16,7 @@
 import logging
 
 from heron.api.src.python.custom_grouping import ICustomGrouping
-import heron.api.src.python.constants as constants
+import heron.api.src.python.api_constants as constants
 from heron.api.src.python import Topology, Grouping
 
 from heron.examples.src.python.spout import WordSpout
@@ -37,9 +37,7 @@ class SampleCustomGrouping(ICustomGrouping):
     return [self.target_tasks[0]]
 
 class CustomGrouping(Topology):
-  custom_grouping_path = "heron.examples.src.python.custom_grouping_topology.SampleCustomGrouping"
-
   word_spout = WordSpout.spec(par=1)
   consume_bolt = ConsumeBolt.spec(par=3,
-                                  inputs={word_spout: Grouping.custom(custom_grouping_path)},
+                                  inputs={word_spout: Grouping.custom(SampleCustomGrouping())},
                                   config={constants.TOPOLOGY_TICK_TUPLE_FREQ_SECS: 10})


### PR DESCRIPTION
Currently to use custom grouping, you need to specify the full path of the custom grouping implementation classpath. This is very unnatural and very cumbersome. This pr changes that to take an actual object itself that is then ser/deser.