### PR TITLE
For stateful topologies, TMaster should connect with checkpoint manager

### DIFF
--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -428,7 +428,8 @@ class HeronExecutor(object):
         self.zkroot,
         self.heron_internals_config_file,
         self.metrics_sinks_config_file,
-        self.metricsmgr_port]
+        self.metricsmgr_port,
+        self.ckptmgr_port]
     retval["heron-tmaster"] = tmaster_cmd
 
     retval["heron-metricscache"] = self._get_metrics_cache_cmd()

--- a/heron/executor/tests/python/heron_executor_unittest.py
+++ b/heron/executor/tests/python/heron_executor_unittest.py
@@ -136,7 +136,8 @@ class HeronExecutorTest(unittest.TestCase):
                   'tmaster_binary %s master_port '
                   'tmaster_controller_port tmaster_stats_port '
                   'topname topid zknode zkroot '
-                  '%s metrics_sinks_config_file metricsmgr_port' % (HOSTNAME, INTERNAL_CONF_PATH )),
+                  '%s metrics_sinks_config_file metricsmgr_port '
+                  'ckptmgr-port' % (HOSTNAME, INTERNAL_CONF_PATH )),
       ProcessInfo(MockPOpen(), 'heron-metricscache', get_expected_metricscachemgr_command()),
   ]
 

--- a/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
@@ -255,11 +255,13 @@ void StartTMaster(EventLoopImpl*& ss, heron::tmaster::TMaster*& tmaster,
                   const sp_string& topology_name, const sp_string& topology_id,
                   const sp_string& dpath,
                   sp_int32 tmaster_port, sp_int32 tmaster_controller_port,
-                  sp_int32 tmaster_stats_port, sp_int32 metrics_mgr_port) {
+                  sp_int32 tmaster_stats_port, sp_int32 metrics_mgr_port,
+                  sp_int32 ckptmgr_port) {
   ss = new EventLoopImpl();
   tmaster = new heron::tmaster::TMaster(zkhostportlist, topology_name, topology_id, dpath,
                                   tmaster_controller_port, tmaster_port, tmaster_stats_port,
-                                  metrics_mgr_port, metrics_sinks_config_filename, LOCALHOST, ss);
+                                  metrics_mgr_port, ckptmgr_port,
+                                  metrics_sinks_config_filename, LOCALHOST, ss);
   tmaster_thread = new std::thread(StartServer, ss);
 }
 
@@ -467,7 +469,7 @@ void StartTMaster(CommonResources& common) {
   StartTMaster(tmaster_eventLoop, common.tmaster_, common.tmaster_thread_, common.zkhostportlist_,
                common.topology_name_, common.topology_id_, common.dpath_,
                common.tmaster_port_, common.tmaster_controller_port_, common.tmaster_stats_port_,
-               common.metricsmgr_port_ + 1);
+               common.metricsmgr_port_ + 1, common.ckptmgr_port_);
   common.ss_list_.push_back(tmaster_eventLoop);
 }
 

--- a/heron/tmaster/src/cpp/manager/tmaster.h
+++ b/heron/tmaster/src/cpp/manager/tmaster.h
@@ -36,6 +36,7 @@ class TController;
 class StatsInterface;
 class TMasterServer;
 class TMetricsCollector;
+class CkptMgrClient;
 
 typedef std::map<std::string, StMgrState*> StMgrMap;
 typedef StMgrMap::iterator StMgrMapIter;
