### PR TITLE
Sort the task ids to ensure that identical fields grouping tuples end up in same task ids even accross runs

### DIFF
--- a/heron/stmgr/src/cpp/grouping/grouping.cpp
+++ b/heron/stmgr/src/cpp/grouping/grouping.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "grouping/grouping.h"
+#include <algorithm>
 #include <functional>
 #include <iostream>
 #include <list>
@@ -34,7 +35,10 @@
 namespace heron {
 namespace stmgr {
 
-Grouping::Grouping(const std::vector<sp_int32>& _task_ids) : task_ids_(_task_ids) {}
+Grouping::Grouping(const std::vector<sp_int32>& _task_ids)
+  : task_ids_(_task_ids) {
+  sort(task_ids_.begin(), task_ids_.end());
+}
 
 Grouping::~Grouping() {}
 

--- a/heron/stmgr/tests/cpp/grouping/fields-grouping_unittest.cpp
+++ b/heron/stmgr/tests/cpp/grouping/fields-grouping_unittest.cpp
@@ -39,6 +39,11 @@ TEST(FieldsGrouping, test_sametuple) {
   task_ids.push_back(2);
   task_ids.push_back(4);
   task_ids.push_back(8);
+  std::vector<sp_int32> unsorted_ids;
+  unsorted_ids.push_back(4);
+  unsorted_ids.push_back(2);
+  unsorted_ids.push_back(8);
+  unsorted_ids.push_back(0);
 
   heron::proto::api::InputStream is;
   heron::proto::api::StreamSchema* s = is.mutable_grouping_fields();
@@ -47,6 +52,7 @@ TEST(FieldsGrouping, test_sametuple) {
   kt->set_key("field1");
 
   heron::stmgr::FieldsGrouping* g = new heron::stmgr::FieldsGrouping(is, *s, task_ids);
+  heron::stmgr::FieldsGrouping* g_unsorted = new heron::stmgr::FieldsGrouping(is, *s, unsorted_ids);
   heron::proto::system::HeronDataTuple tuple;
   tuple.add_values("dummy");
 
@@ -54,13 +60,18 @@ TEST(FieldsGrouping, test_sametuple) {
   for (sp_int32 i = 0; i < 1000; ++i) {
     std::vector<sp_int32> dests;
     g->GetListToSend(tuple, dests);
+    std::vector<sp_int32> unsorted_dests;
+    g_unsorted->GetListToSend(tuple, unsorted_dests);
     EXPECT_EQ(dests.size(), (sp_uint32)1);
+    EXPECT_EQ(unsorted_dests.size(), (sp_uint32)1);
+    EXPECT_EQ(dests[0], unsorted_dests[0]);
     all_dests.insert(dests.front());
   }
 
   EXPECT_EQ(all_dests.size(), (sp_uint32)1);
 
   delete g;
+  delete g_unsorted;
 }
 
 // Test that only the relevant fields are hashed


### PR DESCRIPTION
For Fields grouping, tuple routing is done at stmgr. Currently stmgr takes a vector of task-ids and hashes the input tuple to one of them. This ensures that tuples are routed properly in that run of the topology. However during different runs of the same topology(that is submit, kill, submit), the task_ids could be in different order. This pr ensures that they get sorted, to make sure that even across runs the tuples are routed to the same dest task.
Added a unittest to ensure the behaviour as well.