### PR TITLE
update heron instance message incoming/outgoing queue with type Message

### DIFF
--- a/heron/instance/src/java/com/twitter/heron/instance/AbstractOutputCollector.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/AbstractOutputCollector.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.Message;
 
 import com.twitter.heron.api.Config;
 import com.twitter.heron.api.serializer.IPluggableSerializer;
@@ -44,7 +45,7 @@ public class AbstractOutputCollector {
   @SuppressWarnings("deprecation")
   public AbstractOutputCollector(IPluggableSerializer serializer,
                                  PhysicalPlanHelper helper,
-                                 Communicator<HeronTuples.HeronTupleSet> streamOutQueue,
+                                 Communicator<Message> streamOutQueue,
                                  ComponentMetrics metrics) {
     this.serializer = serializer;
     this.metrics = metrics;

--- a/heron/instance/src/java/com/twitter/heron/instance/Gateway.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/Gateway.java
@@ -19,6 +19,8 @@ import java.time.Duration;
 import java.util.List;
 import java.util.logging.Logger;
 
+import com.google.protobuf.Message;
+
 import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.basics.NIOLooper;
 import com.twitter.heron.common.basics.SingletonRegistry;
@@ -31,7 +33,6 @@ import com.twitter.heron.common.utils.misc.ThreadNames;
 import com.twitter.heron.metrics.GatewayMetrics;
 import com.twitter.heron.network.MetricsManagerClient;
 import com.twitter.heron.network.StreamManagerClient;
-import com.twitter.heron.proto.system.HeronTuples;
 import com.twitter.heron.proto.system.Metrics;
 import com.twitter.heron.proto.system.PhysicalPlans;
 
@@ -66,8 +67,8 @@ public class Gateway implements Runnable, AutoCloseable {
    */
   public Gateway(String topologyName, String topologyId, PhysicalPlans.Instance instance,
                  int streamPort, int metricsPort, final NIOLooper gatewayLooper,
-                 final Communicator<HeronTuples.HeronTupleSet> inStreamQueue,
-                 final Communicator<HeronTuples.HeronTupleSet> outStreamQueue,
+                 final Communicator<Message> inStreamQueue,
+                 final Communicator<Message> outStreamQueue,
                  final Communicator<InstanceControlMsg> inControlQueue,
                  final List<Communicator<Metrics.MetricPublisherPublishMessage>> outMetricsQueues)
       throws IOException {

--- a/heron/instance/src/java/com/twitter/heron/instance/HeronInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/HeronInstance.java
@@ -26,6 +26,8 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.google.protobuf.Message;
+
 import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.basics.NIOLooper;
 import com.twitter.heron.common.basics.SingletonRegistry;
@@ -35,7 +37,6 @@ import com.twitter.heron.common.config.SystemConfig;
 import com.twitter.heron.common.utils.logging.ErrorReportLoggingHandler;
 import com.twitter.heron.common.utils.logging.LoggingHelper;
 import com.twitter.heron.common.utils.misc.ThreadNames;
-import com.twitter.heron.proto.system.HeronTuples;
 import com.twitter.heron.proto.system.Metrics;
 import com.twitter.heron.proto.system.PhysicalPlans;
 
@@ -52,11 +53,11 @@ public class HeronInstance {
   private final SlaveLooper slaveLooper;
 
   // Only one outStreamQueue, which is responsible for both control tuples and data tuples
-  private final Communicator<HeronTuples.HeronTupleSet> outStreamQueue;
+  private final Communicator<Message> outStreamQueue;
 
   // This blocking queue is used to buffer tuples read from socket and ready to be used by instance
   // For spout, it will buffer Control tuple, while for bolt, it will buffer data tuple.
-  private final Communicator<HeronTuples.HeronTupleSet> inStreamQueue;
+  private final Communicator<Message> inStreamQueue;
 
   // This queue is used to pass Control Message from Gateway to Slave
   // TODO:- currently it would just pass the PhysicalPlanHelper
@@ -93,8 +94,8 @@ public class HeronInstance {
     slaveLooper.addTasksOnExit(new SlaveExitTask());
 
     // For stream
-    inStreamQueue = new Communicator<HeronTuples.HeronTupleSet>(gatewayLooper, slaveLooper);
-    outStreamQueue = new Communicator<HeronTuples.HeronTupleSet>(slaveLooper, gatewayLooper);
+    inStreamQueue = new Communicator<Message>(gatewayLooper, slaveLooper);
+    outStreamQueue = new Communicator<Message>(slaveLooper, gatewayLooper);
     inControlQueue = new Communicator<InstanceControlMsg>(gatewayLooper, slaveLooper);
 
     // Now for metrics

--- a/heron/instance/src/java/com/twitter/heron/instance/IInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/IInstance.java
@@ -14,11 +14,12 @@
 
 package com.twitter.heron.instance;
 
+import com.google.protobuf.Message;
+
 import com.twitter.heron.classification.InterfaceAudience;
 import com.twitter.heron.classification.InterfaceStability;
 import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.utils.misc.PhysicalPlanHelper;
-import com.twitter.heron.proto.system.HeronTuples;
 
 /**
  * Implementing this interface allows an object to be target of HeronInstance
@@ -44,7 +45,7 @@ public interface IInstance {
    *
    * @param inQueue the queue to read tuples from
    */
-  void readTuplesAndExecute(Communicator<HeronTuples.HeronTupleSet> inQueue);
+  void readTuplesAndExecute(Communicator<Message> inQueue);
 
   /**
    * Activate the instance
@@ -61,4 +62,10 @@ public interface IInstance {
    * @param physicalPlanHelper
    */
   void update(PhysicalPlanHelper physicalPlanHelper);
+
+  /**
+   * Save the state and send it out for persistence
+   * @param checkpointId
+   */
+  void persistState(String checkpointId);
 }

--- a/heron/instance/src/java/com/twitter/heron/instance/OutgoingTupleCollection.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/OutgoingTupleCollection.java
@@ -14,6 +14,8 @@
 
 package com.twitter.heron.instance;
 
+import com.google.protobuf.Message;
+
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.common.basics.Communicator;
@@ -33,7 +35,7 @@ import com.twitter.heron.proto.system.HeronTuples;
 public class OutgoingTupleCollection {
   protected PhysicalPlanHelper helper;
   // We have just one outQueue responsible for both control tuples and data tuples
-  private final Communicator<HeronTuples.HeronTupleSet> outQueue;
+  private final Communicator<Message> outQueue;
 
   // Maximum data tuple size in bytes we can put in one HeronTupleSet
   private final ByteAmount maxDataTupleSize;
@@ -51,7 +53,7 @@ public class OutgoingTupleCollection {
 
   public OutgoingTupleCollection(
       PhysicalPlanHelper helper,
-      Communicator<HeronTuples.HeronTupleSet> outQueue) {
+      Communicator<Message> outQueue) {
     this.outQueue = outQueue;
     this.helper = helper;
     SystemConfig systemConfig =
@@ -151,7 +153,7 @@ public class OutgoingTupleCollection {
   }
 
   private void pushTupleToQueue(HeronTuples.HeronTupleSet.Builder bldr,
-                                Communicator<HeronTuples.HeronTupleSet> out) {
+                                Communicator<Message> out) {
     // The Communicator has un-bounded capacity so the offer will always be successful
     out.offer(bldr.build());
   }

--- a/heron/instance/src/java/com/twitter/heron/instance/Slave.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/Slave.java
@@ -17,6 +17,8 @@ package com.twitter.heron.instance;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.google.protobuf.Message;
+
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.basics.SingletonRegistry;
@@ -27,7 +29,6 @@ import com.twitter.heron.common.utils.misc.PhysicalPlanHelper;
 import com.twitter.heron.common.utils.misc.ThreadNames;
 import com.twitter.heron.instance.bolt.BoltInstance;
 import com.twitter.heron.instance.spout.SpoutInstance;
-import com.twitter.heron.proto.system.HeronTuples;
 import com.twitter.heron.proto.system.Metrics;
 
 /**
@@ -43,8 +44,8 @@ public class Slave implements Runnable, AutoCloseable {
   private final SlaveLooper slaveLooper;
   private final MetricsCollector metricsCollector;
   // Communicator
-  private final Communicator<HeronTuples.HeronTupleSet> streamInCommunicator;
-  private final Communicator<HeronTuples.HeronTupleSet> streamOutCommunicator;
+  private final Communicator<Message> streamInCommunicator;
+  private final Communicator<Message> streamOutCommunicator;
   private final Communicator<InstanceControlMsg> inControlQueue;
   private IInstance instance;
   private PhysicalPlanHelper helper;
@@ -53,8 +54,8 @@ public class Slave implements Runnable, AutoCloseable {
   private boolean isInstanceStarted = false;
 
   public Slave(SlaveLooper slaveLooper,
-               final Communicator<HeronTuples.HeronTupleSet> streamInCommunicator,
-               final Communicator<HeronTuples.HeronTupleSet> streamOutCommunicator,
+               final Communicator<Message> streamInCommunicator,
+               final Communicator<Message> streamOutCommunicator,
                final Communicator<InstanceControlMsg> inControlQueue,
                final Communicator<Metrics.MetricPublisherPublishMessage> metricsOutCommunicator) {
     this.slaveLooper = slaveLooper;

--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltOutputCollectorImpl.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltOutputCollectorImpl.java
@@ -22,6 +22,8 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.google.protobuf.Message;
+
 import com.twitter.heron.api.bolt.IOutputCollector;
 import com.twitter.heron.api.serializer.IPluggableSerializer;
 import com.twitter.heron.api.tuple.Tuple;
@@ -58,7 +60,7 @@ public class BoltOutputCollectorImpl extends AbstractOutputCollector implements 
 
   protected BoltOutputCollectorImpl(IPluggableSerializer serializer,
                                     PhysicalPlanHelper helper,
-                                    Communicator<HeronTuples.HeronTupleSet> streamOutQueue,
+                                    Communicator<Message> streamOutQueue,
                                     BoltMetrics boltMetrics) {
     super(serializer, helper, streamOutQueue, boltMetrics);
     this.boltMetrics = boltMetrics;

--- a/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutOutputCollectorImpl.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutOutputCollectorImpl.java
@@ -24,6 +24,8 @@ import java.util.Queue;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.google.protobuf.Message;
+
 import com.twitter.heron.api.serializer.IPluggableSerializer;
 import com.twitter.heron.api.spout.ISpoutOutputCollector;
 import com.twitter.heron.common.basics.Communicator;
@@ -61,7 +63,7 @@ public class SpoutOutputCollectorImpl
 
   protected SpoutOutputCollectorImpl(IPluggableSerializer serializer,
                                      PhysicalPlanHelper helper,
-                                     Communicator<HeronTuples.HeronTupleSet> streamOutQueue,
+                                     Communicator<Message> streamOutQueue,
                                      ComponentMetrics spoutMetrics) {
     super(serializer, helper, streamOutQueue, spoutMetrics);
     if (helper.getMySpout() == null) {

--- a/heron/instance/tests/java/com/twitter/heron/grouping/AbstractTupleRoutingTest.java
+++ b/heron/instance/tests/java/com/twitter/heron/grouping/AbstractTupleRoutingTest.java
@@ -17,6 +17,8 @@ package com.twitter.heron.grouping;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
+import com.google.protobuf.Message;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -119,7 +121,11 @@ public abstract class AbstractTupleRoutingTest {
           if (slaveTester.getOutStreamQueue().isEmpty()) {
             continue;
           }
-          HeronTuples.HeronTupleSet set = slaveTester.getOutStreamQueue().poll();
+
+          Message msg = slaveTester.getOutStreamQueue().poll();
+          assertTrue(msg instanceof HeronTuples.HeronTupleSet);
+
+          HeronTuples.HeronTupleSet set = (HeronTuples.HeronTupleSet) msg;
 
           assertTrue(set.isInitialized());
           assertFalse(set.hasControl());
@@ -136,11 +142,11 @@ public abstract class AbstractTupleRoutingTest {
             assertEquals((Integer) tupleReceived, destTaskIds.get(0));
             tupleReceived++;
           }
-        }
 
-        assertEquals(expectedTuplesValidated, tupleReceived);
-        assertEquals(getExpectedComponentInitInfo(), groupingInitInfo.toString());
-        slaveTester.getTestLooper().exitLoop();
+          assertEquals(expectedTuplesValidated, tupleReceived);
+          assertEquals(getExpectedComponentInitInfo(), groupingInitInfo.toString());
+          slaveTester.getTestLooper().exitLoop();
+        }
       }
     };
 
@@ -212,13 +218,13 @@ public abstract class AbstractTupleRoutingTest {
   }
 
   protected void initBoltA(TopologyBuilder topologyBuilder,
-                         String boltId, String upstreamComponentId) {
+                           String boltId, String upstreamComponentId) {
     topologyBuilder.setBolt(boltId, new TestBolt(), 1)
         .shuffleGrouping(upstreamComponentId);
   }
 
   protected void initBoltB(TopologyBuilder topologyBuilder,
-                         String boltId, String upstreamComponentId) {
+                           String boltId, String upstreamComponentId) {
     topologyBuilder.setBolt(boltId, new TestBolt(), 1)
         .shuffleGrouping(upstreamComponentId);
   }

--- a/heron/instance/tests/java/com/twitter/heron/instance/CommunicatorTester.java
+++ b/heron/instance/tests/java/com/twitter/heron/instance/CommunicatorTester.java
@@ -16,12 +16,13 @@ package com.twitter.heron.instance;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 
+import com.google.protobuf.Message;
+
 import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.basics.NIOLooper;
 import com.twitter.heron.common.basics.SlaveLooper;
 import com.twitter.heron.common.basics.WakeableLooper;
 import com.twitter.heron.common.testhelpers.CommunicatorTestHelper;
-import com.twitter.heron.proto.system.HeronTuples;
 import com.twitter.heron.proto.system.Metrics;
 import com.twitter.heron.resource.Constants;
 import com.twitter.heron.resource.UnitTestHelper;
@@ -34,11 +35,11 @@ public class CommunicatorTester {
   private final SlaveLooper slaveLooper;
 
   // Only one outStreamQueue, which is responsible for both control tuples and data tuples
-  private final Communicator<HeronTuples.HeronTupleSet> outStreamQueue;
+  private final Communicator<Message> outStreamQueue;
 
   // This blocking queue is used to buffer tuples read from socket and ready to be used by instance
   // For spout, it will buffer Control tuple, while for bolt, it will buffer data tuple.
-  private final Communicator<HeronTuples.HeronTupleSet> inStreamQueue;
+  private final Communicator<Message> inStreamQueue;
   private final Communicator<InstanceControlMsg> inControlQueue;
   private final Communicator<Metrics.MetricPublisherPublishMessage> slaveMetricsOut;
 
@@ -59,10 +60,10 @@ public class CommunicatorTester {
     this.testLooper = testLooper;
     slaveLooper = new SlaveLooper();
     outStreamQueue = initCommunicator(
-        new Communicator<HeronTuples.HeronTupleSet>(slaveLooper, testLooper),
+        new Communicator<Message>(slaveLooper, testLooper),
         outStreamQueueOfferLatch);
     inStreamQueue = initCommunicator(
-        new Communicator<HeronTuples.HeronTupleSet>(testLooper, slaveLooper),
+        new Communicator<Message>(testLooper, slaveLooper),
         inStreamQueueOfferLatch);
     inControlQueue = initCommunicator(
         new Communicator<InstanceControlMsg>(testLooper, slaveLooper), inControlQueueOfferLatch);
@@ -107,11 +108,11 @@ public class CommunicatorTester {
     return inControlQueue;
   }
 
-  public Communicator<HeronTuples.HeronTupleSet> getInStreamQueue() {
+  public Communicator<Message> getInStreamQueue() {
     return inStreamQueue;
   }
 
-  public Communicator<HeronTuples.HeronTupleSet> getOutStreamQueue() {
+  public Communicator<Message> getOutStreamQueue() {
     return outStreamQueue;
   }
 }

--- a/heron/instance/tests/java/com/twitter/heron/network/AbstractNetworkTest.java
+++ b/heron/instance/tests/java/com/twitter/heron/network/AbstractNetworkTest.java
@@ -24,6 +24,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import com.google.protobuf.Message;
+
 import org.junit.After;
 import org.junit.Before;
 
@@ -38,7 +40,6 @@ import com.twitter.heron.common.testhelpers.HeronServerTester;
 import com.twitter.heron.instance.CommunicatorTester;
 import com.twitter.heron.instance.InstanceControlMsg;
 import com.twitter.heron.metrics.GatewayMetrics;
-import com.twitter.heron.proto.system.HeronTuples;
 import com.twitter.heron.resource.UnitTestHelper;
 
 import static org.junit.Assert.assertEquals;
@@ -122,7 +123,7 @@ public abstract class AbstractNetworkTest {
     return communicatorTester.getInControlQueue();
   }
 
-  protected Communicator<HeronTuples.HeronTupleSet> getInStreamQueue() {
+  protected Communicator<Message> getInStreamQueue() {
     return communicatorTester.getInStreamQueue();
   }
 

--- a/heron/instance/tests/java/com/twitter/heron/network/HandleReadTest.java
+++ b/heron/instance/tests/java/com/twitter/heron/network/HandleReadTest.java
@@ -76,7 +76,10 @@ public class HandleReadTest extends AbstractNetworkTest {
 
       Assert.assertEquals(1, getInStreamQueue().size());
 
-      HeronTuples.HeronTupleSet heronTupleSet = getInStreamQueue().poll();
+      Message msg = getInStreamQueue().poll();
+      Assert.assertTrue(msg instanceof HeronTuples.HeronTupleSet);
+
+      HeronTuples.HeronTupleSet heronTupleSet = (HeronTuples.HeronTupleSet) msg;
 
       Assert.assertTrue(heronTupleSet.hasData());
       Assert.assertFalse(heronTupleSet.hasControl());

--- a/heron/simulator/src/java/com/twitter/heron/simulator/executors/InstanceExecutor.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/executors/InstanceExecutor.java
@@ -17,12 +17,13 @@ package com.twitter.heron.simulator.executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.google.protobuf.Message;
+
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.basics.SlaveLooper;
 import com.twitter.heron.common.utils.metrics.MetricsCollector;
 import com.twitter.heron.common.utils.misc.PhysicalPlanHelper;
-import com.twitter.heron.proto.system.HeronTuples;
 import com.twitter.heron.proto.system.Metrics;
 import com.twitter.heron.proto.system.PhysicalPlans;
 import com.twitter.heron.simulator.instance.BoltInstance;
@@ -45,8 +46,8 @@ public class InstanceExecutor implements Runnable {
 
   private final SlaveLooper looper;
 
-  private final Communicator<HeronTuples.HeronTupleSet> streamInQueue;
-  private final Communicator<HeronTuples.HeronTupleSet> streamOutQueue;
+  private final Communicator<Message> streamInQueue;
+  private final Communicator<Message> streamOutQueue;
   private final Communicator<Metrics.MetricPublisherPublishMessage> metricsOutQueue;
 
   private IInstance instance;
@@ -74,11 +75,11 @@ public class InstanceExecutor implements Runnable {
         new Object[]{physicalPlanHelper.getMyComponent(), physicalPlanHelper.getMyTaskId()});
   }
 
-  public Communicator<HeronTuples.HeronTupleSet> getStreamInQueue() {
+  public Communicator<Message> getStreamInQueue() {
     return streamInQueue;
   }
 
-  public Communicator<HeronTuples.HeronTupleSet> getStreamOutQueue() {
+  public Communicator<Message> getStreamOutQueue() {
     return streamOutQueue;
   }
 

--- a/heron/simulator/src/java/com/twitter/heron/simulator/executors/StreamExecutor.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/executors/StreamExecutor.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
 
+import com.google.protobuf.Message;
+
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.SlaveLooper;
 import com.twitter.heron.common.basics.WakeableLooper;
@@ -131,41 +133,45 @@ public class StreamExecutor implements Runnable {
 
       int items = executor.getStreamOutQueue().size();
       for (int i = 0; i < items; i++) {
-        HeronTuples.HeronTupleSet tupleSet = executor.getStreamOutQueue().poll();
-        if (tupleSet == null) {
-          // No stream from this queue
-          break;
-        }
+        Message msg = executor.getStreamOutQueue().poll();
 
-        if (tupleSet.hasData()) {
-          HeronTuples.HeronDataTupleSet d = tupleSet.getData();
-          TopologyAPI.StreamId streamId = d.getStream();
-          StreamConsumers consumers = streamIdStreamConsumersMap.get(streamId);
-          if (consumers != null) {
-            for (HeronTuples.HeronDataTuple tuple : d.getTuplesList()) {
-              List<Integer> outTasks = consumers.getListToSend(tuple);
+        if (msg instanceof HeronTuples.HeronTupleSet) {
+          HeronTuples.HeronTupleSet tupleSet = (HeronTuples.HeronTupleSet) msg;
+          if (tupleSet == null) {
+            // No stream from this queue
+            break;
+          }
 
-              outTasks.addAll(tuple.getDestTaskIdsList());
+          if (tupleSet.hasData()) {
+            HeronTuples.HeronDataTupleSet d = tupleSet.getData();
+            TopologyAPI.StreamId streamId = d.getStream();
+            StreamConsumers consumers = streamIdStreamConsumersMap.get(streamId);
+            if (consumers != null) {
+              for (HeronTuples.HeronDataTuple tuple : d.getTuplesList()) {
+                List<Integer> outTasks = consumers.getListToSend(tuple);
 
-              if (outTasks.isEmpty()) {
-                LOG.severe("Nobody to sent the tuple to");
+                outTasks.addAll(tuple.getDestTaskIdsList());
+
+                if (outTasks.isEmpty()) {
+                  LOG.severe("Nobody to sent the tuple to");
+                }
+
+                copyDataOutBound(taskId, isLocalSpout, streamId, tuple, outTasks);
               }
-
-              copyDataOutBound(taskId, isLocalSpout, streamId, tuple, outTasks);
+            } else {
+              LOG.severe("Nobody consumes stream: " + streamId);
             }
-          } else {
-            LOG.severe("Nobody consumes stream: " + streamId);
-          }
-        }
-
-        if (tupleSet.hasControl()) {
-          HeronTuples.HeronControlTupleSet c = tupleSet.getControl();
-          for (HeronTuples.AckTuple ack : c.getAcksList()) {
-            copyControlOutBound(tupleSet.getSrcTaskId(), ack, true);
           }
 
-          for (HeronTuples.AckTuple fail : c.getFailsList()) {
-            copyControlOutBound(tupleSet.getSrcTaskId(), fail, false);
+          if (tupleSet.hasControl()) {
+            HeronTuples.HeronControlTupleSet c = tupleSet.getControl();
+            for (HeronTuples.AckTuple ack : c.getAcksList()) {
+              copyControlOutBound(tupleSet.getSrcTaskId(), ack, true);
+            }
+
+            for (HeronTuples.AckTuple fail : c.getFailsList()) {
+              copyControlOutBound(tupleSet.getSrcTaskId(), fail, false);
+            }
           }
         }
       }

--- a/heron/simulator/src/java/com/twitter/heron/simulator/instance/BoltOutputCollectorImpl.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/instance/BoltOutputCollectorImpl.java
@@ -14,12 +14,13 @@
 
 package com.twitter.heron.simulator.instance;
 
+import com.google.protobuf.Message;
+
 import com.twitter.heron.api.bolt.IOutputCollector;
 import com.twitter.heron.api.serializer.IPluggableSerializer;
 import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.utils.metrics.BoltMetrics;
 import com.twitter.heron.common.utils.misc.PhysicalPlanHelper;
-import com.twitter.heron.proto.system.HeronTuples;
 
 /**
  * BoltOutputCollectorImpl is used by bolt to emit tuples, it contains:
@@ -45,7 +46,7 @@ public class BoltOutputCollectorImpl
 
   public BoltOutputCollectorImpl(IPluggableSerializer serializer,
                                  PhysicalPlanHelper helper,
-                                 Communicator<HeronTuples.HeronTupleSet> streamOutQueue,
+                                 Communicator<Message> streamOutQueue,
                                  BoltMetrics boltMetrics) {
     super(serializer, helper, streamOutQueue, boltMetrics);
   }

--- a/heron/simulator/src/java/com/twitter/heron/simulator/instance/IInstance.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/instance/IInstance.java
@@ -14,8 +14,9 @@
 
 package com.twitter.heron.simulator.instance;
 
+import com.google.protobuf.Message;
+
 import com.twitter.heron.common.basics.Communicator;
-import com.twitter.heron.proto.system.HeronTuples;
 
 /**
  * Implementing this interface allows an object to be target of HeronInstance
@@ -40,7 +41,7 @@ public interface IInstance {
    *
    * @param inQueue the queue to read tuples from
    */
-  void readTuplesAndExecute(Communicator<HeronTuples.HeronTupleSet> inQueue);
+  void readTuplesAndExecute(Communicator<Message> inQueue);
 
   /**
    * Activate the instance

--- a/heron/simulator/src/java/com/twitter/heron/simulator/instance/OutgoingTupleCollection.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/instance/OutgoingTupleCollection.java
@@ -14,9 +14,10 @@
 
 package com.twitter.heron.simulator.instance;
 
+import com.google.protobuf.Message;
+
 import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.utils.misc.PhysicalPlanHelper;
-import com.twitter.heron.proto.system.HeronTuples;
 
 /**
  * Implements OutgoingTupleCollection will be able to handle some basic methods for send out tuples
@@ -29,7 +30,7 @@ import com.twitter.heron.proto.system.HeronTuples;
 public class OutgoingTupleCollection extends com.twitter.heron.instance.OutgoingTupleCollection {
 
   public OutgoingTupleCollection(PhysicalPlanHelper helper,
-                                 Communicator<HeronTuples.HeronTupleSet> outQueue) {
+                                 Communicator<Message> outQueue) {
     super(helper, outQueue);
   }
 }

--- a/heron/simulator/src/java/com/twitter/heron/simulator/instance/SpoutInstance.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/instance/SpoutInstance.java
@@ -17,6 +17,8 @@ package com.twitter.heron.simulator.instance;
 import java.time.Duration;
 import java.util.Map;
 
+import com.google.protobuf.Message;
+
 import com.twitter.heron.api.Config;
 import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.common.basics.Communicator;
@@ -25,7 +27,6 @@ import com.twitter.heron.common.basics.SlaveLooper;
 import com.twitter.heron.common.basics.TypeUtils;
 import com.twitter.heron.common.config.SystemConfig;
 import com.twitter.heron.common.utils.misc.PhysicalPlanHelper;
-import com.twitter.heron.proto.system.HeronTuples;
 
 public class SpoutInstance
     extends com.twitter.heron.instance.spout.SpoutInstance implements IInstance {
@@ -40,8 +41,8 @@ public class SpoutInstance
    */
   @SuppressWarnings("deprecation")
   public SpoutInstance(PhysicalPlanHelper helper,
-                       Communicator<HeronTuples.HeronTupleSet> streamInQueue,
-                       Communicator<HeronTuples.HeronTupleSet> streamOutQueue, SlaveLooper looper) {
+                       Communicator<Message> streamInQueue,
+                       Communicator<Message> streamOutQueue, SlaveLooper looper) {
     super(helper, streamInQueue, streamOutQueue, looper);
     Map<String, Object> config = helper.getTopologyContext().getTopologyConfig();
     SystemConfig systemConfig =

--- a/heron/simulator/src/java/com/twitter/heron/simulator/instance/SpoutOutputCollectorImpl.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/instance/SpoutOutputCollectorImpl.java
@@ -14,12 +14,13 @@
 
 package com.twitter.heron.simulator.instance;
 
+import com.google.protobuf.Message;
+
 import com.twitter.heron.api.serializer.IPluggableSerializer;
 import com.twitter.heron.api.spout.ISpoutOutputCollector;
 import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.utils.metrics.ComponentMetrics;
 import com.twitter.heron.common.utils.misc.PhysicalPlanHelper;
-import com.twitter.heron.proto.system.HeronTuples;
 
 /**
  * SpoutOutputCollectorImpl is used by bolt to emit tuples, it contains:
@@ -40,7 +41,7 @@ public class SpoutOutputCollectorImpl
 
   public SpoutOutputCollectorImpl(IPluggableSerializer serializer,
                                   PhysicalPlanHelper helper,
-                                  Communicator<HeronTuples.HeronTupleSet> streamOutQueue,
+                                  Communicator<Message> streamOutQueue,
                                   ComponentMetrics spoutMetrics) {
     super(serializer, helper, streamOutQueue, spoutMetrics);
   }


### PR DESCRIPTION
This is the first stateful processing PR for instance side. In this PR, 
1. the message incoming and outgoing queue is updated to accept `Message` instead of `HeronTupleSet`.
2. the `persistState(ckpt_id)` interface is added into `IInstance`
3. fixed any affected tests and simulator code