### PR TITLE
Mempool acquire should always return a Clean protobuf

### DIFF
--- a/heron/common/src/cpp/basics/mempool.h
+++ b/heron/common/src/cpp/basics/mempool.h
@@ -83,7 +83,9 @@ extern std::mutex __global_protobuf_pool_mutex__;
 template<typename T>
 T* __global_protobuf_pool_acquire__(T* _m) {
   std::lock_guard<std::mutex> guard(__global_protobuf_pool_mutex__);
-  return __global_protobuf_pool__->acquire(_m);
+  T* t = __global_protobuf_pool__->acquire(_m);
+  t->Clear();
+  return t;
 }
 
 template<typename T>

--- a/heron/stmgr/src/cpp/manager/stmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr.cpp
@@ -569,7 +569,6 @@ void StMgr::ProcessAcksAndFails(sp_int32 _src_task_id, sp_int32 _task_id,
                                 const proto::system::HeronControlTupleSet& _control) {
   proto::system::HeronTupleSet2* current_control_tuple_set = nullptr;
   current_control_tuple_set = __global_protobuf_pool_acquire__(current_control_tuple_set);
-  current_control_tuple_set->Clear();
   current_control_tuple_set->set_src_task_id(_src_task_id);
 
   // First go over emits. This makes sure that new emits makes

--- a/heron/stmgr/src/cpp/util/tuple-cache.h
+++ b/heron/stmgr/src/cpp/util/tuple-cache.h
@@ -79,7 +79,6 @@ class TupleCache {
     proto::system::HeronTupleSet2* acquire_clean_set() {
      proto::system::HeronTupleSet2* set = nullptr;
      set = __global_protobuf_pool_acquire__(set);
-     set->Clear();
      return set;
     }
 


### PR DESCRIPTION
Uncleared protobufs might have left over stuff that could cause memory corruption