### PR TITLE
Fix stateful processing bug during restore

### DIFF
--- a/heron/stmgr/src/cpp/manager/stmgr-server.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-server.cpp
@@ -759,7 +759,11 @@ void StMgrServer::HandleCheckpointMarker(sp_int32 _src_task_id, sp_int32 _destin
 bool StMgrServer::SendRestoreInstanceStateRequest(sp_int32 _task_id,
             const proto::ckptmgr::InstanceStateCheckpoint& _state) {
   LOG(INFO) << "Sending RestoreInstanceState request to task " << _task_id;
-  CHECK(instance_info_.find(_task_id) != instance_info_.end());
+  if (instance_info_.find(_task_id) == instance_info_.end()) {
+    LOG(WARNING) << "Cannot send RestoreInstanceState Request to task "
+                 << _task_id << " because it is not connected to us";
+    return false;
+  }
   Connection* conn = instance_info_[_task_id]->conn_;
   if (conn) {
     proto::ckptmgr::RestoreInstanceStateRequest* message = nullptr;


### PR DESCRIPTION
If an instance is not connected, stmgr server should return false while sending restore message. Currently we assume that we are always connected to instance which is not the case when the instance has died