### PR TITLE
Make submitting examples easier from the command line.

### DIFF
--- a/heron/examples/src/java/com/twitter/heron/examples/AckingTopology.java
+++ b/heron/examples/src/java/com/twitter/heron/examples/AckingTopology.java
@@ -17,6 +17,8 @@ package com.twitter.heron.examples;
 import java.util.Map;
 import java.util.Random;
 
+import com.twitter.heron.examples.util.ExampleResources;
+
 import backtype.storm.Config;
 import backtype.storm.StormSubmitter;
 import backtype.storm.metric.api.GlobalMetrics;

--- a/heron/examples/src/java/com/twitter/heron/examples/ExclamationTopology.java
+++ b/heron/examples/src/java/com/twitter/heron/examples/ExclamationTopology.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import com.twitter.heron.api.topology.IUpdatable;
 import com.twitter.heron.examples.spout.TestWordSpout;
+import com.twitter.heron.examples.util.ExampleResources;
 
 import backtype.storm.Config;
 import backtype.storm.LocalCluster;

--- a/heron/examples/src/java/com/twitter/heron/examples/MultiSpoutExclamationTopology.java
+++ b/heron/examples/src/java/com/twitter/heron/examples/MultiSpoutExclamationTopology.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.examples.spout.TestWordSpout;
+import com.twitter.heron.examples.util.ExampleResources;
 
 import backtype.storm.Config;
 import backtype.storm.LocalCluster;

--- a/heron/examples/src/java/com/twitter/heron/examples/MultiStageAckingTopology.java
+++ b/heron/examples/src/java/com/twitter/heron/examples/MultiStageAckingTopology.java
@@ -17,6 +17,8 @@ package com.twitter.heron.examples;
 import java.util.Map;
 import java.util.Random;
 
+import com.twitter.heron.examples.util.ExampleResources;
+
 import backtype.storm.Config;
 import backtype.storm.StormSubmitter;
 import backtype.storm.metric.api.GlobalMetrics;

--- a/heron/examples/src/java/com/twitter/heron/examples/WordCountTopology.java
+++ b/heron/examples/src/java/com/twitter/heron/examples/WordCountTopology.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Random;
 
 import com.twitter.heron.common.basics.ByteAmount;
+import com.twitter.heron.examples.util.ExampleResources;
 
 import backtype.storm.Config;
 import backtype.storm.StormSubmitter;

