### PR TITLE
Fix Python docs generation

### DIFF
--- a/website/Makefile
+++ b/website/Makefile
@@ -31,13 +31,13 @@ python-docs:
 site:
 	@make clean
 	@make build-static-assets
-	@make pages
 	@make javadocs
 	@make python-docs
+	@make pages
 
 travis-site:
 	@make clean
 	@make build-static-assets
-	@make pages
 	@scripts/javadocs.sh --travis
 	@make python-docs
+	@make pages

--- a/website/config.yaml
+++ b/website/config.yaml
@@ -19,9 +19,9 @@ params:
   author: Twitter, Inc.
   description: A realtime, distributed, fault-tolerant stream processing engine from Twitter
   versions:
-    heron: 0.15.1
+    heron: 0.15.2
     bazel: 0.5.4
-    heronpy: 0.15.1
+    heronpy: 0.15.2
   assets:
     favicon:
       small: /img/favicon-16x16.png

--- a/website/scripts/javadocs.sh
+++ b/website/scripts/javadocs.sh
@@ -46,7 +46,7 @@ $JAVADOC $FLAGS \
   -windowtitle "Heron Java API" \
   -doctitle "The Heron Java API" \
   -overview $OVERVIEW_HTML_FILE \
-  -d $JAVADOC_OUTPUT_DIR $GEN_FILES $HERON_SRC_FILES $BACKTYPE_SRC_FILES $APACHE_SRC_FILES
+  -d $JAVADOC_OUTPUT_DIR $GEN_FILES $HERON_SRC_FILES $BACKTYPE_SRC_FILES $APACHE_SRC_FILES || true
 
 # Generated Java API doc needs to be copied to $JAVADOC_OUTPUT_LOCAL_DIR
 # for the following two reasons:

--- a/website/scripts/python-doc-gen.sh
+++ b/website/scripts/python-doc-gen.sh
@@ -9,8 +9,8 @@ pip install heronpy==${HERONPY_VERSION}
 
 mkdir -p static/api && rm -rf static/api/python
 
-pdoc heron \
+pdoc heronpy \
   --html \
   --html-dir $TMP_DIR
 
-mv $TMP_DIR/heron static/api/python
+mv $TMP_DIR/heronpy static/api/python


### PR DESCRIPTION
This PR fixes an issue with documentation generation that was created when the library was renamed from `heron` back to `heronpy`. It also fixes two other issues that came to my attention: running `make pages` needs to happen *after* all API doc generation or else API docs won't end up in the `public` folder, which is necessary for GitHub Pages; and appending the `|| true` statement to the end of the Javadoc generation command ensures that Javadoc errors won't prevent us from being able to generate the site.