### PR TITLE
Notify both producer and consumer when init the Communicator

### DIFF
--- a/heron/common/src/java/com/twitter/heron/common/basics/Communicator.java
+++ b/heron/common/src/java/com/twitter/heron/common/basics/Communicator.java
@@ -125,6 +125,10 @@ public class Communicator<E> {
 
     // We set the default expected available capacity half as the capacity
     this.expectedAvailableCapacity = capacity / 2;
+
+    // Notify both sides to pick up new values
+    informConsumer();
+    informProducer();
   }
 
   /**


### PR DESCRIPTION
Currently, when we init the Communicator, the changes will be picked up only when the producer/consumer
are notified by other events. It can lead to a race condition.

This pull request fixes the issue by notifying both producer/consumer immediately to run with new configs/values.

It is fixing the same issue mentioned in #2278. Reproduced the issue and have tested the fixing with this pull request with Local Scheduler.