### PR TITLE
Move over from using iteritems to items since its more python3 friendly

### DIFF
--- a/heron/api/src/python/component/component_spec.py
+++ b/heron/api/src/python/component/component_spec.py
@@ -108,7 +108,7 @@ class HeronComponentSpec(object):
     # iterate through self.custom_config
     if self.custom_config is not None:
       sanitized = self._sanitize_config(self.custom_config)
-      for key, value in sanitized.iteritems():
+      for key, value in sanitized.items():
         if isinstance(value, str):
           kvs = proto_config.kvs.add()
           kvs.key = key
@@ -142,7 +142,7 @@ class HeronComponentSpec(object):
       raise TypeError("Component-specific configuration must be given as a dict type, given: %s"
                       % str(type(custom_config)))
     sanitized = {}
-    for key, value in custom_config.iteritems():
+    for key, value in custom_config.items():
       if not isinstance(key, str):
         raise TypeError("Key for component-specific configuration must be string, given: %s:%s"
                         % (str(type(key)), str(key)))
@@ -163,7 +163,7 @@ class HeronComponentSpec(object):
     # sanitize inputs and get a map <GlobalStreamId -> Grouping>
     input_dict = self._sanitize_inputs()
 
-    for global_streamid, gtype in input_dict.iteritems():
+    for global_streamid, gtype in input_dict.items():
       in_stream = bolt.inputs.add()
       in_stream.stream.CopyFrom(self._get_stream_id(global_streamid.component_id,
                                                     global_streamid.stream_id))
@@ -189,7 +189,7 @@ class HeronComponentSpec(object):
     if isinstance(self.inputs, dict):
       # inputs are dictionary, must be either <HeronComponentSpec -> Grouping> or
       # <GlobalStreamId -> Grouping>
-      for key, grouping in self.inputs.iteritems():
+      for key, grouping in self.inputs.items():
         if not Grouping.is_grouping_sane(grouping):
           raise ValueError('A given grouping is not supported')
         if isinstance(key, HeronComponentSpec):
@@ -232,7 +232,7 @@ class HeronComponentSpec(object):
     # sanitize outputs and get a map <stream_id -> out fields>
     output_map = self._sanitize_outputs()
 
-    for stream_id, out_fields in output_map.iteritems():
+    for stream_id, out_fields in output_map.items():
       out_stream = spbl.outputs.add()
       out_stream.stream.CopyFrom(self._get_stream_id(self.name, stream_id))
       out_stream.schema.CopyFrom(self._get_stream_schema(out_fields))

--- a/heron/api/src/python/metrics.py
+++ b/heron/api/src/python/metrics.py
@@ -56,7 +56,7 @@ class MultiCountMetric(IMetric):
 
   def get_value_and_reset(self):
     ret = {}
-    for key, value in self.value.iteritems():
+    for key, value in self.value.items():
       ret[key] = value.get_value_and_reset()
     return ret
 
@@ -137,7 +137,7 @@ class MultiReducedMetric(IMetric):
 
   def get_value_and_reset(self):
     ret = {}
-    for key, value in self.value.iteritems():
+    for key, value in self.value.items():
       ret[key] = value.get_value_and_reset()
       self.value[key] = value
     return ret

--- a/heron/api/src/python/topology.py
+++ b/heron/api/src/python/topology.py
@@ -65,7 +65,7 @@ class TopologyType(type):
     """Takes a class `__dict__` and returns `HeronComponentSpec` entries"""
     specs = {}
 
-    for name, spec in class_dict.iteritems():
+    for name, spec in class_dict.items():
       if isinstance(spec, HeronComponentSpec):
         # Use the variable name as the specification name.
         if spec.name is None:
@@ -95,7 +95,7 @@ class TopologyType(type):
     # add defaults
     topo_config.update(mcs.DEFAULT_TOPOLOGY_CONFIG)
 
