### PR TITLE
Add a heron downloader to download and extract topology packages.

### DIFF
--- a/heron/downloaders/src/java/BUILD
+++ b/heron/downloaders/src/java/BUILD
@@ -1,0 +1,19 @@
+package(default_visibility = ["//visibility:public"])
+
+downloader_deps = [
+  "//third_party/java:commons-compress",
+]
+
+java_binary(
+  name = 'heron-downloader-unshaded',
+  srcs = glob(["**/downloader/*.java"]),
+  main_class = "com.twitter.heron.downloader.DownloadRunner",
+  deps = downloader_deps,
+)
+
+genrule(
+  name = "heron-downloader",
+  srcs = [":heron-downloader-unshaded_deploy.jar"],
+  outs = ["heron-downloader.jar"],
+  cmd  = "cp $< $@",
+)

--- a/heron/downloaders/src/java/com/twitter/heron/downloader/DownloadRunner.java
+++ b/heron/downloaders/src/java/com/twitter/heron/downloader/DownloadRunner.java
@@ -1,0 +1,47 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.downloader;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public final class DownloadRunner {
+
+  // takes topology package URI and extracts it to a directory
+  public static void main(String[] args) throws Exception {
+    if (args.length != 2) {
+      System.err.println("Usage: downloader <topology-package-uri> <extract-destination>");
+      System.exit(1);
+    }
+
+    final String uri = args[0];
+    final String destination = args[1];
+
+    final URI topologyLocation = new URI(uri);
+    final Path topologyDestination = Paths.get(destination);
+
+    final File file = topologyDestination.toFile();
+    if (!file.exists()) {
+      file.mkdirs();
+    }
+
+    final Downloader downloader = Registry.get().getDownloader(topologyLocation);
+    downloader.download(topologyLocation, topologyDestination);
+  }
+
+  private DownloadRunner() {
+  }
+}

