### PR TITLE
Initialize the instance state before open/prepare instance

### DIFF
--- a/heron/instance/src/java/com/twitter/heron/instance/AbstractOutputCollector.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/AbstractOutputCollector.java
@@ -103,7 +103,7 @@ public class AbstractOutputCollector {
   }
 
   // Flush the states
-  public void sendOutState(State<? extends Serializable, ? extends Serializable> state,
+  public void sendOutState(State<Serializable, Serializable> state,
                            String checkpointId) {
     outputter.sendOutState(state, checkpointId);
   }

--- a/heron/instance/src/java/com/twitter/heron/instance/IInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/IInstance.java
@@ -33,7 +33,7 @@ public interface IInstance {
   /**
    * Do the basic setup for HeronInstance
    */
-  void start(State<? extends Serializable, ? extends Serializable> state);
+  void start(State<Serializable, Serializable> state);
 
   /**
    * Do the basic clean for HeronInstance

--- a/heron/instance/src/java/com/twitter/heron/instance/OutgoingTupleCollection.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/OutgoingTupleCollection.java
@@ -90,7 +90,7 @@ public class OutgoingTupleCollection {
    * @param state instance's state
    * @param checkpointId the checkpointId
    */
-  public void sendOutState(State<? extends Serializable, ? extends Serializable> state,
+  public void sendOutState(State<Serializable, Serializable> state,
                            String checkpointId) {
     // Serialize the state
     byte[] serializedState = serializer.serialize(state);

--- a/heron/instance/src/java/com/twitter/heron/instance/Slave.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/Slave.java
@@ -62,7 +62,7 @@ public class Slave implements Runnable, AutoCloseable {
 
   private boolean isInstanceStarted = false;
 
-  private State<? extends Serializable, ? extends Serializable> instanceState;
+  private State<Serializable, Serializable> instanceState;
   private boolean isStatefulProcessingStarted;
 
   public Slave(SlaveLooper slaveLooper,
@@ -249,8 +249,8 @@ public class Slave implements Runnable, AutoCloseable {
     }
     if (request.getState().hasState() && !request.getState().getState().isEmpty()) {
       @SuppressWarnings("unchecked")
-      State<? extends Serializable, ? extends Serializable> stateToRestore =
-          (State<? extends Serializable, ? extends Serializable>) serializer.deserialize(
+      State<Serializable, Serializable> stateToRestore =
+          (State<Serializable, Serializable>) serializer.deserialize(
               request.getState().getState().toByteArray());
 
       instanceState = stateToRestore;

--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
@@ -63,7 +63,7 @@ public class BoltInstance implements IInstance {
 
   private final boolean isTopologyStateful;
 
-  private State<? extends Serializable, ? extends Serializable> instanceState;
+  private State<Serializable, Serializable> instanceState;
 
   private final SlaveLooper looper;
 
@@ -144,6 +144,7 @@ public class BoltInstance implements IInstance {
     collector.sendOutState(instanceState, checkpointId);
   }
 
+  @SuppressWarnings("unchecked")
   public void start() {
     TopologyContextImpl topologyContext = helper.getTopologyContext();
 
@@ -154,7 +155,7 @@ public class BoltInstance implements IInstance {
 
     // Initialize the instanceState if the bolt is stateful
     if (bolt instanceof IStatefulComponent) {
-      ((IStatefulComponent) bolt).initState(instanceState);
+      ((IStatefulComponent<Serializable, Serializable>) bolt).initState(instanceState);
     }
 
     // Delegate
@@ -171,7 +172,7 @@ public class BoltInstance implements IInstance {
   }
 
   @Override
-  public void start(State<? extends Serializable, ? extends Serializable> state) {
+  public void start(State<Serializable, Serializable> state) {
     this.instanceState = state;
     start();
   }

--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
@@ -152,6 +152,11 @@ public class BoltInstance implements IInstance {
 
     boltMetrics.registerMetrics(topologyContext);
 
+    // Initialize the bolt is it's stateful
+    if (bolt instanceof IStatefulComponent) {
+      ((IStatefulComponent) bolt).initState(instanceState);
+    }
+
     // Delegate
     bolt.prepare(
         topologyContext.getTopologyConfig(), topologyContext, new OutputCollector(collector));

--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
@@ -152,7 +152,7 @@ public class BoltInstance implements IInstance {
 
     boltMetrics.registerMetrics(topologyContext);
 
-    // Initialize the bolt is it's stateful
+    // Initialize the instanceState if the bolt is stateful
     if (bolt instanceof IStatefulComponent) {
       ((IStatefulComponent) bolt).initState(instanceState);
     }

--- a/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutInstance.java
@@ -164,6 +164,11 @@ public class SpoutInstance implements IInstance {
 
     spoutMetrics.registerMetrics(topologyContext);
 
+    // Initialize the instanceState if the spout is stateful
+    if (spout instanceof IStatefulComponent) {
+      ((IStatefulComponent) spout).initState(instanceState);
+    }
+
     spout.open(
         topologyContext.getTopologyConfig(), topologyContext, new SpoutOutputCollector(collector));
 

--- a/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutInstance.java
@@ -60,7 +60,7 @@ public class SpoutInstance implements IInstance {
   private final boolean enableMessageTimeouts;
 
   private final boolean isTopologyStateful;
-  private State<? extends Serializable, ? extends Serializable> instanceState;
+  private State<Serializable, Serializable> instanceState;
 
   private final SlaveLooper looper;
 
@@ -156,6 +156,7 @@ public class SpoutInstance implements IInstance {
     collector.sendOutState(instanceState, checkpointId);
   }
 
+  @SuppressWarnings("unchecked")
   public void start() {
     TopologyContextImpl topologyContext = helper.getTopologyContext();
 
@@ -166,7 +167,7 @@ public class SpoutInstance implements IInstance {
 
     // Initialize the instanceState if the spout is stateful
     if (spout instanceof IStatefulComponent) {
-      ((IStatefulComponent) spout).initState(instanceState);
+      ((IStatefulComponent<Serializable, Serializable>) spout).initState(instanceState);
     }
 
     spout.open(
@@ -185,7 +186,7 @@ public class SpoutInstance implements IInstance {
   }
 
   @Override
-  public void start(State<? extends Serializable, ? extends Serializable> state) {
+  public void start(State<Serializable, Serializable> state) {
     this.instanceState = state;
     start();
   }


### PR DESCRIPTION
This PR made the following two changes:
1. call `initState()` if the component is a statefulComponent during `start()`
2. Replace the `? extends Serializable`  with `Serializable` for `State` related variables and methods in Instance code