-    for name, custom_config in class_dict.iteritems():
+    for name, custom_config in class_dict.items():
       if name == 'config' and isinstance(custom_config, dict):
         sanitized_dict = mcs._sanitize_config(custom_config)
         topo_config.update(sanitized_dict)
@@ -123,7 +123,7 @@ class TopologyType(type):
     config = topology_pb2.Config()
     conf_dict = class_dict['_topo_config']
 
-    for key, value in conf_dict.iteritems():
+    for key, value in conf_dict.items():
       if isinstance(value, str):
         kvs = config.kvs.add()
         kvs.key = key
@@ -234,7 +234,7 @@ class TopologyType(type):
       These values will need to be serialized before adding to a protobuf message.
     """
     sanitized = {}
-    for key, value in custom_config.iteritems():
+    for key, value in custom_config.items():
       if not isinstance(key, str):
         raise TypeError("Key for topology-wide configuration must be string, given: %s: %s"
                         % (str(type(key)), str(key)))

--- a/heron/common/src/python/utils/metrics/metrics_helper.py
+++ b/heron/common/src/python/utils/metrics/metrics_helper.py
@@ -33,7 +33,7 @@ class BaseMetricsHelper(object):
 
   def register_metrics(self, metrics_collector, interval):
     """Registers its metrics to a given metrics collector with a given interval"""
-    for field, metrics in self.metrics.iteritems():
+    for field, metrics in self.metrics.items():
       metrics_collector.register_metric(field, metrics, interval)
 
   def update_count(self, name, incr_by=1, key=None):
@@ -371,7 +371,7 @@ class MetricsCollector(object):
     if metric_value is None:
       return
     elif isinstance(metric_value, dict):
-      for key, value in metric_value.iteritems():
+      for key, value in metric_value.items():
         if key is not None and value is not None:
           self._add_data_to_message(message, name + "/" + str(key), value)
           self._add_data_to_message(message, "%s/%s" % (name, str(key)), value)

--- a/heron/common/src/python/utils/misc/custom_grouping_helper.py
+++ b/heron/common/src/python/utils/misc/custom_grouping_helper.py
@@ -38,7 +38,7 @@ class CustomGroupingHelper(object):
 
   def prepare(self, context):
     """Prepares the custom grouping for this component"""
-    for stream_id, targets in self.targets.iteritems():
+    for stream_id, targets in self.targets.items():
       for target in targets:
         target.prepare(context, stream_id)
 

--- a/heron/common/src/python/utils/topology/topology_context_impl.py
+++ b/heron/common/src/python/utils/topology/topology_context_impl.py
@@ -103,7 +103,7 @@ class TopologyContextImpl(TopologyContext):
   def get_component_tasks(self, component_id):
     """Returns the task ids allocated for the given component id"""
     ret = []
-    for task_id, comp_id in self.task_to_component_map.iteritems():
+    for task_id, comp_id in self.task_to_component_map.items():
       if comp_id == component_id:
         ret.append(task_id)
     return ret

--- a/heron/common/tests/python/mock_protobuf.py
+++ b/heron/common/tests/python/mock_protobuf.py
@@ -31,7 +31,7 @@ def get_mock_config(config_dict=None):
   proto_config = topology_pb2.Config()
   config_serializer = PythonSerializer()
   assert isinstance(config_dict, dict)
-  for key, value in config_dict.iteritems():
+  for key, value in config_dict.items():
     if isinstance(value, bool):
       kvs = proto_config.kvs.add()
       kvs.key = key

--- a/heron/common/tests/python/utils/metrics_helper_unittest.py
+++ b/heron/common/tests/python/utils/metrics_helper_unittest.py
@@ -38,7 +38,7 @@ class BaseMetricsHelperTest(unittest.TestCase):
 
   def test_register_metrics(self):
     self.metrics_helper.register_metrics(self.metrics_collector, 60)
-    for name, metric in self.metrics.iteritems():
+    for name, metric in self.metrics.items():
       self.assertEqual(self.metrics_collector.metrics_map[name], metric)
     self.assertEqual(len(self.metrics_collector.time_bucket_in_sec_to_metrics_name[60]), 4)
     self.assertIn(60, self.metrics_collector.registered_timers)

--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -720,7 +720,7 @@ class HeronExecutor(object):
   def _kill_processes(self, commands):
     # remove the command from processes_to_monitor and kill the process
     with self.process_lock:
-      for command_name, command in commands.iteritems():
+      for command_name, command in commands.items():
         for process_info in self.processes_to_monitor.values():
           if process_info.name == command_name:
             del self.processes_to_monitor[process_info.pid]
@@ -808,7 +808,7 @@ class HeronExecutor(object):
 
     # if the current command has a matching command in the updated commands we keep it
     # otherwise we kill it
-    for current_name, current_command in current_commands.iteritems():
+    for current_name, current_command in current_commands.items():
       # We don't restart tmaster since it watches the packing plan and updates itself. The stream
       # manager is restarted just to reset state, but we could update it to do so without a restart
       if current_name in updated_commands.keys() and \
@@ -819,7 +819,7 @@ class HeronExecutor(object):
         commands_to_kill[current_name] = current_command
 
     # updated commands not in the keep list need to be started
-    for updated_name, updated_command in updated_commands.iteritems():
+    for updated_name, updated_command in updated_commands.items():
       if updated_name not in commands_to_keep.keys():
         commands_to_start[updated_name] = updated_command
 

--- a/heron/instance/src/python/basics/spout_instance.py
+++ b/heron/instance/src/python/basics/spout_instance.py
@@ -297,7 +297,9 @@ class SpoutInstance(BaseInstance):
     now = time.time()
 
     timeout_lst = []
-    for key, tuple_info in self.in_flight_tuples.iteritems():
+    while self.in_flight_tuples:
+      key = next(iter(self.in_flight_tuples))
+      tuple_info = self.in_flight_tuples[key]
       if tuple_info.is_expired(now, timeout_sec):
         timeout_lst.append(tuple_info)
         self.in_flight_tuples.pop(key)

--- a/heron/statemgrs/src/python/filestatemanager.py
+++ b/heron/statemgrs/src/python/filestatemanager.py
@@ -92,7 +92,7 @@ class FileStateManager(StateManager):
       For all the topologies in the watchers, check if the data
       in directory has changed. Trigger the callback if it has.
       """
