### PR TITLE
Replace all localhost by 127.0.0.1

### DIFF
--- a/heron/common/src/cpp/metrics/metrics-mgr-st.cpp
+++ b/heron/common/src/cpp/metrics/metrics-mgr-st.cpp
@@ -34,7 +34,7 @@ namespace heron {
 namespace common {
 
 MetricsMgrSt::MetricsMgrSt(sp_int32 _metricsmgr_port, sp_int32 _interval, EventLoop* eventLoop) {
-  options_.set_host("localhost");
+  options_.set_host("127.0.0.1");
   options_.set_port(_metricsmgr_port);
   options_.set_max_packet_size(1024 * 1024);
   options_.set_socket_family(PF_INET);

--- a/heron/common/src/cpp/network/networkoptions.cpp
+++ b/heron/common/src/cpp/network/networkoptions.cpp
@@ -27,7 +27,7 @@ const sp_int64 systemHWMOutstandingBytes = 100_MB;
 const sp_int64 systemLWMOutstandingBytes = 50_MB;
 
 NetworkOptions::NetworkOptions() {
-  host_ = "localhost";
+  host_ = "127.0.0.1";
   port_ = 8080;
   max_packet_size_ = 1_KB;
   socket_family_ = PF_INET;

--- a/heron/common/tests/python/mock_protobuf.py
+++ b/heron/common/tests/python/mock_protobuf.py
@@ -112,7 +112,7 @@ def get_mock_topology(id="topology_id", name="topology_name", state=1, spouts=[]
 
   return topology
 
-def get_mock_stmgr(id="Stmgr_id", host="localhost", port=9999, endpoint="hello"):
+def get_mock_stmgr(id="Stmgr_id", host="127.0.0.1", port=9999, endpoint="hello"):
   """Returns a mock protobuf StMgr object from physical_plan_pb2"""
   stmgr = physical_plan_pb2.StMgr()
   stmgr.id = id

--- a/heron/connectors/pulsar/src/java/com/twitter/heron/connectors/pulsar/PulsarSpout.java
+++ b/heron/connectors/pulsar/src/java/com/twitter/heron/connectors/pulsar/PulsarSpout.java
@@ -48,7 +48,7 @@ import com.twitter.heron.api.tuple.Values;
  * Simple usage:
  *
  * new PulsarSpout.Builder()
- *  .setServiceUrl("pulsar://localhost:6650")
+ *  .setServiceUrl("pulsar://127.0.0.1:6650")
  *  .setTopic("persistent://sample/standalone/ns1/my-topic")
  *  .setSubscription("my-subscription")
  *  .setMessageToValuesMapper(new MyMessageToValuesMapper()

--- a/heron/healthmgr/src/java/com/twitter/heron/healthmgr/HealthManager.java
+++ b/heron/healthmgr/src/java/com/twitter/heron/healthmgr/HealthManager.java
@@ -89,7 +89,7 @@ import com.twitter.heron.spi.utils.ReflectionUtils;
  * <li>config directory: <code> -p ~/.heron/conf</code>, required if mode is local
  * <li>metrics type: <code>-s f.q.class.name</code>,
  * default: <code>com.twitter.heron.healthmgr.sensors.TrackerMetricsProvider</code>
- * <li>metrics source: <code>-t http://host:port</code>, default: <code>http://localhost:8888</code>
+ * <li>metrics source: <code>-t http://host:port</code>, default: <code>http://127.0.0.1:8888</code>
  * <li>enable verbose mode: <code> -v</code>
  * </ul>
  */
@@ -159,7 +159,7 @@ public class HealthManager {
       throw new RuntimeException("Error parsing command line options: ", e);
     }
 
-    String metricsUrl = getOptionValue(cmd, CliArgs.METRIC_SOURCE_URL, "http://localhost:8888");
+    String metricsUrl = getOptionValue(cmd, CliArgs.METRIC_SOURCE_URL, "http://127.0.0.1:8888");
     String metricsProviderClassName = getOptionValue(cmd,
         CliArgs.METRIC_SOURCE_TYPE, "com.twitter.heron.healthmgr.sensors.TrackerMetricsProvider");
 

--- a/heron/healthmgr/tests/java/com/twitter/heron/healthmgr/HealthManagerTest.java
+++ b/heron/healthmgr/tests/java/com/twitter/heron/healthmgr/HealthManagerTest.java
@@ -59,12 +59,12 @@ public class HealthManagerTest {
 
     SchedulerLocation schedulerLocation = SchedulerLocation.newBuilder()
         .setTopologyName(topologyName)
-        .setHttpEndpoint("http://localhost")
+        .setHttpEndpoint("http://127.0.0.1")
         .build();
     when(adaptor.getSchedulerLocation(anyString())).thenReturn(schedulerLocation);
 
     AbstractModule baseModule = HealthManager
-        .buildMetricsProviderModule(config, "localhost", TrackerMetricsProvider.class);
+        .buildMetricsProviderModule(config, "127.0.0.1", TrackerMetricsProvider.class);
 
     HealthManager healthManager = new HealthManager(config, baseModule);
 

--- a/heron/healthmgr/tests/java/com/twitter/heron/healthmgr/sensors/MetricsCacheMetricsProviderTest.java
+++ b/heron/healthmgr/tests/java/com/twitter/heron/healthmgr/sensors/MetricsCacheMetricsProviderTest.java
@@ -211,7 +211,7 @@ public class MetricsCacheMetricsProviderTest {
 
   private MetricsCacheMetricsProvider createMetricsProviderSpy() {
     MetricsCacheMetricsProvider metricsProvider
-        = new MetricsCacheMetricsProvider("localhost");
+        = new MetricsCacheMetricsProvider("127.0.0.1");
 
     MetricsCacheMetricsProvider spyMetricsProvider = spy(metricsProvider);
     spyMetricsProvider.setClock(new TestClock(70000));

--- a/heron/healthmgr/tests/java/com/twitter/heron/healthmgr/sensors/TrackerMetricsProviderTest.java
+++ b/heron/healthmgr/tests/java/com/twitter/heron/healthmgr/sensors/TrackerMetricsProviderTest.java
@@ -151,7 +151,7 @@ public class TrackerMetricsProviderTest {
 
   private TrackerMetricsProvider createMetricsProviderSpy() {
     TrackerMetricsProvider metricsProvider
-        = new TrackerMetricsProvider("localhost", "topology", "dev", "env");
+        = new TrackerMetricsProvider("127.0.0.1", "topology", "dev", "env");
 
     TrackerMetricsProvider spyMetricsProvider = spy(metricsProvider);
     spyMetricsProvider.setClock(new TestClock(70000));

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/NetworkUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/NetworkUtils.java
@@ -43,7 +43,7 @@ import com.twitter.heron.spi.common.Config;
 public final class NetworkUtils {
   private static final String CONTENT_LENGTH = "Content-Length";
   private static final String CONTENT_TYPE = "Content-Type";
-  static final String LOCAL_HOST = "127.0.0.1";
+  static final String LOCAL_HOST = "localhost";
 
   public static final String JSON_TYPE = "application/json";
   public static final String URL_ENCODE_TYPE = "application/x-www-form-urlencoded";
@@ -403,7 +403,7 @@ public final class NetworkUtils {
       hostName = InetAddress.getLocalHost().getHostName();
     } catch (UnknownHostException e) {
       LOG.log(Level.SEVERE, "Unable to get local host name", e);
-      hostName = "127.0.0.1";
+      hostName = "localhost";
     }
 
     return hostName;

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/NetworkUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/NetworkUtils.java
@@ -43,7 +43,7 @@ import com.twitter.heron.spi.common.Config;
 public final class NetworkUtils {
   private static final String CONTENT_LENGTH = "Content-Length";
   private static final String CONTENT_TYPE = "Content-Type";
-  static final String LOCAL_HOST = "localhost";
+  static final String LOCAL_HOST = "127.0.0.1";
 
   public static final String JSON_TYPE = "application/json";
   public static final String URL_ENCODE_TYPE = "application/x-www-form-urlencoded";
@@ -403,7 +403,7 @@ public final class NetworkUtils {
       hostName = InetAddress.getLocalHost().getHostName();
     } catch (UnknownHostException e) {
       LOG.log(Level.SEVERE, "Unable to get local host name", e);
-      hostName = "localhost";
+      hostName = "127.0.0.1";
     }
 
     return hostName;

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/ZkUtils.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/ZkUtils.java
@@ -25,7 +25,7 @@ import com.twitter.heron.spi.common.Context;
 import com.twitter.heron.spi.utils.NetworkUtils;
 
 public final class ZkUtils {
-  public static final String LOCAL_HOST = "localhost";
+  public static final String LOCAL_HOST = "127.0.0.1";
 
   private static final Logger LOG = Logger.getLogger(ZkUtils.class.getName());
 

--- a/heron/statemgrs/src/python/configloader.py
+++ b/heron/statemgrs/src/python/configloader.py
@@ -42,7 +42,7 @@ def load_state_manager_locations(cluster, state_manager_config_file='heron-conf/
   state_manager_location = {
       'type': 'file',
       'name': 'local',
-      'tunnelhost': 'localhost',
+      'tunnelhost': '127.0.0.1',
       'rootpath': '~/.herondata/repository/state/local',
   }
 

--- a/heron/statemgrs/tests/python/configloader_unittest.py
+++ b/heron/statemgrs/tests/python/configloader_unittest.py
@@ -46,7 +46,7 @@ class ConfigLoaderTest(unittest.TestCase):
       'hostport': 'LOCALMODE',
       'name': 'local',
       'rootpath': '/user/fake/.herondata/repository/state/local',
-      'tunnelhost': 'localhost',
+      'tunnelhost': '127.0.0.1',
       'type': 'file'
     }], self.load_locations('local'))
 
@@ -64,7 +64,7 @@ class ConfigLoaderTest(unittest.TestCase):
       'hostport': 'LOCALMODE',
       'name': 'local',
       'rootpath': '/user/fake/.herondata/repository/state/marathon',
-      'tunnelhost': 'localhost',
+      'tunnelhost': '127.0.0.1',
       'type': 'file'
     }], self.load_locations('marathon'))
 
@@ -73,7 +73,7 @@ class ConfigLoaderTest(unittest.TestCase):
       'hostport': 'LOCALMODE',
       'name': 'local',
       'rootpath': '/user/fake/.herondata/repository/state/mesos',
-      'tunnelhost': 'localhost',
+      'tunnelhost': '127.0.0.1',
       'type': 'file'
     }], self.load_locations('mesos'))
 
@@ -82,7 +82,7 @@ class ConfigLoaderTest(unittest.TestCase):
       'hostport': 'LOCALMODE',
       'name': 'local',
       'rootpath': '/user/fake/.herondata/repository/state/slurm',
-      'tunnelhost': 'localhost',
+      'tunnelhost': '127.0.0.1',
       'type': 'file'
     }], self.load_locations('slurm'))
 
@@ -91,6 +91,6 @@ class ConfigLoaderTest(unittest.TestCase):
       'hostport': 'LOCALMODE',
       'name': 'local',
       'rootpath': '/user/fake/.herondata/repository/state/yarn',
-      'tunnelhost': 'localhost',
+      'tunnelhost': '127.0.0.1',
       'type': 'file'
     }], self.load_locations('yarn'))

