### PR TITLE
Refactor DSL by trimming streamlet class and pushing more code into individual operators

### DIFF
--- a/heron/dsl/src/python/__init__.py
+++ b/heron/dsl/src/python/__init__.py
@@ -12,4 +12,5 @@ that data as tuples (lists in Python) to
 """
 
 # Load basic dsl modules
-from .streamlet import Streamlet, OperationType, TimeWindow
+from .streamlet import Streamlet, TimeWindow
+from .operation import OperationType

--- a/heron/dsl/src/python/filterbolt.py
+++ b/heron/dsl/src/python/filterbolt.py
@@ -13,6 +13,11 @@
 # limitations under the License.
 """module for filter bolt: FilterBolt"""
 from heron.api.src.python import Bolt, Stream, StatefulComponent
+from heron.api.src.python.component import GlobalStreamId
+from heron.api.src.python.stream import Grouping
+
+from heron.dsl.src.python import Streamlet
+from heron.dsl.src.python import OperationType
 
 # pylint: disable=unused-argument
 class FilterBolt(Bolt, StatefulComponent):
@@ -46,3 +51,34 @@ class FilterBolt(Bolt, StatefulComponent):
       self.emitted += 1
     self.processed += 1
     self.ack(tup)
+
+# pylint: disable=protected-access
+class FilterStreamlet(Streamlet):
+  """FilterStreamlet"""
+  def __init__(self, filter_function, parents, stage_name=None, parallelism=None):
+    super(FilterStreamlet, self).__init__(parents=parents, operation=OperationType.Filter,
+                                          stage_name=stage_name, parallelism=parallelism)
+    self._filter_function = filter_function
+
+  def _calculate_inputs(self):
+    return {GlobalStreamId(self._parents[0]._stage_name, self._parents[0]._output) :
+            Grouping.SHUFFLE}
+
+  def _calculate_stage_name(self, existing_stage_names):
+    funcname = "filter-" + self._filter_function.__name__
+    if funcname not in existing_stage_names:
+      return funcname
+    else:
+      index = 1
+      newfuncname = funcname + str(index)
+      while newfuncname in existing_stage_names:
+        index = index + 1
+        newfuncname = funcname + str(index)
+      return newfuncname
+
+  def _build_this(self, builder):
+    if not callable(self._filter_function):
+      raise RuntimeError("filter function must be callable")
+    builder.add_bolt(self._stage_name, FilterBolt, par=self._parallelism,
+                     inputs=self._inputs,
+                     config={FilterBolt.FUNCTION : self._filter_function})

--- a/heron/dsl/src/python/joinbolt.py
+++ b/heron/dsl/src/python/joinbolt.py
@@ -15,7 +15,12 @@
 import collections
 
 from heron.api.src.python import SlidingWindowBolt, Stream
+from heron.api.src.python.component import GlobalStreamId
 from heron.api.src.python.custom_grouping import ICustomGrouping
+from heron.api.src.python.stream import Grouping
+
+from heron.dsl.src.python import Streamlet, TimeWindow
+from heron.dsl.src.python import OperationType
 
 # pylint: disable=unused-argument
 class JoinBolt(SlidingWindowBolt):
@@ -57,3 +62,40 @@ class JoinGrouping(ICustomGrouping):
     hashvalue = hash(userdata[0])
     target_index = hashvalue % len(self.target_tasks)
     return [self.target_tasks[target_index]]
+
+# pylint: disable=protected-access
+class JoinStreamlet(Streamlet):
+  """JoinStreamlet"""
+  def __init__(self, time_window, parents, stage_name=None, parallelism=None):
+    super(JoinStreamlet, self).__init__(parents=parents, operation=OperationType.Join,
+                                        stage_name=stage_name, parallelism=parallelism)
+    self._time_window = time_window
+
+  def _calculate_inputs(self):
+    inputs = {}
+    for parent in self._parents:
+      inputs[GlobalStreamId(parent._stage_name, parent._output)] = \
+             Grouping.custom("heron.dsl.src.python.joinbolt.JoinGrouping")
+    return inputs
+
+  def _calculate_stage_name(self, existing_stage_names):
+    stage_name = self._parents[0]._stage_name
+    for stage in self._parents[1:]:
+      stage_name = stage_name + '.join.' + stage._stage_name
+    if stage_name not in existing_stage_names:
+      return stage_name
+    else:
+      index = 1
+      tmp_name = stage_name + str(index)
+      while tmp_name in existing_stage_names:
+        index = index + 1
+        tmp_name = stage_name + str(index)
+      return tmp_name
+
+  def _build_this(self, builder):
+    if not isinstance(self._time_window, TimeWindow):
+      raise RuntimeError("Join's time_window should be TimeWindow")
+    builder.add_bolt(self._stage_name, JoinBolt, par=self._parallelism,
+                     inputs=self._inputs,
+                     config={JoinBolt.WINDOWDURATION : self._time_window.duration,
+                             JoinBolt.SLIDEINTERVAL : self._time_window.sliding_interval})

--- a/heron/dsl/src/python/mapbolt.py
+++ b/heron/dsl/src/python/mapbolt.py
@@ -13,6 +13,11 @@
 # limitations under the License.
 """module for map bolt: MapBolt"""
 from heron.api.src.python import Bolt, Stream, StatefulComponent
+from heron.api.src.python.component import GlobalStreamId
+from heron.api.src.python.stream import Grouping
+
+from heron.dsl.src.python import Streamlet
+from heron.dsl.src.python import OperationType
 
 # pylint: disable=unused-argument
 class MapBolt(Bolt, StatefulComponent):
@@ -46,3 +51,34 @@ class MapBolt(Bolt, StatefulComponent):
     self.processed += 1
     self.emitted += 1
     self.ack(tup)
+
+# pylint: disable=protected-access
+class MapStreamlet(Streamlet):
+  """MapStreamlet"""
+  def __init__(self, map_function, parents, stage_name=None, parallelism=None):
+    super(MapStreamlet, self).__init__(parents=parents, operation=OperationType.Map,
+                                       stage_name=stage_name, parallelism=parallelism)
+    self._map_function = map_function
+
+  def _calculate_inputs(self):
+    return {GlobalStreamId(self._parents[0]._stage_name, self._parents[0]._output) :
+            Grouping.SHUFFLE}
+
+  def _calculate_stage_name(self, existing_stage_names):
+    funcname = "map-" + self._map_function.__name__
+    if funcname not in existing_stage_names:
+      return funcname
+    else:
+      index = 1
+      newfuncname = funcname + str(index)
+      while newfuncname in existing_stage_names:
+        index = index + 1
+        newfuncname = funcname + str(index)
+      return newfuncname
+
+  def _build_this(self, builder):
+    if not callable(self._map_function):
+      raise RuntimeError("map function must be callable")
+    builder.add_bolt(self._stage_name, MapBolt, par=self._parallelism,
+                     inputs=self._inputs,
+                     config={MapBolt.FUNCTION : self._map_function})

--- a/heron/dsl/src/python/operation.py
+++ b/heron/dsl/src/python/operation.py
@@ -1,0 +1,32 @@
+# Copyright 2016 - Twitter, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+'''operation.py: module for defining the various different operations for python dsl'''
+
+class OperationType(object):
+  Input = 1
+  Map = 2
+  FlatMap = 3
+  Filter = 4
+  Sample = 5
+  Join = 6
+  Repartition = 7
+  ReduceByKeyAndWindow = 8
+  Output = 10
+
+  AllOperations = [Input, Map, FlatMap, Filter, Sample, Join,
+                   Repartition, ReduceByKeyAndWindow, Output]
+
+  @staticmethod
+  def valid(typ):
+    return typ in OperationType.AllOperations

--- a/heron/dsl/src/python/streamlet.py
+++ b/heron/dsl/src/python/streamlet.py
@@ -13,35 +13,11 @@
 # limitations under the License.
 '''streamlet.py: module for defining the basic concept of the heron python dsl'''
 from collections import namedtuple
+from abc import abstractmethod
+
 from heron.api.src.python import TopologyBuilder
-from heron.api.src.python.component import GlobalStreamId
-from heron.api.src.python.stream import Grouping
 
-from .mapbolt import MapBolt
-from .flatmapbolt import FlatMapBolt
-from .filterbolt import FilterBolt
-from .samplebolt import SampleBolt
-from .joinbolt import JoinBolt
-from .repartitionbolt import RepartitionBolt
-from .reducebykeyandwindowbolt import ReduceByKeyAndWindowBolt
-
-class OperationType(object):
-  Input = 1
-  Map = 2
-  FlatMap = 3
-  Filter = 4
-  Sample = 5
-  Join = 6
-  Repartition = 7
-  ReduceByKeyAndWindow = 8
-  Output = 10
-
-  AllOperations = [Input, Map, FlatMap, Filter, Sample, Join,
-                   Repartition, ReduceByKeyAndWindow, Output]
-
-  @staticmethod
-  def valid(typ):
-    return typ in OperationType.AllOperations
+from heron.dsl.src.python.operation import OperationType
 
 TimeWindow = namedtuple('TimeWindow', 'duration sliding_interval')
 
@@ -49,23 +25,15 @@ TimeWindow = namedtuple('TimeWindow', 'duration sliding_interval')
 class Streamlet(object):
   """A Streamlet is a (potentially unbounded) ordered collection of tuples
   """
-  # pylint: disable=too-many-arguments
-  # pylint: disable=too-many-function-args
-  def __init__(self, parents=None, operation=None, stage_name=None,
-               parallelism=None, inputs=None,
-               map_function=None, flatmap_function=None,
-               filter_function=None, time_window=None,
-               sample_fraction=None, reduce_function=None):
+  def __init__(self, parents, operation=None, stage_name=None,
+               parallelism=None, inputs=None):
     """
     """
     if operation is None:
       raise RuntimeError("Streamlet's operation cannot be None")
     if not OperationType.valid(operation):
       raise RuntimeError("Streamlet's operation must be of type OperationType")
-    if operation == OperationType.Input:
-      if parents is not None:
-        raise RuntimeError("A input Streamlet's parents should be None")
-    elif not isinstance(parents, list):
+    if not isinstance(parents, list):
       raise RuntimeError("Streamlet's parents have to be a list")
     self._parents = parents
     self._operation = operation
@@ -73,53 +41,48 @@ class Streamlet(object):
     self._parallelism = parallelism
     self._inputs = inputs
     self._output = 'output'
-    self._map_function = map_function
-    self._flatmap_function = flatmap_function
-    self._filter_function = filter_function
-    self._sample_fraction = sample_fraction
-    self._time_window = time_window
-    self._reduce_function = reduce_function
 
   def map(self, map_function, stage_name=None, parallelism=None):
-    return Streamlet(parents=[self], operation=OperationType.Map,
-                     stage_name=stage_name, parallelism=parallelism,
-                     map_function=map_function)
+    from heron.dsl.src.python.mapbolt import MapStreamlet
+    return MapStreamlet(map_function, parents=[self], stage_name=stage_name,
+                        parallelism=parallelism)
 
   def flatMap(self, flatmap_function, stage_name=None, parallelism=None):
-    return Streamlet(parents=[self], operation=OperationType.FlatMap,
-                     stage_name=stage_name, parallelism=parallelism,
-                     flatmap_function=flatmap_function)
+    from heron.dsl.src.python.flatmapbolt import FlatMapStreamlet
+    return FlatMapStreamlet(flatmap_function, parents=[self], stage_name=stage_name,
+                            parallelism=parallelism)
 
   def filter(self, filter_function, stage_name=None, parallelism=None):
-    return Streamlet(parents=[self], operation=OperationType.Filter,
-                     stage_name=stage_name, parallelism=parallelism,
-                     filter_function=filter_function)
+    from heron.dsl.src.python.filterbolt import FilterStreamlet
+    return FilterStreamlet(filter_function, parents=[self], stage_name=stage_name,
+                           parallelism=parallelism)
 
   def sample(self, sample_fraction, stage_name=None, parallelism=None):
-    return Streamlet(parents=[self], operation=OperationType.Sample,
-                     stage_name=stage_name, parallelism=parallelism,
-                     sample_fraction=sample_fraction)
+    from heron.dsl.src.python.samplebolt import SampleStreamlet
+    return SampleStreamlet(sample_fraction, parents=[self], stage_name=stage_name,
+                           parallelism=parallelism)
 
   def repartition(self, parallelism, stage_name=None):
-    return Streamlet(parents=[self], operation=OperationType.Repartition,
-                     stage_name=stage_name, parallelism=parallelism)
+    from heron.dsl.src.python.repartitionbolt import RepartitionStreamlet
+    return RepartitionStreamlet(parallelism, parents=[self], stage_name=stage_name)
 
   def join(self, join_streamlet, time_window, stage_name=None, parallelism=None):
-    return Streamlet(parents=[self, join_streamlet], time_window=time_window,
-                     operation=OperationType.Join,
-                     stage_name=stage_name, parallelism=parallelism)
+    from heron.dsl.src.python.joinbolt import JoinStreamlet
+    return JoinStreamlet(time_window, parents=[self, join_streamlet],
+                         operation=OperationType.Join,
+                         stage_name=stage_name, parallelism=parallelism)
 
   def reduceByWindow(self, time_window, reduce_function, stage_name=None):
-    return Streamlet(parents=[self], operation=OperationType.ReduceByKeyAndWindow,
-                     stage_name=stage_name, parallelism=1,
-                     time_window=time_window,
-                     reduce_function=reduce_function)
+    from heron.dsl.src.python.reducebykeyandwindowbolt import ReduceByKeyAndWindowStreamlet
+    return ReduceByKeyAndWindowStreamlet(time_window, reduce_function,
+                                         parents=[self],
+                                         stage_name=stage_name, parallelism=1)
 
   def reduceByKeyAndWindow(self, time_window, reduce_function, stage_name=None, parallelism=None):
-    return Streamlet(parents=[self], operation=OperationType.ReduceByKeyAndWindow,
-                     stage_name=stage_name, parallelism=parallelism,
-                     time_window=time_window,
-                     reduce_function=reduce_function)
+    from heron.dsl.src.python.reducebykeyandwindowbolt import ReduceByKeyAndWindowStreamlet
+    return ReduceByKeyAndWindowStreamlet(time_window, reduce_function,
+                                         parents=[self],
+                                         stage_name=stage_name, parallelism=parallelism)
 
   def run(self, name, config=None):
     if name is None or not isinstance(name, str):
@@ -137,169 +100,34 @@ class Streamlet(object):
   def _build(self, bldr, stage_names):
     for parent in self._parents:
       parent._build(bldr, stage_names)
-    self._calculate_inputs()
-    self._calculate_parallelism()
-    return self._build_this(bldr, stage_names)
-
-  # pylint: disable=too-many-branches
-  def _build_this(self, builder, stage_names):
-    if self._operation == OperationType.Input:
-      raise RuntimeError("_build_this called from Input. Did the input implement it")
-    elif self._operation == OperationType.Map:
-      self.check_callable(self._map_function)
-      self._generate_stage_name(stage_names, self._map_function, "map")
-      builder.add_bolt(self._stage_name, MapBolt, par=self._parallelism,
-                       inputs=self._inputs,
-                       config={MapBolt.FUNCTION : self._map_function})
-    elif self._operation == OperationType.FlatMap:
-      self.check_callable(self._flatmap_function)
-      self._generate_stage_name(stage_names, self._flatmap_function, "flatmap")
-      builder.add_bolt(self._stage_name, FlatMapBolt, par=self._parallelism,
-                       inputs=self._inputs,
-                       config={FlatMapBolt.FUNCTION : self._flatmap_function})
-    elif self._operation == OperationType.Filter:
-      self.check_callable(self._filter_function)
-      self._generate_stage_name(stage_names, self._filter_function, "filter")
-      builder.add_bolt(self._stage_name, FilterBolt, par=self._parallelism,
-                       inputs=self._inputs,
-                       config={FilterBolt.FUNCTION : self._filter_function})
-    elif self._operation == OperationType.Sample:
-      if not isinstance(self._sample_fraction, float):
-        raise RuntimeError("Sample Fraction has to be a float")
-      if self._sample_fraction > 1.0:
-        raise RuntimeError("Sample Fraction has to be <= 1.0")
-      self._generate_sample_stage_name(stage_names)
-      builder.add_bolt(self._stage_name, SampleBolt, par=self._parallelism,
-                       inputs=self._inputs,
-                       config={SampleBolt.FRACTION : self._sample_fraction})
-    elif self._operation == OperationType.Join:
-      self._generate_join_stage_name(stage_names)
-      if not isinstance(self._time_window, TimeWindow):
-        raise RuntimeError("Join's time_window should be TimeWindow")
-      builder.add_bolt(self._stage_name, JoinBolt, par=self._parallelism,
-                       inputs=self._inputs,
-                       config={JoinBolt.WINDOWDURATION : self._time_window.duration,
-                               JoinBolt.SLIDEINTERVAL : self._time_window.sliding_interval})
-    elif self._operation == OperationType.Repartition:
-      self._generate_repartition_stage_name(stage_names)
-      builder.add_bolt(self._stage_name, RepartitionBolt, par=self._parallelism,
-                       inputs=self._inputs)
-    elif self._operation == OperationType.ReduceByKeyAndWindow:
-      self.check_callable(self._reduce_function)
-      self._generate_stage_name(stage_names, self._reduce_function, "reducebykeyandwindow")
-      if not isinstance(self._time_window, TimeWindow):
-        raise RuntimeError("ReduceByKeyAndWindow's time_window should be TimeWindow")
-      builder.add_bolt(self._stage_name, ReduceByKeyAndWindowBolt, par=self._parallelism,
-                       inputs=self._inputs,
-                       config={ReduceByKeyAndWindowBolt.FUNCTION : self._reduce_function,
-                               ReduceByKeyAndWindowBolt.WINDOWDURATION : self._time_window.duration,
-                               ReduceByKeyAndWindowBolt.SLIDEINTERVAL :
-                               self._time_window.sliding_interval})
-    else:
-      raise RuntimeError("Unknown type of operator", self._operation)
-
-    return builder
-
-  @staticmethod
-  def check_callable(func):
-    if not callable(func):
-      raise RuntimeError("dsl functions must be callable")
-
-  def _generate_stage_name(self, stage_names, func, functype):
-    if self._stage_name is None:
-      funcname = functype + "-" + func.__name__
-      if funcname not in stage_names:
-        self._stage_name = funcname
-      else:
-        index = 1
-        while funcname in stage_names:
-          index = index + 1
-          funcname = functype + "-" + func.__name__ + str(index)
-        self._stage_name = funcname
-    elif self._stage_name in stage_names:
-      raise RuntimeError("duplicated stage name %s" % self._stage_name)
-    stage_names[self._stage_name] = 1
-
-  def _generate_sample_stage_name(self, stage_names):
-    if self._stage_name is None:
-      self._stage_name = "sample"
-      index = 1
-      while self._stage_name in stage_names:
-        index = index + 1
-        self._stage_name = "sample" + str(index)
-    elif self._stage_name in stage_names:
-      raise RuntimeError("duplicated stage name %s" % self._stage_name)
-    stage_names[self._stage_name] = 1
-
-
-  # pylint: disable=protected-access
-  def _generate_join_stage_name(self, stage_names):
-    stage_name = self._parents[0]._stage_name
-    for stage in self._parents[1:]:
-      stage_name = stage_name + '.join.' + stage._stage_name
-    if stage_name not in stage_names:
-      self._stage_name = stage_name
-    else:
-      index = 1
-      tmp_name = stage_name + str(index)
-      while tmp_name in stage_names:
-        index = index + 1
-        tmp_name = stage_name + str(index)
-      self._stage_name = tmp_name
-    stage_names[self._stage_name] = 1
-
-  def _generate_repartition_stage_name(self, stage_names):
-    stage_name = "repartition"
-    index = 1
-    tmp_name = stage_name
-    while tmp_name in stage_names:
-      index = index + 1
-      tmp_name = stage_name + str(index)
-    self._stage_name = tmp_name
-    stage_names[self._stage_name] = 1
-
-  # pylint: disable=protected-access
-  # pylint: disable=too-many-boolean-expressions
-  def _calculate_parallelism(self):
-    if self._parallelism is not None:
-      return
-    elif self._operation == OperationType.Map or \
-         self._operation == OperationType.FlatMap or \
-         self._operation == OperationType.Filter or \
-         self._operation == OperationType.Sample or \
-         self._operation == OperationType.Join or \
-         self._operation == OperationType.ReduceByKeyAndWindow or \
-         self._operation == OperationType.Output:
-      parallelism = 1
-      for parent in self._parents:
-        if parent._parallelism > parallelism:
-          parallelism = parent._parallelism
-      self._parallelism = parallelism
+    self._inputs = self._calculate_inputs()
     if self._parallelism is None:
-      raise RuntimeError("Missed figuring out parallelism for", self._operation)
+      self._parallelism = self._calculate_parallelism()
+    if self._stage_name is None:
+      self._stage_name = self._calculate_stage_name(stage_names)
+    if self._stage_name in stage_names:
+      raise RuntimeError("duplicated stage name %s" % self._stage_name)
+    stage_names[self._stage_name] = 1
+    self._build_this(bldr)
+    return bldr
+
+  @abstractmethod
+  def _build_this(self, builder):
+    raise RuntimeError("Streamlet's _build_this not implemented")
 
   # pylint: disable=protected-access
-  # pylint: disable=fixme
+  @abstractmethod
+  def _calculate_parallelism(self):
+    parallelism = 1
+    for parent in self._parents:
+      if parent._parallelism > parallelism:
+        parallelism = parent._parallelism
+    return parallelism
+
+  @abstractmethod
   def _calculate_inputs(self):
-    if self._operation == OperationType.Input:
-      self._inputs = None
-    elif self._operation == OperationType.Map or \
-         self._operation == OperationType.FlatMap or \
-         self._operation == OperationType.Filter or \
-         self._operation == OperationType.Sample or \
-         self._operation == OperationType.Repartition:
-      self._inputs = {GlobalStreamId(self._parents[0]._stage_name, self._parents[0]._output) :
-                      Grouping.SHUFFLE}
-    elif self._operation == OperationType.Join:
-      self._inputs = {}
-      for parent in self._parents:
-        self._inputs[GlobalStreamId(parent._stage_name, parent._output)] = \
-                     Grouping.custom("heron.dsl.src.python.joinbolt.JoinGrouping")
-    elif self._operation == OperationType.ReduceByKeyAndWindow:
-      self._inputs = {GlobalStreamId(self._parents[0]._stage_name, self._parents[0]._output) :
-                      Grouping.custom(\
-                      "heron.dsl.src.python.reducebykeyandwindowbolt.ReduceGrouping")}
-    elif self._operation == OperationType.Output:
-      # FIXME:- is this correct
-      self._inputs = {GlobalStreamId(self._parents[0]._stage_name, self._parents[0]._output) :
-                      Grouping.SHUFFLE}
+    raise RuntimeError("Streamlet's calculate inputs not implemented")
+
+  @abstractmethod
+  def _calculate_stage_name(self, existing_stage_names):
+    raise RuntimeError("Streamlet's calculate stage name not implemented")

--- a/heron/spouts/src/python/__init__.py
+++ b/heron/spouts/src/python/__init__.py
@@ -9,5 +9,5 @@ from .fixedlines.fixedlinesspout import FixedLinesSpout
 from .fixedlines.fixedlinesstreamlet import FixedLinesStreamlet
 from .textfiles.textfilespout import TextFileSpout
 from .textfiles.textfilestreamlet import TextFileStreamlet
-from .pulsar.pulsarspout import PulsarSpout
-from .pulsar.pulsarstreamlet import PulsarStreamlet
+# from .pulsar.pulsarspout import PulsarSpout
+# from .pulsar.pulsarstreamlet import PulsarStreamlet

--- a/heron/spouts/src/python/fixedlines/fixedlinesstreamlet.py
+++ b/heron/spouts/src/python/fixedlines/fixedlinesstreamlet.py
@@ -23,7 +23,7 @@ class FixedLinesStreamlet(Streamlet):
   """
   # pylint: disable=no-self-use
   def __init__(self, stage_name=None, parallelism=None):
