### PR TITLE
Increase timeout for integration test result checking

### DIFF
--- a/integration_test/src/python/test_runner/main.py
+++ b/integration_test/src/python/test_runner/main.py
@@ -16,7 +16,7 @@ from heron.common.src.python.utils import log
 # The location of default configure file
 DEFAULT_TEST_CONF_FILE = "integration_test/src/python/test_runner/resources/test.json"
 
-RETRY_ATTEMPTS = 15
+RETRY_ATTEMPTS = 30
 #seconds
 RETRY_INTERVAL = 10
 


### PR DESCRIPTION
I've seen integration tests where tuples are still being processed when the test harness times out. Extending timeout.