### PR TITLE
Renamed Exactly Once to Effectively Once

### DIFF
--- a/heron/api/src/java/com/twitter/heron/api/Config.java
+++ b/heron/api/src/java/com/twitter/heron/api/Config.java
@@ -129,7 +129,7 @@ public class Config extends HashMap<String, Object> {
     ATLEAST_ONCE,
     /**
      * Heron guarantees that each emitted tuple is seen by the downstream components
-     * exactly once. This is achieved via distributed snapshotting approach is described at
+     * effectively once. This is achieved via distributed snapshotting approach is described at
      * https://docs.google.com/document/d/1pNuE77diSrYHb7vHPuPO3DZqYdcxrhywH_f7loVryCI/edit
      * In this mode Heron will try to take the snapshots of
      * all of the components of the topology every
@@ -137,7 +137,7 @@ public class Config extends HashMap<String, Object> {
      * any component or detection of any network failure, Heron will initiate a recovery
      * mechanism to revert the topology to the last globally consistent checkpoint
      */
-    EXACTLY_ONCE;
+    EFFECTIVELY_ONCE;
   }
   /**
    * A Heron topology can be run in any one of the TopologyReliabilityMode

--- a/heron/common/src/cpp/config/topology-config-helper.cpp
+++ b/heron/common/src/cpp/config/topology-config-helper.cpp
@@ -34,8 +34,8 @@ TopologyConfigVars::TopologyReliabilityMode StringToReliabilityMode(const std::s
     return TopologyConfigVars::TopologyReliabilityMode::ATMOST_ONCE;
   } else if (_mode == "ATLEAST_ONCE") {
     return TopologyConfigVars::TopologyReliabilityMode::ATLEAST_ONCE;
-  } else if (_mode == "EXACTLY_ONCE") {
-    return TopologyConfigVars::TopologyReliabilityMode::EXACTLY_ONCE;
+  } else if (_mode == "EFFECTIVELY_ONCE") {
+    return TopologyConfigVars::TopologyReliabilityMode::EFFECTIVELY_ONCE;
   } else {
     LOG(FATAL) << "Unknown Topology Reliability Mode " << _mode;
     return TopologyConfigVars::TopologyReliabilityMode::ATMOST_ONCE;

--- a/heron/common/src/cpp/config/topology-config-vars.h
+++ b/heron/common/src/cpp/config/topology-config-vars.h
@@ -46,7 +46,7 @@ class TopologyConfigVars {
   enum TopologyReliabilityMode {
     ATMOST_ONCE,
     ATLEAST_ONCE,
-    EXACTLY_ONCE
+    EFFECTIVELY_ONCE
   };
   static const sp_string TOPOLOGY_RELIABILITY_MODE;
   static const sp_string TOPOLOGY_CONTAINER_CPU_REQUESTED;

--- a/heron/common/src/java/com/twitter/heron/common/utils/topology/TopologyUtils.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/topology/TopologyUtils.java
@@ -143,7 +143,7 @@ public final class TopologyUtils {
       return false;
     } else {
       return Config.TopologyReliabilityMode.valueOf(mode)
-             == Config.TopologyReliabilityMode.EXACTLY_ONCE;
+             == Config.TopologyReliabilityMode.EFFECTIVELY_ONCE;
     }
   }
 

--- a/heron/examples/src/python/stateful_word_count_topology.py
+++ b/heron/examples/src/python/stateful_word_count_topology.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
                                 config={constants.TOPOLOGY_TICK_TUPLE_FREQ_SECS: 10})
 
   topology_config = {constants.TOPOLOGY_RELIABILITY_MODE:
-                         constants.TopologyReliabilityMode.EXACTLY_ONCE,
+                         constants.TopologyReliabilityMode.EFFECTIVELY_ONCE,
                      constants.TOPOLOGY_STATEFUL_CHECKPOINT_INTERVAL_SECONDS: 30}
   builder.set_config(topology_config)
 

--- a/heron/instance/src/java/com/twitter/heron/instance/Slave.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/Slave.java
@@ -186,7 +186,7 @@ public class Slave implements Runnable, AutoCloseable {
     //     - If the topology is not stateful
     if (helper != null && helper.getTopologyState().equals(TopologyAPI.TopologyState.RUNNING)) {
       Map<String, Object> config = helper.getTopologyContext().getTopologyConfig();
-      boolean isTopologyStateful = String.valueOf(Config.TopologyReliabilityMode.EXACTLY_ONCE)
+      boolean isTopologyStateful = String.valueOf(Config.TopologyReliabilityMode.EFFECTIVELY_ONCE)
           .equals(config.get(Config.TOPOLOGY_RELIABILITY_MODE));
 
       if (!isTopologyStateful || isStatefulProcessingStarted) {

--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
@@ -84,7 +84,7 @@ public class BoltInstance implements IInstance {
         SystemConfig.HERON_SYSTEM_CONFIG);
 
     Map<String, Object> config = helper.getTopologyContext().getTopologyConfig();
-    this.isTopologyStateful = String.valueOf(Config.TopologyReliabilityMode.EXACTLY_ONCE)
+    this.isTopologyStateful = String.valueOf(Config.TopologyReliabilityMode.EFFECTIVELY_ONCE)
         .equals(config.get(Config.TOPOLOGY_RELIABILITY_MODE));
 
     LOG.info("Is this topology stateful: " + isTopologyStateful);

--- a/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutInstance.java
@@ -91,7 +91,7 @@ public class SpoutInstance implements IInstance {
     this.enableMessageTimeouts =
         Boolean.parseBoolean((String) config.get(Config.TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS));
 
-    this.isTopologyStateful = String.valueOf(Config.TopologyReliabilityMode.EXACTLY_ONCE)
+    this.isTopologyStateful = String.valueOf(Config.TopologyReliabilityMode.EFFECTIVELY_ONCE)
         .equals(config.get(Config.TOPOLOGY_RELIABILITY_MODE));
 
     LOG.info("Is this topology stateful: " + isTopologyStateful);

--- a/heron/instance/src/python/basics/base_instance.py
+++ b/heron/instance/src/python/basics/base_instance.py
@@ -59,7 +59,7 @@ class BaseInstance(object):
     context = pplan_helper.context
     mode = context.get_cluster_config().get(api_constants.TOPOLOGY_RELIABILITY_MODE,
                                             api_constants.TopologyReliabilityMode.ATMOST_ONCE)
-    self.is_stateful = bool(mode == api_constants.TopologyReliabilityMode.EXACTLY_ONCE)
+    self.is_stateful = bool(mode == api_constants.TopologyReliabilityMode.EFFECTIVELY_ONCE)
     self._stateful_state = None
     self.serializer = SerializerHelper.get_serializer(pplan_helper.context)
     self._initialized_global_metrics = False

--- a/heron/instance/src/python/instance/st_heron_instance.py
+++ b/heron/instance/src/python/instance/st_heron_instance.py
@@ -293,7 +293,7 @@ class SingleThreadHeronInstance(object):
     context = self.my_pplan_helper.context
     mode = context.get_cluster_config().get(api_constants.TOPOLOGY_RELIABILITY_MODE,
                                             api_constants.TopologyReliabilityMode.ATMOST_ONCE)
-    is_stateful = bool(mode == api_constants.TopologyReliabilityMode.EXACTLY_ONCE)
+    is_stateful = bool(mode == api_constants.TopologyReliabilityMode.EFFECTIVELY_ONCE)
     if is_stateful and not self.is_stateful_started:
       return
     try:

--- a/heron/proto/ckptmgr.proto
+++ b/heron/proto/ckptmgr.proto
@@ -6,7 +6,7 @@ import "common.proto";
 import "physical_plan.proto";
 
 // The messages in this file are for stateful processing and providing
-// exactly once semantics. Below are the various sequence of events that
+// effectively once semantics. Below are the various sequence of events that
 // happen in a few(non exhaustive) scenarios
 //
 // On Startup

--- a/heron/proto/ckptmgr.proto
+++ b/heron/proto/ckptmgr.proto
@@ -10,7 +10,7 @@ import "physical_plan.proto";
 // happen in a few(non exhaustive) scenarios
 //
 // On Startup
-//   For topologies needing exact once, the startup sequence of
+//   For topologies needing effectively once, the startup sequence of
 // tmaster/stmgr/instance is a little different. Normally, upon
 // startup, all stmgrs connect to tmaster and then tmaster computes pplan
 // and distributes to stmgrs, which in turn send it to all their

--- a/heron/stmgr/src/cpp/manager/stateful-restorer.h
+++ b/heron/stmgr/src/cpp/manager/stateful-restorer.h
@@ -49,7 +49,7 @@ class TupleCache;
 class StMgrClientMgr;
 class CkptMgrClient;
 
-// For Heron topologies running in exactly once semantics, the tmaster
+// For Heron topologies running in effectively once semantics, the tmaster
 // could initiate restore topology to a certain globally consistent checkpoint.
 // This could be triggered either during startup or after failure of certain
 // topology components. StatefulRestorer implements the state machine of this recovery

--- a/heron/stmgr/src/cpp/manager/stmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr.cpp
@@ -112,7 +112,7 @@ void StMgr::Init() {
                        topology_name_, [this]() { this->FetchMetricsCacheLocation(); });
 
   reliability_mode_ = heron::config::TopologyConfigHelper::GetReliabilityMode(*hydrated_topology_);
-  if (reliability_mode_ == config::TopologyConfigVars::EXACTLY_ONCE) {
+  if (reliability_mode_ == config::TopologyConfigVars::EFFECTIVELY_ONCE) {
     // Start checkpoint manager client
     CreateCheckpointMgrClient();
   } else {
@@ -143,7 +143,7 @@ void StMgr::Init() {
   FetchTMasterLocation();
   FetchMetricsCacheLocation();
 
-  if (reliability_mode_ == config::TopologyConfigVars::EXACTLY_ONCE) {
+  if (reliability_mode_ == config::TopologyConfigVars::EFFECTIVELY_ONCE) {
     // Now start the stateful restorer
     stateful_restorer_ = new StatefulRestorer(ckptmgr_client_, clientmgr_,
                                tuple_cache_, server_, metrics_manager_client_,
@@ -531,7 +531,7 @@ void StMgr::NewPhysicalPlan(proto::system::PhysicalPlan* _pplan) {
   delete pplan_;
   pplan_ = _pplan;
   neighbour_calculator_->Reconstruct(*pplan_);
-  // For exactly once topologies, we only start connecting after we have recovered
+  // For effectively once topologies, we only start connecting after we have recovered
   // from a globally consistent checkpoint. The act of starting connections is initiated
   // by the restorer
   if (!stateful_restorer_) {

--- a/heron/tmaster/src/cpp/manager/stateful-controller.h
+++ b/heron/tmaster/src/cpp/manager/stateful-controller.h
@@ -36,7 +36,7 @@ namespace tmaster {
 class StatefulRestorer;
 class StatefulCheckpointer;
 
-// For Heron topologies running in exactly once semantics, the tmaster
+// For Heron topologies running in effectively once semantics, the tmaster
 // utilizes the stateful controller to handle all the work related with
 // checkpointing and restoring from checkpoints. The statful controller
 // offers methods to start checkpoint/restore. It also manages the state

--- a/heron/tmaster/src/cpp/manager/tmaster.cpp
+++ b/heron/tmaster/src/cpp/manager/tmaster.cpp
@@ -318,7 +318,7 @@ void TMaster::GetTopologyDone(proto::system::StatusCode _code) {
   LOG(INFO) << "Topology read and validated\n";
 
   if (heron::config::TopologyConfigHelper::GetReliabilityMode(*topology_)
-      == config::TopologyConfigVars::EXACTLY_ONCE) {
+      == config::TopologyConfigVars::EFFECTIVELY_ONCE) {
     // Establish connection to ckptmgr
     NetworkOptions ckpt_options;
     ckpt_options.set_host("127.0.0.1");

--- a/heron/tmaster/tests/cpp/server/stateful_restorer_unittest.cpp
+++ b/heron/tmaster/tests/cpp/server/stateful_restorer_unittest.cpp
@@ -110,7 +110,7 @@ static heron::proto::api::Topology* GenerateDummyTopology(
   heron::proto::api::Config* topology_config = topology->mutable_topology_config();
   heron::proto::api::Config::KeyValue* kv = topology_config->add_kvs();
   kv->set_key(heron::config::TopologyConfigVars::TOPOLOGY_RELIABILITY_MODE);
-  kv->set_value(std::to_string(heron::config::TopologyConfigVars::EXACTLY_ONCE));
+  kv->set_value(std::to_string(heron::config::TopologyConfigVars::EFFECTIVELY_ONCE));
 
   // Set state
   topology->set_state(heron::proto::api::RUNNING);

--- a/heronpy/api/api_constants.py
+++ b/heronpy/api/api_constants.py
@@ -20,7 +20,7 @@
 class TopologyReliabilityMode(object):
   ATMOST_ONCE = "ATMOST_ONCE"
   ATLEAST_ONCE = "ATLEAST_ONCE"
-  EXACTLY_ONCE = "EXACTLY_ONCE"
+  EFFECTIVELY_ONCE = "EFFECTIVELY_ONCE"
 
 # Topology-specific options for the worker child process.
 TOPOLOGY_WORKER_CHILDOPTS = "topology.worker.childopts"

--- a/heronpy/api/state/stateful_component.py
+++ b/heronpy/api/state/stateful_component.py
@@ -16,7 +16,7 @@ from abc import abstractmethod
 
 class StatefulComponent(object):
   """Defines a component that saves its internal state using the State interface
-  When running under exactly once semantics, the state is periodically checkpointed
+  When running under effectively once semantics, the state is periodically checkpointed
   and is replayed when errors occur to a globally consistent checkpoint.
   """
   @abstractmethod

--- a/heronpy/connectors/pulsar/pulsarspout.py
+++ b/heronpy/connectors/pulsar/pulsarspout.py
@@ -97,7 +97,7 @@ class PulsarSpout(Spout, DslBoltBase):
     self.logger.info("Generated LogConf at %s" % self.logConfFileName)
 
     # We currently use the high level consumer api
-    # For supporting exactly once, we will need to switch
+    # For supporting effectively once, we will need to switch
     # to using lower level Reader api, when it becomes
     # available in python
     self.client = pulsar.Client(self.pulsar_cluster, log_conf_file_path=self.logConfFileName)


### PR DESCRIPTION
The stateful processing in Heron relies on Distributed snapshotting method where state is periodically check pointed and restored when a failure occurs. However once a failure occurs and the last globally consistent checkpoint is restored, tuples which were already processed(but not check pointed) could be replayed. Thus it is possible that a tuple is processed more than once, however because all state information is stored in the state variable, the effects are applied once once. In other words, this mechanism is effectively once.
To achieve true exactly once processing where one needs to guarantee that every tuple is processed only once, one needs to adopt MillWheel Style approach where each incoming and outgoing tuple is stored and deduped.
This pr thus renames exactly once wordings with effectively once to reflect the thought above.