### PR TITLE
Added stateful processing restore state machine to stmgr.

### DIFF
--- a/heron/stmgr/src/cpp/BUILD
+++ b/heron/stmgr/src/cpp/BUILD
@@ -77,6 +77,7 @@ cc_library(
         "manager/tmaster-client.cpp",
         "manager/ckptmgr-client.cpp",
         "manager/checkpoint-gateway.cpp",
+        "manager/stateful-restorer.cpp",
 
         "manager/stmgr-client.h",
         "manager/stmgr-clientmgr.h",
@@ -86,6 +87,7 @@ cc_library(
         "manager/tmaster-client.h",
         "manager/ckptmgr-client.h",
         "manager/checkpoint-gateway.h",
+        "manager/stateful-restorer.h",
     ],
     copts = [
         "-Iheron",

--- a/heron/stmgr/src/cpp/manager/ckptmgr-client.h
+++ b/heron/stmgr/src/cpp/manager/ckptmgr-client.h
@@ -41,9 +41,9 @@ class CkptMgrClient : public Client {
   void Quit();
 
   // TODO(nlu): add requests methods
-  void SaveInstanceState(proto::ckptmgr::SaveInstanceStateRequest* _request);
-  void GetInstanceState(const proto::system::Instance& _instance,
-                        const std::string& _checkpoint_id);
+  virtual void SaveInstanceState(proto::ckptmgr::SaveInstanceStateRequest* _request);
+  virtual void GetInstanceState(const proto::system::Instance& _instance,
+                                const std::string& _checkpoint_id);
 
  protected:
   void GetInstanceState(const proto::system::Instance& _instance,

--- a/heron/stmgr/src/cpp/manager/stateful-restorer.cpp
+++ b/heron/stmgr/src/cpp/manager/stateful-restorer.cpp
@@ -175,14 +175,14 @@ void StatefulRestorer::HandleCheckpointState(proto::system::StatusCode _status, 
 }
 
 void StatefulRestorer::HandleInstanceRestoredState(sp_int32 _task_id,
-                                                   const proto::system::Status& _status,
+                                                   const proto::system::StatusCode _status,
                                                    const std::string& _checkpoint_id) {
   LOG(INFO) << "Instance " << _task_id << " restored its state for " << _checkpoint_id
-            << " with status " << _status.status();
+            << " with status " << _status;
 
   // We don't handle well if instances are not able to restore
   // TODO(skukarni) Fix this
-  CHECK_EQ(_status.status(), proto::system::OK);
+  CHECK_EQ(_status, proto::system::OK);
 
   multi_count_metric_->scope(METRIC_INSTANCE_RESTORE_RESPONSES)->incr();
   if (!in_progress_) {

--- a/heron/stmgr/src/cpp/manager/stateful-restorer.cpp
+++ b/heron/stmgr/src/cpp/manager/stateful-restorer.cpp
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2015 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "manager/stateful-restorer.h"
+#include <functional>
+#include <iostream>
+#include <list>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+#include "manager/stmgr-server.h"
+#include "manager/ckptmgr-client.h"
+#include "manager/stmgr-clientmgr.h"
+#include "util/tuple-cache.h"
+#include "metrics/metrics.h"
+#include "proto/messages.h"
+#include "basics/basics.h"
+#include "errors/errors.h"
+#include "threads/threads.h"
+#include "network/network.h"
+
+namespace heron {
+namespace stmgr {
+
+// Stats for restore
+const sp_string METRIC_START_RESTORE = "__start_restore";
+const sp_string METRIC_START_RESTORE_IN_PROGRESS = "__start_restore_in_progress";
+const sp_string METRIC_START_RESTORE_FAILED = "__start_restore_failed";
+const sp_string METRIC_CKPT_REQUESTS = "__ckpt_requests";
+const sp_string METRIC_CKPT_RESPONSES = "__ckpt_responses";
+const sp_string METRIC_CKPT_RESPONSES_IGNORED = "__ckpt_responses_ignored";
+const sp_string METRIC_CKPT_RESPONSES_ERROR = "__ckpt_responses_error";
+const sp_string METRIC_INSTANCE_RESTORE_REQUESTS = "__instance_restore_requests";
+const sp_string METRIC_INSTANCE_RESTORE_RESPONSES = "__instance_restore_responses";
+const sp_string METRIC_INSTANCE_RESTORE_RESPONSES_IGNORED = "__instance_restore_response_ignored";
+
+StatefulRestorer::StatefulRestorer(CkptMgrClient* _ckptmgr,
+                             StMgrClientMgr* _clientmgr, TupleCache* _tuple_cache,
+                             StMgrServer* _server,
+                             common::MetricsMgrSt* _metrics_manager_client,
+                             std::function<void(proto::system::StatusCode,
+                                                std::string, sp_int64)> _restore_done_watcher) {
+  ckptmgr_ = _ckptmgr;
+  clientmgr_ = _clientmgr;
+  tuple_cache_ = _tuple_cache;
+  server_ = _server;
+
+  in_progress_ = false;
+  restore_done_watcher_ = _restore_done_watcher;
+  metrics_manager_client_ = _metrics_manager_client;
+  multi_count_metric_ = new common::MultiCountMetric();
+  time_spent_metric_ = new common::TimeSpentMetric();
+  metrics_manager_client_->register_metric("__stateful_restore_count", multi_count_metric_);
+  metrics_manager_client_->register_metric("__stateful_restore_time", time_spent_metric_);
+}
+
+StatefulRestorer::~StatefulRestorer() {
+  metrics_manager_client_->unregister_metric("__stateful_restore_count");
+  metrics_manager_client_->unregister_metric("__stateful_restore_time");
+  delete multi_count_metric_;
+  delete time_spent_metric_;
+}
+
+void StatefulRestorer::StartRestore(const std::string& _checkpoint_id, sp_int64 _restore_txid,
+                                    proto::system::PhysicalPlan* _pplan) {
+  multi_count_metric_->scope(METRIC_START_RESTORE)->incr();
+  if (in_progress_) {
+    multi_count_metric_->scope(METRIC_START_RESTORE_IN_PROGRESS)->incr();
+    LOG(WARNING) << "Got a RestoreTopologyState request for " << _checkpoint_id
+                 << " " << _restore_txid << " while we were still in old one "
+                 << checkpoint_id_ << " " << restore_txid_;
+    if (_restore_txid <= restore_txid_) {
+      LOG(FATAL) << "New restore txid: " << _restore_txid << " is <= old "
+                 << restore_txid_<< "!!! Dying!!! ";
+    }
+  } else {
+    LOG(INFO) << "Starting Restore for checkpoint_id " << _checkpoint_id
+              << " and txid " << _restore_txid;
+    tuple_cache_->clear();
+    clientmgr_->CloseConnectionsAndClear();
+    server_->ClearCache();
+    time_spent_metric_->Start();
+  }
+  // This is a new one for this checkpoint
+  in_progress_ = true;
+  clients_connections_pending_ = true;
+  instance_connections_pending_ = true;
+  std::vector<proto::system::Instance*> instances;
+  server_->GetInstanceInfo(instances);
+  local_taskids_.clear();
+  for (auto instance : instances) {
+    local_taskids_.insert(instance->info().task_id());
+  }
+  restore_pending_ = local_taskids_;
+  get_ckpt_pending_ = local_taskids_;
+  checkpoint_id_ = _checkpoint_id;
+  restore_txid_ = _restore_txid;
+
+  // Send messages to ckpt
+  GetCheckpoints();
+
+  clientmgr_->StartConnections(_pplan);
+  if (clientmgr_->AllStMgrClientsRegistered()) {
+    // Its possible that this is really a restore while we were already in progress
+    // and there was no change in pplan. In which case there would be no new
+    // connections to restore
+    clients_connections_pending_ = false;
+  }
+  if (server_->HaveAllInstancesConnectedToUs()) {
+    instance_connections_pending_ = false;
+  }
+}
+
+void StatefulRestorer::GetCheckpoints() {
+  for (auto task_id : get_ckpt_pending_) {
+    ckptmgr_->GetInstanceState(*(server_->GetInstanceInfo(task_id)), checkpoint_id_);
+    multi_count_metric_->scope(METRIC_CKPT_REQUESTS)->incr();
+  }
+}
+
+void StatefulRestorer::HandleCheckpointState(proto::system::StatusCode _status, sp_int32 _task_id,
+                                       sp_string _checkpoint_id,
+                                       const proto::ckptmgr::InstanceStateCheckpoint& _state) {
+  LOG(INFO) << "Got InstanceState from checkpoint mgr for task " << _task_id
+            << " and checkpoint " << _state.checkpoint_id();
+  multi_count_metric_->scope(METRIC_CKPT_RESPONSES)->incr();
+  if (!in_progress_) {
+    LOG(INFO) << "Ignoring it because we are not in restore";
+    multi_count_metric_->scope(METRIC_CKPT_RESPONSES_IGNORED)->incr();
+    return;
+  }
+  if (_checkpoint_id != checkpoint_id_) {
+    LOG(INFO) << "InstanceState from checkpont mgr for a checkpoint_id "
+              << _checkpoint_id << " that is different from ours "
+              << checkpoint_id_;
+    multi_count_metric_->scope(METRIC_CKPT_RESPONSES_IGNORED)->incr();
+    return;
+  }
+  if (_status == proto::system::OK) {
+    if (_state.checkpoint_id() != checkpoint_id_) {
+      LOG(WARNING) << "Discarding state retrieved from checkpoint mgr because the checkpoint"
+                   << " id in the response does not match ours " << checkpoint_id_;
+      multi_count_metric_->scope(METRIC_CKPT_RESPONSES_IGNORED)->incr();
+      return;
+    }
+    if (server_->SendRestoreInstanceStateRequest(_task_id, _state)) {
+      multi_count_metric_->scope(METRIC_INSTANCE_RESTORE_REQUESTS)->incr();
+      get_ckpt_pending_.erase(_task_id);
+    }
+    // Note that if we are unable to send the restore instance state request(i.e. if the
+    // last call returns false, its because of connection issues and we will get back to
+    // restore anyways.
+  } else {
+    LOG(INFO) << "InstanceState from checkpont mgr contained non ok status " << _status;
+    in_progress_ = false;
+    time_spent_metric_->Stop();
+    multi_count_metric_->scope(METRIC_CKPT_RESPONSES_ERROR)->incr();
+    multi_count_metric_->scope(METRIC_START_RESTORE_FAILED)->incr();
+    restore_done_watcher_(_status, checkpoint_id_, restore_txid_);
+  }
+}
+
+void StatefulRestorer::HandleInstanceRestoredState(sp_int32 _task_id,
+                                                   const proto::system::Status& _status,
+                                                   const std::string& _checkpoint_id) {
+  LOG(INFO) << "Instance " << _task_id << " restored its state for " << _checkpoint_id
+            << " with status " << _status.status();
+
+  // We don't handle well if instances are not able to restore
+  // TODO(skukarni) Fix this
+  CHECK_EQ(_status.status(), proto::system::OK);
+
+  multi_count_metric_->scope(METRIC_INSTANCE_RESTORE_RESPONSES)->incr();
+  if (!in_progress_) {
+    LOG(INFO) << "Ignoring the message because we are not in Restore";
+    multi_count_metric_->scope(METRIC_INSTANCE_RESTORE_RESPONSES_IGNORED)->incr();
+    return;
+  }
+  if (_checkpoint_id != checkpoint_id_) {
+    LOG(WARNING) << "Ignoring it because we are operating on a different one " << checkpoint_id_;
+    multi_count_metric_->scope(METRIC_INSTANCE_RESTORE_RESPONSES_IGNORED)->incr();
+    return;
+  }
+  restore_pending_.erase(_task_id);
+  CheckAndFinishRestore();
+}
+
+void StatefulRestorer::HandleCkptMgrRestart() {
+  LOG(INFO) << "Checkpoint ClientMgr restarted";
+  if (in_progress_) {
+    GetCheckpoints();
+  }
+}
+
+void StatefulRestorer::HandleAllStMgrClientsConnected() {
+  LOG(INFO) << "All StMgr Clients Connected";
+  if (!in_progress_) {
+    LOG(INFO) << "Ignoring it becuase we are not in restore";
+    return;
+  }
+  clients_connections_pending_ = false;
+  CheckAndFinishRestore();
+}
+
+void StatefulRestorer::HandleDeadStMgrConnection() {
+  if (in_progress_) {
+    clients_connections_pending_ = true;
+  }
+}
+
+void StatefulRestorer::HandleAllInstancesConnected() {
+  LOG(INFO) << "All Instances Connected";
+  if (!in_progress_) {
+    LOG(INFO) << "Ignoring it becuase we are not in restore";
+    return;
+  }
+  instance_connections_pending_ = false;
+  if (!get_ckpt_pending_.empty()) {
+    GetCheckpoints();
+  } else {
+    CheckAndFinishRestore();
+  }
+}
+
+void StatefulRestorer::HandleDeadInstanceConnection(sp_int32 _task_id) {
+  if (in_progress_) {
+    instance_connections_pending_ = true;
+    CHECK(local_taskids_.find(_task_id) != local_taskids_.end());
+    restore_pending_.insert(_task_id);
+    get_ckpt_pending_.insert(_task_id);
+  }
+}
+
+void StatefulRestorer::CheckAndFinishRestore() {
+  if (!instance_connections_pending_ && !clients_connections_pending_ &&
+      restore_pending_.empty()) {
+    LOG(INFO) << "Restore Done Successfully for " << checkpoint_id_
+              << " " << restore_txid_;
+    in_progress_ = false;
+    time_spent_metric_->Stop();
+    restore_done_watcher_(proto::system::OK, checkpoint_id_, restore_txid_);
+  }
+}
+
+}  // namespace stmgr
+}  // namespace heron

--- a/heron/stmgr/src/cpp/manager/stateful-restorer.h
+++ b/heron/stmgr/src/cpp/manager/stateful-restorer.h
@@ -65,7 +65,7 @@ class StatefulRestorer {
   void HandleCkptMgrRestart();
   // Called when instance responds back with RestoredInstanceStateResponse
   void HandleInstanceRestoredState(sp_int32 _task_id,
-                                   const proto::system::Status& _status,
+                                   const proto::system::StatusCode _status,
                                    const std::string& _checkpoint_id);
   // called when ckptmgr returns with instance state
   void HandleCheckpointState(proto::system::StatusCode _status, sp_int32 _task_id,

--- a/heron/stmgr/src/cpp/manager/stateful-restorer.h
+++ b/heron/stmgr/src/cpp/manager/stateful-restorer.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2017 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_CPP_SVCS_STMGR_SRC_MANAGER_STATEFUL_RESTORER_H_
+#define SRC_CPP_SVCS_STMGR_SRC_MANAGER_STATEFUL_RESTORER_H_
+
+#include <ostream>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+#include <typeinfo>   // operator typeid
+#include "proto/messages.h"
+#include "network/network.h"
+#include "basics/basics.h"
+#include "grouping/shuffle-grouping.h"
+
+namespace heron {
+namespace proto {
+namespace system {
+class PhysicalPlan;
+}
+}
+namespace common {
+class MetricsMgrSt;
+class MultiCountMetric;
+class TimeSpentMetric;
+}
+}  // namespace heron
+
+namespace heron {
+namespace stmgr {
+
+class StMgrServer;
+class TupleCache;
+class StMgrClientMgr;
+class CkptMgrClient;
+
+class StatefulRestorer {
+ public:
+  explicit StatefulRestorer(CkptMgrClient* _ckptmgr,
+                            StMgrClientMgr* _clientmgr, TupleCache* _tuple_cache,
+                            StMgrServer* _server,
+                            common::MetricsMgrSt* _metrics_manager_client,
+                            std::function<void(proto::system::StatusCode,
+                                               std::string, sp_int64)> _restore_done_watcher);
+  virtual ~StatefulRestorer();
+  // Called when stmgr receives a RestoreTopologyStateRequest message
+  void StartRestore(const std::string& _checkpoint_id, sp_int64 _restore_txid,
+                    proto::system::PhysicalPlan* _pplan);
+  // Called when ckptmgr client restarts
+  void HandleCkptMgrRestart();
+  // Called when instance responds back with RestoredInstanceStateResponse
+  void HandleInstanceRestoredState(sp_int32 _task_id,
+                                   const proto::system::Status& _status,
+                                   const std::string& _checkpoint_id);
+  // called when ckptmgr returns with instance state
+  void HandleCheckpointState(proto::system::StatusCode _status, sp_int32 _task_id,
+                             sp_string _checkpoint_id,
+                             const proto::ckptmgr::InstanceStateCheckpoint& _state);
+  // called when a stmgr connection closes
+  void HandleDeadStMgrConnection();
+  // called when all clients get connected
+  void HandleAllStMgrClientsConnected();
+  // called when an instance is dead
+  void HandleDeadInstanceConnection(sp_int32 _task_id);
+  // called when all instances are connected
+  void HandleAllInstancesConnected();
+  bool InProgress() const { return in_progress_; }
+
+ private:
+  void GetCheckpoints();
+  void CheckAndFinishRestore();
+
+  // Set of task ids for which we have sent out get checkpoint requests
+  // to the ckptmgr but haven't gotten response back
+  std::set<sp_int32> get_ckpt_pending_;
+  // Set of task ids which still haven;'t gotten back after
+  // restoring their state
+  std::set<sp_int32> restore_pending_;
+  // Have we not connected with some of our peer stmgrs?
+  bool clients_connections_pending_;
+  // Are any of our local instances still not connected with us?
+  bool instance_connections_pending_;
+  // What is the checkpoint id that we are currently restoring
+  std::string checkpoint_id_;
+  // What is the restore txid associated with our attempt of restoring
+  sp_int64 restore_txid_;
+  // What are all our local taskids that we need to restore
+  std::set<sp_int32> local_taskids_;
+
+  CkptMgrClient* ckptmgr_;
+  StMgrClientMgr* clientmgr_;
+  TupleCache* tuple_cache_;
+  StMgrServer* server_;
+  common::MetricsMgrSt* metrics_manager_client_;
+
+  // Are we in the middle of a restore
+  bool in_progress_;
+  // We will call this function after we are done restoring. We pass
+  // the status(whether we were successfull in restoring all our components),
+  // the ckpt id that we restored and the restore txid
+  std::function<void(proto::system::StatusCode, std::string, sp_int64)> restore_done_watcher_;
+
+  // Different metrics
+  common::MultiCountMetric* multi_count_metric_;
+  common::TimeSpentMetric* time_spent_metric_;
+};
+}  // namespace stmgr
+}  // namespace heron
+
+#endif  // SRC_CPP_SVCS_STMGR_SRC_MANAGER_STATEFUL_RESTORER_H_

--- a/heron/stmgr/src/cpp/manager/stmgr-clientmgr.h
+++ b/heron/stmgr/src/cpp/manager/stmgr-clientmgr.h
@@ -43,7 +43,7 @@ class StMgrClientMgr {
   virtual ~StMgrClientMgr();
 
   // Start the appropriate clients based on a new physical plan
-  void StartConnections(const proto::system::PhysicalPlan* _pplan);
+  virtual void StartConnections(const proto::system::PhysicalPlan* _pplan);
   // return true if we are successful in sending the message. false otherwise
   bool SendTupleStreamMessage(sp_int32 _task_id,
                               const sp_string& _stmgr_id,
@@ -66,10 +66,10 @@ class StMgrClientMgr {
                                         proto::ckptmgr::DownstreamStatefulCheckpoint* _message);
 
   // Interface to close all connections
-  void CloseConnectionsAndClear();
+  virtual void CloseConnectionsAndClear();
 
   // Check if all clients are registered
-  bool AllStMgrClientsRegistered();
+  virtual bool AllStMgrClientsRegistered();
 
  private:
   StMgrClient* CreateClient(const sp_string& _other_stmgr_id, const sp_string& _host_name,

--- a/heron/stmgr/src/cpp/manager/stmgr-server.h
+++ b/heron/stmgr/src/cpp/manager/stmgr-server.h
@@ -68,27 +68,27 @@ class StMgrServer : public Server {
   // Relieve back pressure
   void StopBackPressureClientCb(const sp_string& _other_stmgr_id);
 
-  bool HaveAllInstancesConnectedToUs() const {
+  virtual bool HaveAllInstancesConnectedToUs() const {
     return active_instances_.size() == expected_instances_.size();
   }
 
   // Gets all the Instance information
-  void GetInstanceInfo(std::vector<proto::system::Instance*>& _return);
+  virtual void GetInstanceInfo(std::vector<proto::system::Instance*>& _return);
   // Get instance info for this task_id
-  proto::system::Instance* GetInstanceInfo(sp_int32 _task_id);
+  virtual proto::system::Instance* GetInstanceInfo(sp_int32 _task_id);
 
   bool DidAnnounceBackPressure() { return !remote_ends_who_caused_back_pressure_.empty(); }
 
   // Send messages to all local spouts to start the process of checkpointing
   void InitiateStatefulCheckpoint(const sp_string& _checkpoint_tag);
   // Send a RestoreInstanceStateRequest to _task_id asking it to restore itself from _state
-  bool SendRestoreInstanceStateRequest(sp_int32 _task_id,
-                                       const proto::ckptmgr::InstanceStateCheckpoint& _state);
+  virtual bool SendRestoreInstanceStateRequest(sp_int32 _task_id,
+                                           const proto::ckptmgr::InstanceStateCheckpoint& _state);
   // Send StartInstanceStatefulProcessing message to all instances so that they can start
   // processing
   void SendStartInstanceStatefulProcessing(const std::string& _ckpt_id);
   // Clears all buffered state in stateful-gateway
-  void ClearCache();
+  virtual void ClearCache();
 
  protected:
   virtual void HandleNewConnection(Connection* newConnection);

--- a/heron/stmgr/src/cpp/util/tuple-cache.h
+++ b/heron/stmgr/src/cpp/util/tuple-cache.h
@@ -61,7 +61,7 @@ class TupleCache {
   // Clear all data of all task_ids
   // This is different from the drain because while drain clears the messages
   // calling the drainer functions, this one just deletes the messages.
-  void clear();
+  virtual void clear();
 
  private:
   void drain(EventLoop::Status);

--- a/heron/stmgr/tests/cpp/server/BUILD
+++ b/heron/stmgr/tests/cpp/server/BUILD
@@ -58,3 +58,32 @@ cc_test(
     ],
     linkstatic = 1,
 )
+
+cc_test(
+    name = "stateful-restorer_unittest",
+    srcs = [
+        "stateful-restorer_unittest.cpp",
+        "dummy_ckptmgr_client.cpp",
+
+        "dummy_tuple_cache.h",
+        "dummy_ckptmgr_client.h",
+        "dummy_stmgr_clientmgr.h",
+        "dummy_stmgr_server.h",
+    ],
+    deps = [
+        "//heron/stmgr/src/cpp:manager-cxx",
+        "//heron/stmgr/src/cpp:grouping-cxx",
+        "//heron/stmgr/src/cpp:util-cxx",
+        "//third_party/gtest:gtest-cxx",
+    ],
+    copts = [
+        "-Iheron",
+        "-Iheron/common/src/cpp",
+        "-Iheron/statemgrs/src/cpp",
+        "-Iheron/stmgr/src/cpp",
+        "-Iheron/stmgr/tests/cpp",
+        "-I$(GENDIR)/heron",
+        "-I$(GENDIR)/heron/common/src/cpp",
+    ],
+    linkstatic = 1,
+)

--- a/heron/stmgr/tests/cpp/server/BUILD
+++ b/heron/stmgr/tests/cpp/server/BUILD
@@ -61,6 +61,7 @@ cc_test(
 
 cc_test(
     name = "stateful-restorer_unittest",
+    args = ["$(location //heron/config/src/yaml:test-config-internals-yaml)"],
     srcs = [
         "stateful-restorer_unittest.cpp",
         "dummy_ckptmgr_client.cpp",
@@ -76,6 +77,7 @@ cc_test(
         "//heron/stmgr/src/cpp:util-cxx",
         "//third_party/gtest:gtest-cxx",
     ],
+    data = ["//heron/config/src/yaml:test-config-internals-yaml"],
     copts = [
         "-Iheron",
         "-Iheron/common/src/cpp",

--- a/heron/stmgr/tests/cpp/server/dummy_ckptmgr_client.cpp
+++ b/heron/stmgr/tests/cpp/server/dummy_ckptmgr_client.cpp
@@ -78,6 +78,14 @@ bool DummyCkptMgrClient::GetCalled(const std::string& _ckpt_id, int32_t _task_id
   return iter->second.find(_task_id) != iter->second.end();
 }
 
+void DummyCkptMgrClient::ClearGetCalled(const std::string& _ckpt_id, int32_t _task_id) {
+  auto iter = gets_.find(_ckpt_id);
+  if (iter == gets_.end()) {
+    LOG(FATAL) << "No such ckpt found";
+  }
+  iter->second.erase(_task_id);
+}
+
 void DummyCkptMgrClient::DummySaveWatcher(const heron::proto::system::Instance&,
                                           const std::string&) {
 }

--- a/heron/stmgr/tests/cpp/server/dummy_ckptmgr_client.cpp
+++ b/heron/stmgr/tests/cpp/server/dummy_ckptmgr_client.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2015 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <iostream>
+#include <limits>
+#include <set>
+#include <string>
+#include "proto/messages.h"
+#include "basics/basics.h"
+#include "errors/errors.h"
+#include "threads/threads.h"
+#include "network/network.h"
+#include "server/dummy_ckptmgr_client.h"
+
+DummyCkptMgrClient::DummyCkptMgrClient(EventLoop* _eventLoop, const NetworkOptions& _options,
+                                       const std::string& _stmgr,
+                                       heron::proto::system::PhysicalPlan* _pplan)
+  : heron::stmgr::CkptMgrClient(_eventLoop, _options, _pplan->topology().name(),
+                               _pplan->topology().id(), "ckptmgr", _stmgr,
+                               std::bind(&DummyCkptMgrClient::DummySaveWatcher, this,
+                                         std::placeholders::_1,
+                                         std::placeholders::_2),
+                               std::bind(&DummyCkptMgrClient::DummyGetWatcher, this,
+                                         std::placeholders::_1,
+                                         std::placeholders::_2,
+                                         std::placeholders::_3,
+                                         std::placeholders::_4),
+                               std::bind(&DummyCkptMgrClient::DummyRegisterWatcher, this)) {
+}
+
+DummyCkptMgrClient::~DummyCkptMgrClient() {
+}
+
+void DummyCkptMgrClient::SaveInstanceState(heron::proto::ckptmgr::SaveInstanceStateRequest* _req) {
+  const std::string& ckpt_id = _req->checkpoint().checkpoint_id();
+  if (saves_.find(ckpt_id) == saves_.end()) {
+    saves_[ckpt_id] = std::set<int32_t>();
+  }
+  saves_[ckpt_id].insert(_req->instance().info().task_id());
+  delete _req;
+}
+
+void DummyCkptMgrClient::GetInstanceState(const heron::proto::system::Instance& _instance,
+                                          const std::string& _ckpt_id) {
+  if (gets_.find(_ckpt_id) == gets_.end()) {
+    gets_[_ckpt_id] = std::set<int32_t>();
+  }
+  gets_[_ckpt_id].insert(_instance.info().task_id());
+}
+
+bool DummyCkptMgrClient::SaveCalled(const std::string& _ckpt_id, int32_t _task_id) const {
+  auto iter = saves_.find(_ckpt_id);
+  if (iter == saves_.end()) {
+    return false;
+  }
+  return iter->second.find(_task_id) != iter->second.end();
+}
+
+bool DummyCkptMgrClient::GetCalled(const std::string& _ckpt_id, int32_t _task_id) const {
+  auto iter = gets_.find(_ckpt_id);
+  if (iter == gets_.end()) {
+    return false;
+  }
+  return iter->second.find(_task_id) != iter->second.end();
+}
+
+void DummyCkptMgrClient::DummySaveWatcher(const heron::proto::system::Instance&,
+                                          const std::string&) {
+}
+
+void DummyCkptMgrClient::DummyGetWatcher(heron::proto::system::StatusCode,
+                                         int32_t,
+                                         const std::string&,
+                                         const heron::proto::ckptmgr::InstanceStateCheckpoint&) {
+}
+
+void DummyCkptMgrClient::DummyRegisterWatcher() {
+}

--- a/heron/stmgr/tests/cpp/server/dummy_ckptmgr_client.h
+++ b/heron/stmgr/tests/cpp/server/dummy_ckptmgr_client.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __DUMMY_CKPTMGR_CLIENT_H
+#define __DUMMY_CKPTMGR_CLIENT_H
+
+#include <map>
+#include <set>
+#include <string>
+
+#include "proto/messages.h"
+#include "manager/ckptmgr-client.h"
+
+class DummyCkptMgrClient : public heron::stmgr::CkptMgrClient {
+ public:
+  DummyCkptMgrClient(EventLoop* eventLoop, const NetworkOptions& _options,
+                     const std::string& _stmgr,
+                     heron::proto::system::PhysicalPlan* _pplan);
+
+  virtual ~DummyCkptMgrClient();
+
+  virtual void SaveInstanceState(heron::proto::ckptmgr::SaveInstanceStateRequest* _request);
+  virtual void GetInstanceState(const heron::proto::system::Instance& _instance,
+                                const std::string& _checkpoint_id);
+
+  bool SaveCalled(const std::string& _ckpt_id, int32_t _task_id) const;
+  bool GetCalled(const std::string& _ckpt_id, int32_t _task_id) const;
+
+ private:
+  void DummySaveWatcher(const heron::proto::system::Instance& _instance,
+                        const std::string& _ckpt_id);
+  void DummyGetWatcher(heron::proto::system::StatusCode _status,
+                       int32_t _restore_txid,
+                       const std::string& _ckpt_id,
+                       const heron::proto::ckptmgr::InstanceStateCheckpoint& _ckpt);
+  void DummyRegisterWatcher();
+  // Map from ckptid to task_ids for which the call was made
+  std::map<std::string, std::set<int32_t>> saves_;
+  std::map<std::string, std::set<int32_t>> gets_;
+};
+
+#endif

--- a/heron/stmgr/tests/cpp/server/dummy_ckptmgr_client.h
+++ b/heron/stmgr/tests/cpp/server/dummy_ckptmgr_client.h
@@ -38,6 +38,7 @@ class DummyCkptMgrClient : public heron::stmgr::CkptMgrClient {
 
   bool SaveCalled(const std::string& _ckpt_id, int32_t _task_id) const;
   bool GetCalled(const std::string& _ckpt_id, int32_t _task_id) const;
+  void ClearGetCalled(const std::string& _ckpt_id, int32_t _task_id);
 
  private:
   void DummySaveWatcher(const heron::proto::system::Instance& _instance,

--- a/heron/stmgr/tests/cpp/server/dummy_stmgr_clientmgr.h
+++ b/heron/stmgr/tests/cpp/server/dummy_stmgr_clientmgr.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __DUMMY_STMGR_CLIENTMGR_H
+#define __DUMMY_STMGR_CLIENTMGR_H
+
+#include <string>
+
+#include "proto/messages.h"
+#include "manager/stmgr-clientmgr.h"
+
+class DummyStMgrClientMgr : public heron::stmgr::StMgrClientMgr {
+ public:
+  DummyStMgrClientMgr(EventLoop* _eventLoop, heron::common::MetricsMgrSt* _metrics,
+                      const std::string& _stmgr,
+                      heron::proto::system::PhysicalPlan* _pplan)
+  : heron::stmgr::StMgrClientMgr(_eventLoop, _pplan->topology().name(),
+                                 _pplan->topology().id(), _stmgr,
+                                 NULL, _metrics, 1024, 2048),
+    close_connections_called_(false), start_connections_called_(false),
+    all_stmgrclients_registered_(false) {
+  }
+
+  virtual ~DummyStMgrClientMgr() { }
+
+  virtual void CloseConnectionsAndClear() { close_connections_called_ = true; }
+  bool CloseConnectionsCalled() const { return close_connections_called_; }
+
+  virtual void StartConnections(const heron::proto::system::PhysicalPlan*) {
+    start_connections_called_ = true;
+  }
+  bool StartConnectionsCalled() const { return start_connections_called_; }
+
+  virtual bool AllStMgrClientsRegistered() { return all_stmgrclients_registered_; }
+  virtual void SetAllStMgrClientsRegistered(bool val) { all_stmgrclients_registered_ = val; }
+
+ private:
+  bool close_connections_called_;
+  bool start_connections_called_;
+  bool all_stmgrclients_registered_;
+};
+
+#endif

--- a/heron/stmgr/tests/cpp/server/dummy_stmgr_server.h
+++ b/heron/stmgr/tests/cpp/server/dummy_stmgr_server.h
@@ -72,6 +72,9 @@ class DummyStMgrServer : public heron::stmgr::StMgrServer {
   bool DidSendRestoreRequest(sp_int32 _task_id) {
     return restore_sent_.find(_task_id) != restore_sent_.end();
   }
+  void ClearSendRestoreRequest(sp_int32 _task_id) {
+    restore_sent_.erase(_task_id);
+  }
 
  private:
   heron::proto::system::PhysicalPlan* pplan_;

--- a/heron/stmgr/tests/cpp/server/dummy_stmgr_server.h
+++ b/heron/stmgr/tests/cpp/server/dummy_stmgr_server.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2015 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __DUMMY_STMGR_SERVER_H
+#define __DUMMY_STMGR_SERVER_H
+
+#include <set>
+#include <string>
+#include <vector>
+
+#include "proto/messages.h"
+#include "util/neighbour-calculator.h"
+#include "manager/stmgr-server.h"
+
+class DummyStMgrServer : public heron::stmgr::StMgrServer {
+ public:
+  DummyStMgrServer(EventLoop* _eventLoop, const NetworkOptions& _options,
+                   const std::string& _stmgr,
+                   heron::proto::system::PhysicalPlan* _pplan,
+                   const std::vector<sp_string>& _expected_instances,
+                   heron::common::MetricsMgrSt* _metrics)
+  : heron::stmgr::StMgrServer(_eventLoop, _options, _pplan->topology().name(),
+                              _pplan->topology().id(), _stmgr,
+                              _expected_instances, NULL, _metrics,
+                              new heron::stmgr::NeighbourCalculator()),
+    pplan_(_pplan), clear_called_(false), all_instances_connected_(false),
+    my_stmgr_id_(_stmgr) {
+  }
+
+  virtual ~DummyStMgrServer() { }
+
+  virtual void ClearCache() { clear_called_ = true; }
+  bool ClearCalled() const { return clear_called_; }
+
+  virtual void GetInstanceInfo(std::vector<heron::proto::system::Instance*>& _return) {
+    for (int i = 0; i < pplan_->instances_size(); ++i) {
+      if (pplan_->instances(i).stmgr_id() == my_stmgr_id_) {
+        _return.push_back(pplan_->mutable_instances(i));
+      }
+    }
+  }
+  virtual heron::proto::system::Instance* GetInstanceInfo(int32_t _task_id) {
+    for (int i = 0; i < pplan_->instances_size(); ++i) {
+       if (pplan_->instances(i).info().task_id() == _task_id) {
+         return pplan_->mutable_instances(i);
+       }
+    }
+    return NULL;
+  }
+
+  virtual bool HaveAllInstancesConnectedToUs() const { return all_instances_connected_; }
+  virtual void SetAllInstancesConnectedToUs(bool val) { all_instances_connected_ = val; }
+
+  virtual bool SendRestoreInstanceStateRequest(sp_int32 _task_id,
+                                         const heron::proto::ckptmgr::InstanceStateCheckpoint&) {
+    restore_sent_.insert(_task_id);
+    return true;
+  }
+  bool DidSendRestoreRequest(sp_int32 _task_id) {
+    return restore_sent_.find(_task_id) != restore_sent_.end();
+  }
+
+ private:
+  heron::proto::system::PhysicalPlan* pplan_;
+  bool clear_called_;
+  bool all_instances_connected_;
+  std::set<int32_t> restore_sent_;
+  std::string my_stmgr_id_;
+};
+
+#endif

--- a/heron/stmgr/tests/cpp/server/dummy_tuple_cache.h
+++ b/heron/stmgr/tests/cpp/server/dummy_tuple_cache.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __DUMMY_TUPLE_CACHE_H
+#define __DUMMY_TUPLE_CACHE_H
+
+#include "proto/messages.h"
+#include "util/tuple-cache.h"
+
+class DummyTupleCache : public heron::stmgr::TupleCache {
+ public:
+  explicit DummyTupleCache(EventLoop* _eventLoop)
+  : heron::stmgr::TupleCache(_eventLoop, 1024),
+    clear_called_(false) { }
+  virtual ~DummyTupleCache() { }
+
+  virtual void clear() { clear_called_ = true; }
+  bool clear_called() const { return clear_called_; }
+
+ private:
+  bool clear_called_;
+};
+
+#endif

--- a/heron/stmgr/tests/cpp/server/stateful-restorer_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/stateful-restorer_unittest.cpp
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2015 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <limits>
+#include <map>
+#include <vector>
+#include <sstream>
+#include <thread>
+#include <string>
+#include <unordered_set>
+#include <unordered_map>
+#include "gtest/gtest.h"
+#include "glog/logging.h"
+#include "proto/messages.h"
+#include "basics/basics.h"
+#include "errors/errors.h"
+#include "threads/threads.h"
+#include "network/network.h"
+#include "basics/modinit.h"
+#include "errors/modinit.h"
+#include "threads/modinit.h"
+#include "network/modinit.h"
+#include "config/topology-config-vars.h"
+#include "config/topology-config-helper.h"
+#include "config/physical-plan-helper.h"
+#include "config/heron-internals-config-reader.h"
+#include "metrics/metrics-mgr-st.h"
+#include "manager/stateful-restorer.h"
+#include "server/dummy_ckptmgr_client.h"
+#include "server/dummy_tuple_cache.h"
+#include "server/dummy_stmgr_clientmgr.h"
+#include "server/dummy_stmgr_server.h"
+
+const sp_string SPOUT_NAME = "spout";
+const sp_string BOLT_NAME = "bolt";
+const sp_string STREAM_NAME = "stream";
+const sp_string CONTAINER_INDEX = "0";
+const sp_string STMGR_NAME = "stmgr";
+const sp_string LOCALHOST = "127.0.0.1";
+
+sp_string heron_internals_config_filename =
+    "../../../../../../../../heron/config/heron_internals.yaml";
+
+// Generate a dummy topology
+static heron::proto::api::Topology* GenerateDummyTopology(
+    const sp_string& topology_name, const sp_string& topology_id, int num_spouts,
+    int num_spout_instances, int num_bolts, int num_bolt_instances,
+    const heron::proto::api::Grouping& grouping) {
+  heron::proto::api::Topology* topology = new heron::proto::api::Topology();
+  topology->set_id(topology_id);
+  topology->set_name(topology_name);
+  size_t spouts_size = num_spouts;
+  size_t bolts_size = num_bolts;
+  // Set spouts
+  for (size_t i = 0; i < spouts_size; ++i) {
+    heron::proto::api::Spout* spout = topology->add_spouts();
+    // Set the component information
+    heron::proto::api::Component* component = spout->mutable_comp();
+    sp_string compname = SPOUT_NAME;
+    compname += std::to_string(i);
+    component->set_name(compname);
+    heron::proto::api::ComponentObjectSpec compspec = heron::proto::api::JAVA_CLASS_NAME;
+    component->set_spec(compspec);
+    // Set the stream information
+    heron::proto::api::OutputStream* ostream = spout->add_outputs();
+    heron::proto::api::StreamId* tstream = ostream->mutable_stream();
+    sp_string streamid = STREAM_NAME;
+    streamid += std::to_string(i);
+    tstream->set_id(streamid);
+    tstream->set_component_name(compname);
+    heron::proto::api::StreamSchema* schema = ostream->mutable_schema();
+    heron::proto::api::StreamSchema::KeyType* key_type = schema->add_keys();
+    key_type->set_key("dummy");
+    key_type->set_type(heron::proto::api::OBJECT);
+    // Set the config
+    heron::proto::api::Config* config = component->mutable_config();
+    heron::proto::api::Config::KeyValue* kv = config->add_kvs();
+    kv->set_key(heron::config::TopologyConfigVars::TOPOLOGY_COMPONENT_PARALLELISM);
+    kv->set_value(std::to_string(num_spout_instances));
+  }
+  // Set bolts
+  for (size_t i = 0; i < bolts_size; ++i) {
+    heron::proto::api::Bolt* bolt = topology->add_bolts();
+    // Set the component information
+    heron::proto::api::Component* component = bolt->mutable_comp();
+    sp_string compname = BOLT_NAME;
+    compname += std::to_string(i);
+    component->set_name(compname);
+    heron::proto::api::ComponentObjectSpec compspec = heron::proto::api::JAVA_CLASS_NAME;
+    component->set_spec(compspec);
+    // Set the stream information
+    heron::proto::api::InputStream* istream = bolt->add_inputs();
+    heron::proto::api::StreamId* tstream = istream->mutable_stream();
+    sp_string streamid = STREAM_NAME;
+    streamid += std::to_string(i);
+    tstream->set_id(streamid);
+    sp_string input_compname = SPOUT_NAME;
+    input_compname += std::to_string(i);
+    tstream->set_component_name(input_compname);
+    istream->set_gtype(grouping);
+    // Set the config
+    heron::proto::api::Config* config = component->mutable_config();
+    heron::proto::api::Config::KeyValue* kv = config->add_kvs();
+    kv->set_key(heron::config::TopologyConfigVars::TOPOLOGY_COMPONENT_PARALLELISM);
+    kv->set_value(std::to_string(num_bolt_instances));
+  }
+  // Set message timeout
+  heron::proto::api::Config* topology_config = topology->mutable_topology_config();
+  heron::proto::api::Config::KeyValue* kv = topology_config->add_kvs();
+  kv->set_key(heron::config::TopologyConfigVars::TOPOLOGY_STATEFUL_ENABLED);
+  kv->set_value("true");
+
+  // Set state
+  topology->set_state(heron::proto::api::RUNNING);
+
+  return topology;
+}
+
+const sp_string CreateInstanceId(int32_t _global_index) {
+  std::ostringstream instanceid_stream;
+  instanceid_stream << "instance-" << _global_index;
+  return instanceid_stream.str();
+}
+
+std::string GenerateStMgrId(int32_t _index) {
+  std::ostringstream ostr;
+  ostr << "stmgr-" << _index;
+  return ostr.str();
+}
+
+heron::proto::system::Instance* CreateInstance(int32_t _comp, int32_t _comp_instance,
+                                               int32_t _stmgr_id,
+                                               int32_t _global_index, bool _is_spout) {
+  heron::proto::system::Instance* imap = new heron::proto::system::Instance();
+  imap->set_instance_id(CreateInstanceId(_global_index));
+  imap->set_stmgr_id(GenerateStMgrId(_stmgr_id));
+  heron::proto::system::InstanceInfo* inst = imap->mutable_info();
+  inst->set_task_id(_global_index);
+  inst->set_component_index(_comp_instance);
+  if (_is_spout) {
+    inst->set_component_name("spout" + std::to_string(_comp));
+  } else {
+    inst->set_component_name("bolt" + std::to_string(_comp));
+  }
+  return imap;
+}
+
+heron::proto::system::PhysicalPlan* CreatePplan(int32_t _ncontainers,
+                                                int32_t _nsbcomp, int32_t _ninstances) {
+  int32_t nContainers = _ncontainers;
+  int32_t nSpouts = _nsbcomp;
+  int32_t nSpoutInstances = _ninstances;
+  int32_t nBolts = _nsbcomp;
+  int32_t nBoltInstances = _ninstances;
+  auto topology = GenerateDummyTopology("TestTopology", "TestTopology-12345",
+                                        nSpouts, nSpoutInstances, nBolts, nBoltInstances,
+                                        heron::proto::api::SHUFFLE);
+  auto pplan = new heron::proto::system::PhysicalPlan();
+  pplan->mutable_topology()->CopyFrom(*topology);
+  delete topology;
+  for (int32_t i = 0; i < nContainers; ++i) {
+    auto stmgr = pplan->add_stmgrs();
+    stmgr->set_id(GenerateStMgrId(i));
+    stmgr->set_host_name("127.0.0.1");
+    stmgr->set_data_port(100);
+    stmgr->set_local_endpoint("101");
+  }
+  int32_t stmgr_assignment = 0;
+  int32_t global_index = 1;
+  for (int spout = 0; spout < nSpouts; ++spout) {
+    for (int spout_instance = 0; spout_instance < nSpoutInstances; ++spout_instance) {
+      heron::proto::system::Instance* instance =
+          CreateInstance(spout, spout_instance, stmgr_assignment, global_index++, true);
+      if (++stmgr_assignment >= nContainers) {
+        stmgr_assignment = 0;
+      }
+      pplan->add_instances()->CopyFrom(*instance);
+      delete instance;
+    }
+  }
+  for (int bolt = 0; bolt < nBolts; ++bolt) {
+    for (int bolt_instance = 0; bolt_instance < nBoltInstances; ++bolt_instance) {
+      heron::proto::system::Instance* instance =
+          CreateInstance(bolt, bolt_instance, stmgr_assignment, global_index++, false);
+      if (++stmgr_assignment >= nContainers) {
+        stmgr_assignment = 0;
+      }
+      pplan->add_instances()->CopyFrom(*instance);
+      delete instance;
+    }
+  }
+  return pplan;
+}
+
+DummyCkptMgrClient* CreateDummyCkptMgr(heron::proto::system::PhysicalPlan* _pplan,
+                                       EventLoop* _eventLoop) {
+  NetworkOptions options;
+  return new DummyCkptMgrClient(_eventLoop, options, GenerateStMgrId(1), _pplan);
+}
+
+DummyStMgrServer* CreateDummyStMgrServer(EventLoop* _eventLoop,
+                                         const std::string& _stmgr,
+                                         heron::proto::system::PhysicalPlan* _pplan,
+                                         heron::common::MetricsMgrSt* _metrics) {
+  NetworkOptions options;
+  std::vector<std::string> dummy_instances;
+  return new DummyStMgrServer(_eventLoop, options, _stmgr, _pplan, dummy_instances,
+                              _metrics);
+}
+
+void RestoreDone(bool* _restore_done) {
+  *_restore_done = true;
+}
+
+// Normal case. Start Restore, get ckpts from all, send restores, get restores from all
+// and then the done watcher called
+TEST(StatefulRestorer, normalcase) {
+  auto pplan = CreatePplan(2, 4, 3);
+  EventLoop* dummyLoop = new EventLoopImpl();
+  auto ckptmgr_client = CreateDummyCkptMgr(pplan, dummyLoop);
+  auto tuple_cache = new DummyTupleCache(dummyLoop);
+  auto dummy_metrics_client = new heron::common::MetricsMgrSt("localhost", 11000, 11001,
+                                                               "_stmgr", "_stmgr", 100,
+                                                               dummyLoop);
+  auto dummy_stmgr_clientmgr = new DummyStMgrClientMgr(dummyLoop, dummy_metrics_client,
+                                                       GenerateStMgrId(1), pplan);
+  auto dummy_stmgr_server = CreateDummyStMgrServer(dummyLoop, GenerateStMgrId(1),
+                                                   pplan, dummy_metrics_client);
+  bool restore_done = false;
+  std::string ckpt_id = "ckpt1";
+  auto restorer = new heron::stmgr::StatefulRestorer(ckptmgr_client, dummy_stmgr_clientmgr,
+                                                     tuple_cache, dummy_stmgr_server,
+                                                     dummy_metrics_client,
+                                                     std::bind(&RestoreDone, &restore_done));
+  // At the start the restore is not in progress
+  EXPECT_FALSE(restorer->InProgress());
+  restorer->StartRestore(ckpt_id, 1, pplan);
+  // Now we are in restore
+  EXPECT_TRUE(restorer->InProgress());
+  // Make sure that the ckpt messages were sent to our tasks
+  std::unordered_set<int32_t> local_tasks;
+  heron::config::PhysicalPlanHelper::GetTasks(*pplan, GenerateStMgrId(1), local_tasks);
+  for (auto task : local_tasks) {
+    EXPECT_TRUE(ckptmgr_client->GetCalled(ckpt_id, task));
+  }
+  local_tasks.clear();
+  // Make sure that the ckpt messages were not sent to some other tasks
+  heron::config::PhysicalPlanHelper::GetTasks(*pplan, GenerateStMgrId(0), local_tasks);
+  for (auto task : local_tasks) {
+    EXPECT_FALSE(ckptmgr_client->GetCalled(ckpt_id, task));
+  }
+  local_tasks.clear();
+
+  // Responses from ckptmgr
+  heron::config::PhysicalPlanHelper::GetTasks(*pplan, GenerateStMgrId(1), local_tasks);
+  for (auto task : local_tasks) {
+    EXPECT_FALSE(dummy_stmgr_server->DidSendRestoreRequest(task));
+    heron::proto::ckptmgr::InstanceStateCheckpoint c;
+    c.set_checkpoint_id(ckpt_id);
+    restorer->HandleCheckpointState(heron::proto::system::OK, task, ckpt_id, c);
+    // Make sure that restore is sent to the instances
+    EXPECT_TRUE(dummy_stmgr_server->DidSendRestoreRequest(task));
+  }
+  EXPECT_TRUE(restorer->InProgress());
+
+  // Send notification that tasks have recovered
+  for (auto task : local_tasks) {
+    restorer->HandleInstanceRestoredState(task, heron::proto::system::OK, ckpt_id);
+  }
+  EXPECT_TRUE(restorer->InProgress());
+
+  restorer->HandleAllStMgrClientsConnected();
+  EXPECT_TRUE(restorer->InProgress());
+  restorer->HandleAllInstancesConnected();
+  EXPECT_FALSE(restorer->InProgress());
+  EXPECT_TRUE(restore_done);
+
+  delete restorer;
+  delete dummy_stmgr_clientmgr;
+  delete dummy_metrics_client;
+  delete tuple_cache;
+  delete ckptmgr_client;
+  delete pplan;
+  delete dummyLoop;
+}
+
+int main(int argc, char** argv) {
+  heron::common::Initialize(argv[0]);
+  testing::InitGoogleTest(&argc, argv);
+  if (argc > 1) {
+    std::cerr << "Using config file " << argv[1] << std::endl;
+    heron_internals_config_filename = argv[1];
+  }
+  // Create the sington for heron_internals_config_reader, if it does not exist
+  if (!heron::config::HeronInternalsConfigReader::Exists()) {
+    heron::config::HeronInternalsConfigReader::Create(heron_internals_config_filename);
+  }
+  return RUN_ALL_TESTS();
+}

--- a/heron/stmgr/tests/cpp/server/stateful-restorer_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/stateful-restorer_unittest.cpp
@@ -386,6 +386,80 @@ TEST(StatefulRestorer, deadinstances) {
   delete dummyLoop;
 }
 
+// This tests the scenario where ckptmgr
+// dies in the middle of a restore
+TEST(StatefulRestorer, deadckptmgr) {
+  auto pplan = CreatePplan(2, 4, 3);
+  EventLoop* dummyLoop = new EventLoopImpl();
+  auto ckptmgr_client = CreateDummyCkptMgr(pplan, dummyLoop);
+  auto tuple_cache = new DummyTupleCache(dummyLoop);
+  auto dummy_metrics_client = new heron::common::MetricsMgrSt("localhost", 11000, 11001,
+                                                               "_stmgr", "_stmgr", 100,
+                                                               dummyLoop);
+  auto dummy_stmgr_clientmgr = new DummyStMgrClientMgr(dummyLoop, dummy_metrics_client,
+                                                       GenerateStMgrId(1), pplan);
+  dummy_stmgr_clientmgr->SetAllStMgrClientsRegistered(true);
+  auto dummy_stmgr_server = CreateDummyStMgrServer(dummyLoop, GenerateStMgrId(1),
+                                                   pplan, dummy_metrics_client);
+  dummy_stmgr_server->SetAllInstancesConnectedToUs(true);
+  bool restore_done = false;
+  std::string ckpt_id = "ckpt1";
+  auto restorer = new heron::stmgr::StatefulRestorer(ckptmgr_client, dummy_stmgr_clientmgr,
+                                                     tuple_cache, dummy_stmgr_server,
+                                                     dummy_metrics_client,
+                                                     std::bind(&RestoreDone, &restore_done));
+  // At the start the restore is not in progress
+  EXPECT_FALSE(restorer->InProgress());
+  restorer->StartRestore(ckpt_id, 1, pplan);
+  // Now we are in restore
+  EXPECT_TRUE(restorer->InProgress());
+
+  // Responses from ckptmgr
+  std::unordered_set<int32_t> local_tasks;
+  heron::config::PhysicalPlanHelper::GetTasks(*pplan, GenerateStMgrId(1), local_tasks);
+  // Send notification that some tasks have recovered
+  EXPECT_GT(local_tasks.size(), 1);
+  bool first = true;
+  int32_t troublesome_task;
+  // ckpt delivers some checkpoints
+  for (auto task : local_tasks) {
+    if (first) {
+      first = false;
+      troublesome_task = task;
+    } else {
+      heron::proto::ckptmgr::InstanceStateCheckpoint c;
+      c.set_checkpoint_id(ckpt_id);
+      restorer->HandleCheckpointState(heron::proto::system::OK, task, ckpt_id, c);
+      restorer->HandleInstanceRestoredState(task, heron::proto::system::OK, ckpt_id);
+    }
+  }
+  EXPECT_TRUE(restorer->InProgress());
+
+  dummy_stmgr_server->ClearSendRestoreRequest(troublesome_task);
+  ckptmgr_client->ClearGetCalled(ckpt_id, troublesome_task);
+  EXPECT_FALSE(ckptmgr_client->GetCalled(ckpt_id, troublesome_task));
+
+  // Now ckpt mgr dies and comes back
+  restorer->HandleCkptMgrRestart();
+
+  // make sure that we sent the recover ckpt request
+  EXPECT_TRUE(ckptmgr_client->GetCalled(ckpt_id, troublesome_task));
+  EXPECT_TRUE(restorer->InProgress());
+  restorer->HandleInstanceRestoredState(troublesome_task, heron::proto::system::OK, ckpt_id);
+
+  // Now everything is done
+  EXPECT_FALSE(restorer->InProgress());
+  EXPECT_TRUE(restore_done);
+
+  delete restorer;
+  delete dummy_stmgr_clientmgr;
+  delete dummy_metrics_client;
+  delete tuple_cache;
+  delete ckptmgr_client;
+  delete pplan;
+  delete dummyLoop;
+}
+
 int main(int argc, char** argv) {
   heron::common::Initialize(argv[0]);
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
For Heron topologies running in exactly once semantics, the tmaster could initiate restore topology to a certain globally consistent checkpoint. This could be triggered either during startup or after failure of certain topology components. StatefulRestorer implements the state machine of this recovery process inside the stmgr. When stmgr receives the request to restore the topology to a specific checkpoint, it starts the statemachine by invoking the StartRestore. The main task of the restore state machine is to:-
  1. Clear all internal caches(like tuple cache, checkpoint_gateway buffer, etc)
  2. Retreive State of all local instances via the checkpoint manager
  3. Sending RestoreState request with the retreived state to all local instances
  4. Upon completion of recovery process, calling the _restore_done_watcher
Note that while all of this is in process, instances could die, stmgr clients might get disconnected, checkpoint manager could disappear, etc. 
Note that this is currently not yet plugged into stmgr yet. That will happen in a future pr.

For more information, please refer to the stateful processing design doc at  https://docs.google.com/document/d/1pNuE77diSrYHb7vHPuPO3DZqYdcxrhywH_f7loVryCI/edit#heading=h.i3ogdfl4p63o
and in particular the recovery section