--- a/heron/downloaders/src/java/com/twitter/heron/downloader/DownloadRunner.java
+++ b/heron/downloaders/src/java/com/twitter/heron/downloader/DownloadRunner.java
@@ -24,7 +24,7 @@ public final class DownloadRunner {
   public static void main(String[] args) throws Exception {
     if (args.length != 2) {
       System.err.println("Usage: downloader <topology-package-uri> <extract-destination>");
-      System.exit(1);
+      return;
     }
 
     final String uri = args[0];

--- a/heron/downloaders/src/java/com/twitter/heron/downloader/Downloader.java
+++ b/heron/downloaders/src/java/com/twitter/heron/downloader/Downloader.java
@@ -1,0 +1,21 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.downloader;
+
+import java.net.URI;
+import java.nio.file.Path;
+
+public interface Downloader {
+  void download(URI uri, Path destination) throws Exception;
+}

--- a/heron/downloaders/src/java/com/twitter/heron/downloader/Extractor.java
+++ b/heron/downloaders/src/java/com/twitter/heron/downloader/Extractor.java
@@ -1,0 +1,56 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.downloader;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+
+final class Extractor {
+
+  static void extract(InputStream in, Path destination) throws IOException {
+    try (
+        final BufferedInputStream bufferedInputStream = new BufferedInputStream(in);
+        final GzipCompressorInputStream gzipInputStream =
+            new GzipCompressorInputStream(bufferedInputStream);
+        final TarArchiveInputStream tarInputStream = new TarArchiveInputStream(gzipInputStream)
+    ) {
+      final String destinationAbsolutePath = destination.toFile().getAbsolutePath();
+
+      TarArchiveEntry entry;
+      while ((entry = (TarArchiveEntry) tarInputStream.getNextEntry()) != null) {
+        if (entry.isDirectory()) {
+          File f = Paths.get(destinationAbsolutePath, entry.getName()).toFile();
+          f.mkdirs();
+        } else {
+          Path fileDestinationPath = Paths.get(destinationAbsolutePath, entry.getName());
+
+          Files.copy(tarInputStream, fileDestinationPath, StandardCopyOption.REPLACE_EXISTING);
+        }
+      }
+    }
+  }
+
+  private Extractor() {
+  }
+}

--- a/heron/downloaders/src/java/com/twitter/heron/downloader/HttpDownloader.java
+++ b/heron/downloaders/src/java/com/twitter/heron/downloader/HttpDownloader.java
@@ -1,0 +1,27 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.downloader;
+
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Path;
+
+public class HttpDownloader implements Downloader {
+
+  @Override
+  public void download(URI uri, Path destination) throws Exception {
+    final URL url = uri.toURL();
+    Extractor.extract(url.openStream(), destination);
+  }
+}

--- a/heron/downloaders/src/java/com/twitter/heron/downloader/Registry.java
+++ b/heron/downloaders/src/java/com/twitter/heron/downloader/Registry.java
@@ -1,0 +1,52 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.downloader;
+
+import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+final class Registry {
+
+  private static final Map<String, Class<? extends Downloader>> DOWNLOADERS =
+      new HashMap<>();
+
+  static {
+    DOWNLOADERS.put("http", HttpDownloader.class);
+    DOWNLOADERS.put("https", HttpDownloader.class);
+  }
+
+  private static final Registry INSTANCE = new Registry();
+
+  private Registry() {
+  }
+
+  static Registry get() {
+    return INSTANCE;
+  }
+
+  Downloader getDownloader(URI uri) throws Exception {
+    final Class<? extends Downloader> downloaderClass =
+        DOWNLOADERS.get(uri.getScheme().toLowerCase());
+    try {
+      return downloaderClass.getConstructor().newInstance();
+    } catch (InstantiationException | IllegalAccessException
+        | InvocationTargetException | NoSuchMethodException e) {
+      final String message =
+            String.format("Unable to create downloader for uri %s", uri.toString());
+      throw new Exception(message, e);
+    }
+  }
+}

--- a/heron/downloaders/src/shell/BUILD
+++ b/heron/downloaders/src/shell/BUILD
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+genrule(
+  name = "heron-downloader",
+  srcs = [":heron-downloader.sh"],
+  outs = ["heron-downloader"],
+  cmd  = "cp $< $@",
+)

--- a/heron/downloaders/src/shell/heron-downloader.sh
+++ b/heron/downloaders/src/shell/heron-downloader.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+BINDIR=$(dirname "$0")
+HERON_CORE=$(dirname ${BINDIR})
+HERON_DOWNLOADER_JAR=${HERON_CORE}/lib/downloaders/heron-downloader.jar
+
+# Check for the java to use
+if [[ -z $JAVA_HOME ]]; then
+  JAVA=$(which java)
+  if [ $? != 0 ]; then
+   echo "Error: JAVA_HOME not set, and no java executable found in $PATH." 1>&2
+   exit 1
+  fi
+else
+  JAVA=${JAVA_HOME}/bin/java
+fi
+
+exec $JAVA -jar $HERON_DOWNLOADER_JAR $@

--- a/heron/downloaders/tests/java/BUILD
+++ b/heron/downloaders/tests/java/BUILD
@@ -1,0 +1,30 @@
+load("/tools/rules/java_tests", "java_tests")
+
+load("/tools/rules/heron_deps", "heron_java_proto_files")
+
+common_deps_files = [
+    "//third_party/java:powermock",
+    "//third_party/java:mockito",
+    "//third_party/java:junit4",
+    "//third_party/java:commons-compress",
+    "//heron/common/src/java:basics-java",
+]
+
+downloader_test_deps_files = \
+  common_deps_files + [
+    "//heron/downloaders/src/java:heron-downloader"
+  ]
+
+java_library(
+    name = "tests",
+    srcs = glob(["**/downloader/**/*.java"]),
+    deps = downloader_test_deps_files,
+)
+
+java_tests(
+  test_classes = [
+    "com.twitter.heron.downloader.ExtractorTests",
+  ],
+  runtime_deps = [ ":tests" ],
+  size = "small",
+)

--- a/heron/downloaders/tests/java/com/twitter/heron/downloader/ExtractorTests.java
+++ b/heron/downloaders/tests/java/com/twitter/heron/downloader/ExtractorTests.java
@@ -1,0 +1,131 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.downloader;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.twitter.heron.common.basics.FileUtils;
+
+import static org.junit.Assert.assertTrue;
+
+public class ExtractorTests {
+
+  private String tempDirectory;
+  private String workingDirectory;
+
+  @Before
+  public void before() throws IOException {
+    tempDirectory =
+        Files.createTempDirectory("temp").toFile().getAbsolutePath();
+    workingDirectory =
+        Files.createTempDirectory("working").toFile().getAbsolutePath();
+  }
+
+  @Test
+  public void testFlatExtract() throws Exception {
+    final Path file1 = Paths.get(tempDirectory, "file1");
+    final Path file2 = Paths.get(tempDirectory, "file2");
+
+    Files.createFile(file1);
+    Files.createFile(file2);
+
+    assertTrue(Files.exists(file1));
+    assertTrue(Files.exists(file2));
+
+    // build tar.gz with file1 and file2
+    final Path tar = Paths.get(workingDirectory, "topology.tar.gz");
+    createTarGz(tar.toFile().getAbsolutePath(),
+        tempDirectory);
+    assertTrue(Files.exists(tar));
+
+    Extractor.extract(new FileInputStream(tar.toFile()), Paths.get(workingDirectory));
+
+    assertTrue(Files.exists(Paths.get(workingDirectory, "file1")));
+    assertTrue(Files.exists(Paths.get(workingDirectory, "file2")));
+  }
+
+  @Test
+  public void testNestedOneLevelExtract() throws Exception {
+    final Path file1 = Paths.get(tempDirectory, "file");
+    final Path nestedFile = Paths.get(tempDirectory, "dir", "file");
+
+    Files.createFile(file1);
+    nestedFile.getParent().toFile().mkdir();
+    Files.createFile(nestedFile);
+
+    // build tar.gz with file and dir/file
+    final Path tar = Paths.get(workingDirectory, "topology.tar.gz");
+    createTarGz(tar.toFile().getAbsolutePath(),
+        tempDirectory);
+    assertTrue(Files.exists(tar));
+
+    Extractor.extract(new FileInputStream(tar.toFile()), Paths.get(workingDirectory));
+
+    assertTrue(Files.exists(Paths.get(workingDirectory, "file")));
+    assertTrue(Files.exists(Paths.get(workingDirectory, "dir", "file")));
+  }
+
+  @Test
+  public void testNestedTwoLevelsExtract() throws Exception {
+    final Path file1 = Paths.get(tempDirectory, "file1");
+    final Path nestedFile = Paths.get(tempDirectory, "dir", "file");
+    final Path nestedFile2 = Paths.get(tempDirectory, "dir", "dir2", "file");
+
+    Files.createFile(file1);
+    nestedFile.getParent().toFile().mkdir();
+    Files.createFile(nestedFile);
+    nestedFile2.getParent().toFile().mkdir();
+    Files.createFile(nestedFile2);
+
+    // build tar.gz with file1 and dir/file dir/dir2/file
+    final Path tar = Paths.get(workingDirectory, "topology.tar.gz");
+    createTarGz(tar.toFile().getAbsolutePath(),
+        tempDirectory);
+    assertTrue(Files.exists(tar));
+
+    Extractor.extract(new FileInputStream(tar.toFile()), Paths.get(workingDirectory));
+
+    assertTrue(Files.exists(Paths.get(workingDirectory, "file1")));
+    assertTrue(Files.exists(Paths.get(workingDirectory, "dir", "file")));
+    assertTrue(Files.exists(Paths.get(workingDirectory, "dir", "dir2", "file")));
+  }
+
+  @After
+  public void after() {
+    cleanAndDeleteDirectory(tempDirectory);
+    cleanAndDeleteDirectory(workingDirectory);
+  }
+
+  private static void cleanAndDeleteDirectory(String directory) {
+    if (directory != null) {
+      FileUtils.cleanDir(directory);
+      FileUtils.deleteDir(directory);
+    }
+  }
+
+  private void createTarGz(String name, String directory) throws Exception {
+    final String command = String.format("tar -C %s -czvf %s .", directory, name);
+    final Process p = Runtime.getRuntime().exec(command);
+    p.waitFor(10, TimeUnit.SECONDS);
+  }
+}

--- a/scripts/packages/BUILD
+++ b/scripts/packages/BUILD
@@ -25,6 +25,7 @@ load("/tools/rules/heron_core", "heron_core_lib_scheduler_files")
 load("/tools/rules/heron_core", "heron_core_lib_statemgr_files")
 load("/tools/rules/heron_core", "heron_core_lib_ckptmgr_files")
 load("/tools/rules/heron_core", "heron_core_lib_statefulstorage_files")
+load("/tools/rules/heron_core", "heron_core_lib_downloader_files")
 
 load("/tools/rules/heron_tools", "heron_tools_files")
 load("/tools/rules/heron_tools", "heron_tools_bin_files")
@@ -96,6 +97,7 @@ pkg_tar(
         ":heron-core-lib-instance",
         ":heron-core-lib-ckptmgr",
         ":heron-core-lib-statefulstorage",
+        ":heron-core-lib-downloader",
     ],
 )
 
@@ -157,6 +159,12 @@ pkg_tar(
     name = "heron-core-lib-statefulstorage",
     package_dir = "heron-core/lib/statefulstorage",
     files = heron_core_lib_statefulstorage_files(),
+)
+
+pkg_tar(
+    name = "heron-core-lib-downloader",
+    package_dir = "heron-core/lib/downloaders",
+    files = heron_core_lib_downloader_files(),
 )
 
 ################################################################################

--- a/tools/rules/heron_core.bzl
+++ b/tools/rules/heron_core.bzl
@@ -11,6 +11,7 @@ def heron_core_bin_files():
         "//heron/stmgr/src/cpp:heron-stmgr",
         "//heron/tmaster/src/cpp:heron-tmaster",
         "//heron/instance/src/python/instance:heron-python-instance",
+        "//heron/downloaders/src/shell:heron-downloader"
     ]
 
 def heron_core_conf_files():
@@ -27,7 +28,8 @@ def heron_core_lib_files():
         heron_core_lib_statemgr_files() + \
         heron_core_lib_instance_files() + \
         heron_core_lib_ckptmgr_files() + \
-        heron_core_lib_statefulstorage_files()
+        heron_core_lib_statefulstorage_files() + \
+        heron_core_lib_downloader_files()
 
 def heron_core_lib_scheduler_files():
     return [
@@ -81,3 +83,8 @@ def heron_core_lib_statefulstorage_files():
         "//heron/statefulstorages/src/java:heron-localfs-statefulstorage",
         "//heron/statefulstorages/src/java:heron-hdfs-statefulstorage",
     ]
+
+def heron_core_lib_downloader_files():
+  return [
+    "//heron/downloaders/src/java:heron-downloader",
+  ]


### PR DESCRIPTION
This is needed to offer support for downloading topology packages from storage systems that do not support a http interface.