### PR TITLE
Correct heap memory usage of stream manager

### DIFF
--- a/heron/common/src/cpp/basics/processutils.cpp
+++ b/heron/common/src/cpp/basics/processutils.cpp
@@ -23,10 +23,43 @@ pid_t ProcessUtils::getPid() { return ::getpid(); }
 
 int ProcessUtils::getResourceUsage(struct rusage *usage) { return ::getrusage(RUSAGE_SELF, usage); }
 
+/* ``generic.heap_size'' also includes unmapped pages in heap. These bytes
+ * have been release back to OS. They always count towards virtual memory
+ * memory usage, and depending on OS, typically do nto count towards physical
+ * memory usage.
+ *
+ * See more at: https://gperftools.github.io/gperftools/tcmalloc.html
+ *
+ * Here is a sample output of heap usage statistic by
+ * ``MallocExtension::instance()->GetStats''
+ *
+ *       484254200 (  461.8 MiB) Bytes in use by application
+ *  +            0 (    0.0 MiB) Bytes in page heap freelist
+ *  +     22847400 (   21.8 MiB) Bytes in central cache freelist
+ *  +     11551232 (   11.0 MiB) Bytes in transfer cache freelist
+ *  +      5528672 (    5.3 MiB) Bytes in thread cache freelists
+ *  +      2617504 (    2.5 MiB) Bytes in malloc metadata
+ *    ------------
+ *  =    526799008 (  502.4 MiB) Actual memory used (physical + swap)
+ *  +     41000960 (   39.1 MiB) Bytes released to OS (aka unmapped)
+ *    ------------
+ *  =    567799968 (  541.5 MiB) Virtual address space used
+ *
+ *           17441              Spans in use
+ *               3              Thread heaps in use
+ *            8192              Tcmalloc page size
+ *
+ * In this example, ``generic.heap_size'' is 541.5 MiB, and
+ * ``tcmalloc.pageheap_unmapped_bytes'' is 391.1 MiB. Acutal memory
+ * usage would be 502.4 MiB.
+ *
+ */
 size_t ProcessUtils::getTotalMemoryUsed() {
-  size_t total = 0;
+  size_t total = 0, unmapped = 0;
   MallocExtension::instance()->GetNumericProperty("generic.heap_size", &total);
-  return total;
+  MallocExtension::instance()->GetNumericProperty(
+      "tcmalloc.pageheap_unmapped_bytes", &unmapped);
+  return total - unmapped;
 }
 
 sp_string ProcessUtils::getCurrentWorkingDirectory() {

--- a/heron/common/src/cpp/basics/processutils.cpp
+++ b/heron/common/src/cpp/basics/processutils.cpp
@@ -50,7 +50,7 @@ int ProcessUtils::getResourceUsage(struct rusage *usage) { return ::getrusage(RU
  *            8192              Tcmalloc page size
  *
  * In this example, ``generic.heap_size'' is 541.5 MiB, and
- * ``tcmalloc.pageheap_unmapped_bytes'' is 391.1 MiB. Acutal memory
+ * ``tcmalloc.pageheap_unmapped_bytes'' is 39.1 MiB. Actual memory
  * usage would be 502.4 MiB.
  *
  */


### PR DESCRIPTION
We believe current heap memory usage stat of stream manager is not accurate. Here is an example,

1. Stats reported by `MallocExtension::instance()->GetStats`

```
MALLOC:      191445352 (  182.6 MiB) Bytes in use by application
MALLOC: +            0 (    0.0 MiB) Bytes in page heap freelist
MALLOC: +    101689440 (   97.0 MiB) Bytes in central cache freelist
MALLOC: +     22577280 (   21.5 MiB) Bytes in transfer cache freelist
MALLOC: +     24591800 (   23.5 MiB) Bytes in thread cache freelists
MALLOC: +      3600544 (    3.4 MiB) Bytes in malloc metadata
MALLOC:   ------------
MALLOC: =    343904416 (  328.0 MiB) Actual memory used (physical + swap)
MALLOC: +    418865152 (  399.5 MiB) Bytes released to OS (aka unmapped)
MALLOC:   ------------
MALLOC: =    762769568 (  727.4 MiB) Virtual address space used
MALLOC:
MALLOC:          19427              Spans in use
MALLOC:              3              Thread heaps in use
MALLOC:           8192              Tcmalloc page size
```
2. Stat reported by viz: 724 MB

3. Actual RSS memory size (the one Aurora will use): 420MB ~ 470MB.

I am unsure if my change will give us the most accurate value. So I opened a PR **only for discussion here**.

resolves #2077 
