### PR TITLE
fix bugs in stmgr unit test

### DIFF
--- a/heron/stmgr/src/cpp/manager/tmaster-client.cpp
+++ b/heron/stmgr/src/cpp/manager/tmaster-client.cpp
@@ -108,8 +108,9 @@ void TMasterClient::HandleConnect(NetworkErrorCode _status) {
                << get_clientoptions().get_port() << std::endl;
     LOG(INFO) << "Will retry again..." << std::endl;
     // Shouldn't be in a state where a previous timer is not cleared yet.
-    CHECK_EQ(reconnect_timer_id, 0);
-    reconnect_timer_id = AddTimer(reconnect_timer_cb, reconnect_tmaster_interval_sec_ * 1000000);
+    if (reconnect_timer_id == 0) {
+      reconnect_timer_id = AddTimer(reconnect_timer_cb, reconnect_tmaster_interval_sec_ * 1000000);
+    }
   }
 }
 

--- a/heron/stmgr/src/cpp/manager/tmaster-client.cpp
+++ b/heron/stmgr/src/cpp/manager/tmaster-client.cpp
@@ -217,6 +217,7 @@ void TMasterClient::SendRegisterRequest() {
 
 void TMasterClient::SetStmgrRegisterRequest(
                                     const std::vector<proto::system::Instance*>& _instances) {
+    register_request_.Clear();
     register_request_set_ = true;
 
     sp_string cwd;

--- a/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
@@ -320,7 +320,7 @@ void StartDummyMtrMgr(EventLoopImpl*& ss, DummyMtrMgr*& mgr, std::thread*& mtmgr
   NetworkOptions options;
   options.set_host(LOCALHOST);
   options.set_port(mtmgr_port);
-  options.set_max_packet_size(1_MB);
+  options.set_max_packet_size(10_MB);
   options.set_socket_family(PF_INET);
 
   mgr = new DummyMtrMgr(ss, options, stmgr_id, tmasterLatch, connectionCloseLatch);
@@ -343,7 +343,7 @@ void StartDummySpoutInstance(EventLoopImpl*& ss, DummySpoutInstance*& worker,
   NetworkOptions options;
   options.set_host(LOCALHOST);
   options.set_port(stmgr_port);
-  options.set_max_packet_size(1_MB);
+  options.set_max_packet_size(10_MB);
   options.set_socket_family(PF_INET);
 
   worker = new DummySpoutInstance(ss, options, topology_name, topology_id, instance_id,
@@ -365,7 +365,7 @@ void StartDummyBoltInstance(EventLoopImpl*& ss, DummyBoltInstance*& worker,
   NetworkOptions options;
   options.set_host(LOCALHOST);
   options.set_port(stmgr_port);
-  options.set_max_packet_size(1_MB);
+  options.set_max_packet_size(10_MB);
   options.set_socket_family(PF_INET);
 
   worker =


### PR DESCRIPTION
Three problems found for the current stmgr and its unit test:
1. `register_request_` needs to be cleared before setting it again. Otherwise it will cause duplicate instances' info.
2. Increase the packet size limit option for dummy stmgr, spout and bolt. This is to match with the real stmgr started during the unit test.
3. use `if` clause instead of the `CHECK_EQ` on `reconnect_timer_id` to create timer