### PR TITLE
Added ability in tmaster to accept stateful processing messages from stmgr

### DIFF
--- a/heron/tmaster/src/cpp/manager/tmaster.cpp
+++ b/heron/tmaster/src/cpp/manager/tmaster.cpp
@@ -339,6 +339,23 @@ void TMaster::GetTopologyDone(proto::system::StatusCode _code) {
   state_mgr_->GetPhysicalPlan(tmaster_location_->topology_name(), pplan, std::move(cb));
 }
 
+void TMaster::ResetTopologyState(Connection*, const std::string&,
+                                 int32_t, const std::string&) {
+  // TODO(srkukarni): Implement this
+}
+
+void TMaster::HandleInstanceStateStored(const std::string&,
+                                        const proto::system::Instance&) {
+  // TODO(srkukarni): Implement this
+}
+
+void TMaster::HandleRestoreTopologyStateResponse(Connection*,
+                                                 const std::string&,
+                                                 int64_t,
+                                                 proto::system::StatusCode) {
+  // TODO(srkukarni): Implement this
+}
+
 void TMaster::GetPhysicalPlanDone(proto::system::PhysicalPlan* _pplan,
                                   proto::system::StatusCode _code) {
   // Physical plan need not exist. First check if some other error occurred.

--- a/heron/tmaster/src/cpp/manager/tmaster.h
+++ b/heron/tmaster/src/cpp/manager/tmaster.h
@@ -83,6 +83,20 @@ class TMaster {
   // Now used in GetMetrics function in tmetrics-collector
   const proto::api::Topology* getInitialTopology() const { return topology_; }
 
+  // Called by tmaster server when it gets InstanceStateStored message
+  void HandleInstanceStateStored(const std::string& _checkpoint_id,
+                                 const proto::system::Instance& _instance);
+
+  // Called by tmaster server when it gets RestoreTopologyStateResponse message
+  void HandleRestoreTopologyStateResponse(Connection* _conn,
+                                          const std::string& _checkpoint_id,
+                                          int64_t _restore_txid,
+                                          proto::system::StatusCode _status);
+
+  // Called by tmaster server when it gets ResetTopologyState message
+  void ResetTopologyState(Connection* _conn, const std::string& _dead_stmgr,
+                          int32_t _dead_instance, const std::string& _reason);
+
  private:
   // Function to be called that calls MakePhysicalPlan and sends it to all stmgrs
   void DoPhysicalPlan(EventLoop::Status _code);

--- a/heron/tmaster/src/cpp/manager/tmasterserver.h
+++ b/heron/tmaster/src/cpp/manager/tmasterserver.h
@@ -20,6 +20,7 @@
 #include "network/network_error.h"
 #include "network/network.h"
 #include "proto/tmaster.pb.h"
+#include "proto/ckptmgr.pb.h"
 #include "basics/basics.h"
 
 namespace heron {
@@ -45,6 +46,17 @@ class TMasterServer : public Server {
   void HandleStMgrHeartbeatRequest(REQID _id, Connection* _conn,
                                    proto::tmaster::StMgrHeartbeatRequest* _request);
   void HandleMetricsMgrStats(Connection*, proto::tmaster::PublishMetrics* _request);
+
+  // Message sent by stmgr to tell tmaster that a particular checkpoint message
+  // was saved. This way the tmaster can keep track of which all instances have saved their
+  // state for any given checkpoint id.
+  void HandleInstanceStateStored(Connection*, proto::ckptmgr::InstanceStateStored* _message);
+  // Handle response from stmgr for the RestoreTopologyStateRequest
+  void HandleRestoreTopologyStateResponse(Connection*,
+                                     proto::ckptmgr::RestoreTopologyStateResponse* _message);
+  // Stmgr can request tmaster to reset the state of the topology in case it finds any errors.
+  void HandleResetTopologyStateMessage(Connection*,
+                                     proto::ckptmgr::ResetTopologyState* _message);
 
   // our tmaster
   TMetricsCollector* collector_;


### PR DESCRIPTION
For Stateful topologies, stmgr and tmaster exchange a bunch of information. This pr adds handlers for these various requests in tmaster. Note that the actual handling of these requests will come in a future pr.