### PR TITLE
While unzipping pex files, don't overwrite existing files.

### DIFF
--- a/heron/common/src/java/com/twitter/heron/common/basics/FileUtils.java
+++ b/heron/common/src/java/com/twitter/heron/common/basics/FileUtils.java
@@ -117,21 +117,29 @@ public final class FileUtils {
   }
 
   public static boolean deleteDir(String dir) {
-    return deleteDir(new File(dir));
+    return deleteDir(new File(dir), true);
   }
 
-  public static boolean deleteDir(File dir) {
+  public static boolean deleteDir(File dir, boolean deleteSelf) {
     if (dir.isDirectory()) {
       String[] children = dir.list();
 
       for (String child : children) {
-        boolean success = deleteDir(new File(dir, child));
+        boolean success = deleteDir(new File(dir, child), true);
         if (!success) {
           return false;
         }
       }
     }
 
-    return dir.delete();
+    if (deleteSelf) {
+      return dir.delete();
+    } else {
+      return true;
+    }
+  }
+
+  public static boolean cleanDir(String dir) {
+    return deleteDir(new File(dir), false);
   }
 }

--- a/heron/common/tests/java/com/twitter/heron/common/basics/FileUtilsTest.java
+++ b/heron/common/tests/java/com/twitter/heron/common/basics/FileUtilsTest.java
@@ -14,7 +14,6 @@
 
 package com.twitter.heron.common.basics;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -29,7 +28,6 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.times;
 
 /**
@@ -135,7 +133,7 @@ public class FileUtilsTest {
   public void testDeleteDirWithFile() throws IOException {
     // Test delete a file
     Path file = Files.createTempFile("testDeleteFile", "txt");
-    Assert.assertEquals(true, FileUtils.deleteDir(file.toFile()));
+    Assert.assertEquals(true, FileUtils.deleteDir(file.toFile(), true));
     Assert.assertFalse(file.toFile().exists());
   }
 
@@ -155,12 +153,35 @@ public class FileUtilsTest {
 
     PowerMockito.spy(FileUtils.class);
 
-    FileUtils.deleteDir(parent.toFile());
+    FileUtils.deleteDir(parent.toFile(), true);
 
     PowerMockito.verifyStatic(times(4));
-    FileUtils.deleteDir(any(File.class));
 
     Assert.assertFalse(parent.toFile().exists());
+    Assert.assertFalse(child1.toFile().exists());
+    Assert.assertFalse(child2.toFile().exists());
+    Assert.assertFalse(child3.toFile().exists());
+  }
+
+  /**
+   * Method: cleanDir(String dir)
+   */
+  @Test
+  public void testCleanDir() throws IOException {
+    // Test clean dirs,
+    //  parent/ -- child1/ -- child3/
+    //          |
+    //          -- child2/
+    Path parent = Files.createTempDirectory("testDeleteDir");
+    Path child1 = Files.createTempDirectory(parent, "child1");
+    Path child2 = Files.createTempDirectory(parent, "child2");
+    Path child3 = Files.createTempDirectory(child1, "child3");
+
+    PowerMockito.spy(FileUtils.class);
+
+    FileUtils.cleanDir(parent.toString());
+
+    Assert.assertTrue(parent.toFile().exists());
     Assert.assertFalse(child1.toFile().exists());
     Assert.assertFalse(child2.toFile().exists());
     Assert.assertFalse(child3.toFile().exists());

--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -677,7 +677,7 @@ class HeronExecutor(object):
     if self.pkg_type == "tar":
       os.system("tar -xvf %s" % self.topology_bin_file)
     elif self.pkg_type == "pex":
-      os.system("unzip %s" % self.topology_bin_file)
+      os.system("unzip -qq -n %s" % self.topology_bin_file)
 
   # pylint: disable=no-self-use
   def _wait_process_std_out_err(self, name, process):

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/SchedulerUtils.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/SchedulerUtils.java
@@ -392,6 +392,12 @@ public final class SchedulerUtils {
       }
     }
 
+    // Cleanup the directory
+    if (!FileUtils.cleanDir(workingDirectory)) {
+      LOG.severe("Failed to clean directory: " + workingDirectory);
+      return false;
+    }
+
     // Curl and extract heron core release package and topology package
     // And then delete the downloaded release package
     boolean ret =

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/utils/SchedulerUtilsTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/utils/SchedulerUtilsTest.java
@@ -135,6 +135,15 @@ public class SchedulerUtilsTest {
     // OK to create dir
     PowerMockito.when(FileUtils.createDirectory(Mockito.anyString())).thenReturn(true);
 
+    // Fail to cleanup
+    PowerMockito.when(FileUtils.cleanDir(Mockito.anyString())).thenReturn(false);
+    Assert.assertFalse(SchedulerUtils.setupWorkingDirectory(
+            WORKING_DIR, CORE_RELEASE_URI, CORE_RELEASE_DEST,
+            TOPOLOGY_URI, TOPOLOGY_DEST, isVerbose));
+
+    // Ok to cleanup
+    PowerMockito.when(FileUtils.cleanDir(Mockito.anyString())).thenReturn(true);
+
     PowerMockito.spy(SchedulerUtils.class);
     // OK to curl and extract core-release-package
     PowerMockito.doReturn(true).when(SchedulerUtils.class, "curlAndExtractPackage",

--- a/heron/statefulstorages/src/java/com/twitter/heron/statefulstorage/localfs/LocalFileSystemStorage.java
+++ b/heron/statefulstorages/src/java/com/twitter/heron/statefulstorage/localfs/LocalFileSystemStorage.java
@@ -108,7 +108,7 @@ public class LocalFileSystemStorage implements IStatefulStorage {
       String[] names = new File(topologyCheckpointRoot).list();
       for (String name : names) {
         if (name.compareTo(oldestCheckpointPreserved) < 0) {
-          FileUtils.deleteDir(new File(topologyCheckpointRoot, name));
+          FileUtils.deleteDir(new File(topologyCheckpointRoot, name), true);
         }
       }
 


### PR DESCRIPTION
This is useful while running multi container python topologies in local mode
where multiple executors are unzipping the same file