### PR TITLE
limit stmgr client reconnect attempts

### DIFF
--- a/heron/common/src/cpp/config/heron-internals-config-reader.cpp
+++ b/heron/common/src/cpp/config/heron-internals-config-reader.cpp
@@ -213,6 +213,10 @@ sp_int32 HeronInternalsConfigReader::GetHeronStreammgrXormgrRotatingmapNbuckets(
   return config_[HeronInternalsConfigVars::HERON_STREAMMGR_XORMGR_ROTATINGMAP_NBUCKETS].as<int>();
 }
 
+sp_int32 HeronInternalsConfigReader::GetHeronStreammgrClientReconnectMaxAttempts() {
+  return config_[HeronInternalsConfigVars::HERON_STREAMMGR_CLIENT_RECONNECT_MAX_ATTEMPTS].as<int>();
+}
+
 sp_int32 HeronInternalsConfigReader::GetHeronStreammgrClientReconnectIntervalSec() {
   return config_[HeronInternalsConfigVars::HERON_STREAMMGR_CLIENT_RECONNECT_INTERVAL_SEC].as<int>();
 }

--- a/heron/common/src/cpp/config/heron-internals-config-reader.h
+++ b/heron/common/src/cpp/config/heron-internals-config-reader.h
@@ -162,6 +162,9 @@ class HeronInternalsConfigReader : public YamlFileReader {
   // Get the Nbucket value, for efficient acknowledgement
   sp_int32 GetHeronStreammgrXormgrRotatingmapNbuckets();
 
+  // The max reconnect attempts to other stream managers for stream manager client
+  sp_int32 GetHeronStreammgrClientReconnectMaxAttempts();
+
   // The reconnect interval to other stream managers in second for stream manager client
   sp_int32 GetHeronStreammgrClientReconnectIntervalSec();
 

--- a/heron/common/src/cpp/config/heron-internals-config-vars.cpp
+++ b/heron/common/src/cpp/config/heron-internals-config-vars.cpp
@@ -92,6 +92,8 @@ const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_MEMPOOL_MAX_MESSAGE_NU
     "heron.streammgr.mempool.max.message.number";
 const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_XORMGR_ROTATINGMAP_NBUCKETS =
     "heron.streammgr.xormgr.rotatingmap.nbuckets";
+const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_CLIENT_RECONNECT_MAX_ATTEMPTS =
+    "heron.streammgr.client.reconnect.max.attempts";
 const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_CLIENT_RECONNECT_INTERVAL_SEC =
     "heron.streammgr.client.reconnect.interval.sec";
 const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_CLIENT_RECONNECT_TMASTER_INTERVAL_SEC =

--- a/heron/common/src/cpp/config/heron-internals-config-vars.h
+++ b/heron/common/src/cpp/config/heron-internals-config-vars.h
@@ -146,6 +146,9 @@ class HeronInternalsConfigVars {
   // For efficient acknowledgement
   static const sp_string HERON_STREAMMGR_XORMGR_ROTATINGMAP_NBUCKETS;
 
+  // The max reconnect attempts to other stream managers for stream manager client
+  static const sp_string HERON_STREAMMGR_CLIENT_RECONNECT_MAX_ATTEMPTS;
+
   // The reconnect interval to other stream managers in second for stream manager client
   static const sp_string HERON_STREAMMGR_CLIENT_RECONNECT_INTERVAL_SEC;
 

--- a/heron/config/src/yaml/conf/aurora/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/aurora/heron_internals.yaml
@@ -68,6 +68,9 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 # The max number of messages in the memory pool for each message type
 heron.streammgr.mempool.max.message.number: 512
 
+# The max reconnect attempts to other stream managers for stream manager client
+heron.streammgr.client.reconnect.max.attempts: 30
+
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 

--- a/heron/config/src/yaml/conf/aurora/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/aurora/heron_internals.yaml
@@ -69,7 +69,7 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 heron.streammgr.mempool.max.message.number: 512
 
 # The max reconnect attempts to other stream managers for stream manager client
-heron.streammgr.client.reconnect.max.attempts: 30
+heron.streammgr.client.reconnect.max.attempts: 300
 
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1

--- a/heron/config/src/yaml/conf/examples/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/examples/heron_internals.yaml
@@ -68,6 +68,9 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 # The max number of messages in the memory pool for each message type
 heron.streammgr.mempool.max.message.number: 512
 
+# The max reconnect attempts to other stream managers for stream manager client
+heron.streammgr.client.reconnect.max.attempts: 30
+
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 

--- a/heron/config/src/yaml/conf/examples/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/examples/heron_internals.yaml
@@ -69,7 +69,7 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 heron.streammgr.mempool.max.message.number: 512
 
 # The max reconnect attempts to other stream managers for stream manager client
-heron.streammgr.client.reconnect.max.attempts: 30
+heron.streammgr.client.reconnect.max.attempts: 300
 
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1

--- a/heron/config/src/yaml/conf/kubernetes/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/kubernetes/heron_internals.yaml
@@ -67,6 +67,9 @@ heron.streammgr.mempool.max.message.number: 512
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 
+# The max reconnect attempts to other stream managers for stream manager client
+heron.streammgr.client.reconnect.max.attempts: 30
+
 # The reconnect interval to tamster in second for stream manager client
 heron.streammgr.client.reconnect.tmaster.interval.sec: 10
 

--- a/heron/config/src/yaml/conf/kubernetes/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/kubernetes/heron_internals.yaml
@@ -68,7 +68,7 @@ heron.streammgr.mempool.max.message.number: 512
 heron.streammgr.client.reconnect.interval.sec: 1
 
 # The max reconnect attempts to other stream managers for stream manager client
-heron.streammgr.client.reconnect.max.attempts: 30
+heron.streammgr.client.reconnect.max.attempts: 300
 
 # The reconnect interval to tamster in second for stream manager client
 heron.streammgr.client.reconnect.tmaster.interval.sec: 10

--- a/heron/config/src/yaml/conf/local/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/local/heron_internals.yaml
@@ -68,6 +68,9 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 # The max number of messages in the memory pool for each message type
 heron.streammgr.mempool.max.message.number: 512
 
+# The max reconnect attempts to other stream managers for stream manager client
+heron.streammgr.client.reconnect.max.attempts: 30
+
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 

--- a/heron/config/src/yaml/conf/local/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/local/heron_internals.yaml
@@ -69,7 +69,7 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 heron.streammgr.mempool.max.message.number: 512
 
 # The max reconnect attempts to other stream managers for stream manager client
-heron.streammgr.client.reconnect.max.attempts: 30
+heron.streammgr.client.reconnect.max.attempts: 300
 
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1

--- a/heron/config/src/yaml/conf/localzk/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/localzk/heron_internals.yaml
@@ -68,6 +68,9 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 # The max number of messages in the memory pool for each message type
 heron.streammgr.mempool.max.message.number: 512
 
+# The max reconnect attempts to other stream managers for stream manager client
+heron.streammgr.client.reconnect.max.attempts: 30
+
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 

--- a/heron/config/src/yaml/conf/localzk/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/localzk/heron_internals.yaml
@@ -69,7 +69,7 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 heron.streammgr.mempool.max.message.number: 512
 
 # The max reconnect attempts to other stream managers for stream manager client
-heron.streammgr.client.reconnect.max.attempts: 30
+heron.streammgr.client.reconnect.max.attempts: 300
 
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1

--- a/heron/config/src/yaml/conf/marathon/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/marathon/heron_internals.yaml
@@ -68,6 +68,9 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 # The max number of messages in the memory pool for each message type
 heron.streammgr.mempool.max.message.number: 512
 
+# The max reconnect attempts to other stream managers for stream manager client
+heron.streammgr.client.reconnect.max.attempts: 30
+
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 

--- a/heron/config/src/yaml/conf/marathon/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/marathon/heron_internals.yaml
@@ -69,7 +69,7 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 heron.streammgr.mempool.max.message.number: 512
 
 # The max reconnect attempts to other stream managers for stream manager client
-heron.streammgr.client.reconnect.max.attempts: 30
+heron.streammgr.client.reconnect.max.attempts: 300
 
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1

--- a/heron/config/src/yaml/conf/mesos/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/mesos/heron_internals.yaml
@@ -68,6 +68,9 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 # The max number of messages in the memory pool for each message type
 heron.streammgr.mempool.max.message.number: 512
 
+# The max reconnect attempts to other stream managers for stream manager client
+heron.streammgr.client.reconnect.max.attempts: 30
+
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 

--- a/heron/config/src/yaml/conf/mesos/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/mesos/heron_internals.yaml
@@ -69,7 +69,7 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 heron.streammgr.mempool.max.message.number: 512
 
 # The max reconnect attempts to other stream managers for stream manager client
-heron.streammgr.client.reconnect.max.attempts: 30
+heron.streammgr.client.reconnect.max.attempts: 300
 
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1

--- a/heron/config/src/yaml/conf/slurm/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/slurm/heron_internals.yaml
@@ -68,6 +68,9 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 # The max number of messages in the memory pool for each message type
 heron.streammgr.mempool.max.message.number: 512
 
+# The max reconnect attempts to other stream managers for stream manager client
+heron.streammgr.client.reconnect.max.attempts: 30
+
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1 
 

--- a/heron/config/src/yaml/conf/slurm/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/slurm/heron_internals.yaml
@@ -69,7 +69,7 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 heron.streammgr.mempool.max.message.number: 512
 
 # The max reconnect attempts to other stream managers for stream manager client
-heron.streammgr.client.reconnect.max.attempts: 30
+heron.streammgr.client.reconnect.max.attempts: 300
 
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1 

--- a/heron/config/src/yaml/conf/test/test_heron_internals.yaml
+++ b/heron/config/src/yaml/conf/test/test_heron_internals.yaml
@@ -56,6 +56,9 @@ heron.streammgr.mempool.max.message.number: 512
 # For efficient acknowledgement
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
+# The max reconnect attempts to other stream managers for stream manager client
+heron.streammgr.client.reconnect.max.attempts: 30
+
 # The reconnect interval to other stream managers in second for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 

--- a/heron/config/src/yaml/conf/test/test_heron_internals.yaml
+++ b/heron/config/src/yaml/conf/test/test_heron_internals.yaml
@@ -57,7 +57,7 @@ heron.streammgr.mempool.max.message.number: 512
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
 # The max reconnect attempts to other stream managers for stream manager client
-heron.streammgr.client.reconnect.max.attempts: 30
+heron.streammgr.client.reconnect.max.attempts: 300
 
 # The reconnect interval to other stream managers in second for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1

--- a/heron/config/src/yaml/conf/yarn/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/yarn/heron_internals.yaml
@@ -68,6 +68,9 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 # The max number of messages in the memory pool for each message type
 heron.streammgr.mempool.max.message.number: 512
 
+# The max reconnect attempts to other stream managers for stream manager client
+heron.streammgr.client.reconnect.max.attempts: 30
+
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 

--- a/heron/config/src/yaml/conf/yarn/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/yarn/heron_internals.yaml
@@ -69,7 +69,7 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 heron.streammgr.mempool.max.message.number: 512
 
 # The max reconnect attempts to other stream managers for stream manager client
-heron.streammgr.client.reconnect.max.attempts: 30
+heron.streammgr.client.reconnect.max.attempts: 300
 
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1

--- a/heron/stmgr/src/cpp/manager/stmgr-client.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-client.cpp
@@ -94,6 +94,10 @@ void StMgrClient::HandleConnect(NetworkErrorCode _status) {
     LOG(INFO) << "Connected to stmgr " << other_stmgr_id_ << " running at "
               << get_clientoptions().get_host() << ":" << get_clientoptions().get_port()
               << std::endl;
+
+    // reset the reconnect attempt once connection established
+    reconnect_attempts_ = 0;
+
     if (quit_) {
       Stop();
     } else {

--- a/heron/stmgr/src/cpp/manager/stmgr-client.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-client.cpp
@@ -64,9 +64,12 @@ StMgrClient::StMgrClient(EventLoop* eventLoop, const NetworkOptions& _options,
       client_manager_(_client_manager),
       metrics_manager_client_(_metrics_manager_client),
       ndropped_messages_(0),
+      reconnect_attempts_(0),
       is_registered_(false) {
   reconnect_other_streammgrs_interval_sec_ =
       config::HeronInternalsConfigReader::Instance()->GetHeronStreammgrClientReconnectIntervalSec();
+  reconnect_other_streammgrs_max_attempt_ =
+      config::HeronInternalsConfigReader::Instance()->GetHeronStreammgrClientReconnectMaxAttempts();
 
   InstallResponseHandler(new proto::stmgr::StrMgrHelloRequest(), &StMgrClient::HandleHelloResponse);
   InstallMessageHandler(&StMgrClient::HandleTupleStreamMessage);
@@ -101,7 +104,7 @@ void StMgrClient::HandleConnect(NetworkErrorCode _status) {
                  << get_clientoptions().get_host() << ":" << get_clientoptions().get_port()
                  << " due to: " << _status << std::endl;
     if (quit_) {
-      LOG(ERROR) << "Quitting";
+      LOG(ERROR) << "Instructed to quit. Quitting...";
       delete this;
       return;
     } else {
@@ -160,7 +163,16 @@ void StMgrClient::HandleHelloResponse(void*, proto::stmgr::StrMgrHelloResponse* 
   client_manager_->HandleStMgrClientRegistered();
 }
 
-void StMgrClient::OnReConnectTimer() { Start(); }
+void StMgrClient::OnReConnectTimer() {
+  reconnect_attempts_ += 1;
+
+  if (reconnect_attempts_ < reconnect_other_streammgrs_max_attempt_) {
+    Start();
+  } else {
+    LOG(FATAL) << "Could not connect to stmgr " << other_stmgr_id_
+               << " after reaching the max reconnect attempts. Quitting...";
+  }
+}
 
 void StMgrClient::SendHelloRequest() {
   auto request = new proto::stmgr::StrMgrHelloRequest();

--- a/heron/stmgr/src/cpp/manager/stmgr-client.h
+++ b/heron/stmgr/src/cpp/manager/stmgr-client.h
@@ -78,9 +78,11 @@ class StMgrClient : public Client {
 
   // Configs to be read
   sp_int32 reconnect_other_streammgrs_interval_sec_;
+  sp_int32 reconnect_other_streammgrs_max_attempt_;
 
   // Counters
   sp_int64 ndropped_messages_;
+  sp_int32 reconnect_attempts_;
 
   // Have we registered ourselves
   bool is_registered_;


### PR DESCRIPTION
We found that when network partition happens, stmgr client keeps reconnecting to the other stmgr without any limit. If the network partition problem keeps going on, the whole topology is stuck. 

This PR is to mitigate this problem at heron level. Now stmgr client will kill the whole stmgr process after a configured amount of reconnecting. And if a stmgr process is killed multiple times, heron-executor will die and cause the scheduler to reschedule it. There's a great chance that after rescheduling, the whole container is scheduled to another host and thus avoid the network partition problem.

The PR is tested with local cluster.