### PR TITLE
Cleanup of params

### DIFF
--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/LaunchRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/LaunchRunner.java
@@ -64,7 +64,7 @@ public class LaunchRunner {
     builder.setTopologyName(topology.getName()).
         setTopologyId(topology.getId())
         .setSubmissionTime(System.currentTimeMillis() / 1000)
-        .setSubmissionUser(System.getProperty("user.name"))
+        .setSubmissionUser(Context.submitUser(config))
         .setCluster(Context.cluster(config))
         .setRole(Context.role(config))
         .setEnviron(Context.environ(config));

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
@@ -85,6 +85,14 @@ public class RuntimeManagerMain {
         .required()
         .build();
 
+    Option submitUser = Option.builder("s")
+        .desc("User submitting the topology")
+        .longOpt("submit_user")
+        .hasArgs()
+        .argName("submit userid")
+        .required()
+        .build();
+
     Option topologyName = Option.builder("n")
         .desc("Name of the topology")
         .longOpt("topology_name")
@@ -166,6 +174,7 @@ public class RuntimeManagerMain {
     options.addOption(cluster);
     options.addOption(role);
     options.addOption(environment);
+    options.addOption(submitUser);
     options.addOption(topologyName);
     options.addOption(configFile);
     options.addOption(configOverrides);
@@ -229,6 +238,7 @@ public class RuntimeManagerMain {
     String cluster = cmd.getOptionValue("cluster");
     String role = cmd.getOptionValue("role");
     String environ = cmd.getOptionValue("environment");
+    String submitUser = cmd.getOptionValue("submit_user");
     String heronHome = cmd.getOptionValue("heron_home");
     String configPath = cmd.getOptionValue("config_path");
     String overrideConfigFile = cmd.getOptionValue("override_config_file");
@@ -264,6 +274,7 @@ public class RuntimeManagerMain {
         .put(Key.CLUSTER, cluster)
         .put(Key.ROLE, role)
         .put(Key.ENVIRON, environ)
+        .put(Key.SUBMIT_USER, submitUser)
         .put(Key.DRY_RUN, dryRun)
         .put(Key.DRY_RUN_FORMAT_TYPE, dryRunFormat)
         .put(Key.VERBOSE, verbose)

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
@@ -292,7 +292,7 @@ public class SubmitterMain {
     // build the final config by expanding all the variables
     return Config.toLocalMode(Config.newBuilder()
         .putAll(ConfigLoader.loadConfig(heronHome, configPath, releaseFile, overrideConfigFile))
-        .putAll(commandLineConfigs(cluster, role, environ, submitUser, dryRun, 
+        .putAll(commandLineConfigs(cluster, role, environ, submitUser, dryRun,
                                    dryRunFormat, isVerbose(cmd)))
         .putAll(topologyConfigs(topologyPackage, topologyBinaryFile, topologyDefnFile, topology))
         .build());

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
@@ -95,6 +95,7 @@ public class SubmitterMain {
   protected static Config commandLineConfigs(String cluster,
                                              String role,
                                              String environ,
+                                             String submitUser,
                                              Boolean dryRun,
                                              DryRunFormatType dryRunFormat,
                                              Boolean verbose) {
@@ -102,6 +103,7 @@ public class SubmitterMain {
         .put(Key.CLUSTER, cluster)
         .put(Key.ROLE, role)
         .put(Key.ENVIRON, environ)
+        .put(Key.SUBMIT_USER, submitUser)
         .put(Key.DRY_RUN, dryRun)
         .put(Key.DRY_RUN_FORMAT_TYPE, dryRunFormat)
         .put(Key.VERBOSE, verbose)
@@ -139,6 +141,14 @@ public class SubmitterMain {
         .longOpt("environment")
         .hasArgs()
         .argName("environment")
+        .required()
+        .build();
+
+    Option submitUser = Option.builder("s")
+        .desc("User submitting the topology")
+        .longOpt("submit_user")
+        .hasArgs()
+        .argName("submit userid")
         .required()
         .build();
 
@@ -217,6 +227,7 @@ public class SubmitterMain {
     options.addOption(cluster);
     options.addOption(role);
     options.addOption(environment);
+    options.addOption(submitUser);
     options.addOption(heronHome);
     options.addOption(configFile);
     options.addOption(configOverrides);
@@ -252,6 +263,7 @@ public class SubmitterMain {
     String cluster = cmd.getOptionValue("cluster");
     String role = cmd.getOptionValue("role");
     String environ = cmd.getOptionValue("environment");
+    String submitUser = cmd.getOptionValue("submit_user");
     String heronHome = cmd.getOptionValue("heron_home");
     String configPath = cmd.getOptionValue("config_path");
     String overrideConfigFile = cmd.getOptionValue("override_config_file");
@@ -280,7 +292,8 @@ public class SubmitterMain {
     // build the final config by expanding all the variables
     return Config.toLocalMode(Config.newBuilder()
         .putAll(ConfigLoader.loadConfig(heronHome, configPath, releaseFile, overrideConfigFile))
-        .putAll(commandLineConfigs(cluster, role, environ, dryRun, dryRunFormat, isVerbose(cmd)))
+        .putAll(commandLineConfigs(cluster, role, environ, submitUser, dryRun, 
+                                   dryRunFormat, isVerbose(cmd)))
         .putAll(topologyConfigs(topologyPackage, topologyBinaryFile, topologyDefnFile, topology))
         .build());
   }

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/LaunchRunnerTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/LaunchRunnerTest.java
@@ -70,6 +70,7 @@ public class LaunchRunnerTest {
   private static final String CLUSTER = "testCluster";
   private static final String ROLE = "testRole";
   private static final String ENVIRON = "testEnviron";
+  private static final String SUBMIT_USER = "testUser";
   private static final String BUILD_VERSION = "live";
   private static final String BUILD_USER = "user";
 
@@ -114,6 +115,7 @@ public class LaunchRunnerTest {
     when(config.getStringValue(Key.CLUSTER)).thenReturn(CLUSTER);
     when(config.getStringValue(Key.ROLE)).thenReturn(ROLE);
     when(config.getStringValue(Key.ENVIRON)).thenReturn(ENVIRON);
+    when(config.getStringValue(Key.SUBMIT_USER)).thenReturn(SUBMIT_USER);
     when(config.getStringValue(Key.BUILD_VERSION)).thenReturn(BUILD_VERSION);
     when(config.getStringValue(Key.BUILD_USER)).thenReturn(BUILD_USER);
 
@@ -205,7 +207,7 @@ public class LaunchRunnerTest {
     assertEquals(CLUSTER, executionState.getCluster());
     assertEquals(ROLE, executionState.getRole());
     assertEquals(ENVIRON, executionState.getEnviron());
-    assertEquals(System.getProperty("user.name"), executionState.getSubmissionUser());
+    assertEquals(SUBMIT_USER, executionState.getSubmissionUser());
 
     assertNotNull(executionState.getTopologyId());
     assertTrue(executionState.getSubmissionTime() <= (System.currentTimeMillis() / 1000));

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Context.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Context.java
@@ -37,6 +37,10 @@ public class Context {
     return cfg.getStringValue(Key.ENVIRON);
   }
 
+  public static String submitUser(Config cfg) {
+    return cfg.getStringValue(Key.SUBMIT_USER);
+  }
+
   public static Boolean dryRun(Config cfg) {
     return cfg.getBooleanValue(Key.DRY_RUN);
   }

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Key.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Key.java
@@ -50,6 +50,7 @@ public enum Key {
   CLUSTER                  ("heron.config.cluster",             Type.STRING),
   ROLE                     ("heron.config.role",                Type.STRING),
   ENVIRON                  ("heron.config.environ",             Type.STRING),
+  SUBMIT_USER              ("heron.config.submit_user",         Type.STRING),
   DRY_RUN                  ("heron.config.dry_run",             Boolean.FALSE),
   DRY_RUN_FORMAT_TYPE      ("heron.config.dry_run_format_type", Type.DRY_RUN_FORMAT_TYPE),
   VERBOSE                  ("heron.config.verbose",             Boolean.FALSE),

--- a/heron/tools/cli/src/python/cli_helper.py
+++ b/heron/tools/cli/src/python/cli_helper.py
@@ -61,6 +61,7 @@ def run(command, cl_args, action, extra_args=[], extra_lib_jars=[]):
       "--cluster", cl_args['cluster'],
       "--role", cl_args['role'],
       "--environment", cl_args['environ'],
+      "--submit_user", cl_args['submit_user'],
       "--heron_home", config.get_heron_dir(),
       "--config_path", cl_args['config_path'],
       "--override_config_file", cl_args['override_config_file'],

--- a/heron/tools/cli/src/python/main.py
+++ b/heron/tools/cli/src/python/main.py
@@ -16,6 +16,7 @@
 ''' main.py '''
 import argparse
 import atexit
+import getpass
 import os
 import shutil
 import sys
@@ -175,6 +176,7 @@ def extract_common_args(command, parser, cl_args):
     new_cl_args['cluster'] = cluster_tuple[0]
     new_cl_args['role'] = cluster_tuple[1]
     new_cl_args['environ'] = cluster_tuple[2]
+    new_cl_args['submit_user'] = getpass.getuser()
     new_cl_args['config_path'] = config_path
     new_cl_args['override_config_file'] = override_config_file
   except Exception as ex:

--- a/heron/tools/cli/src/python/submit.py
+++ b/heron/tools/cli/src/python/submit.py
@@ -88,6 +88,7 @@ def launch_a_topology(cl_args, tmp_dir, topology_file, topology_defn_file, topol
       "--cluster", cl_args['cluster'],
       "--role", cl_args['role'],
       "--environment", cl_args['environ'],
+      "--submit_user", cl_args['submit_user'],
       "--heron_home", config.get_heron_dir(),
       "--config_path", config_path,
       "--override_config_file", cl_args['override_config_file'],

--- a/heron/tools/cli/tests/python/client_command_unittest.py
+++ b/heron/tools/cli/tests/python/client_command_unittest.py
@@ -16,6 +16,7 @@ import unittest2 as unittest
 import mock
 from mock import call, patch, Mock, MagicMock
 import os
+import getpass
 import subprocess
 import sys
 import tempfile
@@ -78,11 +79,12 @@ class SubmitTest(ClientCommandTest):
                       ':/heron/lib/jars/scheduler/*:/heron/lib/jars/uploader/*:' \
                       '/heron/lib/jars/statemgr/*:/heron/lib/jars/packing/* ' \
                       'com.twitter.heron.scheduler.SubmitterMain --cluster local ' \
-                      '--role user --environment default --heron_home /heron/home ' \
+                      '--role user --environment default --submit_user %s ' \
+                      '--heron_home /heron/home ' \
                       '--config_path /heron/home/conf/local --override_config_file ' \
                       '/heron/home/override.yaml --release_file /heron/home/release.yaml ' \
                       '--topology_package /tmp/heron_tmp/topology.tar.gz --topology_defn T.defn ' \
-                      '--topology_bin heron-examples.jar'
+                      '--topology_bin heron-examples.jar' % (getpass.getuser())
     env = {'HERON_OPTIONS':
            'cmdline.topologydefn.tmpdirectory=/tmp/heron_tmp,cmdline.topology.initial.state=RUNNING'}
     ClientCommandTest.run_test(self, command, [create_defn_commands, submit_commands], env)


### PR DESCRIPTION
In the current implementation, some of the useful params are passed from cli to java while some are picked by java itself. Such parameters include

- submitting user (which is used by SubmitterMain but it gathers itself)
- build user (which is picked up from release.yaml)
- release tag (which is picked up from release.yaml)
- release version (which is picked up from release.yaml)

In this PR, we are making it consistent that these are passed from python to the java programs.