### PR TITLE
Move away from HeronTupleSet

### DIFF
--- a/heron/common/src/python/utils/misc/outgoing_tuple_helper.py
+++ b/heron/common/src/python/utils/misc/outgoing_tuple_helper.py
@@ -37,9 +37,9 @@ class OutgoingTupleHelper(object):
   :ivar current_data_tuple_set: (HeronDataTupleSet) currently buffered data tuple
   :ivar current_control_tuple_set: (HeronControlTupleSet) currently buffered control tuple
   """
-  make_data_tuple_set = lambda _: tuple_pb2.HeronDataTupleSet()
+  make_data_tuple_set = lambda _: tuple_pb2.HeronDataTupleSet2()
   make_control_tuple_set = lambda _: tuple_pb2.HeronControlTupleSet()
-  make_tuple_set = lambda _: tuple_pb2.HeronTupleSet()
+  make_tuple_set = lambda _: tuple_pb2.HeronTupleSet2()
   make_stream_id = lambda _: topology_pb2.StreamId()
 
   def __init__(self, pplan_helper, out_stream):
@@ -72,8 +72,7 @@ class OutgoingTupleHelper(object):
         (self.current_data_tuple_size_in_bytes >= self.max_data_tuple_size_in_bytes):
       self._init_new_data_tuple(stream_id)
 
-    added_tuple = self.current_data_tuple_set.tuples.add()
-    added_tuple.CopyFrom(new_data_tuple)
+    self.current_data_tuple_set.tuples.append(new_data_tuple.SerializeToString())
 
     self.current_data_tuple_size_in_bytes += tuple_size_in_bytes
     self.total_data_emitted_in_bytes += tuple_size_in_bytes

--- a/heron/common/tests/python/utils/outgoing_tuple_helper_unittest.py
+++ b/heron/common/tests/python/utils/outgoing_tuple_helper_unittest.py
@@ -17,6 +17,8 @@ import unittest
 
 import heron.common.tests.python.utils.mock_generator as mock_generator
 
+from heron.proto import tuple_pb2
+
 class OutgoingTupleHelperTest(unittest.TestCase):
   DEFAULT_STREAM_ID = "stream_id"
   def setUp(self):
@@ -43,4 +45,6 @@ class OutgoingTupleHelperTest(unittest.TestCase):
 
     sent_data_tuple_set = out_helper.out_stream.poll().data
     self.assertEqual(sent_data_tuple_set.stream.id, self.DEFAULT_STREAM_ID)
-    self.assertEqual(sent_data_tuple_set.tuples[0], prim_data_tuple)
+    dtuple = tuple_pb2.HeronDataTuple()
+    dtuple.ParseFromString(sent_data_tuple_set.tuples[0])
+    self.assertEqual(dtuple, prim_data_tuple)

--- a/heron/instance/src/java/com/twitter/heron/instance/OutgoingTupleCollection.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/OutgoingTupleCollection.java
@@ -42,7 +42,7 @@ public class OutgoingTupleCollection {
   private final int dataTupleSetCapacity;
   private final int controlTupleSetCapacity;
 
-  private HeronTuples.HeronDataTupleSet.Builder currentDataTuple;
+  private HeronTuples.HeronDataTupleSet2.Builder currentDataTuple;
   private HeronTuples.HeronControlTupleSet.Builder currentControlTuple;
 
   // Total data emitted in bytes for the entire life
@@ -83,7 +83,7 @@ public class OutgoingTupleCollection {
         || currentDataTupleSizeInBytes >= maxDataTupleSize.asBytes()) {
       initNewDataTuple(streamId);
     }
-    currentDataTuple.addTuples(newTuple);
+    currentDataTuple.addTuples(newTuple.build().toByteString());
 
     currentDataTupleSizeInBytes += tupleSizeInBytes;
     totalDataEmittedInBytes += tupleSizeInBytes;
@@ -122,7 +122,7 @@ public class OutgoingTupleCollection {
     TopologyAPI.StreamId.Builder sbldr = TopologyAPI.StreamId.newBuilder();
     sbldr.setId(streamId);
     sbldr.setComponentName(helper.getMyComponent());
-    currentDataTuple = HeronTuples.HeronDataTupleSet.newBuilder();
+    currentDataTuple = HeronTuples.HeronDataTupleSet2.newBuilder();
     currentDataTuple.setStream(sbldr);
   }
 
@@ -133,7 +133,7 @@ public class OutgoingTupleCollection {
 
   private void flushRemaining() {
     if (currentDataTuple != null) {
-      HeronTuples.HeronTupleSet.Builder bldr = HeronTuples.HeronTupleSet.newBuilder();
+      HeronTuples.HeronTupleSet2.Builder bldr = HeronTuples.HeronTupleSet2.newBuilder();
       bldr.setSrcTaskId(helper.getMyTaskId());
       bldr.setData(currentDataTuple);
 
@@ -142,7 +142,7 @@ public class OutgoingTupleCollection {
       currentDataTuple = null;
     }
     if (currentControlTuple != null) {
-      HeronTuples.HeronTupleSet.Builder bldr = HeronTuples.HeronTupleSet.newBuilder();
+      HeronTuples.HeronTupleSet2.Builder bldr = HeronTuples.HeronTupleSet2.newBuilder();
       bldr.setSrcTaskId(helper.getMyTaskId());
       bldr.setControl(currentControlTuple);
 
@@ -152,7 +152,7 @@ public class OutgoingTupleCollection {
     }
   }
 
-  private void pushTupleToQueue(HeronTuples.HeronTupleSet.Builder bldr,
+  private void pushTupleToQueue(HeronTuples.HeronTupleSet2.Builder bldr,
                                 Communicator<Message> out) {
     // The Communicator has un-bounded capacity so the offer will always be successful
     out.offer(bldr.build());

--- a/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutInstance.java
@@ -376,8 +376,8 @@ public class SpoutInstance implements IInstance {
         persistState(checkpintId);
       }
 
-      if (msg instanceof HeronTuples.HeronTupleSet) {
-        HeronTuples.HeronTupleSet tuples = (HeronTuples.HeronTupleSet) msg;
+      if (msg instanceof HeronTuples.HeronTupleSet2) {
+        HeronTuples.HeronTupleSet2 tuples = (HeronTuples.HeronTupleSet2) msg;
         // For spout, it should read only control tuples(ack&fail)
         if (tuples.hasData()) {
           throw new RuntimeException("Spout cannot get incoming data tuples from other components");

--- a/heron/instance/src/java/com/twitter/heron/network/StreamManagerClient.java
+++ b/heron/instance/src/java/com/twitter/heron/network/StreamManagerClient.java
@@ -17,8 +17,6 @@ package com.twitter.heron.network;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.google.protobuf.ByteString;
-import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 
 import com.twitter.heron.common.basics.Communicator;
@@ -272,28 +270,7 @@ public class StreamManagerClient extends HeronClient {
   }
 
   private void handleNewTuples2(HeronTuples.HeronTupleSet2 set) {
-    HeronTuples.HeronTupleSet.Builder toFeed = HeronTuples.HeronTupleSet.newBuilder();
-    // Set the source task id
-    toFeed.setSrcTaskId(set.getSrcTaskId());
-
-    if (set.hasControl()) {
-      toFeed.setControl(set.getControl());
-    } else {
-      // Either control or data
-      HeronTuples.HeronDataTupleSet.Builder builder = HeronTuples.HeronDataTupleSet.newBuilder();
-      builder.setStream(set.getData().getStream());
-      try {
-        for (ByteString bs : set.getData().getTuplesList()) {
-          builder.addTuples(HeronTuples.HeronDataTuple.parseFrom(bs));
-        }
-      } catch (InvalidProtocolBufferException e) {
-        LOG.log(Level.SEVERE, "Failed to parse protobuf", e);
-      }
-      toFeed.setData(builder);
-    }
-
-    HeronTuples.HeronTupleSet s = toFeed.build();
-    inStreamQueue.offer(s);
+    inStreamQueue.offer(set);
   }
 
   private void handleAssignmentMessage(PhysicalPlans.PhysicalPlan pplan) {

--- a/heron/instance/src/python/basics/bolt_instance.py
+++ b/heron/instance/src/python/basics/bolt_instance.py
@@ -178,14 +178,19 @@ class BoltInstance(BaseInstance):
       except Queue.Empty:
         break
 
-      if isinstance(tuples, tuple_pb2.HeronTupleSet):
+      if isinstance(tuples, tuple_pb2.HeronTupleSet2):
         if tuples.HasField("control"):
           raise RuntimeError("Bolt cannot get acks/fails from other components")
         elif tuples.HasField("data"):
           stream = tuples.data.stream
 
-          for data_tuple in tuples.data.tuples:
-            self._handle_data_tuple(data_tuple, stream)
+          try:
+            for trunk in tuples.data.tuples:
+              data_tuple = tuple_pb2.HeronDataTuple()
+              data_tuple.ParseFromString(trunk)
+              self._handle_data_tuple(data_tuple, stream)
+          except Exception:
+            Log.exception('Fail to deserialize HeronDataTuple')
         else:
           Log.error("Received tuple neither data nor control")
       else:

--- a/heron/instance/src/python/basics/spout_instance.py
+++ b/heron/instance/src/python/basics/spout_instance.py
@@ -186,7 +186,7 @@ class SpoutInstance(BaseInstance):
       except Queue.Empty:
         break
 
-      if isinstance(tuples, tuple_pb2.HeronTupleSet):
+      if isinstance(tuples, tuple_pb2.HeronTupleSet2):
         if tuples.HasField("data"):
           raise RuntimeError("Spout cannot get incoming data tuples from other components")
         elif tuples.HasField("control"):

--- a/heron/instance/src/python/instance/st_heron_instance.py
+++ b/heron/instance/src/python/instance/st_heron_instance.py
@@ -27,7 +27,7 @@ from heron.common.src.python.utils.metrics import GatewayMetrics, PyMetrics, Met
 from heron.common.src.python.utils.misc import HeronCommunicator
 from heron.common.src.python.network import create_socket_options
 
-from heron.proto import physical_plan_pb2, tuple_pb2
+from heron.proto import physical_plan_pb2
 from heron.instance.src.python.network import MetricsManagerClient, SingleThreadStmgrClient
 from heron.instance.src.python.basics import SpoutInstance, BoltInstance
 
@@ -105,20 +105,7 @@ class SingleThreadHeronInstance(object):
     if self.my_pplan_helper is None or self.my_instance is None:
       Log.error("Got tuple set when no instance assigned yet")
     else:
-      hts = tuple_pb2.HeronTupleSet()
-      if hts2.HasField('control'):
-        hts.control.CopyFrom(hts2.control)
-      else:
-        hdts = tuple_pb2.HeronDataTupleSet()
-        hdts.stream.CopyFrom(hts2.data.stream)
-        try:
-          for trunk in hts2.data.tuples:
-            added_tuple = hdts.tuples.add()
-            added_tuple.ParseFromString(trunk)
-        except Exception:
-          Log.exception('Fail to deserialize HeronDataTuple')
-        hts.data.CopyFrom(hdts)
-      self.in_stream.offer(hts)
+      self.in_stream.offer(hts2)
       if self.my_pplan_helper.is_topology_running():
         self.my_instance.py_class.process_incoming_tuples()
 

--- a/heron/instance/tests/java/com/twitter/heron/instance/bolt/BoltInstanceTest.java
+++ b/heron/instance/tests/java/com/twitter/heron/instance/bolt/BoltInstanceTest.java
@@ -103,9 +103,10 @@ public class BoltInstanceTest {
     SingletonRegistry.INSTANCE.registerSingleton(Constants.RECEIVED_STRING_LIST, receivedStrings);
 
     // Send tuples to bolt instance
-    HeronTuples.HeronTupleSet.Builder heronTupleSet = HeronTuples.HeronTupleSet.newBuilder();
+    HeronTuples.HeronTupleSet2.Builder heronTupleSet = HeronTuples.HeronTupleSet2.newBuilder();
     heronTupleSet.setSrcTaskId(SRC_TASK_ID);
-    HeronTuples.HeronDataTupleSet.Builder dataTupleSet = HeronTuples.HeronDataTupleSet.newBuilder();
+    HeronTuples.HeronDataTupleSet2.Builder dataTupleSet =
+                                           HeronTuples.HeronDataTupleSet2.newBuilder();
     TopologyAPI.StreamId.Builder streamId = TopologyAPI.StreamId.newBuilder();
     streamId.setComponentName("test-spout");
     streamId.setId("default");
@@ -124,7 +125,7 @@ public class BoltInstanceTest {
       String tupleValue = (i & 1) == 0 ? "A" : "B";
       dataTuple.addValues(ByteString.copyFrom(serializer.serialize(tupleValue)));
 
-      dataTupleSet.addTuples(dataTuple);
+      dataTupleSet.addTuples(dataTuple.build().toByteString());
     }
 
     heronTupleSet.setData(dataTupleSet);

--- a/heron/proto/stmgr.proto
+++ b/heron/proto/stmgr.proto
@@ -67,6 +67,6 @@ message TupleStreamMessage {
   required int32 src_task_id = 3;
   // This is actually the destination task_id
   required int32 task_id = 1;
-  // serialized data
+  // serialized bytes of HeronTupleSet2
   required bytes set = 2;
 }

--- a/heron/proto/tuple.proto
+++ b/heron/proto/tuple.proto
@@ -46,6 +46,7 @@ message HeronTupleSet {
 
 message HeronDataTupleSet2 {
   required heron.proto.api.StreamId stream = 1;
+  // serialized bytes of HeronDataTuple
   repeated bytes tuples = 2;
 }
 

--- a/heron/stmgr/src/cpp/manager/stmgr-server.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-server.cpp
@@ -414,7 +414,7 @@ void StMgrServer::HandleRegisterInstanceRequest(REQID _reqid, Connection* _conn,
 }
 
 void StMgrServer::HandleTupleSetMessage(Connection* _conn,
-                                        proto::system::HeronTupleSet* _message) {
+                                        proto::system::HeronTupleSet2* _message) {
   auto iter = active_instances_.find(_conn);
   if (iter == active_instances_.end()) {
     LOG(ERROR) << "Received TupleSet from unknown instance connection. Dropping..";

--- a/heron/stmgr/src/cpp/manager/stmgr-server.h
+++ b/heron/stmgr/src/cpp/manager/stmgr-server.h
@@ -117,7 +117,7 @@ class StMgrServer : public Server {
   // Next from local instances
   void HandleRegisterInstanceRequest(REQID _id, Connection* _conn,
                                      proto::stmgr::RegisterInstanceRequest* _request);
-  void HandleTupleSetMessage(Connection* _conn, proto::system::HeronTupleSet* _message);
+  void HandleTupleSetMessage(Connection* _conn, proto::system::HeronTupleSet2* _message);
   void HandleStoreInstanceStateCheckpointMessage(Connection* _conn,
                                          proto::ckptmgr::StoreInstanceStateCheckpoint* _message);
   void HandleRestoreInstanceStateResponse(Connection* _conn,

--- a/heron/stmgr/src/cpp/manager/stmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr.cpp
@@ -711,7 +711,7 @@ void StMgr::ProcessAcksAndFails(sp_int32 _src_task_id, sp_int32 _task_id,
 
 // Called when local tasks generate data
 void StMgr::HandleInstanceData(const sp_int32 _src_task_id, bool _local_spout,
-                               proto::system::HeronTupleSet* _message) {
+                               proto::system::HeronTupleSet2* _message) {
   if (stateful_restorer_ && stateful_restorer_->InProgress()) {
     LOG(INFO) << "Dropping data received from instance " << _src_task_id
               << " because we are in Restore";
@@ -724,7 +724,7 @@ void StMgr::HandleInstanceData(const sp_int32 _src_task_id, bool _local_spout,
   // before any acks/fails
 
   if (_message->has_data()) {
-    proto::system::HeronDataTupleSet* d = _message->mutable_data();
+    proto::system::HeronDataTupleSet2* d = _message->mutable_data();
     std::pair<sp_string, sp_string> stream =
         make_pair(d->stream().component_name(), d->stream().id());
     auto s = stream_consumers_.find(stream);

--- a/heron/stmgr/src/cpp/manager/stmgr.h
+++ b/heron/stmgr/src/cpp/manager/stmgr.h
@@ -72,7 +72,7 @@ class StMgr {
   void HandleStreamManagerData(const sp_string& _stmgr_id,
                                proto::stmgr::TupleStreamMessage* _message);
   void HandleInstanceData(sp_int32 _task_id, bool _local_spout,
-                          proto::system::HeronTupleSet* _message);
+                          proto::system::HeronTupleSet2* _message);
   // Called when an instance does checkpoint and sends its checkpoint
   // to the stmgr to save it
   void HandleStoreInstanceStateCheckpoint(const proto::ckptmgr::InstanceStateCheckpoint& _message,

--- a/heron/stmgr/tests/cpp/server/dummy_instance.cpp
+++ b/heron/stmgr/tests/cpp/server/dummy_instance.cpp
@@ -142,20 +142,22 @@ void DummySpoutInstance::HandleNewInstanceAssignmentMsg(
 void DummySpoutInstance::CreateAndSendTupleMessages() {
   for (int i = 0; (i < batch_size_) && (total_msgs_sent_ < max_msgs_to_send_);
        ++total_msgs_sent_, ++i) {
-    heron::proto::system::HeronTupleSet tuple_set;
-    heron::proto::system::HeronDataTupleSet* data_set = tuple_set.mutable_data();
+    heron::proto::system::HeronTupleSet2 tuple_set;
+    heron::proto::system::HeronDataTupleSet2* data_set = tuple_set.mutable_data();
     heron::proto::api::StreamId* tstream = data_set->mutable_stream();
     tstream->set_id(stream_id_);
     tstream->set_component_name(component_name_);
-    heron::proto::system::HeronDataTuple* tuple = data_set->add_tuples();
-    tuple->set_key(0);
+    heron::proto::system::HeronDataTuple tuple;
+    tuple.set_key(0);
     // Add lots of data
-    for (size_t i = 0; i < 500; ++i) *(tuple->add_values()) = "dummy data";
+    for (size_t i = 0; i < 500; ++i) *(tuple.add_values()) = "dummy data";
 
     // Add custom grouping if need be
     if (do_custom_grouping_) {
-      tuple->add_dest_task_ids(custom_grouping_dest_task_);
+      tuple.add_dest_task_ids(custom_grouping_dest_task_);
     }
+    std::string* tup = data_set->add_tuples();
+    tuple.SerializeToString(tup);
     SendMessage(tuple_set);
   }
   if (total_msgs_sent_ != max_msgs_to_send_) {


### PR DESCRIPTION
Currently the communication between stmgr <-> instance is asymmetric
1. stmgr sends HeronTupleSet2 messages to Instance
2. Instance sends HeronTupleSet messages to stmgr

HeronTupleSet2 was added as a performant variant to decrease the deserialization cost. But the instance deals entirely in HeronTupleSet(to the point of converting the incoming HeronTupleSet2 messages to HeronTupleSet).
This change moves everything in instance deal with HeronTupleSet2. 