--- a/heron/statemgrs/tests/python/statemanagerfactory_unittest.py
+++ b/heron/statemgrs/tests/python/statemanagerfactory_unittest.py
@@ -23,13 +23,13 @@ class StateManagerFacotryTest(unittest.TestCase):
   def test_all_zk_supports_comma_separated_hostports(self):
     """Verify that a comma separated list of host ports is ok"""
     conf = Config()
-    conf.set_state_locations([{'type':'zookeeper', 'name':'zk', 'hostport':'localhost:2181,localhost:2281',
-                              'rootpath':'/heron', 'tunnelhost':'localhost'}])
+    conf.set_state_locations([{'type':'zookeeper', 'name':'zk', 'hostport':'127.0.0.1:2181,127.0.0.1:2281',
+                              'rootpath':'/heron', 'tunnelhost':'127.0.0.1'}])
     statemanagers = statemanagerfactory.get_all_zk_state_managers(conf)
     # 1 state_location should result in 1 state manager
     self.assertEquals(1, len(statemanagers))
 
     statemanager = statemanagers[0]
     # statemanager.hostportlist should contain both host port pairs
-    self.assertTrue(('localhost', 2181) in statemanager.hostportlist)
-    self.assertTrue(('localhost', 2281) in statemanager.hostportlist)
+    self.assertTrue(('127.0.0.1', 2181) in statemanager.hostportlist)
+    self.assertTrue(('127.0.0.1', 2281) in statemanager.hostportlist)

