### PR TITLE
Instantiate checkpoint manager client in stmgr

### DIFF
--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -581,7 +581,9 @@ class HeronExecutor(object):
         self.master_port,
         self.metricsmgr_port,
         self.shell_port,
-        self.heron_internals_config_file]
+        self.heron_internals_config_file,
+        self.ckptmgr_port,
+        self.ckptmgr_ids[self.shard]]
     retval[self.stmgr_ids[self.shard]] = stmgr_cmd
 
     # metricsmgr_metrics_sink_config_file = 'metrics_sinks.yaml'

--- a/heron/executor/tests/python/heron_executor_unittest.py
+++ b/heron/executor/tests/python/heron_executor_unittest.py
@@ -145,7 +145,8 @@ class HeronExecutorTest(unittest.TestCase):
       ProcessInfo(MockPOpen(), 'stmgr-1',
                   'stmgr_binary topname topid topdefnfile zknode zkroot stmgr-1 '
                   'container_1_word_3,container_1_exclaim1_2,container_1_exclaim1_1 %s master_port '
-                  'metricsmgr_port shell-port %s' % (HOSTNAME, INTERNAL_CONF_PATH)),
+                  'metricsmgr_port shell-port %s ckptmgr-port ckptmgr-1'
+                  % (HOSTNAME, INTERNAL_CONF_PATH)),
       ProcessInfo(MockPOpen(), 'container_1_word_3', get_expected_instance_command('word', 3, 1)),
       ProcessInfo(MockPOpen(), 'container_1_exclaim1_1',
                   get_expected_instance_command('exclaim1', 1, 1)),
@@ -163,7 +164,8 @@ class HeronExecutorTest(unittest.TestCase):
       ProcessInfo(MockPOpen(), 'stmgr-7',
                 'stmgr_binary topname topid topdefnfile zknode zkroot stmgr-7 '
                 'container_7_word_11,container_7_exclaim1_210 %s master_port '
-                'metricsmgr_port shell-port %s' % (HOSTNAME, INTERNAL_CONF_PATH)),
+                'metricsmgr_port shell-port %s ckptmgr-port ckptmgr-7'
+                % (HOSTNAME, INTERNAL_CONF_PATH)),
       ProcessInfo(MockPOpen(), 'metricsmgr-7', get_expected_metricsmgr_command(7)),
       ProcessInfo(MockPOpen(), 'heron-shell-7', get_expected_shell_command(7)),
   ]
@@ -199,7 +201,7 @@ class HeronExecutorTest(unittest.TestCase):
     cluster role environ instance_classpath metrics_sinks_config_file
     scheduler_classpath scheduler_port python_instance_binary
     metricscachemgr_classpath metricscachemgr_masterport metricscachemgr_statsport