-      for topology, callbacks in watchers.iteritems():
+      for topology, callbacks in watchers.items():
         file_path = os.path.join(path, topology)
         data = ""
         if os.path.exists(file_path):

--- a/heron/tools/cli/src/python/cli_helper.py
+++ b/heron/tools/cli/src/python/cli_helper.py
@@ -51,7 +51,7 @@ def create_parser(subparsers, action, help_arg):
 ################################################################################
 def flatten_args(fargs):
   temp_args = []
-  for k, v in fargs.iteritems():
+  for k, v in fargs.items():
     if isinstance(v, list):
       temp_args.extend([(k, value) for value in v])
     else:

--- a/heron/tools/common/src/python/access/heron_api.py
+++ b/heron/tools/common/src/python/access/heron_api.py
@@ -376,7 +376,7 @@ def get_comp_instance_metrics(cluster, environ, topology, component,
   all_instances = instances if isinstance(instances, list) else [instances]
 
   # append each metric to the url
-  for _, metric_name in metrics.iteritems():
+  for _, metric_name in metrics.items():
     request_url = tornado.httputil.url_concat(request_url, dict(metricname=metric_name[0]))
 
   # append each instance to the url

--- a/heron/tools/explorer/src/python/logicalplan.py
+++ b/heron/tools/explorer/src/python/logicalplan.py
@@ -55,9 +55,9 @@ def parse_topo_loc(cl_args):
 def to_table(components, topo_info):
   """ normalize raw logical plan info to table """
   inputs, outputs = defaultdict(list), defaultdict(list)
-  for ctype, component in components.iteritems():
+  for ctype, component in components.items():
     if ctype == 'bolts':
-      for component_name, component_info in component.iteritems():
+      for component_name, component_info in component.items():
         for input_stream in component_info['inputs']:
           input_name = input_stream['component_name']
           inputs[component_name].append(input_name)
@@ -65,8 +65,8 @@ def to_table(components, topo_info):
   info = []
   spouts_instance = topo_info['physical_plan']['spouts']
   bolts_instance = topo_info['physical_plan']['bolts']
-  for ctype, component in components.iteritems():
-    for component_name, component_info in component.iteritems():
+  for ctype, component in components.items():
+    for component_name, component_info in component.items():
       row = [ctype[:-1], component_name]
       if ctype == 'spouts':
         row.append(len(spouts_instance[component_name]))

--- a/heron/tools/explorer/src/python/topologies.py
+++ b/heron/tools/explorer/src/python/topologies.py
@@ -37,8 +37,8 @@ def to_table(result):
   ''' normalize raw result to table '''
   max_count = 20
   table, count = [], 0
-  for role, envs_topos in result.iteritems():
-    for env, topos in envs_topos.iteritems():
+  for role, envs_topos in result.items():
+    for env, topos in envs_topos.items():
       for topo in topos:
         count += 1
         if count > max_count:

--- a/heron/tools/tracker/src/python/config.py
+++ b/heron/tools/tracker/src/python/config.py
@@ -54,7 +54,7 @@ class Config(object):
         "${USER}": "user",
     }
     dummy_formatted_viz_url = viz_url_format
