### PR TITLE
Added Stateful processing related message handling in TMasterClient

### DIFF
--- a/heron/proto/ckptmgr.proto
+++ b/heron/proto/ckptmgr.proto
@@ -112,8 +112,15 @@ message RestoreTopologyStateResponse {
 // to some valid checkpoint. This is sent either if stmgr dies
 // and comes back up or if an instance dies.
 message ResetTopologyState {
+  // Was there a dead/recovered stmgr connection that was the reason
+  // for this request?
   optional string dead_stmgr = 1;
+  // Was there a dead/recovered local instance connection that was the reason
+  // for this request?
   optional int32 dead_taskid = 2;
+  // This one describes the reason for sending the message.
+  // Used primarily for debugging
+  required string reason = 3;
 }
 
 // Message sent by stmgr to tmaster informing it about

--- a/heron/stmgr/src/cpp/manager/stmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr.cpp
@@ -239,9 +239,24 @@ void StMgr::CreateTMasterClient(proto::tmaster::TMasterLocation* tmasterLocation
   master_options.set_high_watermark(high_watermark_);
   master_options.set_low_watermark(low_watermark_);
   auto pplan_watch = [this](proto::system::PhysicalPlan* pplan) { this->NewPhysicalPlan(pplan); };
+  auto stateful_checkpoint_watch =
+       [this](sp_string checkpoint_id) {
+    this->InitiateStatefulCheckpoint(checkpoint_id);
+  };
+  auto restore_topology_watch =
+       [this](sp_string checkpoint_id, sp_int64 restore_txid) {
+    this->RestoreTopologyState(checkpoint_id, restore_txid);
+  };
+  auto start_stateful_watch =
+       [this](sp_string checkpoint_id) {
+    this->StartStatefulProcessing(checkpoint_id);
+  };
 
   tmaster_client_ = new TMasterClient(eventLoop_, master_options, stmgr_id_, stmgr_host_,
-                                      stmgr_port_, shell_port_, std::move(pplan_watch));
+                                      stmgr_port_, shell_port_, std::move(pplan_watch),
+                                      std::move(stateful_checkpoint_watch),
+                                      std::move(restore_topology_watch),
+                                      std::move(start_stateful_watch));
 }
 
 void StMgr::CreateTupleCache() {
@@ -767,6 +782,12 @@ void StMgr::HandleDeadInstance(sp_int32 _task_id) {
   // TODO(srkukarni) Complete this
 }
 
+// Initiate the process of stateful checkpointing
+void StMgr::InitiateStatefulCheckpoint(sp_string _checkpoint_id) {
+  // We should start sending checkpoint messages to our local instances
+  // TODO(srkukarni) Complete this
+}
+
 void StMgr::HandleStoreInstanceStateCheckpoint(const proto::ckptmgr::InstanceStateCheckpoint&,
                                                const proto::system::Instance&) {
   // If we are stateful topology, we might want to take some actions like
@@ -791,5 +812,16 @@ void StMgr::HandleDownStreamStatefulCheckpoint(
                                   _message.checkpoint_id());
 }
 
+// Called by TmasterClient when it receives directive from tmaster
+// to restore the topology to _checkpoint_id checkpoint
+void StMgr::RestoreTopologyState(sp_string _checkpoint_id, sp_int64 _restore_txid) {
+  // TODO(srkukarni) Complete this
+}
+
+// Called by TmasterClient when it receives directive from tmaster
+// to restore the topology to _checkpoint_id checkpoint
+void StMgr::StartStatefulProcessing(sp_string _checkpoint_id) {
+  // TODO(srkukarni) Complete this
+}
 }  // namespace stmgr
 }  // namespace heron

--- a/heron/stmgr/src/cpp/manager/stmgr.h
+++ b/heron/stmgr/src/cpp/manager/stmgr.h
@@ -138,6 +138,20 @@ class StMgr {
   void BroadcastTmasterLocation(proto::tmaster::TMasterLocation* tmasterLocation);
   void BroadcastMetricsCacheLocation(proto::tmaster::MetricsCacheLocation* tmasterLocation);
 
+  // Called when TMaster sends a InitiateStatefulCheckpoint message with a checkpoint_id
+  // This will send intiate checkpoint messages to local instances to capture their state.
+  void InitiateStatefulCheckpoint(sp_string checkpoint_id);
+
+  // Invoked when TMaster asks us to restore all our local instances state to
+  // the checkpoint represented by _checkpoint_id. This starts the
+  // Restore state machine
+  void RestoreTopologyState(sp_string _checkpoint_id, sp_int64 _restore_txid);
+
+  // Invoked when TMaster sends the StartStatefulProcessing request to kick
+  // start the computation. We send the StartStatefulProcessing to all our
+  // local instances so that they can start the processing.
+  void StartStatefulProcessing(sp_string _checkpoint_id);
+
   heron::common::HeronStateMgr* state_mgr_;
   proto::system::PhysicalPlan* pplan_;
   sp_string topology_name_;


### PR DESCRIPTION
While running in stateful mode, TMaster sends the following messages to the stmgr
1. Periodic Checkpoint messages(StartStatefulCheckpoint) so that stmgr can send them to local instances for checkpointing their state
2. Restore Topology messages(RestoreTopologyStateRequest) so that stmgr can start restoring the state of the local instances to a specified checkpoint_id
3. Start Processing message(StartStmgrStatefulProcessing) to start the processing when all stmgrs have restored their local instances' state.
This change adds the ability for TMasterClient in stmgr to handle those messages and call the appropriate stmgr callback. Note that the stmgr callbacks themselves are not yet implemented, that will be coming in the next set of prs.