### PR TITLE
clean heron java instance for stateful processing

### DIFF
--- a/examples/src/java/com/twitter/heron/examples/StatefulWordCountTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/StatefulWordCountTopology.java
@@ -129,13 +129,7 @@ public final class StatefulWordCountTopology {
 
     @Override
     public void nextTuple() {
-      try {
-        Thread.sleep(3000);
-      } catch (Exception ex) {
-        //
-      }
       int nextInt = rnd.nextInt(ARRAY_LENGTH);
-      System.out.println("word is: " + words[nextInt]);
       collector.emit(new Values(words[nextInt]));
     }
   }
@@ -168,13 +162,7 @@ public final class StatefulWordCountTopology {
 
     @Override
     public void execute(Tuple tuple) {
-      try {
-        Thread.sleep(3000);
-      } catch (Exception ex) {
-        // do nothing
-      }
       String key = tuple.getString(0);
-      System.out.println(key);
       if (myState.get(key) == null) {
         myState.put(key, 1);
       } else {

--- a/examples/src/java/com/twitter/heron/examples/StatefulWordCountTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/StatefulWordCountTopology.java
@@ -129,7 +129,13 @@ public final class StatefulWordCountTopology {
 
     @Override
     public void nextTuple() {
+      try {
+        Thread.sleep(3000);
+      } catch (Exception ex) {
+        //
+      }
       int nextInt = rnd.nextInt(ARRAY_LENGTH);
+      System.out.println("word is: " + words[nextInt]);
       collector.emit(new Values(words[nextInt]));
     }
   }
@@ -162,7 +168,13 @@ public final class StatefulWordCountTopology {
 
     @Override
     public void execute(Tuple tuple) {
+      try {
+        Thread.sleep(3000);
+      } catch (Exception ex) {
+        // do nothing
+      }
       String key = tuple.getString(0);
+      System.out.println(key);
       if (myState.get(key) == null) {
         myState.put(key, 1);
       } else {
@@ -195,6 +207,7 @@ public final class StatefulWordCountTopology {
     Config conf = new Config();
     conf.setNumStmgrs(parallelism);
     conf.setTopologyReliabilityMode(Config.TopologyReliabilityMode.EFFECTIVELY_ONCE);
+    conf.setTopologyStatefulCheckpointIntervalSecs(20);
 
     // configure component resources
     com.twitter.heron.api.Config.setComponentRam(conf, "word",

--- a/heron/common/src/java/com/twitter/heron/common/utils/misc/PhysicalPlanHelper.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/misc/PhysicalPlanHelper.java
@@ -22,6 +22,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import com.twitter.heron.api.Config;
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.api.grouping.CustomStreamGrouping;
 import com.twitter.heron.api.utils.Utils;
@@ -300,6 +301,16 @@ public class PhysicalPlanHelper {
 
   public boolean isCustomGroupingEmpty() {
     return customGrouper.isCustomGroupingEmpty();
+  }
+
+  public boolean isTopologyStateful() {
+    Map<String, Object> config = topologyContext.getTopologyConfig();
+    return String.valueOf(Config.TopologyReliabilityMode.EFFECTIVELY_ONCE).equals(
+        config.get(Config.TOPOLOGY_RELIABILITY_MODE));
+  }
+
+  public boolean isTopologyRunning() {
+    return getTopologyState().equals(TopologyAPI.TopologyState.RUNNING);
   }
 }
 

--- a/heron/common/src/java/com/twitter/heron/common/utils/misc/PhysicalPlanHelper.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/misc/PhysicalPlanHelper.java
@@ -305,8 +305,11 @@ public class PhysicalPlanHelper {
 
   public boolean isTopologyStateful() {
     Map<String, Object> config = topologyContext.getTopologyConfig();
-    return String.valueOf(Config.TopologyReliabilityMode.EFFECTIVELY_ONCE).equals(
-        config.get(Config.TOPOLOGY_RELIABILITY_MODE));
+    Config.TopologyReliabilityMode mode =
+        Config.TopologyReliabilityMode.valueOf(
+            String.valueOf(config.get(Config.TOPOLOGY_RELIABILITY_MODE)));
+
+    return Config.TopologyReliabilityMode.EFFECTIVELY_ONCE.equals(mode);
   }
 
   public boolean isTopologyRunning() {

--- a/heron/instance/src/java/com/twitter/heron/instance/IInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/IInstance.java
@@ -30,18 +30,34 @@ import com.twitter.heron.common.utils.misc.PhysicalPlanHelper;
 @InterfaceAudience.Private
 @InterfaceStability.Evolving
 public interface IInstance {
-  /**
-   * Do the basic setup for HeronInstance
-   */
-  void start(State<Serializable, Serializable> state);
 
   /**
-   * Do the basic clean for HeronInstance
-   * Notice: this method is not guaranteed to invoke
-   * TODO: - to avoid confusing, we in fact have never called this method yet
-   * TODO: - need to consider whether or not call this method more carefully
+   * Initialize the instance. If it's a stateful topology,
+   * the provided state will be used for initialization.
+   * For non-stateful topology, the state will be ignored.
+   * @param state used for stateful topology to initialize the instance state
    */
-  void stop();
+  void init(State<Serializable, Serializable> state);
+
+  /**
+   * Start the execution of the IInstance
+   */
+  void start();
+
+  /**
+   * Clean the instance. After it's called, the IInstance
+   * will be still alive but with an empty state. Before
+   * starting the IInstance again, an `init()` call is needed
+   * to initialize the instance properly.
+   */
+  void clean();
+
+  /**
+   * Destroy the whole IInstance.
+   * Notice: It should only be called when the whole program is
+   * exiting. And in fact, this method should never be called.
+   */
+  void shutdown();
 
   /**
    * Read tuples from a queue and process the tuples

--- a/heron/instance/src/java/com/twitter/heron/instance/Slave.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/Slave.java
@@ -44,9 +44,6 @@ import com.twitter.heron.proto.system.Metrics;
  * will instantiate a new instance (spout or bolt) according to the PhysicalPlanHelper in SingletonRegistry.
  * It is a Runnable so it could be executed in a Thread. During run(), it will begin the SlaveLooper's loop().
  */
-// TODO (nlu): the slave should handle newPhysicalPlan properly, init() instnace,
-// start() instance, clean() instance properly
-
 public class Slave implements Runnable, AutoCloseable {
   private static final Logger LOG = Logger.getLogger(Slave.class.getName());
 
@@ -198,19 +195,19 @@ public class Slave implements Runnable, AutoCloseable {
     }
 
     if (helper.isTopologyStateful()) {
-      // For stateful topology, the `init(state)` will be
-      // invoked when a RestoreInstanceStateRequest is received
+      // For stateful topology, `init(state)` will be invoked
+      // when a RestoreInstanceStateRequest is received
       if (isStatefulProcessingStarted) {
         instance.init(instanceState);
         instance.start();
         isInstanceStarted = true;
         LOG.info("Instance is started for stateful topology");
       } else {
-        LOG.info("Start StatefulProcessing signal not received. Instance is not started");
+        LOG.info("Start signal not received. Instance is not started");
       }
     } else {
-      // For non-stateful topology, the `null` is provided
-      // as state and will be ignored
+      // For non-stateful topology, any provided state will be ignored
+      // by the instance
       instance.init(null);
       instance.start();
       isInstanceStarted = true;
@@ -267,10 +264,10 @@ public class Slave implements Runnable, AutoCloseable {
     // Create a new MetricsCollector with the clean slaveLooper and register its task
     metricsCollector = new MetricsCollector(slaveLooper, metricsOutCommunicator);
 
-    // re-registering the handling of control msg. instance task
+    // registering the handling of control msg
     handleControlMessage();
 
-    // instance task will be registered when istance.start() is called
+    // instance task will be registered when instance.start() is called
   }
 
   private void handleRestoreInstanceStateRequest(InstanceControlMsg instanceControlMsg) {
@@ -298,7 +295,7 @@ public class Slave implements Runnable, AutoCloseable {
       LOG.info("The restore request does not have an actual state");
     }
 
-    // If there's no checkpoint to restore, heron provides as empty state
+    // If there's no checkpoint to restore, heron provides an empty state
     if (instanceState == null) {
       instanceState = new HashMapState<>();
     }

--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
@@ -135,10 +135,9 @@ public class BoltInstance implements IInstance {
 
     // Checkpoint
     if (bolt instanceof IStatefulComponent) {
-      LOG.info("Starting checkpoint");
       ((IStatefulComponent) bolt).preSave(checkpointId);
     } else {
-      LOG.info("Trying to checkponit a non stateful component. Send empty state");
+      LOG.info("Trying to checkpoint a non stateful component. Send empty state");
     }
 
     collector.sendOutState(instanceState, checkpointId);
@@ -236,7 +235,7 @@ public class BoltInstance implements IInstance {
       if (msg instanceof CheckpointManager.InitiateStatefulCheckpoint) {
         String checkpointId =
             ((CheckpointManager.InitiateStatefulCheckpoint) msg).getCheckpointId();
-        LOG.info("Start checkpoint for: " + checkpointId);
+        LOG.info("Persisting state for checkpoint: " + checkpintId);
         persistState(checkpointId);
       }
 

--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
@@ -226,7 +226,7 @@ public class BoltInstance implements IInstance {
   public void readTuplesAndExecute(Communicator<Message> inQueue) {
     TopologyContextImpl topologyContext = helper.getTopologyContext();
     Duration instanceExecuteBatchTime = systemConfig.getInstanceExecuteBatchTime();
-
+`
     long startOfCycle = System.nanoTime();
     // Read data from in Queues
     while (!inQueue.isEmpty()) {
@@ -235,7 +235,7 @@ public class BoltInstance implements IInstance {
       if (msg instanceof CheckpointManager.InitiateStatefulCheckpoint) {
         String checkpointId =
             ((CheckpointManager.InitiateStatefulCheckpoint) msg).getCheckpointId();
-        LOG.info("Persisting state for checkpoint: " + checkpintId);
+        LOG.info("Persisting state for checkpoint: " + checkpointId);
         persistState(checkpointId);
       }
 

--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
@@ -129,6 +129,8 @@ public class BoltInstance implements IInstance {
 
   @Override
   public void persistState(String checkpointId) {
+    LOG.info("Persisting state for checkpoint: " + checkpointId);
+
     if (!isTopologyStateful) {
       throw new RuntimeException("Could not save a non-stateful topology's state");
     }
@@ -136,8 +138,6 @@ public class BoltInstance implements IInstance {
     // Checkpoint
     if (bolt instanceof IStatefulComponent) {
       ((IStatefulComponent) bolt).preSave(checkpointId);
-    } else {
-      LOG.info("Trying to checkpoint a non stateful component. Send empty state");
     }
 
     collector.sendOutState(instanceState, checkpointId);
@@ -235,7 +235,6 @@ public class BoltInstance implements IInstance {
       if (msg instanceof CheckpointManager.InitiateStatefulCheckpoint) {
         String checkpointId =
             ((CheckpointManager.InitiateStatefulCheckpoint) msg).getCheckpointId();
-        LOG.info("Persisting state for checkpoint: " + checkpointId);
         persistState(checkpointId);
       }
 

--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
@@ -226,7 +226,7 @@ public class BoltInstance implements IInstance {
   public void readTuplesAndExecute(Communicator<Message> inQueue) {
     TopologyContextImpl topologyContext = helper.getTopologyContext();
     Duration instanceExecuteBatchTime = systemConfig.getInstanceExecuteBatchTime();
-`
+
     long startOfCycle = System.nanoTime();
     // Read data from in Queues
     while (!inQueue.isEmpty()) {

--- a/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutInstance.java
@@ -183,7 +183,7 @@ public class SpoutInstance implements IInstance {
 
   @Override
   public void start() {
-    // Add spout ta
+    // Add spout tasks for execution
     addSpoutsTasks();
 
     topologyState = TopologyAPI.TopologyState.RUNNING;

--- a/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutInstance.java
@@ -142,14 +142,14 @@ public class SpoutInstance implements IInstance {
 
   @Override
   public void persistState(String checkpointId) {
+    LOG.info("Persisting state for checkpoint: " + checkpointId);
+
     if (!isTopologyStateful) {
       throw new RuntimeException("Could not save a non-stateful topology's state");
     }
 
     if (spout instanceof IStatefulComponent) {
       ((IStatefulComponent) spout).preSave(checkpointId);
-    } else {
-      LOG.info("Trying to checkponit a non stateful component. Send empty state");
     }
 
     collector.sendOutState(instanceState, checkpointId);
@@ -400,7 +400,6 @@ public class SpoutInstance implements IInstance {
 
       if (msg instanceof CheckpointManager.InitiateStatefulCheckpoint) {
         String checkpintId = ((CheckpointManager.InitiateStatefulCheckpoint) msg).getCheckpointId();
-        LOG.info("Persisting state for checkpoint: " + checkpintId);
         persistState(checkpintId);
       } else if (msg instanceof HeronTuples.HeronTupleSet) {
         HeronTuples.HeronTupleSet tuples = (HeronTuples.HeronTupleSet) msg;

--- a/heron/instance/src/java/com/twitter/heron/network/StreamManagerClient.java
+++ b/heron/instance/src/java/com/twitter/heron/network/StreamManagerClient.java
@@ -283,7 +283,8 @@ public class StreamManagerClient extends HeronClient {
 
   private void handleRestoreInstanceStateRequest(
       CheckpointManager.RestoreInstanceStateRequest request) {
-    LOG.info("Received a RestoreInstanceState request: " + request);
+    LOG.info("Received a RestoreInstanceState request with checkpoint id: "
+          + request.getState().getCheckpointId());
 
     InstanceControlMsg instanceControlMsg = InstanceControlMsg.newBuilder()
         .setRestoreInstanceStateRequest(request)

--- a/heron/simulator/src/java/com/twitter/heron/simulator/executors/InstanceExecutor.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/executors/InstanceExecutor.java
@@ -154,7 +154,7 @@ public class InstanceExecutor implements Runnable {
     }
 
     if (toStop) {
-      instance.stop();
+      instance.shutdown();
       LOG.info("Stopped instance: " + physicalPlanHelper.getMyInstanceId());
 
       // Reset the flag value

--- a/heron/simulator/src/java/com/twitter/heron/simulator/instance/IInstance.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/instance/IInstance.java
@@ -34,7 +34,7 @@ public interface IInstance {
    * TODO: - to avoid confusing, we in fact have never called this method yet
    * TODO: - need to consider whether or not call this method more carefully
    */
-  void stop();
+  void shutdown();
 
   /**
    * Read tuples from a queue and process the tuples

--- a/heron/stmgr/src/cpp/manager/instance-server.cpp
+++ b/heron/stmgr/src/cpp/manager/instance-server.cpp
@@ -226,10 +226,8 @@ void InstanceServer::HandleConnectionClose(Connection* _conn, NetworkErrorCode) 
     // Remove the connection from active instances
     active_instances_.erase(_conn);
 
-    // Remove from instance info
+    // Set the connection to null. Do not delete the structure
     instance_info_[task_id]->set_connection(NULL);
-    delete instance_info_[task_id];
-    instance_info_.erase(task_id);
 
     // Clean the instance_metric_map
     auto immiter = instance_metric_map_.find(instance_id);


### PR DESCRIPTION
During the testing of stateful processing with java HeronInstance, I found several problems:
1. Slave thread is destroyed during restore
2. logic of handling if the instance's slave looper should be started is confusing
3. IInstance interface is not very clean and well organized
4. stmgr accidently cleans instance info 

This PR is fixing the above mentioned issues and with some code refactoring. Tested locally now the stateful processing for java instance is working normally and even with failure cases like instance dying, stmgr dying, tmaster dying.