### PR TITLE
Misc Python fixes

### DIFF
--- a/heron/common/src/python/utils/misc/communicator.py
+++ b/heron/common/src/python/utils/misc/communicator.py
@@ -82,7 +82,7 @@ class HeronCommunicator(object):
       return True
     except Queue.Full:
       Log.debug("%s: Full in offer()" % str(self))
-      return False
+      raise Queue.Full
 
   def clear(self):
     """Clear the buffer"""

--- a/heron/common/tests/python/network/heron_client_unittest.py
+++ b/heron/common/tests/python/network/heron_client_unittest.py
@@ -51,7 +51,7 @@ class ClientTest(unittest.TestCase):
     self.mock_client.context_map[reqid] = None
     self.mock_client.response_message_map[reqid] = None
     self.mock_client._handle_packet(packet)
-    self.assertEqual(self.mock_client.on_response_status, StatusCode.INVALID_PACKET)
+    self.assertEqual(self.mock_client.on_error_called, True)
 
     # message (REQID = zero) -- status OK
     pkt_list, msg_list, builder, typename = mock_generator.get_a_mock_message_list_and_builder()

--- a/heron/common/tests/python/network/mock_generator.py
+++ b/heron/common/tests/python/network/mock_generator.py
@@ -153,6 +153,7 @@ class MockHeronClient(HeronClient):
     self.called_handle_packet = False
     self.dispatcher = MockDispatcher()
     self.incoming_msg = None
+    self.on_error_called = False
 
   def on_connect(self, status):
     if status == StatusCode.OK:
@@ -160,6 +161,9 @@ class MockHeronClient(HeronClient):
 
   def on_response(self, status, context, response):
     self.on_response_status = status
+
+  def on_error(self):
+    self.on_error_called = True
 
   def on_incoming_message(self, message):
     self.incoming_msg = message
@@ -171,3 +175,6 @@ class MockHeronClient(HeronClient):
     # should only be called when packet is complete
     self.called_handle_packet = True
     HeronClient._handle_packet(self, packet)
+
+  def _handle_close(self):
+    pass


### PR DESCRIPTION
1. Correct the calling of on_error. Currently on stmgr connection breakage, we don't call on_error. This pr fixes that.
2. Move handling of assignment info all inside instance rather than in stmgr client. This emulates more the java instance way of doing things.