### PR TITLE
Fixing bug involving race condition with initializing in and out queues

### DIFF
--- a/heron/instance/src/java/com/twitter/heron/instance/Slave.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/Slave.java
@@ -93,9 +93,9 @@ public class Slave implements Runnable, AutoCloseable {
     this.metricsCollector = new MetricsCollector(slaveLooper, metricsOutCommunicator);
 
     /**
-     * initializing queues with default values
-     * this is done after the physical plan is download and here since
-     * components might download physical plans at different rates causing
+     * Initializing queues with default values.
+     * This is done after the physical plan is downloaded and here since
+     * components might download physical plans at different rates
      * and components upstream might already start sending tuples downstream
      */
     this.streamInCommunicator.init(INSTANCE_INTERNAL_BOLT_READ_QUEUE_CAPACITY,

--- a/heron/instance/src/java/com/twitter/heron/instance/Slave.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/Slave.java
@@ -66,6 +66,11 @@ public class Slave implements Runnable, AutoCloseable {
   private State<Serializable, Serializable> instanceState;
   private boolean isStatefulProcessingStarted;
 
+  /**
+   * Default values used to initialize in and out queues prior to downloading the physical plan
+   * These values are transient and will be overwritten when the queue gets reinitialized after
+   * the physical plan is downloaded to values set in heron_interals.yaml
+   */
   private static final int INSTANCE_INTERNAL_BOLT_READ_QUEUE_CAPACITY = 128;
   private static final int INSTANCE_TUNING_EXPECTED_BOLT_READ_QUEUE_SIZE = 8;
   private static final double INSTANCE_TUNING_CURRENT_SAMPLE_WEIGHT = 0.8;


### PR DESCRIPTION
Fixing bug involving race condition with initializing in and out queues and downloading the physical plan.  In and out queues are initialized after the physical plan was download by the instance.  However, physical plans are not going to be download all at the same time causing some components to start sending tuples earlier than others. By initializing the queues earlier allows tuples to be start processing earlier