### PR TITLE
Add scheduler docs missing from website.

### DIFF
--- a/website/data/toc.yaml
+++ b/website/data/toc.yaml
@@ -67,6 +67,10 @@ sections:
     sublinks:
       - name: Aurora Cluster
         url: /docs/operators/deployment/schedulers/aurora
+      - name: DC/OS Cluster
+        url: /docs/operators/deployment/schedulers/dcos
+      - name: Kubernetes Cluster
+        url: /docs/operators/deployment/schedulers/kubernetes
       - name: Local Cluster
         url: /docs/operators/deployment/schedulers/local
 #      - name: Mesos Cluster


### PR DESCRIPTION
Docs for DC/OS Marathon Scheduler and Kubernetes Scheduler exist in the repo, but are not shown on the website as they are missing from `website/data/toc.yaml`.

Verified by building the site after this change, docs for these schedulers are present.