### PR TITLE
fix tmaster client sends incomplete register request to tmaster

### DIFF
--- a/heron/stmgr/src/cpp/manager/stmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr.cpp
@@ -470,7 +470,7 @@ void StMgr::StartTMasterClient() {
   } else {
     std::vector<proto::system::Instance*> all_instance_info;
     server_->GetInstanceInfo(all_instance_info);
-    tmaster_client_->SetInstanceInfo(all_instance_info);
+    tmaster_client_->SetStmgrRegisterRequest(all_instance_info);
     if (!tmaster_client_->IsConnected()) {
       LOG(INFO) << "Connecting to the TMaster as all the instances have connected to us";
       tmaster_client_->Start();

--- a/heron/stmgr/src/cpp/manager/tmaster-client.h
+++ b/heron/stmgr/src/cpp/manager/tmaster-client.h
@@ -40,10 +40,8 @@ class TMasterClient : public Client {
   // Told by the upper layer to disconnect and self destruct
   void Die();
 
-  // Sets the instances that belong to us
-  void SetInstanceInfo(const std::vector<proto::system::Instance*>& _instances) {
-    instances_ = _instances;
-  }
+  // Sets register request when stmgr collects all needed information
+  void SetStmgrRegisterRequest(const std::vector<proto::system::Instance*>& _instances);
 
   // returns the tmaster address "host:port" form.
   sp_string getTmasterHostPort();
@@ -86,7 +84,8 @@ class TMasterClient : public Client {
   sp_string stmgr_host_;
   sp_int32 stmgr_port_;
   sp_int32 shell_port_;
-  std::vector<proto::system::Instance*> instances_;
+  proto::tmaster::StMgrRegisterRequest* register_request_;
+
   bool to_die_;
   // We invoke this callback upon a new physical plan from tmaster
   VCallback<proto::system::PhysicalPlan*> pplan_watch_;

--- a/heron/stmgr/src/cpp/manager/tmaster-client.h
+++ b/heron/stmgr/src/cpp/manager/tmaster-client.h
@@ -84,7 +84,9 @@ class TMasterClient : public Client {
   sp_string stmgr_host_;
   sp_int32 stmgr_port_;
   sp_int32 shell_port_;
-  proto::tmaster::StMgrRegisterRequest* register_request_;
+
+  bool register_request_set_;
+  proto::tmaster::StMgrRegisterRequest register_request_;
 
   bool to_die_;
   // We invoke this callback upon a new physical plan from tmaster


### PR DESCRIPTION
Previously, both tmaster client and stmgr have pointers to instances' information. This is problematic that between the time tmaster client gets the instance pointer and sends the register request using the pointed instances' information, it's possible that stmgr changes some instance info. Then tmaster client sends the changed instance info to tmaster without any knowledge. This causes severe problem for tmaster to compose a complete physical plan.

In this PR, we fix this problem by composing the `StmgrRegisterRequest` instead of maintaining the pointers to instance in tmaster client when stmgr is ready to connect to tmaster. In this way, the request sent by tmaster client is always complete and won't be updated unexpectedly. If the instance is updated between the request is composed and sent, the old complete request is still sent to tmaster and then a new complete request is sent. This won't causing any incomplete physical plan problem.