@@ -45,7 +46,8 @@ class TMaster {
   TMaster(const std::string& _zk_hostport, const std::string& _topology_name,
           const std::string& _topology_id, const std::string& _topdir,
           sp_int32 _controller_port, sp_int32 _master_port,
-          sp_int32 _stats_port, sp_int32 metricsMgrPort, const std::string& metrics_sinks_yaml,
+          sp_int32 _stats_port, sp_int32 metricsMgrPort, sp_int32 _ckptmgr_port,
+          const std::string& metrics_sinks_yaml,
           const std::string& _myhost_name, EventLoop* eventLoop);
 
   virtual ~TMaster();
@@ -67,6 +69,8 @@ class TMaster {
 
   // Called by http server upon receiving a user message to cleanup the state
   void CleanAllStatefulCheckpoint();
+  // Called by ckptmgr client upon receiving CleanStatefulCheckpointResponse
+  void HandleCleanStatefulCheckpointResponse(proto::system::StatusCode);
 
   // Get stream managers registration summary
   proto::tmaster::StmgrsRegistrationSummaryResponse* GetStmgrsRegSummary();
@@ -178,6 +182,10 @@ class TMaster {
   sp_int32 mMetricsMgrPort;
   // Metrics Manager
   heron::common::MetricsMgrSt* mMetricsMgrClient;
+
+  // Ckpt Manager
+  CkptMgrClient* ckptmgr_client_;
+  sp_int32 ckptmgr_port_;
 
   // Process related metrics
   heron::common::MultiAssignableMetric* tmasterProcessMetrics;

--- a/heron/tmaster/src/cpp/server/tmaster-main.cpp
+++ b/heron/tmaster/src/cpp/server/tmaster-main.cpp
@@ -26,12 +26,12 @@
 #include "config/heron-internals-config-reader.h"
 
 int main(int argc, char* argv[]) {
-  if (argc != 12) {
+  if (argc != 13) {
     std::cout << "Usage: " << argv[0] << " "
               << "<master-host> <master-port> <controller-port> <stats-port> "
               << "<topology_name> <topology_id> <zk_hostportlist> "
               << "<topdir> <heron_internals_config_filename> "
-              << "<metrics_sinks_filename> <metrics-manager-port>" << std::endl;
+              << "<metrics_sinks_filename> <metrics-manager-port> <ckptmgr-port>" << std::endl;
     std::cout << "If zk_hostportlist is empty please say LOCALMODE\n";
     ::exit(1);
   }
@@ -50,6 +50,7 @@ int main(int argc, char* argv[]) {
   sp_string heron_internals_config_filename = argv[9];
   sp_string metrics_sinks_yaml = argv[10];
   sp_int32 metrics_manager_port = atoi(argv[11]);
+  sp_int32 ckptmgr_port = atoi(argv[12]);
 
   EventLoopImpl ss;
 
@@ -65,7 +66,7 @@ int main(int argc, char* argv[]) {
 
   heron::tmaster::TMaster tmaster(zkhostportlist, topology_name, topology_id, topdir,
                                   controller_port, master_port, stats_port, metrics_manager_port,
-                                  metrics_sinks_yaml, myhost, &ss);
+                                  ckptmgr_port, metrics_sinks_yaml, myhost, &ss);
   ss.loop();
   return 0;
 }

--- a/heron/tmaster/tests/cpp/server/tmaster_unittest.cpp
+++ b/heron/tmaster/tests/cpp/server/tmaster_unittest.cpp
@@ -259,11 +259,12 @@ void StartTMaster(EventLoopImpl*& ss, heron::tmaster::TMaster*& tmaster,
                   std::thread*& tmaster_thread, const sp_string& zkhostportlist,
                   const sp_string& topology_name, const sp_string& topology_id,
                   const sp_string& dpath, const sp_string& tmaster_host, sp_int32 tmaster_port,
-                  sp_int32 tmaster_controller_port) {
+                  sp_int32 tmaster_controller_port, sp_int32 ckptmgr_port) {
   ss = new EventLoopImpl();
   tmaster = new heron::tmaster::TMaster(zkhostportlist, topology_name, topology_id, dpath,
                                   tmaster_controller_port, tmaster_port, tmaster_port + 2,
-                                  tmaster_port + 3, metrics_sinks_config_filename, LOCALHOST, ss);
+                                  tmaster_port + 3, ckptmgr_port,
+                                  metrics_sinks_config_filename, LOCALHOST, ss);
   tmaster_thread = new std::thread(StartServer, ss);
   // tmaster_thread->start();
 }
@@ -293,6 +294,7 @@ struct CommonResources {
   sp_string tmaster_host_;
   sp_int32 tmaster_port_;
   sp_int32 tmaster_controller_port_;
+  sp_int32 ckptmgr_port_;
   sp_int32 stmgr_baseport_;
   sp_string zkhostportlist_;
   sp_string topology_name_;
@@ -361,7 +363,8 @@ void StartTMaster(CommonResources& common) {
 
   StartTMaster(tmaster_eventLoop, common.tmaster_, common.tmaster_thread_, common.zkhostportlist_,
                common.topology_name_, common.topology_id_, common.dpath_,
-               common.tmaster_host_, common.tmaster_port_, common.tmaster_controller_port_);
+               common.tmaster_host_, common.tmaster_port_, common.tmaster_controller_port_,
+               common.ckptmgr_port_);
   common.ss_list_.push_back(tmaster_eventLoop);
 }
 
@@ -425,6 +428,7 @@ void SetUpCommonResources(CommonResources& common) {
   common.tmaster_host_ = LOCALHOST;
   common.tmaster_port_ = 53001;
   common.tmaster_controller_port_ = 53002;
+  common.ckptmgr_port_ = 53003;
   common.stmgr_baseport_ = 53001;
   common.topology_name_ = "mytopology";
   common.topology_id_ = "abcd-9999";


### PR DESCRIPTION
In this pr, the executor passes the ckptmgr port to the tmaster so it can connect if its a stateful topology