### PR TITLE
Remove website build from Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,6 @@ before_install:
   - ./bazel-0.3.1-installer-linux-x86_64.sh --user
 
 before_script:
-  # required for building the website docs
-  # - (cd website && npm install && npm install gulp && which gulp)
-  - wget -q https://github.com/gohugoio/hugo/releases/download/v0.24.1/hugo_0.24.1_Linux-64bit.deb
-  - sudo dpkg -i hugo_0.24.1_Linux-64bit.deb
-  - hugo version
-
   # install python module for wheel files
   # required for python packaging
   - sudo pip install wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,6 @@ env:
   - CC=gcc-4.8 CXX=g++-4.8 CPP=cpp-4.8 CXXCPP=cpp-4.8
 
 before_install:
-  - . $HOME/.nvm/nvm.sh
-  - nvm install stable
-  - nvm use stable
   # download and install bazel
   - wget -q 'https://github.com/bazelbuild/bazel/releases/download/0.3.1/bazel-0.3.1-installer-linux-x86_64.sh'
   - chmod +x bazel-0.3.1-installer-linux-x86_64.sh


### PR DESCRIPTION
At the moment, the CI job for Heron builds the website but doesn't actually *publish* the website (which requires a manual process described [here](https://github.com/twitter/heron/blob/master/website/README.md)). This means that the CI job is essentially building the website for no good reason, and when website build failures emerge they make the whole CI job fail, and needlessly so.

This PR completely removes the website build process from CI (just a few stray lines in the config...most of it has already been removed). We should have some kind of collective decision process soon in which we determine how we'd like to proceed in the future. A few options:

* Keep the status quo and build the site manually
* Add the current website publishing process (not just the build process) to the CI job
* Publish the website via a different method, for example:
  * Keep using GitHub pages but don't use the separate `gh-pages` branch
  * Using a different hosting provider altogether

I, personally, am agnostic on this question. Until we get it sorted out, though, I think that these changes are necessary.