### PR TITLE
Fixed libtool install command in ubuntu 16.04 

### DIFF
--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -2,14 +2,14 @@
 
 ## To compile source using a docker container:
 ```
-./docker/build-artifacts.sh <platform> <version_string> [source-tarball] <output-directory>
-# e.g.  ./docker/build-artifacts.sh ubuntu14.04 testbuild ~/heron-release
+./docker/scripts/build-artifacts.sh <platform> <version_string> [source-tarball] <output-directory>
+# e.g.  ./docker/scripts/build-artifacts.sh ubuntu14.04 testbuild ~/heron-release
 ```
 
 ## To build docker containers for running heron daemons:
 ```
-./docker/build-docker.sh <platform> <version_string> <output-directory>
-# e.g. ./docker/build-docker.sh ubuntu14.04 testbuild ~/heron-release
+./docker/scripts/build-docker.sh <platform> <version_string> <output-directory>
+# e.g. ./docker/scripts/build-docker.sh ubuntu14.04 testbuild ~/heron-release
 ```
 
 ### To run docker containers for local dev work:

--- a/docker/compile/Dockerfile.ubuntu16.04
+++ b/docker/compile/Dockerfile.ubuntu16.04
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get -y install \
       curl \
       libssl-dev \
       git \
-      libtool \
+      libtool-bin \
       libunwind8 \
       libunwind-setjmp0-dev \
       python \


### PR DESCRIPTION
This fix for #2206, fixes the libtool install command in the `docker/compile/Dockerfile.ubuntu16.04`. The current file results in a container that fails to compile Heron due to libtool not being installed.