### PR TITLE
Code Cleanup in Python DSL

### DIFF
--- a/heron/connectors/mock/src/python/fixedlinesspout.py
+++ b/heron/connectors/mock/src/python/fixedlinesspout.py
@@ -14,14 +14,13 @@
 '''fixedlinesspout.py: module that implements a very simple Spout that emits
    a bunch of fixed lines'''
 
-from heron.api.src.python.stream import Stream
 from heron.api.src.python.spout.spout import Spout
 
-class FixedLinesSpout(Spout):
+from heron.dsl.src.python.dslboltbase import DslBoltBase
+
+class FixedLinesSpout(Spout, DslBoltBase):
   """FixedLinesSpout: Generates a line from a set of static lines again and again
   """
-  outputs = [Stream(fields=['_output_'], name='output')]
-
   # pylint: disable=unused-argument
   def initialize(self, config, context):
     """Implements FixedLines Spout's initialize method"""

--- a/heron/connectors/pulsar/src/python/pulsarspout.py
+++ b/heron/connectors/pulsar/src/python/pulsarspout.py
@@ -20,7 +20,8 @@ import pulsar
 
 import heron.api.src.python.api_constants as api_constants
 from heron.api.src.python.spout.spout import Spout
-from heron.api.src.python.stream import Stream
+
+from heron.dsl.src.python.dslboltbase import DslBoltBase
 
 def GenerateLogConfContents(logFileName):
   return """
@@ -45,13 +46,11 @@ def GenerateLogConfig(context):
   flHandler.close()
   return flHandler.name
 
-class PulsarSpout(Spout):
+class PulsarSpout(Spout, DslBoltBase):
   """PulsarSpout: reads from a pulsar topic"""
 
   # pylint: disable=too-many-instance-attributes
   # pylint: disable=no-self-use
-
-  outputs = [Stream(fields=['_output_'], name='output')]
 
   def default_deserializer(self, msg):
     return [str(msg)]

--- a/heron/dsl/src/python/dslboltbase.py
+++ b/heron/dsl/src/python/dslboltbase.py
@@ -1,0 +1,20 @@
+# Copyright 2016 Twitter. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""module for base dsl bolt: DslBoltBase"""
+from heron.api.src.python.stream import Stream
+
+class DslBoltBase(object):
+  """DslBoltBase"""
+  # output declarer
+  outputs = [Stream(fields=['_output_'], name='output')]

--- a/heron/dsl/src/python/filterbolt.py
+++ b/heron/dsl/src/python/filterbolt.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """module for filter bolt: FilterBolt"""
-from heron.api.src.python.stream import Stream
 from heron.api.src.python.state.stateful_component import StatefulComponent
 from heron.api.src.python.bolt.bolt import Bolt
 from heron.api.src.python.component.component_spec import GlobalStreamId
@@ -20,12 +19,11 @@ from heron.api.src.python.stream import Grouping
 
 from heron.dsl.src.python.streamlet import Streamlet
 from heron.dsl.src.python.operation import OperationType
+from heron.dsl.src.python.dslboltbase import DslBoltBase
 
 # pylint: disable=unused-argument
-class FilterBolt(Bolt, StatefulComponent):
+class FilterBolt(Bolt, StatefulComponent, DslBoltBase):
   """FilterBolt"""
-  # output declarer
-  outputs = [Stream(fields=['_output_'], name='output')]
   FUNCTION = 'function'
 
   def init_state(self, stateful_state):

--- a/heron/dsl/src/python/flatmapbolt.py
+++ b/heron/dsl/src/python/flatmapbolt.py
@@ -14,19 +14,17 @@
 """module for flat_map bolt: FlatMapBolt"""
 import collections
 from heron.api.src.python.bolt.bolt import Bolt
-from heron.api.src.python.stream import Stream
 from heron.api.src.python.state.stateful_component import StatefulComponent
 from heron.api.src.python.component.component_spec import GlobalStreamId
 from heron.api.src.python.stream import Grouping
 
 from heron.dsl.src.python.streamlet import Streamlet
 from heron.dsl.src.python.operation import OperationType
+from heron.dsl.src.python.dslboltbase import DslBoltBase
 
 # pylint: disable=unused-argument
-class FlatMapBolt(Bolt, StatefulComponent):
+class FlatMapBolt(Bolt, StatefulComponent, DslBoltBase):
   """FlatMapBolt"""
-  # output declarer
-  outputs = [Stream(fields=['_output_'], name='output')]
   FUNCTION = 'function'
 
   def init_state(self, stateful_state):

--- a/heron/dsl/src/python/joinbolt.py
+++ b/heron/dsl/src/python/joinbolt.py
@@ -14,7 +14,6 @@
 """module for join bolt: JoinBolt"""
 import collections
 
-from heron.api.src.python.stream import Stream
 from heron.api.src.python.bolt.window_bolt import SlidingWindowBolt
 from heron.api.src.python.component.component_spec import GlobalStreamId
 from heron.api.src.python.custom_grouping import ICustomGrouping
@@ -22,12 +21,11 @@ from heron.api.src.python.stream import Grouping
 
 from heron.dsl.src.python.streamlet import Streamlet, TimeWindow
 from heron.dsl.src.python.operation import OperationType
+from heron.dsl.src.python.dslboltbase import DslBoltBase
 
 # pylint: disable=unused-argument
-class JoinBolt(SlidingWindowBolt):
+class JoinBolt(SlidingWindowBolt, DslBoltBase):
   """JoinBolt"""
-  # output declarer
-  outputs = [Stream(fields=['_output_'], name='output')]
   WINDOWDURATION = SlidingWindowBolt.WINDOW_DURATION_SECS
   SLIDEINTERVAL = SlidingWindowBolt.WINDOW_SLIDEINTERVAL_SECS
 