--- a/heron/statemgrs/tests/python/zkstatemanager_unittest.py
+++ b/heron/statemgrs/tests/python/zkstatemanager_unittest.py
@@ -36,7 +36,7 @@ class ZkStateManagerTest(unittest.TestCase):
 
   def setUp(self):
     # Create a a ZkStateManager that we will test with
-    self.statemanager = ZkStateManager('zk', [('localhost', 2181), ('localhost', 2281)], 'heron', 'reachable.host')
+    self.statemanager = ZkStateManager('zk', [('127.0.0.1', 2181), ('127.0.0.1', 2281)], 'heron', 'reachable.host')
     # replace creation of a KazooClient
     self.mock_kazoo = ZkStateManagerTest.MockKazooClient()
     self.opened_host_ports = []
@@ -65,7 +65,7 @@ class ZkStateManagerTest(unittest.TestCase):
       return True
     self.statemanager.is_host_port_reachable = connection_check
     self.statemanager.start()
-    self.assertEqual('localhost:2181,localhost:2281',self.opened_host_ports[0])
+    self.assertEqual('127.0.0.1:2181,127.0.0.1:2281',self.opened_host_ports[0])
 
   def test_start_opens_proxy_if_no_connection(self):
     def connection_check():

--- a/heron/stmgr/src/cpp/manager/stmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr.cpp
@@ -279,7 +279,7 @@ void StMgr::StartStmgrServer() {
 void StMgr::CreateCheckpointMgrClient() {
   LOG(INFO) << "Creating CheckpointMgr Client at " << stmgr_host_ << ":" << ckptmgr_port_;
   NetworkOptions client_options;
-  client_options.set_host("localhost");
+  client_options.set_host("127.0.0.1");
   client_options.set_port(ckptmgr_port_);
   client_options.set_socket_family(PF_INET);
   client_options.set_max_packet_size(std::numeric_limits<sp_uint32>::max() - 1);

--- a/heron/stmgr/tests/cpp/server/checkpoint-gateway_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/checkpoint-gateway_unittest.cpp
@@ -225,7 +225,7 @@ TEST(CheckpointGateway, emptyckptid) {
       neighbour_calculator->Reconstruct(*pplan);
       EventLoop* dummyLoop = new EventLoopImpl();
       auto dummy_metrics_client_ = new heron::common::MetricsMgrSt(11001, 100, dummyLoop);
-      dummy_metrics_client_->Start("localhost", 11000, "_stmgr", "_stmgr");
+      dummy_metrics_client_->Start("127.0.0.1", 11000, "_stmgr", "_stmgr");
       auto gateway = new heron::stmgr::CheckpointGateway(1024 * 1024, neighbour_calculator,
                                                          dummy_metrics_client_,
                                                          drainer1, drainer2, drainer3);
@@ -281,7 +281,7 @@ TEST(CheckpointGateway, normaloperation) {
       neighbour_calculator->Reconstruct(*pplan);
       EventLoop* dummyLoop = new EventLoopImpl();
       auto dummy_metrics_client_ = new heron::common::MetricsMgrSt(11001, 100, dummyLoop);
-      dummy_metrics_client_->Start("localhost", 11000, "_stmgr", "_stmgr");
+      dummy_metrics_client_->Start("127.0.0.1", 11000, "_stmgr", "_stmgr");
       auto gateway = new heron::stmgr::CheckpointGateway(1024 * 1024, neighbour_calculator,
                                                          dummy_metrics_client_,
                                                          drainer1, drainer2, drainer3);
@@ -370,7 +370,7 @@ TEST(CheckpointGateway, overflow) {
       neighbour_calculator->Reconstruct(*pplan);
       EventLoop* dummyLoop = new EventLoopImpl();
       auto dummy_metrics_client_ = new heron::common::MetricsMgrSt(11001, 100, dummyLoop);
-      dummy_metrics_client_->Start("localhost", 11000, "_stmgr", "_stmgr");
+      dummy_metrics_client_->Start("127.0.0.1", 11000, "_stmgr", "_stmgr");
       auto gateway = new heron::stmgr::CheckpointGateway(1024 * 1024, neighbour_calculator,
                                                          dummy_metrics_client_,
                                                          drainer1, drainer2, drainer3);

--- a/heron/stmgr/tests/cpp/server/stateful-restorer_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/stateful-restorer_unittest.cpp
@@ -233,7 +233,7 @@ TEST(StatefulRestorer, normalcase) {
   auto ckptmgr_client = CreateDummyCkptMgr(pplan, dummyLoop);
   auto tuple_cache = new DummyTupleCache(dummyLoop);
   auto dummy_metrics_client = new heron::common::MetricsMgrSt(11001, 100, dummyLoop);
-  dummy_metrics_client->Start("localhost", 11000, "_stmgr", "_stmgr");
+  dummy_metrics_client->Start("127.0.0.1", 11000, "_stmgr", "_stmgr");
   auto dummy_stmgr_clientmgr = new DummyStMgrClientMgr(dummyLoop, dummy_metrics_client,
                                                        GenerateStMgrId(1), pplan);
   auto dummy_stmgr_server = CreateDummyStMgrServer(dummyLoop, GenerateStMgrId(1),
@@ -306,7 +306,7 @@ TEST(StatefulRestorer, deadinstances) {
   auto ckptmgr_client = CreateDummyCkptMgr(pplan, dummyLoop);
   auto tuple_cache = new DummyTupleCache(dummyLoop);
   auto dummy_metrics_client = new heron::common::MetricsMgrSt(11001, 100, dummyLoop);
-  dummy_metrics_client->Start("localhost", 11000, "_stmgr", "_stmgr");
+  dummy_metrics_client->Start("127.0.0.1", 11000, "_stmgr", "_stmgr");
   auto dummy_stmgr_clientmgr = new DummyStMgrClientMgr(dummyLoop, dummy_metrics_client,
                                                        GenerateStMgrId(1), pplan);
   auto dummy_stmgr_server = CreateDummyStMgrServer(dummyLoop, GenerateStMgrId(1),
@@ -396,7 +396,7 @@ TEST(StatefulRestorer, deadckptmgr) {
   auto ckptmgr_client = CreateDummyCkptMgr(pplan, dummyLoop);
   auto tuple_cache = new DummyTupleCache(dummyLoop);
   auto dummy_metrics_client = new heron::common::MetricsMgrSt(11001, 100, dummyLoop);
-  dummy_metrics_client->Start("localhost", 11000, "_stmgr", "_stmgr");
+  dummy_metrics_client->Start("127.0.0.1", 11000, "_stmgr", "_stmgr");
   auto dummy_stmgr_clientmgr = new DummyStMgrClientMgr(dummyLoop, dummy_metrics_client,
                                                        GenerateStMgrId(1), pplan);
   dummy_stmgr_clientmgr->SetAllStMgrClientsRegistered(true);

--- a/heron/tmaster/src/cpp/manager/tmaster.cpp
+++ b/heron/tmaster/src/cpp/manager/tmaster.cpp
@@ -321,7 +321,7 @@ void TMaster::GetTopologyDone(proto::system::StatusCode _code) {
       == config::TopologyConfigVars::EXACTLY_ONCE) {
     // Establish connection to ckptmgr
     NetworkOptions ckpt_options;
-    ckpt_options.set_host("localhost");
+    ckpt_options.set_host("127.0.0.1");
     ckpt_options.set_port(ckptmgr_port_);
     ckpt_options.set_max_packet_size(config::HeronInternalsConfigReader::Instance()
                                            ->GetHeronTmasterNetworkMasterOptionsMaximumPacketMb() *

--- a/heron/tools/apiserver/tests/java/com/twitter/heron/apiserver/utils/ConfigUtilsTests.java
+++ b/heron/tools/apiserver/tests/java/com/twitter/heron/apiserver/utils/ConfigUtilsTests.java
@@ -38,7 +38,7 @@ public class ConfigUtilsTests {
   public void testCreateOverrides() throws IOException {
     final Properties overrideProperties = createOverrideProperties(
         Pair.create("heron.statemgr.connection.string", "zookeeper:2181"),
-        Pair.create("heron.kubernetes.scheduler.uri", "http://localhost:8001")
+        Pair.create("heron.kubernetes.scheduler.uri", "http://127.0.0.1:8001")
     );
 
     final String overridesPath = ConfigUtils.createOverrideConfiguration(overrideProperties);
@@ -57,7 +57,7 @@ public class ConfigUtilsTests {
   public void testStateManagerFileOverrides() throws IOException {
     final Properties overrideProperties = createOverrideProperties(
         Pair.create("heron.statemgr.connection.string", "zookeeper:2181"),
-        Pair.create("heron.kubernetes.scheduler.uri", "http://localhost:8001")
+        Pair.create("heron.kubernetes.scheduler.uri", "http://127.0.0.1:8001")
     );
 
     final String overridesPath = ConfigUtils.createOverrideConfiguration(overrideProperties);
@@ -87,7 +87,7 @@ public class ConfigUtilsTests {
   @SuppressWarnings("unchecked")
   public void testNoOverridesAppliedToStateManager() throws IOException {
     final Properties overrideProperties = createOverrideProperties(
-        Pair.create("heron.kubernetes.scheduler.uri", "http://localhost:8001")
+        Pair.create("heron.kubernetes.scheduler.uri", "http://127.0.0.1:8001")
     );
 
     final String overridesPath = ConfigUtils.createOverrideConfiguration(overrideProperties);
@@ -118,7 +118,7 @@ public class ConfigUtilsTests {
   public void testApplyOverrides() throws IOException {
     final Properties overrideProperties = createOverrideProperties(
         Pair.create("heron.statemgr.connection.string", "zookeeper:2181"),
-        Pair.create("heron.kubernetes.scheduler.uri", "http://localhost:8001")
+        Pair.create("heron.kubernetes.scheduler.uri", "http://127.0.0.1:8001")
     );
 
     final String overridesPath = ConfigUtils.createOverrideConfiguration(overrideProperties);
@@ -147,7 +147,7 @@ public class ConfigUtilsTests {
   public void testApplyEmptyOverrides() throws IOException {
     final Properties overrideProperties = createOverrideProperties(
         Pair.create("heron.statemgr.connection.string", "zookeeper:2181"),
-        Pair.create("heron.kubernetes.scheduler.uri", "http://localhost:8001")
+        Pair.create("heron.kubernetes.scheduler.uri", "http://127.0.0.1:8001")
     );
 
     final String overridesPath = ConfigUtils.createOverrideConfiguration(overrideProperties);

--- a/heron/tools/config/src/yaml/tracker/heron_tracker.yaml
+++ b/heron/tools/config/src/yaml/tracker/heron_tracker.yaml
@@ -12,7 +12,7 @@ statemgrs:
     type: "file"
     name: "local"
     rootpath: "~/.herondata/repository/state/local"
-    tunnelhost: "localhost"
+    tunnelhost: "127.0.0.1"
 #
 # To use 'localzk', launch a zookeeper server locally
 # and create the following path:
@@ -21,9 +21,9 @@ statemgrs:
 #  -
 #    type: "zookeeper"
 #    name: "localzk"
-#    hostport: "localhost:2181"
+#    hostport: "127.0.0.1:2181"
 #    rootpath: "/heron"
-#    tunnelhost: "localhost"
+#    tunnelhost: "127.0.0.1"
 
 #
 # To specify multiple Zookeeper Nodes for fallback
@@ -47,4 +47,4 @@ statemgrs:
 #
 # This is a sample, and should be changed to point to corresponding dashboard.
 #
-# viz.url.format: "http://localhost/${CLUSTER}/${ENVIRON}/${TOPOLOGY}/${ROLE}/${USER}"
+# viz.url.format: "http://127.0.0.1/${CLUSTER}/${ENVIRON}/${TOPOLOGY}/${ROLE}/${USER}"

--- a/heron/tools/explorer/src/python/args.py
+++ b/heron/tools/explorer/src/python/args.py
@@ -16,7 +16,7 @@ import os
 import heron.tools.common.src.python.utils.config as config
 
 # default parameter - url to connect to heron tracker
-DEFAULT_TRACKER_URL = "http://localhost:8888"
+DEFAULT_TRACKER_URL = "http://127.0.0.1:8888"
 
 
 # add argument for config file path

--- a/heron/tools/tracker/src/python/constants.py
+++ b/heron/tools/tracker/src/python/constants.py
@@ -82,7 +82,7 @@ DEFAULT_STATE_MANAGER_NAME = "local"
 DEFAULT_STATE_MANAGER_ROOTPATH = "~/.herondata/repository/state/local"
 
 # default parameter - if ssh tunneling needs to be established to connect to it
-DEFAULT_STATE_MANAGER_TUNNELHOST = "localhost"
+DEFAULT_STATE_MANAGER_TUNNELHOST = "127.0.0.1"
 
 # default parameter - only used to connect to zk, must be of the form host:port
-DEFAULT_STATE_MANAGER_HOSTPORT = "localhost:2181"
+DEFAULT_STATE_MANAGER_HOSTPORT = "127.0.0.1:2181"

--- a/heron/tools/ui/src/python/consts.py
+++ b/heron/tools/ui/src/python/consts.py
@@ -21,7 +21,7 @@ DEFAULT_ADDRESS = "0.0.0.0"
 DEFAULT_PORT = 8889
 
 # default parameter - url to connect to heron tracker
-DEFAULT_TRACKER_URL = "http://localhost:8888"
+DEFAULT_TRACKER_URL = "http://127.0.0.1:8888"
 
 DEFAULT_BASE_URL = ""
 

--- a/scripts/packages/BUILD
+++ b/scripts/packages/BUILD
@@ -385,7 +385,7 @@ genrule(
         'export HERON_VERSION=$$(grep version $$RELEASE_FILE_DIR/$(location :release.yaml) | awk \'{print $$3}\')',
         'export HERON_VERSION=$$(echo $$HERON_VERSION | sed -e "s/^\'//" -e "s/\'$$//")',
         'export HERON_VERSION=$$(echo $$HERON_VERSION | grep "[0-9]*\.[0-9]*\.[0-9]*")',
-        'export HERON_VERSION=$$([[ -z $$HERON_VERSION ]] && echo "0.15.1-rc1" || echo $$HERON_VERSION)',
+        'export HERON_VERSION=$$([[ -z $$HERON_VERSION ]] && echo "0.0.0" || echo $$HERON_VERSION)',
         'echo $$HERON_VERSION',
         'mkdir -p $$TMP_DIR $$HERONPY_DIR',
         'unzip -qd $$HERONPYAPI_UNZIP $(location //heron/api/src/python:heron-python-package)',

--- a/scripts/packages/BUILD
+++ b/scripts/packages/BUILD
@@ -385,7 +385,7 @@ genrule(
         'export HERON_VERSION=$$(grep version $$RELEASE_FILE_DIR/$(location :release.yaml) | awk \'{print $$3}\')',
         'export HERON_VERSION=$$(echo $$HERON_VERSION | sed -e "s/^\'//" -e "s/\'$$//")',
         'export HERON_VERSION=$$(echo $$HERON_VERSION | grep "[0-9]*\.[0-9]*\.[0-9]*")',
-        'export HERON_VERSION=$$([[ -z $$HERON_VERSION ]] && echo "0.0.0" || echo $$HERON_VERSION)',
+        'export HERON_VERSION=$$([[ -z $$HERON_VERSION ]] && echo "0.15.1-rc1" || echo $$HERON_VERSION)',
         'echo $$HERON_VERSION',
         'mkdir -p $$TMP_DIR $$HERONPY_DIR',
         'unzip -qd $$HERONPYAPI_UNZIP $(location //heron/api/src/python:heron-python-package)',


### PR DESCRIPTION
Sometimes local dns does not map localhost to 127.0.0.1. This will cause topologies to exhibit errors. This pr replaces all references of localhost to 127.0.0.1