### PR TITLE
Make metrics cache client in healthMgr fetch location from statemgr

### DIFF
--- a/heron/healthmgr/src/java/com/twitter/heron/healthmgr/sensors/MetricsCacheMetricsProvider.java
+++ b/heron/healthmgr/src/java/com/twitter/heron/healthmgr/sensors/MetricsCacheMetricsProvider.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.microsoft.dhalion.api.MetricsProvider;
 import com.microsoft.dhalion.metrics.ComponentMetrics;
 import com.microsoft.dhalion.metrics.InstanceMetrics;
@@ -37,23 +38,28 @@ import com.twitter.heron.proto.tmaster.TopologyMaster.MetricInterval;
 import com.twitter.heron.proto.tmaster.TopologyMaster.MetricResponse.IndividualMetric;
 import com.twitter.heron.proto.tmaster.TopologyMaster.MetricResponse.IndividualMetric.IntervalValue;
 import com.twitter.heron.proto.tmaster.TopologyMaster.MetricResponse.TaskMetric;
+import com.twitter.heron.proto.tmaster.TopologyMaster.MetricsCacheLocation;
+import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
 import com.twitter.heron.spi.utils.NetworkUtils;
 
-import static com.twitter.heron.healthmgr.HealthManager.CONF_METRICS_SOURCE_URL;
+import static com.twitter.heron.healthmgr.HealthManager.CONF_TOPOLOGY_NAME;
 
 public class MetricsCacheMetricsProvider implements MetricsProvider {
-  private static final String PATH_STATS = "/stats";
+  private static final String PATH_STATS = "stats";
   private static final Logger LOG = Logger.getLogger(MetricsCacheMetricsProvider.class.getName());
-  private HttpURLConnection con;
+  private SchedulerStateManagerAdaptor stateManagerAdaptor;
+  private String topologyName;
 
   private Clock clock = new Clock();
+  private String metricsCacheLocation;
 
   @Inject
-  public MetricsCacheMetricsProvider(@Named(CONF_METRICS_SOURCE_URL) String metricsCacheURL) {
-    LOG.info("Metrics will be provided by MetricsCache at :" + metricsCacheURL);
+  public MetricsCacheMetricsProvider(SchedulerStateManagerAdaptor stateManagerAdaptor,
+                                     @Named(CONF_TOPOLOGY_NAME) String topologyName) {
+    this.stateManagerAdaptor = stateManagerAdaptor;
+    this.topologyName = topologyName;
 
-    String url = metricsCacheURL + PATH_STATS;
-    con = NetworkUtils.getHttpConnection(url);
+    LOG.info("Metrics will be provided by MetricsCache at :" + getCacheLocation());
   }
 
   @Override
@@ -65,6 +71,7 @@ public class MetricsCacheMetricsProvider implements MetricsProvider {
     for (String component : components) {
       TopologyMaster.MetricResponse response =
           getMetricsFromMetricsCache(metric, component, startTime, duration);
+
       Map<String, InstanceMetrics> metrics = parse(response, component, metric);
       ComponentMetrics componentMetric = new ComponentMetrics(component, metrics);
       result.put(component, componentMetric);
@@ -97,18 +104,18 @@ public class MetricsCacheMetricsProvider implements MetricsProvider {
     }
 
     // convert heron.protobuf.taskMetrics to dhalion.InstanceMetrics
-    for (TaskMetric tm :response.getMetricList()) {
+    for (TaskMetric tm : response.getMetricList()) {
       String instanceId = tm.getInstanceId();
       InstanceMetrics instanceMetrics = new InstanceMetrics(instanceId);
 
-      for (IndividualMetric im: tm.getMetricList()) {
+      for (IndividualMetric im : tm.getMetricList()) {
         String metricName = im.getName();
         Map<Instant, Double> values = new HashMap<>();
 
-        for (IntervalValue iv: im.getIntervalValuesList()) {
+        for (IntervalValue iv : im.getIntervalValuesList()) {
           MetricInterval mi = iv.getInterval();
           String value = iv.getValue();
-          values.put(Instant.ofEpochSecond(mi.getStart()),  Double.parseDouble(value));
+          values.put(Instant.ofEpochSecond(mi.getStart()), Double.parseDouble(value));
         }
 
         if (!values.isEmpty()) {
@@ -129,30 +136,60 @@ public class MetricsCacheMetricsProvider implements MetricsProvider {
         .setComponentName(component)
         .setExplicitInterval(
             MetricInterval.newBuilder()
-            .setStart(start.getEpochSecond())
-            .setEnd(start.plus(duration).getEpochSecond())
-            .build())
+                .setStart(start.getEpochSecond())
+                .setEnd(start.plus(duration).getEpochSecond())
+                .build())
         .addMetric(metric)
         .build();
     LOG.log(Level.FINE, "MetricsCache Query request: {0}", request);
 
-    NetworkUtils.sendHttpPostRequest(con, "X", request.toByteArray());
-    byte[] responseData = NetworkUtils.readHttpResponse(con);
-
+    HttpURLConnection connection = NetworkUtils.getHttpConnection(getCacheLocation());
     try {
-      TopologyMaster.MetricResponse response =
-          TopologyMaster.MetricResponse.parseFrom(responseData);
-      LOG.log(Level.FINE, "MetricsCache Query response: {0}", response);
-      return response;
-    } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-      LOG.severe("protobuf cannot parse the reply from MetricsCache " + e);
-      return null;
+      boolean result = NetworkUtils.sendHttpPostRequest(connection, "X", request.toByteArray());
+      if (!result) {
+        LOG.warning("Failed to get response from metrics cache. Resetting connection...");
+        resetCacheLocation();
+        return null;
+      }
+
+      byte[] responseData = NetworkUtils.readHttpResponse(connection);
+
+      try {
+        TopologyMaster.MetricResponse response =
+            TopologyMaster.MetricResponse.parseFrom(responseData);
+        LOG.log(Level.FINE, "MetricsCache Query response: {0}", response);
+        return response;
+      } catch (InvalidProtocolBufferException e) {
+        LOG.log(Level.SEVERE,"protobuf cannot parse the reply from MetricsCache ", e);
+        return null;
+      }
+    } finally {
+      if (connection != null) {
+        connection.disconnect();
+      }
     }
   }
 
   @VisibleForTesting
   void setClock(Clock clock) {
     this.clock = clock;
+  }
+
+  /* returns last known location of metrics cache
+   */
+  private synchronized String getCacheLocation() {
+    if (metricsCacheLocation != null) {
+      return metricsCacheLocation;
+    }
+
+    MetricsCacheLocation cacheLocation = stateManagerAdaptor.getMetricsCacheLocation(topologyName);
+    metricsCacheLocation = String.format("http://%s:%s/%s", cacheLocation.getHost(),
+        cacheLocation.getStatsPort(), PATH_STATS);
+    return metricsCacheLocation;
+  }
+
+  private synchronized void resetCacheLocation() {
+    metricsCacheLocation = null;
   }
 
   static class Clock {

--- a/heron/healthmgr/src/java/com/twitter/heron/healthmgr/sensors/MetricsCacheMetricsProvider.java
+++ b/heron/healthmgr/src/java/com/twitter/heron/healthmgr/sensors/MetricsCacheMetricsProvider.java
@@ -160,7 +160,7 @@ public class MetricsCacheMetricsProvider implements MetricsProvider {
         LOG.log(Level.FINE, "MetricsCache Query response: {0}", response);
         return response;
       } catch (InvalidProtocolBufferException e) {
-        LOG.log(Level.SEVERE,"protobuf cannot parse the reply from MetricsCache ", e);
+        LOG.log(Level.SEVERE, "protobuf cannot parse the reply from MetricsCache ", e);
         return null;
       }
     } finally {

--- a/heron/healthmgr/tests/java/com/twitter/heron/healthmgr/HealthManagerTest.java
+++ b/heron/healthmgr/tests/java/com/twitter/heron/healthmgr/HealthManagerTest.java
@@ -64,7 +64,7 @@ public class HealthManagerTest {
     when(adaptor.getSchedulerLocation(anyString())).thenReturn(schedulerLocation);
 
     AbstractModule baseModule = HealthManager
-        .buildMetricsProviderModule(config, "127.0.0.1", TrackerMetricsProvider.class);
+        .buildMetricsProviderModule("127.0.0.1", TrackerMetricsProvider.class.getName());
 
     HealthManager healthManager = new HealthManager(config, baseModule);
 

--- a/heron/healthmgr/tests/java/com/twitter/heron/healthmgr/sensors/MetricsCacheMetricsProviderTest.java
+++ b/heron/healthmgr/tests/java/com/twitter/heron/healthmgr/sensors/MetricsCacheMetricsProviderTest.java
@@ -29,13 +29,17 @@ import com.twitter.heron.proto.tmaster.TopologyMaster.MetricInterval;
 import com.twitter.heron.proto.tmaster.TopologyMaster.MetricResponse.IndividualMetric;
 import com.twitter.heron.proto.tmaster.TopologyMaster.MetricResponse.IndividualMetric.IntervalValue;
 import com.twitter.heron.proto.tmaster.TopologyMaster.MetricResponse.TaskMetric;
+import com.twitter.heron.proto.tmaster.TopologyMaster.MetricsCacheLocation;
+import com.twitter.heron.spi.statemgr.SchedulerStateManagerAdaptor;
 
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class MetricsCacheMetricsProviderTest {
   @Test
@@ -210,8 +214,19 @@ public class MetricsCacheMetricsProviderTest {
   }
 
   private MetricsCacheMetricsProvider createMetricsProviderSpy() {
+    MetricsCacheLocation location = MetricsCacheLocation.newBuilder()
+        .setTopologyName("testTopo")
+        .setTopologyId("topoId")
+        .setHost("localhost")
+        .setControllerPort(0)
+        .setMasterPort(0)
+        .build();
+
+    SchedulerStateManagerAdaptor stateMgr = Mockito.mock(SchedulerStateManagerAdaptor.class);
+    when(stateMgr.getMetricsCacheLocation("testTopo")).thenReturn(location);
+
     MetricsCacheMetricsProvider metricsProvider
-        = new MetricsCacheMetricsProvider("127.0.0.1");
+        = new MetricsCacheMetricsProvider(stateMgr, "testTopo");
 
     MetricsCacheMetricsProvider spyMetricsProvider = spy(metricsProvider);
     spyMetricsProvider.setClock(new TestClock(70000));

--- a/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/statemgr/SchedulerStateManagerAdaptor.java
@@ -253,6 +253,16 @@ public class SchedulerStateManagerAdaptor {
   }
 
   /**
+   * Get the metricscache location for the given topology
+   *
+   * @return MetricsCacheLocation
+   */
+  public TopologyMaster.MetricsCacheLocation getMetricsCacheLocation(String topologyName) {
+    return awaitResult(delegate.getMetricsCacheLocation(null, topologyName));
+  }
+
+
+  /**
    * Get the topology definition for the given topology
    *
    * @return Topology


### PR DESCRIPTION
The metrics cache port is selected at runtime. So a user cannot provide
it as a configuration. The cache client needs to fetch it.