### PR TITLE
Remove duplicate variable

### DIFF
--- a/heron/common/src/cpp/config/heron-internals-config-reader.cpp
+++ b/heron/common/src/cpp/config/heron-internals-config-reader.cpp
@@ -188,10 +188,6 @@ sp_int32 HeronInternalsConfigReader::GetHeronTmasterStmgrStateTimeoutSec() {
   return config_[HeronInternalsConfigVars::HERON_TMASTER_STMGR_STATE_TIMEOUT_SEC].as<int>();
 }
 
-sp_int32 HeronInternalsConfigReader::GetHeronStreammgrPacketMaximumSizeBytes() {
-  return config_[HeronInternalsConfigVars::HERON_STREAMMGR_PACKET_MAXIMUM_SIZE_BYTES].as<int>();
-}
-
 sp_int32 HeronInternalsConfigReader::GetHeronStreammgrCacheDrainFrequencyMs() {
   return config_[HeronInternalsConfigVars::HERON_STREAMMGR_CACHE_DRAIN_FREQUENCY_MS].as<int>();
 }

--- a/heron/common/src/cpp/config/heron-internals-config-reader.h
+++ b/heron/common/src/cpp/config/heron-internals-config-reader.h
@@ -143,9 +143,6 @@ class HeronInternalsConfigReader : public YamlFileReader {
   /**
   * Stream manager Config Getters
   **/
-  // Maximum size in bytes of a packet to be send out from stream manager
-  sp_int32 GetHeronStreammgrPacketMaximumSizeBytes();
-
   // The frequency in ms to drain the tuple cache in stream manager
   sp_int32 GetHeronStreammgrCacheDrainFrequencyMs();
 

--- a/heron/common/src/cpp/config/heron-internals-config-vars.cpp
+++ b/heron/common/src/cpp/config/heron-internals-config-vars.cpp
@@ -82,8 +82,6 @@ const sp_string HeronInternalsConfigVars::HERON_TMASTER_STMGR_STATE_TIMEOUT_SEC 
     "heron.tmaster.stmgr.state.timeout.sec";
 
 // heron.streammgr.* configs are for the stream manager
-const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_PACKET_MAXIMUM_SIZE_BYTES =
-    "heron.streammgr.packet.maximum.size.bytes";
 const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_CACHE_DRAIN_FREQUENCY_MS =
     "heron.streammgr.cache.drain.frequency.ms";
 const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_CACHE_DRAIN_SIZE_MB =

--- a/heron/common/src/cpp/config/heron-internals-config-vars.h
+++ b/heron/common/src/cpp/config/heron-internals-config-vars.h
@@ -130,9 +130,6 @@ class HeronInternalsConfigVars {
   * HERON_STREAMMGR_* configs are for the stream manager
   **/
 
-  // Maximum size in bytes of a packet to be send out from stream manager
-  static const sp_string HERON_STREAMMGR_PACKET_MAXIMUM_SIZE_BYTES;
-
   // The tuple cache (used for batching) can be drained in two ways: (a) Time based (b) size based
   // The frequency in ms to drain the tuple cache in stream manager
   static const sp_string HERON_STREAMMGR_CACHE_DRAIN_FREQUENCY_MS;

--- a/heron/config/src/yaml/conf/aurora/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/aurora/heron_internals.yaml
@@ -45,9 +45,6 @@ heron.metrics.max.exceptions.per.message.count: 1024
 # Configs related to Stream Manager, starts with heron.streammgr.*
 ################################################################################
 
-# Maximum size in bytes of a packet to be send out from stream manager
-heron.streammgr.packet.maximum.size.bytes: 102400
-
 # The tuple cache (used for batching) can be drained in two ways:
 # (a) Time based
 # (b) size based
@@ -75,7 +72,7 @@ heron.streammgr.client.reconnect.interval.sec: 1
 heron.streammgr.client.reconnect.tmaster.interval.sec: 10
 
 # The maximum packet size in MB of stream manager's network options
-heron.streammgr.network.options.maximum.packet.mb: 100
+heron.streammgr.network.options.maximum.packet.mb: 10
 
 # The interval in seconds to send heartbeat
 heron.streammgr.tmaster.heartbeat.interval.sec: 10

--- a/heron/config/src/yaml/conf/examples/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/examples/heron_internals.yaml
@@ -45,9 +45,6 @@ heron.metrics.max.exceptions.per.message.count: 1024
 # Configs related to Stream Manager, starts with heron.streammgr.*
 ################################################################################
 
-# Maximum size in bytes of a packet to be send out from stream manager
-heron.streammgr.packet.maximum.size.bytes: 102400
-
 # The tuple cache (used for batching) can be drained in two ways:
 # (a) Time based
 # (b) size based
@@ -75,7 +72,7 @@ heron.streammgr.client.reconnect.interval.sec: 1
 heron.streammgr.client.reconnect.tmaster.interval.sec: 10
 
 # The maximum packet size in MB of stream manager's network options
-heron.streammgr.network.options.maximum.packet.mb: 100
+heron.streammgr.network.options.maximum.packet.mb: 10
 
 # The interval in seconds to send heartbeat
 heron.streammgr.tmaster.heartbeat.interval.sec: 10

--- a/heron/config/src/yaml/conf/kubernetes/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/kubernetes/heron_internals.yaml
@@ -45,9 +45,6 @@ heron.metrics.max.exceptions.per.message.count: 1024
 # Configs related to Stream Manager, starts with heron.streammgr.*
 ################################################################################
 
-# Maximum size in bytes of a packet to be send out from stream manager
-heron.streammgr.packet.maximum.size.bytes: 102400
-
 # The tuple cache (used for batching) can be drained in two ways:
 # (a) Time based
 # (b) size based
@@ -71,7 +68,7 @@ heron.streammgr.client.reconnect.interval.sec: 1
 heron.streammgr.client.reconnect.tmaster.interval.sec: 10
 
 # The maximum packet size in MB of stream manager's network options
-heron.streammgr.network.options.maximum.packet.mb: 100
+heron.streammgr.network.options.maximum.packet.mb: 10
 
 # The interval in seconds to send heartbeat
 heron.streammgr.tmaster.heartbeat.interval.sec: 10

--- a/heron/config/src/yaml/conf/local/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/local/heron_internals.yaml
@@ -45,9 +45,6 @@ heron.metrics.max.exceptions.per.message.count: 1024
 # Configs related to Stream Manager, starts with heron.streammgr.*
 ################################################################################
 
-# Maximum size in bytes of a packet to be send out from stream manager
-heron.streammgr.packet.maximum.size.bytes: 102400
-
 # The tuple cache (used for batching) can be drained in two ways:
 # (a) Time based
 # (b) size based
@@ -75,7 +72,7 @@ heron.streammgr.client.reconnect.interval.sec: 1
 heron.streammgr.client.reconnect.tmaster.interval.sec: 10
 
 # The maximum packet size in MB of stream manager's network options
-heron.streammgr.network.options.maximum.packet.mb: 16
+heron.streammgr.network.options.maximum.packet.mb: 10
 
 # The interval in seconds to send heartbeat
 heron.streammgr.tmaster.heartbeat.interval.sec: 10

--- a/heron/config/src/yaml/conf/localzk/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/localzk/heron_internals.yaml
@@ -45,9 +45,6 @@ heron.metrics.max.exceptions.per.message.count: 1024
 # Configs related to Stream Manager, starts with heron.streammgr.*
 ################################################################################
 
-# Maximum size in bytes of a packet to be send out from stream manager
-heron.streammgr.packet.maximum.size.bytes: 102400
-
 # The tuple cache (used for batching) can be drained in two ways:
 # (a) Time based
 # (b) size based
@@ -75,7 +72,7 @@ heron.streammgr.client.reconnect.interval.sec: 1
 heron.streammgr.client.reconnect.tmaster.interval.sec: 10
 
 # The maximum packet size in MB of stream manager's network options
-heron.streammgr.network.options.maximum.packet.mb: 100
+heron.streammgr.network.options.maximum.packet.mb: 10
 
 # The interval in seconds to send heartbeat
 heron.streammgr.tmaster.heartbeat.interval.sec: 10

--- a/heron/config/src/yaml/conf/marathon/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/marathon/heron_internals.yaml
@@ -45,9 +45,6 @@ heron.metrics.max.exceptions.per.message.count: 1024
 # Configs related to Stream Manager, starts with heron.streammgr.*
 ################################################################################
 
-# Maximum size in bytes of a packet to be send out from stream manager
-heron.streammgr.packet.maximum.size.bytes: 102400
-
 # The tuple cache (used for batching) can be drained in two ways:
 # (a) Time based
 # (b) size based
@@ -75,7 +72,7 @@ heron.streammgr.client.reconnect.interval.sec: 1
 heron.streammgr.client.reconnect.tmaster.interval.sec: 10
 
 # The maximum packet size in MB of stream manager's network options
-heron.streammgr.network.options.maximum.packet.mb: 100
+heron.streammgr.network.options.maximum.packet.mb: 10
 
 # The interval in seconds to send heartbeat
 heron.streammgr.tmaster.heartbeat.interval.sec: 10

--- a/heron/config/src/yaml/conf/mesos/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/mesos/heron_internals.yaml
@@ -45,9 +45,6 @@ heron.metrics.max.exceptions.per.message.count: 1024
 # Configs related to Stream Manager, starts with heron.streammgr.*
 ################################################################################
 
-# Maximum size in bytes of a packet to be send out from stream manager
-heron.streammgr.packet.maximum.size.bytes: 102400
-
 # The tuple cache (used for batching) can be drained in two ways:
 # (a) Time based
 # (b) size based
@@ -75,7 +72,7 @@ heron.streammgr.client.reconnect.interval.sec: 1
 heron.streammgr.client.reconnect.tmaster.interval.sec: 10
 
 # The maximum packet size in MB of stream manager's network options
-heron.streammgr.network.options.maximum.packet.mb: 100
+heron.streammgr.network.options.maximum.packet.mb: 10
 
 # The interval in seconds to send heartbeat
 heron.streammgr.tmaster.heartbeat.interval.sec: 10

--- a/heron/config/src/yaml/conf/slurm/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/slurm/heron_internals.yaml
@@ -45,9 +45,6 @@ heron.metrics.max.exceptions.per.message.count: 1024
 # Configs related to Stream Manager, starts with heron.streammgr.*
 ################################################################################
 
-# Maximum size in bytes of a packet to be send out from stream manager
-heron.streammgr.packet.maximum.size.bytes: 102400 
-
 # The tuple cache (used for batching) can be drained in two ways: 
 # (a) Time based 
 # (b) size based
@@ -75,7 +72,7 @@ heron.streammgr.client.reconnect.interval.sec: 1
 heron.streammgr.client.reconnect.tmaster.interval.sec: 10 
 
 # The maximum packet size in MB of stream manager's network options
-heron.streammgr.network.options.maximum.packet.mb: 100 
+heron.streammgr.network.options.maximum.packet.mb: 10
 
 # The interval in seconds to send heartbeat
 heron.streammgr.tmaster.heartbeat.interval.sec: 10 

--- a/heron/config/src/yaml/conf/test/test_heron_internals.yaml
+++ b/heron/config/src/yaml/conf/test/test_heron_internals.yaml
@@ -35,9 +35,6 @@ heron.metrics.max.exceptions.per.message.count: 1024
 
 ### heron.streammgr.* configs are for the stream manager
 
-# Maximum size in bytes of a packet to be send out from stream manager
-heron.streammgr.packet.maximum.size.bytes: 102400
-
 # The tuple cache (used for batching) can be drained in two ways: (a) Time based (b) size based
 
 # The frequency in ms to drain the tuple cache in stream manager
@@ -63,7 +60,7 @@ heron.streammgr.client.reconnect.interval.sec: 1
 heron.streammgr.client.reconnect.tmaster.interval.sec: 1
 
 # The maximum packet size in MB of stream manager's network options
-heron.streammgr.network.options.maximum.packet.mb: 100
+heron.streammgr.network.options.maximum.packet.mb: 10
 
 # The interval in seconds to send heartbeat
 heron.streammgr.tmaster.heartbeat.interval.sec: 10

--- a/heron/config/src/yaml/conf/yarn/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/yarn/heron_internals.yaml
@@ -45,9 +45,6 @@ heron.metrics.max.exceptions.per.message.count: 1024
 # Configs related to Stream Manager, starts with heron.streammgr.*
 ################################################################################
 
-# Maximum size in bytes of a packet to be send out from stream manager
-heron.streammgr.packet.maximum.size.bytes: 102400
-
 # The tuple cache (used for batching) can be drained in two ways:
 # (a) Time based
 # (b) size based
@@ -75,7 +72,7 @@ heron.streammgr.client.reconnect.interval.sec: 1
 heron.streammgr.client.reconnect.tmaster.interval.sec: 10
 
 # The maximum packet size in MB of stream manager's network options
-heron.streammgr.network.options.maximum.packet.mb: 100
+heron.streammgr.network.options.maximum.packet.mb: 10
 
 # The interval in seconds to send heartbeat
 heron.streammgr.tmaster.heartbeat.interval.sec: 10

--- a/heron/stmgr/src/cpp/util/tuple-cache.cpp
+++ b/heron/stmgr/src/cpp/util/tuple-cache.cpp
@@ -32,8 +32,10 @@ TupleCache::TupleCache(EventLoop* eventLoop, sp_uint32 _drain_threshold)
     : eventLoop_(eventLoop), drain_threshold_bytes_(_drain_threshold) {
   cache_drain_frequency_ms_ =
       config::HeronInternalsConfigReader::Instance()->GetHeronStreammgrCacheDrainFrequencyMs();
+  // leave something for the headers
   tuples_cache_max_tuple_size_ =
-      config::HeronInternalsConfigReader::Instance()->GetHeronStreammgrPacketMaximumSizeBytes();
+    config::HeronInternalsConfigReader::Instance()->GetHeronStreammgrNetworkOptionsMaximumPacketMb()
+      * 1_MB - 1024;
 
   total_size_ = 0;
   auto drain_cb = [this](EventLoop::Status status) { this->drain(status); };


### PR DESCRIPTION
heron.streammgr.packet.maximum.size.bytes and heron.streammgr.network.options.maximum.packet.mb control the same end result: which is the maximum size of packets emitted/read by stmgr. In that sense, one can be eliminated.