### PR TITLE
Do not log exception when OOM.

### DIFF
--- a/heron/instance/src/java/com/twitter/heron/instance/HeronInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/HeronInstance.java
@@ -235,10 +235,13 @@ public class HeronInstance {
     private void handleException(Thread thread, Throwable exception) {
       // We would fail fast when errors occur to avoid unexpected bad situations
       if (exception instanceof Error) {
-        LOG.log(Level.SEVERE,
-            "Error caught in thread: " + thread.getName()
-                + " with thread id: " + thread.getId() + ". Process halting...");
-        Runtime.getRuntime().halt(1);
+        if (exception instanceof OutOfMemoryError) {
+          // Fail fast without logging, otherwise another OOM may happen
+          Runtime.getRuntime().halt(1);
+        } else {
+          LOG.log(Level.SEVERE, "Error caught in thread: " + thread.getName()
+                + " with thread id: " + thread.getId() + ". Process halting...", exception);
+        }
       }
 
       LOG.log(Level.SEVERE,

--- a/heron/instance/src/java/com/twitter/heron/instance/HeronInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/HeronInstance.java
@@ -235,12 +235,13 @@ public class HeronInstance {
     private void handleException(Thread thread, Throwable exception) {
       // We would fail fast when errors occur to avoid unexpected bad situations
       if (exception instanceof Error) {
-        if (exception instanceof OutOfMemoryError) {
-          // Fail fast without logging, otherwise another OOM may happen
-          Runtime.getRuntime().halt(1);
-        } else {
+        try {
           LOG.log(Level.SEVERE, "Error caught in thread: " + thread.getName()
                 + " with thread id: " + thread.getId() + ". Process halting...", exception);
+        } finally {
+          // If an OOM happens, it is likely that logging above will
+          // cause another OOM.
+          Runtime.getRuntime().halt(1);
         }
       }
 

--- a/heron/instance/src/java/com/twitter/heron/instance/HeronInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/HeronInstance.java
@@ -237,8 +237,7 @@ public class HeronInstance {
       if (exception instanceof Error) {
         LOG.log(Level.SEVERE,
             "Error caught in thread: " + thread.getName()
-                + " with thread id: " + thread.getId() + ". Process halting...",
-            exception);
+                + " with thread id: " + thread.getId() + ". Process halting...");
         Runtime.getRuntime().halt(1);
       }
 


### PR DESCRIPTION
In one production topology at Twitter, an instance OOM'ed but did not halt itself. @ttim investigated the issue and believed **another OOM** happened when we were trying to convert exception to string during logging. 

I suggest we remove the logging at all, but @maosongfu thinks we can at least log thread id and names.