### PR TITLE
log large packet without interrupting the heron-instance exectuion

### DIFF
--- a/heron/common/src/java/com/twitter/heron/common/network/IncomingPacket.java
+++ b/heron/common/src/java/com/twitter/heron/common/network/IncomingPacket.java
@@ -75,7 +75,7 @@ public class IncomingPacket {
       int size = header.getInt();
       if (size > limit) {
         LOG.log(Level.SEVERE, "packet size " + size + " exceeds limit " + limit);
-        return -1;
+        // return -1;
       }
       data = ByteBuffer.allocate(size);
     }


### PR DESCRIPTION
Sometimes the large packet was received. The heron-instance closes the connection to stmgr which disconnects the stmgr and heron-instance and the whole topology is down.

This PR lets the heron-instance continue execution. The unexpected large packet is written in log but the execution is not interrupted.