-    for key, value in valid_parameters.iteritems():
+    for key, value in valid_parameters.items():
       dummy_formatted_viz_url = dummy_formatted_viz_url.replace(key, value)
 
     # All $ signs must have been replaced
@@ -81,7 +81,7 @@ class Config(object):
 
     formatted_viz_url = self.viz_url_format
 
-    for key, value in valid_parameters.iteritems():
+    for key, value in valid_parameters.items():
       formatted_viz_url = formatted_viz_url.replace(key, value)
 
     return formatted_viz_url

--- a/heron/tools/tracker/src/python/handlers/runtimestatehandler.py
+++ b/heron/tools/tracker/src/python/handlers/runtimestatehandler.py
@@ -108,7 +108,7 @@ class RuntimeStateHandler(BaseHandler):
       topology = self.tracker.getTopologyByClusterRoleEnvironAndName(
           cluster, role, environ, topology_name)
       reg_summary = yield tornado.gen.Task(self.getStmgrsRegSummary, topology.tmaster)
-      for stmgr, reg in reg_summary.iteritems():
+      for stmgr, reg in reg_summary.items():
         runtime_state["stmgrs"].setdefault(stmgr, {})["is_registered"] = reg
       self.write_success_response(runtime_state)
     except Exception as e:

--- a/heron/tools/tracker/src/python/query_operators.py
+++ b/heron/tools/tracker/src/python/query_operators.py
@@ -37,7 +37,7 @@ class Metrics(object):
   def floorTimestamps(self, start, end, timeline):
     """ floor timestamp """
     ret = {}
-    for timestamp, value in timeline.iteritems():
+    for timestamp, value in timeline.items():
       ts = timestamp / 60 * 60
       if start <= ts <= end:
         ret[ts] = value
@@ -126,9 +126,9 @@ class TS(Operator):
       }
     timelines = metrics["timeline"][self.metricName]
     allMetrics = []
-    for instance, timeline in timelines.iteritems():
+    for instance, timeline in timelines.items():
       toBeDeletedKeys = []
-      for key, value in timeline.iteritems():
+      for key, value in timeline.items():
         floatValue = float(value)
         # Check if the value is really float or not.
         # In python, float("nan") returns "nan" which is actually a float value,
