### PR TITLE
Added stateful processing message handlers in stmgr-server

### DIFF
--- a/heron/stmgr/src/cpp/manager/stmgr-server.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-server.cpp
@@ -684,6 +684,7 @@ void StMgrServer::AttemptStopBackPressureFromSpouts() {
 
 void StMgrServer::InitiateStatefulCheckpoint(const sp_string& _checkpoint_tag) {
   for (auto iter = instance_info_.begin(); iter != instance_info_.end(); ++iter) {
+    // Checkpoint markers originate from spouts.
     if (iter->second->is_local_spout() && iter->second->conn_) {
       LOG(INFO) << "Propagating Initiate Stateful Checkpoint for "
                 << _checkpoint_tag << " to local spout "
@@ -716,8 +717,7 @@ void StMgrServer::HandleStoreInstanceStateCheckpointMessage(Connection* _conn,
   }
 
   // send the checkpoint message to all downstream task ids
-  stmgr_->HandleStoreInstanceStateCheckpoint(task_id, _message->state(),
-                                             it->second->instance_);
+  stmgr_->HandleStoreInstanceStateCheckpoint(_message->state(), *(it->second->instance_));
   __global_protobuf_pool_release__(_message);
 }
 

--- a/heron/stmgr/src/cpp/manager/stmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr.cpp
@@ -756,5 +756,41 @@ void StMgr::HandleAllStMgrClientsRegistered() {
   // TODO(srkukarni) Complete this
 }
 
+void StMgr::HandleAllInstancesConnected() {
+  // Now we can connect to the tmaster
+  StartTMasterClient();
+}
+
+void StMgr::HandleDeadInstance(sp_int32 _task_id) {
+  // If we are stateful topology, we might want to take some actions like
+  // asking tmaster to start recovery
+  // TODO(srkukarni) Complete this
+}
+
+void StMgr::HandleStoreInstanceStateCheckpoint(sp_int32,
+                                 const proto::ckptmgr::InstanceStateCheckpoint&,
+                                 proto::system::Instance*) {
+  // If we are stateful topology, we might want to take some actions like
+  // sending this to ckptmgr for actually saving and propagating markers
+  // to downstream tasks
+  // TODO(srkukarni) Complete this
+}
+
+void StMgr::HandleRestoreInstanceStateResponse(sp_int32,
+                                               const proto::system::Status&,
+                                               const std::string&) {
+  // If we are stateful topology, we might want to see how the restore went
+  // and if it was successful and all other local instances have recovered
+  // send back a success response to tmaster saying that we have recovered
+  // TODO(srkukarni) Complete this
+}
+
+void StMgr::HandleDownStreamStatefulCheckpoint(
+            const proto::ckptmgr::DownstreamStatefulCheckpoint& _message) {
+  server_->HandleCheckpointMarker(_message.origin_task_id(),
+                                  _message.destination_task_id(),
+                                  _message.checkpoint_id());
+}
+
 }  // namespace stmgr
 }  // namespace heron

--- a/heron/stmgr/src/cpp/manager/stmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr.cpp
@@ -767,9 +767,8 @@ void StMgr::HandleDeadInstance(sp_int32 _task_id) {
   // TODO(srkukarni) Complete this
 }
 
-void StMgr::HandleStoreInstanceStateCheckpoint(sp_int32,
-                                 const proto::ckptmgr::InstanceStateCheckpoint&,
-                                 proto::system::Instance*) {
+void StMgr::HandleStoreInstanceStateCheckpoint(const proto::ckptmgr::InstanceStateCheckpoint&,
+                                               const proto::system::Instance&) {
   // If we are stateful topology, we might want to take some actions like
   // sending this to ckptmgr for actually saving and propagating markers
   // to downstream tasks

--- a/heron/stmgr/src/cpp/manager/stmgr.h
+++ b/heron/stmgr/src/cpp/manager/stmgr.h
@@ -69,9 +69,8 @@ class StMgr {
                           proto::system::HeronTupleSet* _message);
   // Called when an instance does checkpoint and sends its checkpoint
   // to the stmgr to save it
-  void HandleStoreInstanceStateCheckpoint(sp_int32 _task_id,
-                                 const proto::ckptmgr::InstanceStateCheckpoint& _message,
-                                 proto::system::Instance* _instance);
+  void HandleStoreInstanceStateCheckpoint(const proto::ckptmgr::InstanceStateCheckpoint& _message,
+                                          const proto::system::Instance& _instance);
   void DrainInstanceData(sp_int32 _task_id, proto::system::HeronTupleSet2* _tuple);
   const proto::system::PhysicalPlan* GetPhysicalPlan() const;
 

--- a/heron/stmgr/src/cpp/manager/stmgr.h
+++ b/heron/stmgr/src/cpp/manager/stmgr.h
@@ -19,6 +19,7 @@
 
 #include <list>
 #include <map>
+#include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -66,6 +67,11 @@ class StMgr {
                                proto::stmgr::TupleStreamMessage2* _message);
   void HandleInstanceData(sp_int32 _task_id, bool _local_spout,
                           proto::system::HeronTupleSet* _message);
+  // Called when an instance does checkpoint and sends its checkpoint
+  // to the stmgr to save it
+  void HandleStoreInstanceStateCheckpoint(sp_int32 _task_id,
+                                 const proto::ckptmgr::InstanceStateCheckpoint& _message,
+                                 proto::system::Instance* _instance);
   void DrainInstanceData(sp_int32 _task_id, proto::system::HeronTupleSet2* _tuple);
   const proto::system::PhysicalPlan* GetPhysicalPlan() const;
 
@@ -81,6 +87,16 @@ class StMgr {
   bool DidAnnounceBackPressure();
   void HandleDeadStMgrConnection(const sp_string& _stmgr);
   void HandleAllStMgrClientsRegistered();
+  void HandleDeadInstance(sp_int32 _task_id);
+  void HandleAllInstancesConnected();
+
+  // Handle checkpoint message coming from an upstream task to a downstream task
+  void HandleDownStreamStatefulCheckpoint(
+                                const proto::ckptmgr::DownstreamStatefulCheckpoint& _message);
+
+  // Handle RestoreInstanceStateResponse message from local instance
+  void HandleRestoreInstanceStateResponse(sp_int32 _task_id, const proto::system::Status& _status,
+                                          const std::string& _checkpoint_id);
 
  private:
   void OnTMasterLocationFetch(proto::tmaster::TMasterLocation* _tmaster, proto::system::StatusCode);


### PR DESCRIPTION
This change makes StreamManager Server accept all stateful processing messages from peer stmgrs and instances and pass them to the stmgr for actual handling.
The actual handling currently is not yet implemented and will come in future prs.