### PR TITLE
Use correct method for getting all local taskids

### DIFF
--- a/heron/stmgr/src/cpp/manager/stateful-restorer.h
+++ b/heron/stmgr/src/cpp/manager/stateful-restorer.h
@@ -19,8 +19,8 @@
 
 #include <ostream>
 #include <map>
-#include <set>
 #include <string>
+#include <unordered_set>
 #include <vector>
 #include <typeinfo>   // operator typeid
 #include "proto/messages.h"
@@ -88,6 +88,7 @@ class StatefulRestorer {
   // callback passing in it the status of the restore along with _checkpoint_id
   // and the _restore_txid
   void StartRestore(const std::string& _checkpoint_id, sp_int64 _restore_txid,
+                    const std::unordered_set<sp_int32>& _local_taskids,
                     proto::system::PhysicalPlan* _pplan);
   // Called when ckptmgr client restarts
   void HandleCkptMgrRestart();
@@ -123,10 +124,10 @@ class StatefulRestorer {
 
   // Set of task ids for which we have sent out get checkpoint requests
   // to the ckptmgr but haven't gotten response back
-  std::set<sp_int32> get_ckpt_pending_;
+  std::unordered_set<sp_int32> get_ckpt_pending_;
   // Set of task ids which still haven;'t gotten back after
   // restoring their state
-  std::set<sp_int32> restore_pending_;
+  std::unordered_set<sp_int32> restore_pending_;
   // Have we not connected with some of our peer stmgrs?
   bool clients_connections_pending_;
   // Are any of our local instances still not connected with us?
@@ -136,7 +137,7 @@ class StatefulRestorer {
   // What is the restore txid associated with our attempt of restoring
   sp_int64 restore_txid_;
   // What are all our local taskids that we need to restore
-  std::set<sp_int32> local_taskids_;
+  std::unordered_set<sp_int32> local_taskids_;
 
   CkptMgrClient* ckptmgr_;
   StMgrClientMgr* clientmgr_;

--- a/heron/stmgr/src/cpp/manager/stmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr.cpp
@@ -1003,7 +1003,9 @@ void StMgr::RestoreTopologyState(sp_string _checkpoint_id, sp_int64 _restore_txi
   CHECK(stateful_restorer_);
 
   // Start the restore process
-  stateful_restorer_->StartRestore(_checkpoint_id, _restore_txid, pplan_);
+  std::unordered_set<sp_int32> local_taskids;
+  config::PhysicalPlanHelper::GetTasks(*pplan_, stmgr_id_, local_taskids),
+  stateful_restorer_->StartRestore(_checkpoint_id, _restore_txid, local_taskids, pplan_);
 }
 
 // Called by TmasterClient when it receives directive from tmaster

--- a/heron/stmgr/tests/cpp/server/stateful-restorer_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/stateful-restorer_unittest.cpp
@@ -247,7 +247,9 @@ TEST(StatefulRestorer, normalcase) {
                                                      std::bind(&RestoreDone, &restore_done));
   // At the start the restore is not in progress
   EXPECT_FALSE(restorer->InProgress());
-  restorer->StartRestore(ckpt_id, 1, pplan);
+  std::unordered_set<sp_int32> local_taskids;
+  heron::config::PhysicalPlanHelper::GetTasks(*pplan, GenerateStMgrId(1), local_taskids);
+  restorer->StartRestore(ckpt_id, 1, local_taskids, pplan);
   // Now we are in restore
   EXPECT_TRUE(restorer->InProgress());
   // Make sure that the ckpt messages were sent to our tasks
@@ -319,7 +321,9 @@ TEST(StatefulRestorer, deadinstances) {
                                                      std::bind(&RestoreDone, &restore_done));
   // At the start the restore is not in progress
   EXPECT_FALSE(restorer->InProgress());
-  restorer->StartRestore(ckpt_id, 1, pplan);
+  std::unordered_set<sp_int32> local_taskids;
+  heron::config::PhysicalPlanHelper::GetTasks(*pplan, GenerateStMgrId(1), local_taskids);
+  restorer->StartRestore(ckpt_id, 1, local_taskids, pplan);
   // Now we are in restore
   EXPECT_TRUE(restorer->InProgress());
   // Just have all stmgrs connected to us
@@ -410,7 +414,9 @@ TEST(StatefulRestorer, deadckptmgr) {
                                                      std::bind(&RestoreDone, &restore_done));
   // At the start the restore is not in progress
   EXPECT_FALSE(restorer->InProgress());
-  restorer->StartRestore(ckpt_id, 1, pplan);
+  std::unordered_set<sp_int32> local_taskids;
+  heron::config::PhysicalPlanHelper::GetTasks(*pplan, GenerateStMgrId(1), local_taskids);
+  restorer->StartRestore(ckpt_id, 1, local_taskids, pplan);
   // Now we are in restore
   EXPECT_TRUE(restorer->InProgress());
 


### PR DESCRIPTION
Currently we use stmgrserver_->GetInstances() to get the list of all local taskids. However this returns only active(connected) instances. Instead we want to get all local instances.