### PR TITLE
initialize instance state if it's null

### DIFF
--- a/heron/instance/src/java/com/twitter/heron/instance/Slave.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/Slave.java
@@ -24,6 +24,7 @@ import com.google.protobuf.Message;
 import com.twitter.heron.api.Config;
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.api.serializer.IPluggableSerializer;
+import com.twitter.heron.api.state.HashMapState;
 import com.twitter.heron.api.state.State;
 import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.basics.SingletonRegistry;
@@ -256,6 +257,12 @@ public class Slave implements Runnable, AutoCloseable {
       instanceState = stateToRestore;
     } else {
       LOG.info("The restore request does not have an actual state");
+    }
+
+    // First time a stateful topology is launched, there's no checkpoint
+    // to restore, heron needs to provide a proper initial empty state
+    if (instanceState == null) {
+      instanceState = new HashMapState<>();
     }
 
     LOG.info("Instance state restored for checkpoint id: "


### PR DESCRIPTION
This PR is to fix a corner case where: the first time a stateful topology is started, there's no `State` to restore. It's heron system's responsibility to properly provide an initial empty state not a `null` for user topology to use.