### PR TITLE
Moved TopologyUtils from spi to common

### DIFF
--- a/heron/common/src/java/com/twitter/heron/common/utils/topology/TopologyTests.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/topology/TopologyTests.java
@@ -1,18 +1,18 @@
-// Copyright 2016 Twitter. All rights reserved.
+//  Copyright 2017 Twitter. All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 
-package com.twitter.heron.spi.utils;
+package com.twitter.heron.common.utils.topology;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/heron/common/src/java/com/twitter/heron/common/utils/topology/TopologyUtils.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/topology/TopologyUtils.java
@@ -1,18 +1,18 @@
-// Copyright 2016 Twitter. All rights reserved.
+//  Copyright 2017 Twitter. All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 
-package com.twitter.heron.spi.utils;
+package com.twitter.heron.common.utils.topology;
 
 import java.io.File;
 import java.io.IOException;

--- a/heron/common/tests/java/BUILD
+++ b/heron/common/tests/java/BUILD
@@ -4,9 +4,12 @@ java_library(
     name = "common-tests",
     srcs = glob(["**/*.java"]),
     deps = [
+        "//heron/proto:proto_topology_java",
+        "//heron/api/src/java:api-java",
         "//heron/common/src/java:basics-java",
         "//heron/common/src/java:config-java",
         "//heron/common/src/java:network-java",
+        "//heron/common/src/java:utils-java",
         "//heron/common/src/java:test-helpers-java",
         "//heron/proto:proto_networktests_java",
         "//third_party/java:powermock",
@@ -29,6 +32,7 @@ java_tests(
         "com.twitter.heron.common.test.HeronServerTest",
         "com.twitter.heron.common.config.ConfigReaderTest",
         "com.twitter.heron.common.config.SystemConfigTest",
+        "com.twitter.heron.common.utils.TopologyUtilsTest",
     ],
     runtime_deps = [
         ":common-tests",

--- a/heron/common/tests/java/com/twitter/heron/common/utils/TopologyUtilsTest.java
+++ b/heron/common/tests/java/com/twitter/heron/common/utils/TopologyUtilsTest.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.twitter.heron.spi.utils;
+package com.twitter.heron.common.utils;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/heron/common/tests/java/com/twitter/heron/common/utils/TopologyUtilsTest.java
+++ b/heron/common/tests/java/com/twitter/heron/common/utils/TopologyUtilsTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 import com.twitter.heron.api.Config;
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.ByteAmount;
+import com.twitter.heron.common.utils.topology.TopologyTests;
+import com.twitter.heron.common.utils.topology.TopologyUtils;
 
 public class TopologyUtilsTest {
   @Test

--- a/heron/healthmgr/tests/java/com/twitter/heron/healthmgr/common/TopologyProviderTest.java
+++ b/heron/healthmgr/tests/java/com/twitter/heron/healthmgr/common/TopologyProviderTest.java
@@ -27,7 +27,7 @@ import com.twitter.heron.api.generated.TopologyAPI.Topology;
 import com.twitter.heron.healthmgr.common.HealthManagerEvents.TopologyUpdate;
 import com.twitter.heron.proto.system.PhysicalPlans;
 import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
-import com.twitter.heron.spi.utils.TopologyTests;
+import com.twitter.heron.common.utils.topology.TopologyTests;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;

--- a/heron/healthmgr/tests/java/com/twitter/heron/healthmgr/resolvers/ScaleUpResolverTest.java
+++ b/heron/healthmgr/tests/java/com/twitter/heron/healthmgr/resolvers/ScaleUpResolverTest.java
@@ -38,7 +38,7 @@ import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Key;
 import com.twitter.heron.spi.packing.IRepacking;
 import com.twitter.heron.spi.packing.PackingPlan;
-import com.twitter.heron.spi.utils.TopologyTests;
+import com.twitter.heron.common.utils.topology.TopologyTests;
 
 import static com.twitter.heron.healthmgr.diagnosers.BaseDiagnoser.DiagnosisName.SYMPTOM_UNDER_PROVISIONING;
 import static com.twitter.heron.healthmgr.sensors.BaseSensor.MetricName.METRIC_BACK_PRESSURE;

--- a/heron/packing/src/java/BUILD
+++ b/heron/packing/src/java/BUILD
@@ -5,6 +5,7 @@ load("/tools/rules/heron_deps", "heron_java_proto_files")
 packing_deps_files = [
     "//heron/spi/src/java:common-spi-java",
     "//heron/common/src/java:basics-java",
+    "//heron/common/src/java:utils-java",
     "//heron/spi/src/java:packing-spi-java",
     "@com_google_guava_guava//jar",
     ":builder",
@@ -32,6 +33,7 @@ java_library(
     srcs = glob(["**/utils/*.java"]),
     deps = heron_java_proto_files() + [
         "//heron/common/src/java:basics-java",
+        "//heron/common/src/java:utils-java",
         "//heron/spi/src/java:common-spi-java",
         "//heron/spi/src/java:packing-spi-java",
         "//heron/spi/src/java:utils-spi-java",

--- a/heron/packing/src/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPacking.java
@@ -23,6 +23,7 @@ import java.util.logging.Logger;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.ByteAmount;
+import com.twitter.heron.common.utils.topology.TopologyUtils;
 import com.twitter.heron.packing.RamRequirement;
 import com.twitter.heron.packing.ResourceExceededException;
 import com.twitter.heron.packing.builder.Container;
@@ -39,7 +40,6 @@ import com.twitter.heron.spi.packing.IRepacking;
 import com.twitter.heron.spi.packing.PackingException;
 import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.packing.Resource;
-import com.twitter.heron.spi.utils.TopologyUtils;
 
 import static com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_MAX_CPU_HINT;
 import static com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_MAX_DISK_HINT;

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
@@ -21,6 +21,7 @@ import java.util.logging.Logger;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.ByteAmount;
+import com.twitter.heron.common.utils.topology.TopologyUtils;
 import com.twitter.heron.packing.ResourceExceededException;
 import com.twitter.heron.packing.builder.Container;
 import com.twitter.heron.packing.builder.ContainerIdScorer;
@@ -35,7 +36,6 @@ import com.twitter.heron.spi.packing.IPacking;
 import com.twitter.heron.spi.packing.IRepacking;
 import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.packing.Resource;
-import com.twitter.heron.spi.utils.TopologyUtils;
 
 import static com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_CPU_REQUESTED;
 import static com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_DISK_REQUESTED;

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
@@ -26,6 +26,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.ByteAmount;
+import com.twitter.heron.common.utils.topology.TopologyUtils;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Context;
 import com.twitter.heron.spi.packing.IPacking;
@@ -33,7 +34,6 @@ import com.twitter.heron.spi.packing.InstanceId;
 import com.twitter.heron.spi.packing.PackingException;
 import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.packing.Resource;
-import com.twitter.heron.spi.utils.TopologyUtils;
 
 /**
  * Round-robin packing algorithm

--- a/heron/packing/src/java/com/twitter/heron/packing/utils/PackingUtils.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/utils/PackingUtils.java
@@ -19,9 +19,9 @@ import java.util.logging.Logger;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.ByteAmount;
+import com.twitter.heron.common.utils.topology.TopologyUtils;
 import com.twitter.heron.spi.packing.PackingException;
 import com.twitter.heron.spi.packing.Resource;
-import com.twitter.heron.spi.utils.TopologyUtils;
 
 /**
  * Shared utilities for packing algorithms

--- a/heron/packing/tests/java/BUILD
+++ b/heron/packing/tests/java/BUILD
@@ -7,7 +7,8 @@ packing_deps_files = [
     "//heron/spi/src/java:packing-spi-java",
     "//heron/packing/src/java:roundrobin-packing",
     "//heron/packing/src/java:binpacking-packing",
-    "//heron/common/src/java:basics-java"
+    "//heron/common/src/java:basics-java",
+    "//heron/common/src/java:utils-java"
 ]
 
 test_deps_files = [
@@ -46,6 +47,7 @@ java_library(
     ),
     deps = [
         "//heron/common/src/java:basics-java",
+        "//heron/common/src/java:utils-java",
         "//heron/packing/src/java:binpacking-packing",
         "//heron/packing/src/java:builder",
         "//heron/packing/src/java:roundrobin-packing",

--- a/heron/packing/tests/java/com/twitter/heron/packing/CommonPackingTests.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/CommonPackingTests.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.common.basics.Pair;
+import com.twitter.heron.common.utils.topology.TopologyTests;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Context;
 import com.twitter.heron.spi.packing.IPacking;
@@ -32,7 +33,6 @@ import com.twitter.heron.spi.packing.PackingException;
 import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.packing.Resource;
 import com.twitter.heron.spi.utils.PackingTestUtils;
-import com.twitter.heron.spi.utils.TopologyTests;
 
 /**
  * There is some common functionality in multiple packing plans. This class contains common tests.

--- a/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPackingTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPackingTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.ByteAmount;
+import com.twitter.heron.common.utils.topology.TopologyUtils;
 import com.twitter.heron.packing.AssertPacking;
 import com.twitter.heron.packing.CommonPackingTests;
 import com.twitter.heron.packing.utils.PackingUtils;
@@ -32,7 +33,6 @@ import com.twitter.heron.spi.packing.IRepacking;
 import com.twitter.heron.spi.packing.PackingException;
 import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.packing.Resource;
-import com.twitter.heron.spi.utils.TopologyUtils;
 
 public class ResourceCompliantRRPackingTest extends CommonPackingTests {
 

--- a/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/RoundRobinPackingTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/RoundRobinPackingTest.java
@@ -22,14 +22,14 @@ import org.junit.Test;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.ByteAmount;
+import com.twitter.heron.common.utils.topology.TopologyTests;
+import com.twitter.heron.common.utils.topology.TopologyUtils;
 import com.twitter.heron.packing.AssertPacking;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.packing.PackingException;
 import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.packing.Resource;
 import com.twitter.heron.spi.utils.PackingTestUtils;
-import com.twitter.heron.spi.utils.TopologyTests;
-import com.twitter.heron.spi.utils.TopologyUtils;
 
 public class RoundRobinPackingTest {
   private static final String BOLT_NAME = "bolt";

--- a/heron/packing/tests/java/com/twitter/heron/packing/utils/PackingUtilsTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/utils/PackingUtilsTest.java
@@ -20,11 +20,11 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.twitter.heron.api.generated.TopologyAPI;
+import com.twitter.heron.common.utils.topology.TopologyTests;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Context;
 import com.twitter.heron.spi.packing.Resource;
 import com.twitter.heron.spi.utils.PackingTestUtils;
-import com.twitter.heron.spi.utils.TopologyTests;
 
 public class PackingUtilsTest {
 

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SchedulerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SchedulerMain.java
@@ -32,6 +32,7 @@ import com.twitter.heron.common.basics.FileUtils;
 import com.twitter.heron.common.basics.SysUtils;
 import com.twitter.heron.common.config.SystemConfig;
 import com.twitter.heron.common.utils.logging.LoggingHelper;
+import com.twitter.heron.common.utils.topology.TopologyUtils;
 import com.twitter.heron.proto.system.PackingPlans;
 import com.twitter.heron.scheduler.server.SchedulerServer;
 import com.twitter.heron.scheduler.utils.LauncherUtils;
@@ -48,7 +49,6 @@ import com.twitter.heron.spi.scheduler.IScheduler;
 import com.twitter.heron.spi.statemgr.IStateManager;
 import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
 import com.twitter.heron.spi.utils.ReflectionUtils;
-import com.twitter.heron.spi.utils.TopologyUtils;
 
 /**
  * Main class of scheduler.

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
@@ -34,6 +34,7 @@ import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.DryRunFormatType;
 import com.twitter.heron.common.basics.SysUtils;
 import com.twitter.heron.common.utils.logging.LoggingHelper;
+import com.twitter.heron.common.utils.topology.TopologyUtils;
 import com.twitter.heron.scheduler.dryrun.SubmitDryRunResponse;
 import com.twitter.heron.scheduler.utils.DryRunRenders;
 import com.twitter.heron.scheduler.utils.LauncherUtils;
@@ -51,7 +52,6 @@ import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
 import com.twitter.heron.spi.uploader.IUploader;
 import com.twitter.heron.spi.uploader.UploaderException;
 import com.twitter.heron.spi.utils.ReflectionUtils;
-import com.twitter.heron.spi.utils.TopologyUtils;
 
 /**
  * Calls Uploader to upload topology package, and Launcher to launch Scheduler.

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
@@ -36,6 +36,7 @@ import com.google.protobuf.Descriptors;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.SysUtils;
+import com.twitter.heron.common.utils.topology.TopologyUtils;
 import com.twitter.heron.proto.system.PackingPlans;
 import com.twitter.heron.proto.system.PhysicalPlans;
 import com.twitter.heron.scheduler.utils.Runtime;
@@ -49,7 +50,6 @@ import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
 import com.twitter.heron.spi.utils.NetworkUtils;
 import com.twitter.heron.spi.utils.TMasterException;
 import com.twitter.heron.spi.utils.TMasterUtils;
-import com.twitter.heron.spi.utils.TopologyUtils;
 
 import static com.twitter.heron.api.Config.TOPOLOGY_UPDATE_DEACTIVATE_WAIT_SECS;
 import static com.twitter.heron.api.Config.TOPOLOGY_UPDATE_REACTIVATE_WAIT_SECS;

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/LauncherUtils.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/LauncherUtils.java
@@ -18,6 +18,7 @@ import java.util.logging.Logger;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.SysUtils;
+import com.twitter.heron.common.utils.topology.TopologyUtils;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Context;
 import com.twitter.heron.spi.common.Key;
@@ -28,7 +29,6 @@ import com.twitter.heron.spi.scheduler.IScheduler;
 import com.twitter.heron.spi.scheduler.SchedulerException;
 import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
 import com.twitter.heron.spi.utils.ReflectionUtils;
-import com.twitter.heron.spi.utils.TopologyUtils;
 
 /**
  * {@link LauncherUtils} contains helper methods used by the server and client side launch

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/SchedulerUtils.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/SchedulerUtils.java
@@ -26,6 +26,7 @@ import javax.xml.bind.DatatypeConverter;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.FileUtils;
+import com.twitter.heron.common.utils.topology.TopologyUtils;
 import com.twitter.heron.proto.scheduler.Scheduler;
 import com.twitter.heron.proto.system.Common;
 import com.twitter.heron.spi.common.Config;
@@ -35,7 +36,6 @@ import com.twitter.heron.spi.packing.PackingPlanProtoSerializer;
 import com.twitter.heron.spi.scheduler.IScheduler;
 import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
 import com.twitter.heron.spi.utils.ShellUtils;
-import com.twitter.heron.spi.utils.TopologyUtils;
 
 public final class SchedulerUtils {
   public static final int PORTS_REQUIRED_FOR_EXECUTOR = 9;

--- a/heron/scheduler-core/tests/java/BUILD
+++ b/heron/scheduler-core/tests/java/BUILD
@@ -7,6 +7,7 @@ common_deps_files = [
     "//third_party/java:powermock",
     "//heron/api/src/java:api-java",
     "//heron/common/src/java:basics-java",
+    "//heron/common/src/java:utils-java",
     "//heron/scheduler-core/src/java:scheduler-java",
     "//third_party/java:junit4",
     "//third_party/java:mockito",

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/SchedulerMainTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/SchedulerMainTest.java
@@ -29,6 +29,8 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.twitter.heron.api.generated.TopologyAPI;
+import com.twitter.heron.common.utils.topology.TopologyTests;
+import com.twitter.heron.common.utils.topology.TopologyUtils;
 import com.twitter.heron.packing.roundrobin.RoundRobinPacking;
 import com.twitter.heron.proto.system.PackingPlans;
 import com.twitter.heron.scheduler.server.SchedulerServer;
@@ -42,8 +44,6 @@ import com.twitter.heron.spi.scheduler.IScheduler;
 import com.twitter.heron.spi.statemgr.IStateManager;
 import com.twitter.heron.spi.utils.PackingTestUtils;
 import com.twitter.heron.spi.utils.ReflectionUtils;
-import com.twitter.heron.spi.utils.TopologyTests;
-import com.twitter.heron.spi.utils.TopologyUtils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/UpdateTopologyManagerTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/UpdateTopologyManagerTest.java
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.twitter.heron.api.generated.TopologyAPI;
+import com.twitter.heron.common.utils.topology.TopologyTests;
 import com.twitter.heron.proto.system.PackingPlans;
 import com.twitter.heron.proto.system.PhysicalPlans;
 import com.twitter.heron.scheduler.UpdateTopologyManager.ContainerDelta;
@@ -56,7 +57,6 @@ import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
 import com.twitter.heron.spi.utils.NetworkUtils;
 import com.twitter.heron.spi.utils.PackingTestUtils;
 import com.twitter.heron.spi.utils.TMasterUtils;
-import com.twitter.heron.spi.utils.TopologyTests;
 
 @RunWith(PowerMockRunner.class)
 public class UpdateTopologyManagerTest {

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/utils/LauncherUtilsTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/utils/LauncherUtilsTest.java
@@ -26,13 +26,13 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.twitter.heron.api.generated.TopologyAPI;
+import com.twitter.heron.common.utils.topology.TopologyUtils;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Key;
 import com.twitter.heron.spi.packing.IPacking;
 import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
 import com.twitter.heron.spi.utils.ReflectionUtils;
-import com.twitter.heron.spi.utils.TopologyUtils;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ReflectionUtils.class, TopologyUtils.class, TopologyAPI.Topology.class})

--- a/heron/schedulers/src/java/BUILD
+++ b/heron/schedulers/src/java/BUILD
@@ -4,6 +4,7 @@ load("/tools/rules/heron_deps", "heron_java_proto_files")
 
 common_deps_files = [
     "//heron/common/src/java:basics-java",
+    "//heron/common/src/java:utils-java",
     "@commons_io_commons_io//jar",
     "@com_google_guava_guava//jar",
 ]

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
@@ -30,6 +30,7 @@ import com.google.common.base.Optional;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.FileUtils;
+import com.twitter.heron.common.utils.topology.TopologyUtils;
 import com.twitter.heron.proto.scheduler.Scheduler;
 import com.twitter.heron.scheduler.UpdateTopologyManager;
 import com.twitter.heron.scheduler.utils.Runtime;
@@ -41,7 +42,6 @@ import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.packing.Resource;
 import com.twitter.heron.spi.scheduler.IScalable;
 import com.twitter.heron.spi.scheduler.IScheduler;
-import com.twitter.heron.spi.utils.TopologyUtils;
 
 public class AuroraScheduler implements IScheduler, IScalable {
   private static final Logger LOG = Logger.getLogger(AuroraLauncher.class.getName());

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/HeronExecutorTask.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/yarn/HeronExecutorTask.java
@@ -33,6 +33,7 @@ import org.apache.reef.wake.EventHandler;
 
 import com.twitter.heron.api.generated.TopologyAPI.Topology;
 import com.twitter.heron.common.basics.SysUtils;
+import com.twitter.heron.common.utils.topology.TopologyUtils;
 import com.twitter.heron.scheduler.utils.SchedulerConfigUtils;
 import com.twitter.heron.scheduler.utils.SchedulerUtils;
 import com.twitter.heron.scheduler.yarn.HeronConfigurationOptions.Cluster;
@@ -48,7 +49,6 @@ import com.twitter.heron.scheduler.yarn.HeronConfigurationOptions.VerboseLogMode
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Key;
 import com.twitter.heron.spi.utils.ShellUtils;
-import com.twitter.heron.spi.utils.TopologyUtils;
 
 @Unit
 public class HeronExecutorTask implements Task {

--- a/heron/schedulers/tests/java/BUILD
+++ b/heron/schedulers/tests/java/BUILD
@@ -6,6 +6,7 @@ common_deps_files = [
     "//third_party/java:powermock",
     "//heron/api/src/java:api-java",
     "//heron/common/src/java:basics-java",
+    "//heron/common/src/java:utils-java",
     "//heron/scheduler-core/src/java:scheduler-java",
     "//third_party/java:junit4",
     "//third_party/java:mockito",

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraSchedulerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraSchedulerTest.java
@@ -38,6 +38,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.ByteAmount;
+import com.twitter.heron.common.utils.topology.TopologyTests;
 import com.twitter.heron.proto.scheduler.Scheduler;
 import com.twitter.heron.proto.system.PackingPlans;
 import com.twitter.heron.scheduler.SubmitterMain;
@@ -48,7 +49,6 @@ import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.packing.Resource;
 import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
 import com.twitter.heron.spi.utils.PackingTestUtils;
-import com.twitter.heron.spi.utils.TopologyTests;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/heron/simulator/src/java/com/twitter/heron/simulator/Simulator.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/Simulator.java
@@ -29,12 +29,12 @@ import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.common.basics.SingletonRegistry;
 import com.twitter.heron.common.config.SystemConfig;
 import com.twitter.heron.common.config.SystemConfigKey;
+import com.twitter.heron.common.utils.topology.TopologyUtils;
 import com.twitter.heron.proto.system.PhysicalPlans;
 import com.twitter.heron.simulator.executors.InstanceExecutor;
 import com.twitter.heron.simulator.executors.MetricsExecutor;
 import com.twitter.heron.simulator.executors.StreamExecutor;
 import com.twitter.heron.simulator.utils.PhysicalPlanUtil;
-import com.twitter.heron.spi.utils.TopologyUtils;
 
 /**
  * One Simulator instance can only submit one topology. Please have multiple Simulator instances

--- a/heron/spi/src/java/BUILD
+++ b/heron/spi/src/java/BUILD
@@ -30,6 +30,7 @@ java_library(
         "//heron/api/src/java:classification",
         "//heron/common/src/java:basics-java",
         "//heron/common/src/java:config-java",
+        "//heron/common/src/java:utils-java",
         "//heron/proto:proto_common_java",
         "//heron/proto:proto_execution_state_java",
         "//heron/proto:proto_scheduler_java",
@@ -54,6 +55,7 @@ utils_deps_files = \
         ":metricsmgr-spi-java",
         "//heron/common/src/java:basics-java",
         "//heron/common/src/java:config-java",
+        "//heron/common/src/java:utils-java",
         "//heron/api/src/java:api-java",
         "@com_google_guava_guava//jar",
     ]

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/PackingTestUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/PackingTestUtils.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.common.basics.Pair;
+import com.twitter.heron.common.utils.topology.TopologyTests;
 import com.twitter.heron.proto.system.PackingPlans;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Key;

--- a/heron/spi/tests/java/BUILD
+++ b/heron/spi/tests/java/BUILD
@@ -42,7 +42,6 @@ java_tests(
     test_classes = [
         "com.twitter.heron.spi.utils.ShellUtilsTest",
         "com.twitter.heron.spi.utils.NetworkUtilsTest",
-        "com.twitter.heron.spi.utils.TopologyUtilsTest",
         "com.twitter.heron.spi.utils.UploaderUtilsTest",
     ],
     runtime_deps = [ ":utils-tests" ],

--- a/heron/tools/apiserver/src/java/BUILD
+++ b/heron/tools/apiserver/src/java/BUILD
@@ -5,6 +5,7 @@ load("/tools/rules/heron_deps", "heron_java_proto_files")
 api_deps_files = [
   "//heron/spi/src/java:heron-spi",
   "//heron/common/src/java:basics-java",
+  "//heron/common/src/java:utils-java",
 ]
 
 scheduler_deps_files = [

--- a/heron/tools/apiserver/src/java/com/twitter/heron/apiserver/actions/ActionFactoryImpl.java
+++ b/heron/tools/apiserver/src/java/com/twitter/heron/apiserver/actions/ActionFactoryImpl.java
@@ -15,8 +15,8 @@ package com.twitter.heron.apiserver.actions;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.apiserver.utils.ConfigUtils;
+import com.twitter.heron.common.utils.topology.TopologyUtils;
 import com.twitter.heron.spi.common.Config;
-import com.twitter.heron.spi.utils.TopologyUtils;
 
 public class ActionFactoryImpl implements ActionFactory {
 


### PR DESCRIPTION
TopologyUtils really is a generic functionality that should belong to the common/utils.