--- a/heron/dsl/src/python/mapbolt.py
+++ b/heron/dsl/src/python/mapbolt.py
@@ -13,19 +13,17 @@
 # limitations under the License.
 """module for map bolt: MapBolt"""
 from heron.api.src.python.bolt.bolt import Bolt
-from heron.api.src.python.stream import Stream
 from heron.api.src.python.state.stateful_component import StatefulComponent
 from heron.api.src.python.component.component_spec import GlobalStreamId
 from heron.api.src.python.stream import Grouping
 
 from heron.dsl.src.python.streamlet import Streamlet
 from heron.dsl.src.python.operation import OperationType
+from heron.dsl.src.python.dslboltbase import DslBoltBase
 
 # pylint: disable=unused-argument
-class MapBolt(Bolt, StatefulComponent):
+class MapBolt(Bolt, StatefulComponent, DslBoltBase):
   """MapBolt"""
-  # output declarer
-  outputs = [Stream(fields=['_output_'], name='output')]
   FUNCTION = 'function'
 
   def init_state(self, stateful_state):

--- a/heron/dsl/src/python/reducebykeyandwindowbolt.py
+++ b/heron/dsl/src/python/reducebykeyandwindowbolt.py
@@ -14,7 +14,6 @@
 """module for join bolt: ReduceByKeyAndWindowBolt"""
 import collections
 
-from heron.api.src.python.stream import Stream
 from heron.api.src.python.bolt.window_bolt import SlidingWindowBolt
 from heron.api.src.python.custom_grouping import ICustomGrouping
 from heron.api.src.python.component.component_spec import GlobalStreamId
@@ -22,12 +21,11 @@ from heron.api.src.python.stream import Grouping
 
 from heron.dsl.src.python.streamlet import Streamlet, TimeWindow
 from heron.dsl.src.python.operation import OperationType
+from heron.dsl.src.python.dslboltbase import DslBoltBase
 
 # pylint: disable=unused-argument
-class ReduceByKeyAndWindowBolt(SlidingWindowBolt):
+class ReduceByKeyAndWindowBolt(SlidingWindowBolt, DslBoltBase):
   """ReduceByKeyAndWindowBolt"""
-  # output declarer
-  outputs = [Stream(fields=['_output_'], name='output')]
   FUNCTION = 'function'
   WINDOWDURATION = SlidingWindowBolt.WINDOW_DURATION_SECS
   SLIDEINTERVAL = SlidingWindowBolt.WINDOW_SLIDEINTERVAL_SECS

--- a/heron/dsl/src/python/repartitionbolt.py
+++ b/heron/dsl/src/python/repartitionbolt.py
@@ -13,19 +13,17 @@
 # limitations under the License.
 """module for map bolt: RepartitionBolt"""
 from heron.api.src.python.bolt.bolt import Bolt
-from heron.api.src.python.stream import Stream
 from heron.api.src.python.state.stateful_component import StatefulComponent
 from heron.api.src.python.component.component_spec import GlobalStreamId
 from heron.api.src.python.stream import Grouping
 
 from heron.dsl.src.python.streamlet import Streamlet
 from heron.dsl.src.python.operation import OperationType
+from heron.dsl.src.python.dslboltbase import DslBoltBase
 
 # pylint: disable=unused-argument
-class RepartitionBolt(Bolt, StatefulComponent):
+class RepartitionBolt(Bolt, StatefulComponent, DslBoltBase):
   """RepartitionBolt"""
-  # output declarer
-  outputs = [Stream(fields=['_output_'], name='output')]
 
   def init_state(self, stateful_state):
     # repartition does not have any state

--- a/heron/dsl/src/python/samplebolt.py
+++ b/heron/dsl/src/python/samplebolt.py
@@ -16,19 +16,17 @@
    can do sampling of the data that it recieves and emit
    only sampled tuples"""
 from heron.api.src.python.bolt.bolt import Bolt
-from heron.api.src.python.stream import Stream
 from heron.api.src.python.state.stateful_component import StatefulComponent
 from heron.api.src.python.component.component_spec import GlobalStreamId
 from heron.api.src.python.stream import Grouping
 
 from heron.dsl.src.python.streamlet import Streamlet
 from heron.dsl.src.python.operation import OperationType
+from heron.dsl.src.python.dslboltbase import DslBoltBase
 
 # pylint: disable=unused-argument
-class SampleBolt(Bolt, StatefulComponent):
+class SampleBolt(Bolt, StatefulComponent, DslBoltBase):
   """SampleBolt"""
-  # output declarer
-  outputs = [Stream(fields=['_output_'], name='output')]
   FRACTION = 'fraction'
 
   def init_state(self, stateful_state):

--- a/heron/dsl/src/python/streamlet.py
+++ b/heron/dsl/src/python/streamlet.py
@@ -18,6 +18,7 @@ from abc import abstractmethod
 from heron.api.src.python.topology import TopologyBuilder
 
 from heron.dsl.src.python.operation import OperationType
+from heron.dsl.src.python.dslboltbase import DslBoltBase
 
 TimeWindow = namedtuple('TimeWindow', 'duration sliding_interval')
 
@@ -43,7 +44,7 @@ class Streamlet(object):
     self._stage_name = stage_name
     self._parallelism = parallelism
     self._inputs = inputs
-    self._output = 'output'
+    self._output = DslBoltBase.outputs[0].stream_id
 
   def map(self, map_function, stage_name=None, parallelism=None):
     """Return a new Streamlet by applying map_function to each element of this Streamlet.


### PR DESCRIPTION
All of dsl methods need to output the same stream. This pr makes DslBoltBase as the refactored place where the output is defined
and the others make use of it by deriving from it