@@ -208,7 +208,7 @@ class Sum(Operator):
 
     # Aggregate all of the them
     for metric in allMetrics:
-      for timestamp, value in metric.timeline.iteritems():
+      for timestamp, value in metric.timeline.items():
         if timestamp in retMetrics.timeline:
           retMetrics.timeline[timestamp] += value
     raise tornado.gen.Return([retMetrics])
@@ -252,7 +252,7 @@ class Max(Operator):
 
     # Aggregate all of the them
     for metric in allMetrics:
-      for timestamp, value in metric.timeline.iteritems():
+      for timestamp, value in metric.timeline.items():
         if start <= timestamp <= end:
           if timestamp not in retMetrics.timeline:
             retMetrics.timeline[timestamp] = value
@@ -306,14 +306,14 @@ class Percentile(Operator):
 
     # Aggregate all of the them
     for metric in allMetrics:
-      for timestamp, value in metric.timeline.iteritems():
+      for timestamp, value in metric.timeline.items():
         if start <= timestamp <= end:
           if timestamp not in timeline:
             timeline[timestamp] = []
           timeline[timestamp].append(value)
 
     retTimeline = {}
-    for timestamp, values in timeline.iteritems():
+    for timestamp, values in timeline.items():
       if not values:
         continue
       index = int(self.quantile * 1.0 * (len(values) - 1) / 100.0)
@@ -423,7 +423,7 @@ class Divide(Operator):
     # If first is univariate
     elif len(metrics) == 1 and "" in metrics:
       allMetrics = []
-      for key, metric in metrics2.iteritems():
+      for key, metric in metrics2.items():
         # Initialize with first metrics timeline, but second metric's instance
         # because that is multivariate
         met = Metrics(None, None, metric.instance, start, end, dict(metrics[""].timeline))
@@ -437,7 +437,7 @@ class Divide(Operator):
     # If second is univariate
     else:
       allMetrics = []
-      for key, metric in metrics.iteritems():
+      for key, metric in metrics.items():
         # Initialize with first metrics timeline and its instance
         met = Metrics(None, None, metric.instance, start, end, dict(metric.timeline))
         for timestamp in met.timeline.keys():
@@ -548,7 +548,7 @@ class Multiply(Operator):
     # If first is univariate
     elif len(metrics) == 1 and "" in metrics:
       allMetrics = []
-      for key, metric in metrics2.iteritems():
+      for key, metric in metrics2.items():
         # Initialize with first metrics timeline, but second metric's instance
         # because that is multivariate
         met = Metrics(None, None, metric.instance, start, end, dict(metrics[""].timeline))
@@ -562,7 +562,7 @@ class Multiply(Operator):
     # If second is univariate
     else:
       allMetrics = []
-      for key, metric in metrics.iteritems():
+      for key, metric in metrics.items():
         # Initialize with first metrics timeline and its instance
         met = Metrics(None, None, metric.instance, start, end, dict(metric.timeline))
         for timestamp in met.timeline.keys():
@@ -671,7 +671,7 @@ class Subtract(Operator):
     # If first is univariate
     elif len(metrics) == 1 and "" in metrics:
       allMetrics = []
-      for key, metric in metrics2.iteritems():
+      for key, metric in metrics2.items():
         # Initialize with first metrics timeline, but second metric's instance
         # because that is multivariate
         met = Metrics(None, None, metric.instance, start, end, dict(metrics[""].timeline))
@@ -685,7 +685,7 @@ class Subtract(Operator):
     # If second is univariate
     else:
       allMetrics = []
-      for key, metric in metrics.iteritems():
+      for key, metric in metrics.items():
         # Initialize with first metrics timeline and its instance
         met = Metrics(None, None, metric.instance, start, end, dict(metric.timeline))
         for timestamp in met.timeline.keys():

