### PR TITLE
Print Command details only in verbose mode

### DIFF
--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/slurm/SlurmController.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/slurm/SlurmController.java
@@ -123,7 +123,7 @@ public class SlurmController {
   protected boolean runProcess(String topologyWorkingDirectory, String[] slurmCmd,
                                StringBuilder stderr) {
     File file = topologyWorkingDirectory == null ? null : new File(topologyWorkingDirectory);
-    return 0 == ShellUtils.runSyncProcess(false, slurmCmd, stderr, file);
+    return 0 == ShellUtils.runSyncProcess(true, false, slurmCmd, stderr, file);
   }
 
   /**

--- a/heron/tools/cli/src/python/main.py
+++ b/heron/tools/cli/src/python/main.py
@@ -240,7 +240,7 @@ def main():
 
   if command not in ('help', 'version'):
     sys.stdout.flush()
-    Log.info('Elapsed time: %.3fs.', (end - start))
+    Log.debug('Elapsed time: %.3fs.', (end - start))
 
   return 0 if result.is_successful(results) else 1
 

--- a/heron/tools/common/src/python/utils/config.py
+++ b/heron/tools/common/src/python/utils/config.py
@@ -245,7 +245,7 @@ def get_heron_cluster(cluster_role_env):
 def parse_cluster_role_env(cluster_role_env, config_path):
   """Parse cluster/[role]/[environ], supply default, if not provided, not required"""
   parts = cluster_role_env.split('/')[:3]
-  Log.info("Using config file under %s" % config_path)
+  Log.debug("Using config file under %s" % config_path)
   if not os.path.isdir(config_path):
     Log.error("Config path cluster directory does not exist: %s" % config_path)
     raise Exception("Invalid config path")


### PR DESCRIPTION
Currently heron submit spews tons of information even under non verbose mode. This is actually very confusing and non expected behavior. Heron already has the verbose mode to print out details of the submission process. This change ensures that the verbose mode is adhered to.