--- a/heron/examples/src/java/com/twitter/heron/examples/util/ExampleResources.java
+++ b/heron/examples/src/java/com/twitter/heron/examples/util/ExampleResources.java
@@ -11,23 +11,23 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-package com.twitter.heron.examples;
+package com.twitter.heron.examples.util;
 
 import com.twitter.heron.common.basics.ByteAmount;
 
 public final class ExampleResources {
 
-  static final long COMPONENT_RAM_MB = 256;
+  public static final long COMPONENT_RAM_MB = 256;
 
-  static ByteAmount getComponentRam() {
+  public static ByteAmount getComponentRam() {
     return ByteAmount.fromMegabytes(COMPONENT_RAM_MB);
   }
 
-  static ByteAmount getContainerDisk(int components, int containers) {
+  public static ByteAmount getContainerDisk(int components, int containers) {
     return ByteAmount.fromGigabytes(Math.max(components / containers, 1));
   }
 
-  static ByteAmount getContainerRam(int components, int containers) {
+  public static ByteAmount getContainerRam(int components, int containers) {
     final int componentsPerContainer = Math.max(components / containers, 1);
     return ByteAmount.fromMegabytes(COMPONENT_RAM_MB * componentsPerContainer);
   }

--- a/heron/tools/cli/src/python/cdefs.py
+++ b/heron/tools/cli/src/python/cdefs.py
@@ -40,7 +40,7 @@ def read_server_mode_cluster_definition(cluster, cl_args, config_file):
     client_confs[cluster] = dict()
 
   # now check if the service-url from command line is set, if so override it
-  if cl_args['service_url']:
+  if cl_args.get('service_url', None):
     client_confs[cluster]['service_url'] = cl_args['service_url']
 
   # the return value of yaml.load can be None if conf_file is an empty file

--- a/heron/tools/cli/src/python/examples.py
+++ b/heron/tools/cli/src/python/examples.py
@@ -1,0 +1,188 @@
+# Copyright 2017 Twitter. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+''' examples.py '''
+import os
+import re
+import zipfile
+
+from heron.common.src.python.utils.log import Log
+from heron.tools.cli.src.python.result import SimpleResult, Status
+import heron.tools.cli.src.python.args as cli_args
+import heron.tools.cli.src.python.submit as submit
+import heron.tools.common.src.python.utils.config as config
+
+
+example_ids = dict(
+    AckingTopology="acking",
+    ComponentJVMOptionsTopology="component-jvm-options",
+    CustomGroupingTopology="custom-grouping",
+    ExclamationTopology="exclamation",
+    MultiSpoutExclamationTopology="ms-exclamation",
+    MultiStageAckingTopology="ms-acking",
+    SentenceWordCountTopology="sentence-wordcount",
+    SlidingWindowTopology="sliding-window",
+    TaskHookTopology="taskhook",
+    WordCountTopology="wordcount")
+
+
+heron_examples = None
+
+def examples():
+  '''
+  :return:
+  '''
+  if heron_examples is None:
+    heron_examples_jar = config.get_heron_examples_jar()
+    archive = zipfile.ZipFile(heron_examples_jar, 'r')
+
+    def to_name(c):
+      return c.split("/")[-1].replace(".class", "")
+
+    def to_clazz(c):
+      return c.replace("/", ".").replace(".class", "")
+
+    example_re = '^com/twitter/heron/examples/[a-zA-Z0-9.-]+.class'
+    pattern = re.compile(example_re)
+    found_examples = ((to_name(c), to_clazz(c)) for c in archive.namelist() if pattern.match(c))
+
+    def to_dict(ex):
+      return dict(name=ex[0], clazz=ex[1], id=example_ids[ex[0]])
+    known_examples = (to_dict(ex) for ex in found_examples if ex[0] in example_ids)
+
+    # sort examples by name
+    heron_exmaples = sorted(known_examples, key=lambda ex: ex["name"])
+
+  return heron_exmaples
+
+
+def classname(example_id):
+  for example in examples():
+    if example["id"] == example_id:
+      return example["clazz"]
+  return None
+
+def example_id_error(example_id):
+  #ex_topos = "\n".join(map(str, ("  %s" % e["name"] for e in examples())))
+  args = (example_id, examples_string())
+  return "Example id '%s' does not exist.\nAvailable examples:\n%s" % args
+
+def no_examples_error():
+  return "Could not find examples at '%s'" % config.get_heron_examples_jar()
+
+def has_examples():
+  examples_jar = config.get_heron_examples_jar()
+
+  # if the file does not exist and is not a file
+  if not os.path.isfile(examples_jar):
+    Log.warn("Required file not found: %s" % examples_jar)
+    return False
+
+  return True
+
+def examples_string():
+  lines = []
+  col_width = max(len(ex["name"]) for ex in examples()) + 4
+  lines.append("".join(word.ljust(col_width) for word in ("Name", "ID")))
+  for ex in examples():
+    lines.append("".join(word.ljust(col_width) for word in (ex["name"], ex["id"])))
+
+  return "\n".join(lines)
+
+
+def create_parser(subparsers):
+  '''
+  :param subparsers:
+  :return:
+  '''
+  parser = subparsers.add_parser(
+      'examples',
+      help='{list|run} heron examples',
+      usage="%(prog)s <command>",
+      formatter_class=config.SubcommandHelpFormatter,
+      add_help=True)
+
+  ex_subparsers = parser.add_subparsers(
+      title="Commands",
+      description=None)
+
+
+  list_parser = ex_subparsers.add_parser(
+      'list',
+      help='Print packaged heron examples',
+      usage="heron examples list",
+      add_help=True)
+  list_parser.set_defaults(subcommand='examples-list')
+
+
+  run_parser = ex_subparsers.add_parser(
+      'run',
+      help='Run a heron example',
+      usage="heron examples run cluster example-id",
+      add_help=True)
+  run_parser.set_defaults(subcommand='examples-run')
+
+  run_parser.add_argument(
+      'cluster',
+      help='Cluster to run topology')
+
+  run_parser.add_argument(
+      'example-id',
+      help='Example id to run')
+
+  # add optional run arguments
+  cli_args.add_config(run_parser)
+  cli_args.add_service_url(run_parser)
+  cli_args.add_verbose(run_parser)
+
+
+  return parser
+
+# pylint: disable=unused-argument
+def list_examples(command, parser, cl_args, unknown_args):
+  if has_examples():
+    print examples_string()
+  else:
+    print no_examples_error()
+  return SimpleResult(Status.Ok)
+
+# pylint: disable=unused-argument
+def run_example(command, parser, cl_args, unknown_args):
+  topology_file = config.get_heron_examples_jar() if has_examples() else None
+  if topology_file is None:
+    return SimpleResult(Status.InvocationError, no_examples_error())
+
+  example_id = cl_args['example-id']
+  topology_classname = classname(example_id)
+  if topology_classname is None:
+    return SimpleResult(Status.InvocationError, example_id_error(example_id))
+
+  cl_args['topology-file-name'] = topology_file
+  cl_args['topology-class-name'] = topology_classname
+
+  return submit.run("submit", parser, cl_args, [example_id])
+
+
+# pylint: disable=unused-argument
+def run(command, parser, cl_args, unknown_args):
+  '''
+  :param command:
+  :param parser:
+  :param cl_args:
+  :param unknown_args:
+  :return:
+  '''
+  if command == 'examples-run':
+    return run_example(command, parser, cl_args, unknown_args)
+  else:
+    return list_examples(command, parser, cl_args, unknown_args)

--- a/heron/tools/cli/src/python/examples.py
+++ b/heron/tools/cli/src/python/examples.py
@@ -73,7 +73,6 @@ def classname(example_id):
   return None
 
 def example_id_error(example_id):
-  #ex_topos = "\n".join(map(str, ("  %s" % e["name"] for e in examples())))
   args = (example_id, examples_string())
   return "Example id '%s' does not exist.\nAvailable examples:\n%s" % args
 
@@ -144,7 +143,6 @@ def create_parser(subparsers):
   cli_args.add_config(run_parser)
   cli_args.add_service_url(run_parser)
   cli_args.add_verbose(run_parser)
-
 
   return parser
 

--- a/heron/tools/cli/src/python/jars.py
+++ b/heron/tools/cli/src/python/jars.py
@@ -82,6 +82,3 @@ def packing_jars():
       os.path.join(config.get_heron_lib_dir(), "packing", "*")
   ]
   return jars
-
-
-

--- a/heron/tools/cli/src/python/jars.py
+++ b/heron/tools/cli/src/python/jars.py
@@ -82,3 +82,6 @@ def packing_jars():
       os.path.join(config.get_heron_lib_dir(), "packing", "*")
   ]
   return jars
+
+
+

--- a/heron/tools/cli/src/python/main.py
+++ b/heron/tools/cli/src/python/main.py
@@ -275,8 +275,6 @@ def extract_common_args(command, parser, cl_args):
     cluster_role_env = cl_args.pop('cluster/[role]/[env]')
   except KeyError:
     try:
-      print command, parser, cl_args
-      Log.info(command)
       cluster_role_env = cl_args.pop('cluster')  # for version command
     except KeyError:
       # if some of the arguments are not found, print error and exit

--- a/heron/tools/cli/src/python/main.py
+++ b/heron/tools/cli/src/python/main.py
@@ -29,6 +29,7 @@ import heron.tools.cli.src.python.cdefs as cdefs
 import heron.tools.cli.src.python.help as cli_help
 import heron.tools.cli.src.python.activate as activate
 import heron.tools.cli.src.python.deactivate as deactivate
+import heron.tools.cli.src.python.examples as examples
 import heron.tools.cli.src.python.kill as kill
 import heron.tools.cli.src.python.result as result
 import heron.tools.cli.src.python.restart as restart
@@ -90,6 +91,7 @@ def create_parser():
   submit.create_parser(subparsers)
   update.create_parser(subparsers)
   version.create_parser(subparsers)
+  examples.create_parser(subparsers)
 
   return parser
 
@@ -107,6 +109,8 @@ def run(command, parser, command_args, unknown_args):
   runners = {
       'activate':activate,
       'deactivate':deactivate,
+      'examples-list': examples,
+      'examples-run': examples,
       'kill':kill,
       'restart':restart,
       'submit':submit,
@@ -271,11 +275,14 @@ def extract_common_args(command, parser, cl_args):
     cluster_role_env = cl_args.pop('cluster/[role]/[env]')
   except KeyError:
     try:
+      print command, parser, cl_args
+      Log.info(command)
       cluster_role_env = cl_args.pop('cluster')  # for version command
     except KeyError:
       # if some of the arguments are not found, print error and exit
       subparser = config.get_subparser(parser, command)
-      print subparser.format_help()
+      if subparser:
+        print subparser.format_help()
       return dict()
 
   new_cl_args = dict()
@@ -287,6 +294,15 @@ def extract_common_args(command, parser, cl_args):
 
   cl_args.update(new_cl_args)
   return cl_args
+
+################################################################################
+def is_example(command):
+  '''
+  :param command:
+  :return: True if the command is an example command
+  '''
+  return command == 'examples-list'
+
 
 ################################################################################
 def main():
@@ -325,7 +341,7 @@ def main():
     results = run(command, parser, command_line_args, unknown_args)
     return 0 if result.is_successful(results) else 1
 
-  if command not in ('help', 'version'):
+  if command not in ('help', 'version') and not is_example(command):
     log.set_logging_level(command_line_args)
     Log.debug("Input Command Line Args: %s", command_line_args)
 
@@ -347,11 +363,11 @@ def main():
 
   start = time.time()
   results = run(command, parser, command_line_args, unknown_args)
-  if command not in ('help', 'version'):
+  if command not in ('help', 'version') and not is_example(command):
     result.render(results)
   end = time.time()
 
-  if command not in ('help', 'version'):
+  if command not in ('help', 'version') and not is_example(command):
     sys.stdout.flush()
     Log.debug('Elapsed time: %.3fs.', (end - start))
 

--- a/heron/tools/cli/src/python/submit.py
+++ b/heron/tools/cli/src/python/submit.py
@@ -39,7 +39,7 @@ def launch_mode_msg(cl_args):
   :param cl_args:
   :return:
   '''
-  if cl_args['dry_run']:
+  if cl_args.get('dry_run', False):
     return "in dry-run mode"
   return ""
 
@@ -116,7 +116,7 @@ def launch_a_topology(cl_args, tmp_dir, topology_file, topology_defn_file, topol
   if Log.getEffectiveLevel() == logging.DEBUG:
     args.append("--verbose")
 
-  if cl_args["dry_run"]:
+  if cl_args.get("dry_run", False):
     args.append("--dry_run")
     if "dry_run_format" in cl_args:
       args += ["--dry_run_format", cl_args["dry_run_format"]]
@@ -124,7 +124,7 @@ def launch_a_topology(cl_args, tmp_dir, topology_file, topology_defn_file, topol
   lib_jars = config.get_heron_libs(
       jars.scheduler_jars() + jars.uploader_jars() + jars.statemgr_jars() + jars.packing_jars()
   )
-  extra_jars = cl_args['extra_launch_classpath'].split(':')
+  extra_jars = cl_args.get('extra_launch_classpath', "").split(':')
 
   # invoke the submitter to submit and launch the topology
   main_class = 'com.twitter.heron.scheduler.SubmitterMain'
@@ -161,7 +161,7 @@ def launch_topology_server(cl_args, topology_file, topology_defn_file, topology_
       user=cl_args['submit_user'],
   )
 
-  if cl_args['dry_run']:
+  if cl_args.get('dry_run', False):
     data["dry_run"] = True
 
   files = dict(
@@ -257,7 +257,7 @@ def submit_fatjar(cl_args, unknown_args, tmp_dir):
       lib_jars=config.get_heron_libs(jars.topology_jars()),
       extra_jars=[topology_file],
       args=tuple(unknown_args),
-      java_defines=cl_args['topology_main_jvm_property'])
+      java_defines=cl_args.get('topology_main_jvm_property', ""))
 
   result.render(res)
 
@@ -371,7 +371,7 @@ def run(command, parser, cl_args, unknown_args):
     return SimpleResult(Status.InvocationError, err_context)
 
   # check if extra launch classpath is provided and if it is validate
-  if cl_args['extra_launch_classpath']:
+  if cl_args.get('extra_launch_classpath', None):
     valid_classpath = classpath.valid_java_classpath(cl_args['extra_launch_classpath'])
     if not valid_classpath:
       err_context = "One of jar or directory in extra launch classpath does not exist: %s" % \
@@ -383,7 +383,7 @@ def run(command, parser, cl_args, unknown_args):
   opts.cleaned_up_files.append(tmp_dir)
 
   # if topology needs to be launched in deactivated state, do it so
-  if cl_args['deploy_deactivated']:
+  if cl_args.get('deploy_deactivated', False):
     initial_state = topology_pb2.TopologyState.Name(topology_pb2.PAUSED)
   else:
     initial_state = topology_pb2.TopologyState.Name(topology_pb2.RUNNING)

--- a/heron/tools/common/src/python/utils/config.py
+++ b/heron/tools/common/src/python/utils/config.py
@@ -34,6 +34,8 @@ ENVIRON = "default"
 BIN_DIR = "bin"
 CONF_DIR = "conf"
 ETC_DIR = "etc"
+EXAMPLES_DIR = "examples"
+EXAMPLES_JAR = "heron-examples.jar"
 LIB_DIR = "lib"
 CLI_DIR = ".heron"
 RELEASE_YAML = "release.yaml"
@@ -90,11 +92,15 @@ def get_subparser(parser, command):
   subparsers_actions = [action for action in parser._actions
                         if isinstance(action, argparse._SubParsersAction)]
 
+  print "subparser", command
+  print str(parser._actions)
+  print subparsers_actions
   # there will probably only be one subparser_action,
   # but better save than sorry
   for subparsers_action in subparsers_actions:
     # get all subparsers
     for choice, subparser in subparsers_action.choices.items():
+      print choice, subparser
       if choice == command:
         return subparser
   return None
@@ -181,6 +187,24 @@ def get_heron_bin_dir():
   """
   bin_path = os.path.join(get_heron_dir(), BIN_DIR)
   return bin_path
+
+
+def get_heron_examples_dir():
+  """
+  This will provide heron examples directory from .pex file.
+  :return: absolute path of heron examples directory
+  """
+  conf_path = os.path.join(get_heron_dir(), EXAMPLES_DIR)
+  return conf_path
+
+
+def get_heron_examples_jar():
+  """
+  This will provide heron examples jar from .pex file.
+  :return: absolute path of heron examples jar
+  """
+  path = os.path.join(get_heron_examples_dir(), EXAMPLES_JAR)
+  return path
 
 
 def get_heron_conf_dir():

--- a/heron/tools/common/src/python/utils/config.py
+++ b/heron/tools/common/src/python/utils/config.py
@@ -92,9 +92,6 @@ def get_subparser(parser, command):
   subparsers_actions = [action for action in parser._actions
                         if isinstance(action, argparse._SubParsersAction)]
 
-  print "subparser", command
-  print str(parser._actions)
-  print subparsers_actions
   # there will probably only be one subparser_action,
   # but better save than sorry
   for subparsers_action in subparsers_actions:

--- a/heron/tools/common/src/python/utils/config.py
+++ b/heron/tools/common/src/python/utils/config.py
@@ -97,7 +97,6 @@ def get_subparser(parser, command):
   for subparsers_action in subparsers_actions:
     # get all subparsers
     for choice, subparser in subparsers_action.choices.items():
-      print choice, subparser
       if choice == command:
         return subparser
   return None


### PR DESCRIPTION
New commands:
  heron examples list
  heron examples run <cluster> <example-id>

This patch is to provide easier commands to get the heron examples up and running.