-    super(FixedLinesStreamlet, self).__init__(operation=OperationType.Input,
+    super(FixedLinesStreamlet, self).__init__(parents=[], operation=OperationType.Input,
                                               stage_name=stage_name,
                                               parallelism=parallelism)
 
@@ -31,16 +31,21 @@ class FixedLinesStreamlet(Streamlet):
   def fixedLinesGenerator(stage_name=None, parallelism=None):
     return FixedLinesStreamlet(stage_name=stage_name, parallelism=parallelism)
 
-  def _build(self, bldr, stage_names):
-    if self._parallelism is None:
-      self._parallelism = 1
-    if self._parallelism < 1:
-      raise RuntimeError("FixedLines parallelism has to be >= 1")
-    if self._stage_name is None:
+  # pylint: disable=no-self-use
+  def _calculate_inputs(self):
+    return {}
+
+  def _calculate_stage_name(self, existing_stage_names):
+    stagename = "fixedlines"
+    if stagename not in existing_stage_names:
+      return stagename
+    else:
       index = 1
-      self._stage_name = "fixedlines"
-      while self._stage_name in stage_names:
+      newname = stagename + str(index)
+      while newname in existing_stage_names:
         index = index + 1
-        self._stage_name = "fixedlines" + str(index)
-      bldr.add_spout(self._stage_name, FixedLinesSpout, par=self._parallelism)
-    return bldr
+        newname = stagename + str(index)
+      return newname
+
+  def _build_this(self, bldr):
+    bldr.add_spout(self._stage_name, FixedLinesSpout, par=self._parallelism)

--- a/heron/spouts/src/python/pulsar/pulsarstreamlet.py
+++ b/heron/spouts/src/python/pulsar/pulsarstreamlet.py
@@ -22,13 +22,13 @@ class PulsarStreamlet(Streamlet):
   """Streamlet facade on top of PulsarSpout"""
   def __init__(self, service_url, topic_name, stage_name=None, parallelism=None,
                receive_timeout_ms=None, input_schema=None):
+    super(PulsarStreamlet, self).__init__(parents=[], operation=OperationType.Input,
+                                          stage_name=stage_name,
+                                          parallelism=parallelism)
     self._pulsar_service_url = service_url
     self._pulsar_topic_name = topic_name
     self._pulsar_receive_timeout_ms = receive_timeout_ms
     self._pulsar_input_schema = input_schema
-    super(PulsarStreamlet, self).__init__(operation=OperationType.Input,
-                                          stage_name=stage_name,
-                                          parallelism=parallelism)
 
   @staticmethod
   def pulsarStreamlet(service_url, topic_name, stage_name=None, parallelism=None,
@@ -41,20 +41,23 @@ class PulsarStreamlet(Streamlet):
                            parallelism=parallelism, receive_timeout_ms=receive_timeout_ms,
                            input_schema=input_schema)
 
-  def _build(self, bldr, stage_names):
-    if self._parallelism is None:
-      self._parallelism = 1
-    if self._stage_name is None:
-      index = 1
-      self._stage_name = "pulsarspout-" + self._pulsar_topic_name
-      while self._stage_name in stage_names:
-        index = index + 1
-        self._stage_name = "pulsarspout-" + self._pulsar_topic_name + str(index)
-      config = {PulsarSpout.serviceUrl : self._pulsar_service_url,
-                PulsarSpout.topicName : self._pulsar_topic_name}
-      if self._pulsar_receive_timeout_ms is not None:
-        config.update({PulsarSpout.receiveTimeoutMs : self._pulsar_receive_timeout_ms})
-      if self._pulsar_input_schema is not None:
-        config.update({PulsarSpout.deserializer : self._pulsar_input_schema})
-      bldr.add_spout(self._stage_name, PulsarSpout, par=self._parallelism, config=config)
-    return bldr
+  # pylint: disable=no-self-use
+  def _calculate_inputs(self):
+    return {}
+
+  def _calculate_stage_name(self, existing_stage_names):
+    index = 1
+    stage_name = "pulsarspout-" + self._pulsar_topic_name
+    while stage_name in existing_stage_names:
+      index = index + 1
+      stage_name = "pulsarspout-" + self._pulsar_topic_name + str(index)
+    return stage_name
+
+  def _build_this(self, bldr):
+    config = {PulsarSpout.serviceUrl : self._pulsar_service_url,
+              PulsarSpout.topicName : self._pulsar_topic_name}
+    if self._pulsar_receive_timeout_ms is not None:
+      config.update({PulsarSpout.receiveTimeoutMs : self._pulsar_receive_timeout_ms})
+    if self._pulsar_input_schema is not None:
+      config.update({PulsarSpout.deserializer : self._pulsar_input_schema})
+    bldr.add_spout(self._stage_name, PulsarSpout, par=self._parallelism, config=config)

--- a/heron/spouts/src/python/textfiles/textfilestreamlet.py
+++ b/heron/spouts/src/python/textfiles/textfilestreamlet.py
@@ -23,25 +23,35 @@ class TextFileStreamlet(Streamlet):
   """A TextFileStreamlet is a list of text input files
   """
   def __init__(self, filepattern, stage_name=None, parallelism=None):
-    self._files = glob.glob(filepattern)
-    super(TextFileStreamlet, self).__init__(operation=OperationType.Input,
+    super(TextFileStreamlet, self).__init__(parents=[], operation=OperationType.Input,
                                             stage_name=stage_name,
                                             parallelism=parallelism)
+    self._files = glob.glob(filepattern)
 
   @staticmethod
   def textFile(filepattern, stage_name=None, parallelism=None):
     return TextFileStreamlet(filepattern, stage_name=stage_name, parallelism=parallelism)
 
-  def _build(self, bldr, stage_names):
-    self._parallelism = len(self._files)
-    if self._parallelism < 1:
-      raise RuntimeError("No matching files")
-    if self._stage_name is None:
+  # pylint: disable=no-self-use
+  def _calculate_inputs(self):
+    return {}
+
+  def _calculate_parallelism(self):
+    return len(self._files)
+
+  # pylint: disable=no-self-use
+  def _calculate_stage_name(self, existing_stage_names):
+    funcname = "textfileinput"
+    if funcname not in existing_stage_names:
+      return funcname
+    else:
       index = 1
-      self._stage_name = "textfileinput"
-      while self._stage_name in stage_names:
+      newfuncname = funcname + "-" + str(index)
+      while newfuncname in existing_stage_names:
         index = index + 1
-        self._stage_name = "textfileinput" + str(index)
-      bldr.add_spout(self._stage_name, TextFileSpout, par=self._parallelism,
-                     config={TextFileSpout.FILES : self._files})
-    return bldr
+        newfuncname = funcname + str(index)
+      return newfuncname
+
+  def _build_this(self, bldr):
+    bldr.add_spout(self._stage_name, TextFileSpout, par=self._parallelism,
+                   config={TextFileSpout.FILES : self._files})


### PR DESCRIPTION
The current DSL code of python has all core logic centralized in streamlet.py. This makes that class too big. It is also harder to add more operators in the future because they now have to modify this class as well. In this pr we have refactored streamlet by establishing interfaces and making the individual operators(like map/flatmap) implement those interfaces.