### PR TITLE
Move uploader init above PackingPlan creation to fix NPE

### DIFF
--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
@@ -425,6 +425,9 @@ public class SubmitterMain {
       // initialize the state manager
       statemgr.initialize(config);
 
+      // initialize the uploader
+      uploader.initialize(config);
+
       // TODO(mfu): timeout should read from config
       SchedulerStateManagerAdaptor adaptor = new SchedulerStateManagerAdaptor(statemgr, 5000);
 
@@ -544,9 +547,6 @@ public class SubmitterMain {
   }
 
   protected URI uploadPackage(IUploader uploader) throws UploaderException {
-    // initialize the uploader
-    uploader.initialize(config);
-
     // upload the topology package to the storage
     return uploader.uploadPackage();
   }


### PR DESCRIPTION
I ran into a corner case when submitting a topology that generated a bad PackingPlan (in this case, I was setting component RAM to 128mb instead of the minimum 192):


```
[2017-07-19 14:04:17 -0400] [INFO] com.twitter.heron.statemgr.zookeeper.curator.CuratorStateManager: Closing the CuratorClient to: localhost:64618  
[2017-07-19 14:04:17 -0400] [FINE] org.apache.curator.framework.imps.CuratorFrameworkImpl: Closing  
[2017-07-19 14:04:17 -0400] [FINE] org.apache.curator.CuratorZookeeperClient: Closing  
[2017-07-19 14:04:17 -0400] [FINE] org.apache.curator.ConnectionState: Closing  
[2017-07-19 14:04:17 -0400] [INFO] com.twitter.heron.statemgr.zookeeper.curator.CuratorStateManager: Closing the tunnel processes  
[2017-07-19 14:04:17 -0400] [FINE] com.twitter.heron.scheduler.SubmitterMain: Exception when submitting topology 
java.lang.NullPointerException
        at com.twitter.heron.uploader.s3.S3Uploader.undo(S3Uploader.java:236)
        at com.twitter.heron.scheduler.SubmitterMain.submitTopology(SubmitterMain.java:464)
        at com.twitter.heron.scheduler.SubmitterMain.main(SubmitterMain.java:336)
 
[2017-07-19 14:04:17 -0400] [ERROR]: null
[2017-07-19 14:04:17 -0400] [ERROR]: Failed to launch topology 'feeds-processor'
[2017-07-19 14:04:17 -0400] [INFO]: Elapsed time: 14.145s.
```


This NPE was covering the reason the topology actually wouldn't submit, because it was being thrown in the catch block of SubmitterMain.submitTopology():

```
} catch (LauncherException | PackingException e) {
 // we undo uploading of topology package only if launcher fails to
 // launch topology, which will throw LauncherException or PackingException
 uploader.undo(); // << -- here
 throw e;
} finally {
 SysUtils.closeIgnoringExceptions(uploader);
 SysUtils.closeIgnoringExceptions(launcher);
 SysUtils.closeIgnoringExceptions(statemgr);
}
```


It happens because SubmitterMain.uploadPackage() (which calls IUploader.initialize()) is only called AFTER the packing plan is generated.  If a PackingException is thrown, uploader.undo() is called on an uninitialized uploader.  

Initializing the uploader at the beginning of the try block in SubmitterMain.submitTopology() fixes the problem, and uncovered the true problem with my topology:

```
[2017-07-19 14:53:21 -0400] [FINE] org.apache.curator.ConnectionState: Closing  
[2017-07-19 14:53:21 -0400] [INFO] com.twitter.heron.statemgr.zookeeper.curator.CuratorStateManager: Closing the tunnel processes  
[2017-07-19 14:53:21 -0400] [FINE] com.twitter.heron.scheduler.SubmitterMain: Exception when submitting topology 
com.twitter.heron.spi.packing.PackingException: Invalid packing plan generated. A minimum of ByteAmount{192 MB (201326592 bytes)} ram is required, but InstancePlan for component 'CassandraWriterBolt' has ByteAmount{128 MB (134217728 bytes)}
        at com.twitter.heron.packing.roundrobin.RoundRobinPacking.validatePackingPlan(RoundRobinPacking.java:330)
        at com.twitter.heron.packing.roundrobin.RoundRobinPacking.pack(RoundRobinPacking.java:150)
        at com.twitter.heron.scheduler.utils.LauncherUtils.createPackingPlan(LauncherUtils.java:66)
        at com.twitter.heron.scheduler.SubmitterMain.submitTopology(SubmitterMain.java:446)
        at com.twitter.heron.scheduler.SubmitterMain.main(SubmitterMain.java:336)
```

I suppose this could affect other uploaders as well? 