-    is_stateful_enabled ckptmgr_classpath ckgtmgr_port stateful_config_file
+    is_stateful_enabled ckptmgr_classpath ckptmgr-port stateful_config_file
     """ % (shard_id, INTERNAL_CONF_PATH)).replace("\n", '').split()
 
   def test_update_packing_plan(self):

--- a/heron/stmgr/src/cpp/server/stmgr-main.cpp
+++ b/heron/stmgr/src/cpp/server/stmgr-main.cpp
@@ -27,12 +27,13 @@
 #include "config/heron-internals-config-reader.h"
 
 int main(int argc, char* argv[]) {
-  if (argc != 13) {
+  if (argc != 15) {
     std::cout << "Usage: " << argv[0] << " "
               << "<topname> <topid> <topdefnfile> "
               << "<zknode> <zkroot> <stmgrid> "
               << "<instanceids> <myhost> <myport> <metricsmgrport> "
-                 "<shellport> <heron_internals_config_filename>"
+              << "<shellport> <heron_internals_config_filename> "
+              << "<ckptmgr_port> <ckptmgr_id>"
               << std::endl;
     std::cout << "If zknode is empty please say LOCALMODE\n";
     ::exit(1);
@@ -54,6 +55,8 @@ int main(int argc, char* argv[]) {
   sp_int32 metricsmgr_port = atoi(argv[10]);
   sp_int32 shell_port = atoi(argv[11]);
   sp_string heron_internals_config_filename = argv[12];
+  sp_int32 ckptmgr_port = atoi(argv[13]);
+  sp_string ckptmgr_id = argv[14];
 
   EventLoopImpl ss;
 
@@ -79,7 +82,7 @@ int main(int argc, char* argv[]) {
                                 1_MB;
   heron::stmgr::StMgr mgr(&ss, myhost, myport, topology_name, topology_id, topology, myid,
                           instances, zkhostportlist, topdir, metricsmgr_port, shell_port,
-                          high_watermark, low_watermark);
+                          ckptmgr_port, ckptmgr_id, high_watermark, low_watermark);
   mgr.Init();
   ss.loop();
   return 0;

--- a/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
@@ -268,15 +268,17 @@ void StartStMgr(EventLoopImpl*& ss, heron::stmgr::StMgr*& mgr, std::thread*& stm
                 const sp_string& topology_id, const heron::proto::api::Topology* topology,
                 const std::vector<sp_string>& workers, const sp_string& stmgr_id,
                 const sp_string& zkhostportlist, const sp_string& dpath, sp_int32 metricsmgr_port,
-                sp_int32 shell_port, sp_int64 _high_watermark, sp_int64 _low_watermark) {
+                sp_int32 shell_port, sp_int32 ckptmgr_port, const sp_string& ckptmgr_id,
+                sp_int64 _high_watermark, sp_int64 _low_watermark) {
   // The topology will be owned and deleted by the strmgr
   heron::proto::api::Topology* stmgr_topology = new heron::proto::api::Topology();
   stmgr_topology->CopyFrom(*topology);
   // Create the select server for this stmgr to use
   ss = new EventLoopImpl();
   mgr = new heron::stmgr::StMgr(ss, stmgr_host, stmgr_port, topology_name, topology_id,
-                              stmgr_topology, stmgr_id, workers, zkhostportlist, dpath,
-                              metricsmgr_port, shell_port, _high_watermark, _low_watermark);
+                                stmgr_topology, stmgr_id, workers, zkhostportlist, dpath,
+                                metricsmgr_port, shell_port, ckptmgr_port, ckptmgr_id,
+                                _high_watermark, _low_watermark);
   mgr->Init();
   stmgr_thread = new std::thread(StartServer, ss);
 }
@@ -371,6 +373,8 @@ struct CommonResources {
   sp_int32 stmgr_baseport_;
   sp_int32 metricsmgr_port_;
   sp_int32 shell_port_;
+  sp_int32 ckptmgr_port_;
+  sp_string ckptmgr_id_;
   sp_string zkhostportlist_;
   sp_string topology_name_;
   sp_string topology_id_;
@@ -669,6 +673,8 @@ TEST(StMgr, test_pplan_decode) {
   common.stmgr_baseport_ = 20000;
   common.metricsmgr_port_ = 30000;
   common.shell_port_ = 40000;
+  common.ckptmgr_port_ = 50000;
+  common.ckptmgr_id_ = "ckptmgr";
   common.topology_name_ = "mytopology";
   common.topology_id_ = "abcd-9999";
   common.num_stmgrs_ = 2;
@@ -747,6 +753,8 @@ TEST(StMgr, test_tuple_route) {
   common.stmgr_baseport_ = 25000;
   common.metricsmgr_port_ = 35000;
   common.shell_port_ = 45000;
+  common.ckptmgr_port_ = 55000;
+  common.ckptmgr_id_ = "ckptmgr";
   common.topology_name_ = "mytopology";
   common.topology_id_ = "abcd-9999";
   common.num_stmgrs_ = 2;
@@ -825,6 +833,8 @@ TEST(StMgr, test_custom_grouping_route) {
   common.stmgr_baseport_ = 25500;
   common.metricsmgr_port_ = 35500;
   common.shell_port_ = 45500;
+  common.ckptmgr_port_ = 55500;
+  common.ckptmgr_id_ = "ckptmgr";
   common.topology_name_ = "mytopology";
   common.topology_id_ = "abcd-9999";
   common.num_stmgrs_ = 2;
@@ -911,6 +921,8 @@ TEST(StMgr, test_back_pressure_instance) {
   common.stmgr_baseport_ = 27000;
   common.metricsmgr_port_ = 37000;
   common.shell_port_ = 47000;
+  common.ckptmgr_port_ = 57000;
+  common.ckptmgr_id_ = "ckptmgr";
   common.topology_name_ = "mytopology";
   common.topology_id_ = "abcd-9999";
   common.num_stmgrs_ = 2;
@@ -1020,6 +1032,8 @@ TEST(StMgr, test_spout_death_under_backpressure) {
   common.stmgr_baseport_ = 27300;
   common.metricsmgr_port_ = 37300;
   common.shell_port_ = 47300;
+  common.ckptmgr_port_ = 57300;
+  common.ckptmgr_id_ = "ckptmgr";
   common.topology_name_ = "mytopology";
   common.topology_id_ = "abcd-9999";
   common.num_stmgrs_ = 2;
@@ -1154,6 +1168,8 @@ TEST(StMgr, test_back_pressure_stmgr) {
   common.stmgr_baseport_ = 28000;
   common.metricsmgr_port_ = 38000;
   common.shell_port_ = 48000;
+  common.ckptmgr_port_ = 58000;
+  common.ckptmgr_id_ = "ckptmgr";
   common.topology_name_ = "mytopology";
   common.topology_id_ = "abcd-9999";
   common.num_stmgrs_ = 3;
@@ -1271,6 +1287,8 @@ TEST(StMgr, test_back_pressure_stmgr_reconnect) {
   common.stmgr_baseport_ = 28500;
   common.metricsmgr_port_ = 39000;
   common.shell_port_ = 49000;
+  common.ckptmgr_port_ = 59000;
+  common.ckptmgr_id_ = "ckptmgr";
   common.topology_name_ = "mytopology";
   common.topology_id_ = "abcd-9999";
   common.num_stmgrs_ = 2;
@@ -1383,6 +1401,8 @@ TEST(StMgr, test_tmaster_restart_on_new_address) {
   common.stmgr_baseport_ = 28510;
   common.metricsmgr_port_ = 39001;
   common.shell_port_ = 49001;
+  common.ckptmgr_port_ = 59001;
+  common.ckptmgr_id_ = "ckptmgr";
   common.topology_name_ = "mytopology";
   common.topology_id_ = "abcd-9999";
   common.num_stmgrs_ = 2;
@@ -1515,6 +1535,8 @@ TEST(StMgr, test_tmaster_restart_on_same_address) {
   common.stmgr_baseport_ = 28520;
   common.metricsmgr_port_ = 39002;
   common.shell_port_ = 49002;
+  common.ckptmgr_port_ = 59002;
+  common.ckptmgr_id_ = "ckptmgr";
   common.topology_name_ = "mytopology";
   common.topology_id_ = "abcd-9999";
   common.num_stmgrs_ = 2;
@@ -1651,6 +1673,8 @@ TEST(StMgr, test_metricsmgr_reconnect) {
   common.stmgr_baseport_ = 29000;
   common.metricsmgr_port_ = 39500;
   common.shell_port_ = 49500;
+  common.ckptmgr_port_ = 59500;
+  common.ckptmgr_id_ = "ckptmgr";
   common.topology_name_ = "mytopology";
   common.topology_id_ = "abcd-9999";
   common.num_stmgrs_ = 2;

--- a/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
@@ -595,8 +595,8 @@ void StartStMgrs(CommonResources& common) {
     StartStMgr(stmgr_ss, mgr, stmgr_thread, common.tmaster_host_, common.stmgr_baseport_ + i,
                common.topology_name_, common.topology_id_, common.topology_,
                common.stmgr_instance_id_list_[i], common.stmgrs_id_list_[i], common.zkhostportlist_,
-               common.dpath_, common.metricsmgr_port_, common.shell_port_, common.high_watermark_,
-               common.low_watermark_);
+               common.dpath_, common.metricsmgr_port_, common.shell_port_, common.ckptmgr_port_,
+               common.ckptmgr_id_, common.high_watermark_, common.low_watermark_);
 
     common.ss_list_.push_back(stmgr_ss);
     common.stmgrs_list_.push_back(mgr);
@@ -953,8 +953,8 @@ TEST(StMgr, test_back_pressure_instance) {
   StartStMgr(regular_stmgr_ss, regular_stmgr, regular_stmgr_thread, common.tmaster_host_,
              common.stmgr_baseport_, common.topology_name_, common.topology_id_, common.topology_,
              common.stmgr_instance_id_list_[0], common.stmgrs_id_list_[0], common.zkhostportlist_,
-             common.dpath_, common.metricsmgr_port_, common.shell_port_, common.high_watermark_,
-             common.low_watermark_);
+             common.dpath_, common.metricsmgr_port_, common.shell_port_, common.ckptmgr_port_,
+             common.ckptmgr_id_, common.high_watermark_, common.low_watermark_);
   common.ss_list_.push_back(regular_stmgr_ss);
 
   // Start a dummy stmgr
@@ -1064,8 +1064,8 @@ TEST(StMgr, test_spout_death_under_backpressure) {
   StartStMgr(regular_stmgr_ss, regular_stmgr, regular_stmgr_thread, common.tmaster_host_,
              common.stmgr_baseport_, common.topology_name_, common.topology_id_, common.topology_,
              common.stmgr_instance_id_list_[0], common.stmgrs_id_list_[0], common.zkhostportlist_,
-             common.dpath_, common.metricsmgr_port_, common.shell_port_, common.high_watermark_,
-             common.low_watermark_);
+             common.dpath_, common.metricsmgr_port_, common.shell_port_, common.ckptmgr_port_,
+             common.ckptmgr_id_, common.high_watermark_, common.low_watermark_);
   common.ss_list_.push_back(regular_stmgr_ss);
 
   // Start a dummy stmgr
@@ -1204,8 +1204,8 @@ TEST(StMgr, test_back_pressure_stmgr) {
   StartStMgr(regular_stmgr_ss1, regular_stmgr1, regular_stmgr_thread1, common.tmaster_host_,
              common.stmgr_baseport_, common.topology_name_, common.topology_id_, common.topology_,
              common.stmgr_instance_id_list_[0], common.stmgrs_id_list_[0], common.zkhostportlist_,
-             common.dpath_, common.metricsmgr_port_, common.shell_port_, common.high_watermark_,
-             common.low_watermark_);
+             common.dpath_, common.metricsmgr_port_, common.shell_port_, common.ckptmgr_port_,
+             common.ckptmgr_id_, common.high_watermark_, common.low_watermark_);
   common.ss_list_.push_back(regular_stmgr_ss1);
 
   EventLoopImpl* regular_stmgr_ss2 = NULL;
@@ -1215,8 +1215,9 @@ TEST(StMgr, test_back_pressure_stmgr) {
   StartStMgr(regular_stmgr_ss2, regular_stmgr2, regular_stmgr_thread2, common.tmaster_host_,
              common.stmgr_baseport_ + 1, common.topology_name_, common.topology_id_,
              common.topology_, common.stmgr_instance_id_list_[1], common.stmgrs_id_list_[1],
-             common.zkhostportlist_, common.dpath_, common.metricsmgr_port_, common.shell_port_,
-             common.high_watermark_, common.low_watermark_);
+             common.zkhostportlist_, common.dpath_, common.metricsmgr_port_,
+             common.shell_port_, common.ckptmgr_port_,
+             common.ckptmgr_id_, common.high_watermark_, common.low_watermark_);
 
   common.ss_list_.push_back(regular_stmgr_ss2);
 
@@ -1319,8 +1320,8 @@ TEST(StMgr, test_back_pressure_stmgr_reconnect) {
   StartStMgr(regular_stmgr_ss, regular_stmgr, regular_stmgr_thread, common.tmaster_host_,
              common.stmgr_baseport_, common.topology_name_, common.topology_id_, common.topology_,
              common.stmgr_instance_id_list_[0], common.stmgrs_id_list_[0], common.zkhostportlist_,
-             common.dpath_, common.metricsmgr_port_, common.shell_port_, common.high_watermark_,
-             common.low_watermark_);
+             common.dpath_, common.metricsmgr_port_, common.shell_port_, common.ckptmgr_port_,
+             common.ckptmgr_id_, common.high_watermark_, common.low_watermark_);
   common.ss_list_.push_back(regular_stmgr_ss);
 
   // Start a dummy stmgr
@@ -1438,8 +1439,8 @@ TEST(StMgr, test_tmaster_restart_on_new_address) {
   StartStMgr(regular_stmgr_ss, regular_stmgr, regular_stmgr_thread, common.tmaster_host_,
              common.stmgr_baseport_, common.topology_name_, common.topology_id_, common.topology_,
              common.stmgr_instance_id_list_[0], common.stmgrs_id_list_[0], common.zkhostportlist_,
-             common.dpath_, common.metricsmgr_port_, common.shell_port_, common.high_watermark_,
-             common.low_watermark_);
+             common.dpath_, common.metricsmgr_port_, common.shell_port_, common.ckptmgr_port_,
+             common.ckptmgr_id_, common.high_watermark_, common.low_watermark_);
   common.ss_list_.push_back(regular_stmgr_ss);
 
   // Start a dummy stmgr
@@ -1572,8 +1573,8 @@ TEST(StMgr, test_tmaster_restart_on_same_address) {
   StartStMgr(regular_stmgr_ss, regular_stmgr, regular_stmgr_thread, common.tmaster_host_,
              common.stmgr_baseport_, common.topology_name_, common.topology_id_, common.topology_,
              common.stmgr_instance_id_list_[0], common.stmgrs_id_list_[0], common.zkhostportlist_,
-             common.dpath_, common.metricsmgr_port_, common.shell_port_, common.high_watermark_,
-             common.low_watermark_);
+             common.dpath_, common.metricsmgr_port_, common.shell_port_, common.ckptmgr_port_,
+             common.ckptmgr_id_, common.high_watermark_, common.low_watermark_);
   common.ss_list_.push_back(regular_stmgr_ss);
 
   // Start a dummy stmgr
@@ -1712,8 +1713,8 @@ TEST(StMgr, test_metricsmgr_reconnect) {
   StartStMgr(regular_stmgr_ss, regular_stmgr, regular_stmgr_thread, common.tmaster_host_,
              common.stmgr_baseport_, common.topology_name_, common.topology_id_, common.topology_,
              common.stmgr_instance_id_list_[0], common.stmgrs_id_list_[0], common.zkhostportlist_,
-             common.dpath_, common.metricsmgr_port_, common.shell_port_, common.high_watermark_,
-             common.low_watermark_);
+             common.dpath_, common.metricsmgr_port_, common.shell_port_, common.ckptmgr_port_,
+             common.ckptmgr_id_, common.high_watermark_, common.low_watermark_);
   common.ss_list_.push_back(regular_stmgr_ss);
 
   // Start a dummy stmgr


### PR DESCRIPTION
The stmgrs in Stateful Processing Heron topologies interact with locally running checkpoint managers to get/save the instance state. This change makes executor pass checkpoint manager port/id to stmgr which allows it to establish a connection.
