### PR TITLE
fix python state manager

### DIFF
--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -898,7 +898,11 @@ class HeronExecutor(object):
     """
     statemgr_config = StateMgrConfig()
     statemgr_config.set_state_locations(configloader.load_state_manager_locations(self.cluster))
-    self.state_managers = statemanagerfactory.get_all_state_managers(statemgr_config)
+    try:
+      self.state_managers = statemanagerfactory.get_all_state_managers(statemgr_config)
+    except Exception as ex:
+      Log.error("Found exception: %s. Bailing out..." % ex)
+      sys.exit(1)
 
     # pylint: disable=unused-argument
     def on_packing_plan_watch(state_manager, new_packing_plan):

--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -901,7 +901,7 @@ class HeronExecutor(object):
     try:
       self.state_managers = statemanagerfactory.get_all_state_managers(statemgr_config)
     except Exception as ex:
-      Log.error("Found exception: %s. Bailing out..." % ex)
+      Log.error("Found exception while initializing state managers: %s. Bailing out..." % ex)
       sys.exit(1)
 
     # pylint: disable=unused-argument

--- a/heron/statemgrs/src/python/statemanagerfactory.py
+++ b/heron/statemgrs/src/python/statemanagerfactory.py
@@ -69,7 +69,6 @@ def get_all_zk_state_managers(conf):
     state_manager = ZkStateManager(name, hostportlist, rootpath, tunnelhost)
     try:
       state_manager.start()
-      raise Exception("Neng's test exception")
     except Exception as ex:
       LOG.error("Exception while connecting to state_manager.")
       LOG.debug(traceback.format_exc())

--- a/heron/statemgrs/src/python/statemanagerfactory.py
+++ b/heron/statemgrs/src/python/statemanagerfactory.py
@@ -33,9 +33,13 @@ def get_all_state_managers(conf):
   Instantiates them, start and then return them.
   """
   state_managers = []
-  state_managers.extend(get_all_zk_state_managers(conf))
-  state_managers.extend(get_all_file_state_managers(conf))
-  return state_managers
+  try:
+    state_managers.extend(get_all_zk_state_managers(conf))
+    state_managers.extend(get_all_file_state_managers(conf))
+    return state_managers
+  except Exception as ex:
+    LOG.error("Exception while getting state_managers.")
+    raise ex
 
 def get_all_zk_state_managers(conf):
   """
@@ -65,9 +69,11 @@ def get_all_zk_state_managers(conf):
     state_manager = ZkStateManager(name, hostportlist, rootpath, tunnelhost)
     try:
       state_manager.start()
-    except Exception:
+      raise Exception("Neng's test exception")
+    except Exception as ex:
       LOG.error("Exception while connecting to state_manager.")
       LOG.debug(traceback.format_exc())
+      raise ex
     state_managers.append(state_manager)
 
   return state_managers
@@ -85,9 +91,10 @@ def get_all_file_state_managers(conf):
     state_manager = FileStateManager(name, rootpath)
     try:
       state_manager.start()
-    except Exception:
+    except Exception as ex:
       LOG.error("Exception while connecting to state_manager.")
       traceback.print_exc()
+      raise ex
     state_managers.append(state_manager)
 
   return state_managers


### PR DESCRIPTION
Recent internal zookeeper server unstable issue caused our topologies fail to be started. The log shows that heron executor  continues execution even after an exception is logged.

```
[2017-09-16 00:21:40 +0000] [ERROR]: Exception while connecting to state_manager.
[2017-09-16 00:21:40 +0000] [INFO]: Adding data watch for path: ${SOME_PATH}
[2017-09-16 00:21:40 +0000] [INFO]: Registered state watch for packing plan changes with state manager <heron.statemgrs.src.python.zkstatemanager.ZkStateManager object at ${SOME_ADDR}>.
[2017-09-16 00:43:27 +0000] [INFO]: signal_handler invoked with signal 15
```

With further investigation, we found that methods in `statemanagerfactory` only logs an exception and then swallows it. Ideally, the state manager should either fail fast or propagate exceptions to upper layer.

This PR is to fix the problem. `statemanagerfactory` propagate exception after logging it and `heron_executor` exit immediately if it catches any exception from state manager.

I tested the logic locally by throwing an exception on purpose. And the heron-executor exits once caught the exception