--- a/heron/tools/tracker/src/python/topology.py
+++ b/heron/tools/tracker/src/python/topology.py
@@ -100,7 +100,7 @@ class Topology(object):
     unregister the corresponding watch.
     """
     to_remove = []
-    for uid, callback in self.watches.iteritems():
+    for uid, callback in self.watches.items():
       try:
         callback(self)
       except Exception as e:

--- a/heron/tools/tracker/src/python/tracker.py
+++ b/heron/tools/tracker/src/python/tracker.py
@@ -502,7 +502,7 @@ class Tracker(object):
     Raises exception if no such topology is found.
     """
     # Iterate over the values to filter the desired topology.
-    for (topology_name, _), topologyInfo in self.topologyInfos.iteritems():
+    for (topology_name, _), topologyInfo in self.topologyInfos.items():
       executionState = topologyInfo["execution_state"]
       if (topologyName == topology_name and
           cluster == executionState["cluster"] and

--- a/heron/tools/ui/src/python/handlers/api/topology.py
+++ b/heron/tools/ui/src/python/handlers/api/topology.py
@@ -89,11 +89,11 @@ class ListTopologiesJsonHandler(base.BaseHandler):
     result = dict()
 
     # now convert some of the fields to be displayable
-    for cluster, cluster_value in topologies.iteritems():
+    for cluster, cluster_value in topologies.items():
       result[cluster] = dict()
-      for environ, environ_value in cluster_value.iteritems():
+      for environ, environ_value in cluster_value.items():
         result[cluster][environ] = dict()
-        for topology, topology_value in environ_value.iteritems():
+        for topology, topology_value in environ_value.items():
           if "jobname" not in topology_value or topology_value["jobname"] is None:
             continue
 

--- a/heron/tools/ui/src/python/handlers/ranges.py
+++ b/heron/tools/ui/src/python/handlers/ranges.py
@@ -42,7 +42,7 @@ def get_time_ranges(ranges):
   # form the new
   time_slots = dict()
 
-  for key, value in ranges.iteritems():
+  for key, value in ranges.items():
     time_slots[key] = (now - value[0], now - value[1], value[2])
 
   return (now, time_slots)

--- a/third_party/pex/_pex.py
+++ b/third_party/pex/_pex.py
@@ -175,7 +175,7 @@ def main():
             os.path.join(pex_builder.BOOTSTRAP_DIR, 'pkg_resources.py'))
 
         # Add the sources listed in the manifest.
-        for dst, src in manifest['modules'].iteritems():
+        for dst, src in manifest['modules'].items():
             # NOTE(agallagher): calls the `add_source` and `add_resource` below
             # hard-link the given source into the PEX temp dir.  Since OS X and
             # Linux behave different when hard-linking a source that is a
@@ -187,7 +187,7 @@ def main():
                 raise Exception("Failed to add {}: {}".format(src, e))
 
         # Add resources listed in the manifest.
-        for dst, src in manifest['resources'].iteritems():
+        for dst, src in manifest['resources'].items():
             # NOTE(agallagher): see rationale above.
             pex_builder.add_resource(dereference_symlinks(src), dst)
 

--- a/third_party/python/cpplint/cpplint.py
+++ b/third_party/python/cpplint/cpplint.py
@@ -840,7 +840,7 @@ class _CppLintState(object):
 
   def PrintErrorCounts(self):
     """Print a summary of errors by category, and the total."""
-    for category, count in self.errors_by_category.iteritems():
+    for category, count in self.errors_by_category.items():
       sys.stderr.write('Category \'%s\' errors found: %d\n' %
                        (category, count))
     if self.error_count > 0:


### PR DESCRIPTION
Python3 dropped iteritems in favor of items. This pr removes all iteritems usages in heron repository replacing them with items.
One difference between items and iteritems while running in python2 is that items actually materializes the list. However apart from the usage in python instance, all other usages of iteritems actually have lists that are typically very small(usually in 10s of items and never more than 1000). Thus the performance implications are minimal.
For python instance usage, we have refactored the code to using next(iter()) which is equally fast in both python2 and 3.