### PR TITLE
Fix Join Bolt implementation

### DIFF
--- a/heron/dsl/src/python/joinbolt.py
+++ b/heron/dsl/src/python/joinbolt.py
@@ -32,6 +32,10 @@ class JoinBolt(SlidingWindowBolt, DslBoltBase):
   def _add(self, key, value, src_component, mymap):
     if not key in mymap:
       mymap[key] = (None, None)
+    # Join Output should be Key -> (V1, V2) where
+    # V1 is coming from the left stream and V2 coming
+    # from the right stream. In this case, _joined_component
+    # represents the right stream
     if src_component == self._joined_component:
       mymap[key][1] = value
     else:

--- a/heron/dsl/src/python/joinbolt.py
+++ b/heron/dsl/src/python/joinbolt.py
@@ -27,13 +27,21 @@ class JoinBolt(SlidingWindowBolt, DslBoltBase):
   """JoinBolt"""
   WINDOWDURATION = SlidingWindowBolt.WINDOW_DURATION_SECS
   SLIDEINTERVAL = SlidingWindowBolt.WINDOW_SLIDEINTERVAL_SECS
+  JOINEDCOMPONENT = '__joined_component__'
 
-  @staticmethod
-  def _add(key, value, mymap):
-    if key in mymap:
-      mymap[key].append(value)
+  def _add(self, key, value, src_component, mymap):
+    if not key in mymap:
+      mymap[key] = (None, None)
+    if src_component == self._joined_component:
+      mymap[key][1] = value
     else:
-      mymap[key] = [value]
+      mymap[key][0] = value
+
+  def initialize(self, config, context):
+    super(JoinBolt, self).__init__(config, context)
+    if not JoinBolt.JOINEDCOMPONENT in config:
+      raise RuntimeError("%s must be specified in the JoinBolt" % JoinBolt.JOINEDCOMPONENT)
+    self._joined_component = config[JoinBolt.JOINEDCOMPONENT]
 
   def processWindow(self, window_config, tuples):
     # our temporary map
@@ -42,7 +50,7 @@ class JoinBolt(SlidingWindowBolt, DslBoltBase):
       userdata = tup.values[0]
       if not isinstance(userdata, collections.Iterable) or len(userdata) != 2:
         raise RuntimeError("Join tuples must be iterable of length 2")
-      self._add(userdata[0], userdata[1], mymap)
+      self._add(userdata[0], userdata[1], tup.component, mymap)
     for (key, values) in mymap.items():
       self.emit([(key, values)], stream='output')
 
@@ -96,4 +104,5 @@ class JoinStreamlet(Streamlet):
     builder.add_bolt(self._stage_name, JoinBolt, par=self._parallelism,
                      inputs=self._calculate_inputs(),
                      config={JoinBolt.WINDOWDURATION : self._time_window.duration,
-                             JoinBolt.SLIDEINTERVAL : self._time_window.sliding_interval})
+                             JoinBolt.SLIDEINTERVAL : self._time_window.sliding_interval,
+                             JoinBolt.JOINEDCOMPONENT : self._parent[1]._stage_name})


### PR DESCRIPTION
Classic join as it is defined, should result in a tuple per matched key. And the tuple must have the right order. This pr fixes that logic inside the Join bolt.