### PR TITLE
Changing TimeTriggerPolicy to use tick tuples as a timer

### DIFF
--- a/heron/api/src/java/com/twitter/heron/api/Config.java
+++ b/heron/api/src/java/com/twitter/heron/api/Config.java
@@ -50,10 +50,10 @@ public class Config extends HashMap<String, Object> {
    */
   public static final String TOPOLOGY_COMPONENT_JVMOPTS = "topology.component.jvmopts";
   /**
-   * How often a tick tuple from the "__system" component and "__tick" stream should be sent
+   * How often (in milliseconds) a tick tuple from the "__system" component and "__tick" stream should be sent
    * to tasks. Meant to be used as a component-specific configuration.
    */
-  public static final String TOPOLOGY_TICK_TUPLE_FREQ_SECS = "topology.tick.tuple.freq.secs";
+  public static final String TOPOLOGY_TICK_TUPLE_FREQ_MS = "topology.tick.tuple.freq.ms";
   /**
    * True if Heron should timeout messages or not. Defaults to true. This is meant to be used
    * in unit tests to prevent tuples from being accidentally timed out during the test.
@@ -248,7 +248,7 @@ public class Config extends HashMap<String, Object> {
     apiVars.add(TOPOLOGY_WORKER_CHILDOPTS);
     apiVars.add(TOPOLOGY_COMPONENT_JVMOPTS);
     apiVars.add(TOPOLOGY_SERIALIZER_CLASSNAME);
-    apiVars.add(TOPOLOGY_TICK_TUPLE_FREQ_SECS);
+    apiVars.add(TOPOLOGY_TICK_TUPLE_FREQ_MS);
     apiVars.add(TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS);
     apiVars.add(TOPOLOGY_CONTAINER_CPU_REQUESTED);
     apiVars.add(TOPOLOGY_CONTAINER_DISK_REQUESTED);
@@ -333,7 +333,11 @@ public class Config extends HashMap<String, Object> {
   }
 
   public static void setTickTupleFrequency(Map<String, Object> conf, int seconds) {
-    conf.put(Config.TOPOLOGY_TICK_TUPLE_FREQ_SECS, Integer.toString(seconds));
+    setTickTupleFrequencyMs(conf, (long) (seconds * 1000));
+  }
+
+  public static void setTickTupleFrequencyMs(Map<String, Object> conf, long millis) {
+    conf.put(Config.TOPOLOGY_TICK_TUPLE_FREQ_MS, millis);
   }
 
   public static void setTopologyReliabilityMode(Map<String, Object> conf,

--- a/heron/api/src/java/com/twitter/heron/api/Constants.java
+++ b/heron/api/src/java/com/twitter/heron/api/Constants.java
@@ -11,39 +11,13 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-package com.twitter.heron.api.windowing;
+package com.twitter.heron.api;
 
-public class EventImpl<T> implements Event<T> {
-  private final T event;
-  private long ts;
+public final class Constants {
 
-  EventImpl(T event, long ts) {
-    this.event = event;
-    this.ts = ts;
+  private Constants() {
   }
 
-  @Override
-  public long getTimestamp() {
-    return ts;
-  }
-
-  @Override
-  public T get() {
-    return event;
-  }
-
-  @Override
-  public boolean isWatermark() {
-    return false;
-  }
-
-  @Override
-  public boolean isTimer() {
-    return false;
-  }
-
-  @Override
-  public String toString() {
-    return "EventImpl{" + "event=" + event + ", ts=" + ts + '}';
-  }
+  public static final String SYSTEM_COMPONENT_ID = "__system";
+  public static final String SYSTEM_TICK_STREAM_ID = "__tick";
 }

--- a/heron/api/src/java/com/twitter/heron/api/bolt/WindowedBoltExecutor.java
+++ b/heron/api/src/java/com/twitter/heron/api/bolt/WindowedBoltExecutor.java
@@ -29,8 +29,10 @@ import com.twitter.heron.api.topology.TopologyContext;
 import com.twitter.heron.api.tuple.Fields;
 import com.twitter.heron.api.tuple.Tuple;
 import com.twitter.heron.api.tuple.Values;
+import com.twitter.heron.api.utils.TupleUtils;
 import com.twitter.heron.api.windowing.Event;
 import com.twitter.heron.api.windowing.EvictionPolicy;
+import com.twitter.heron.api.windowing.TimerEvent;
 import com.twitter.heron.api.windowing.TimestampExtractor;
 import com.twitter.heron.api.windowing.TriggerPolicy;
 import com.twitter.heron.api.windowing.TupleWindowImpl;
@@ -212,7 +214,7 @@ public class WindowedBoltExecutor implements IRichBolt {
         slidingIntervalDurationMs);
     evictionPolicy = getEvictionPolicy(windowLengthCount, windowLengthDurationMs);
     triggerPolicy = getTriggerPolicy(slidingIntervalCount, slidingIntervalDurationMs, manager,
-        evictionPolicy);
+        evictionPolicy, topoConf);
     manager.setEvictionPolicy(evictionPolicy);
     manager.setTriggerPolicy(triggerPolicy);
     return manager;
@@ -245,7 +247,7 @@ public class WindowedBoltExecutor implements IRichBolt {
   @SuppressWarnings("HiddenField")
   private TriggerPolicy<Tuple> getTriggerPolicy(Count slidingIntervalCount, Long
       slidingIntervalDurationMs, WindowManager<Tuple> manager, EvictionPolicy<Tuple>
-      evictionPolicy) {
+      evictionPolicy, Map<String, Object> topoConf) {
     if (slidingIntervalCount != null) {
       if (isTupleTs()) {
         return new WatermarkCountTriggerPolicy<>(slidingIntervalCount.value, manager,
@@ -258,6 +260,8 @@ public class WindowedBoltExecutor implements IRichBolt {
         return new WatermarkTimeTriggerPolicy<>(slidingIntervalDurationMs, manager,
             evictionPolicy, manager);
       } else {
+        // set tick tuple frequency in milliseconds for timer in TimeTriggerPolicy
+        Config.setTickTupleFrequencyMs(topoConf, slidingIntervalDurationMs);
         return new TimeTriggerPolicy<>(slidingIntervalDurationMs, manager, evictionPolicy);
       }
     }
@@ -304,22 +308,28 @@ public class WindowedBoltExecutor implements IRichBolt {
 
   @Override
   public void execute(Tuple input) {
-    if (isTupleTs()) {
-      long ts = timestampExtractor.extractTimestamp(input);
-      if (waterMarkEventGenerator.track(input.getSourceGlobalStreamId(), ts)) {
-        windowManager.add(input, ts);
-      } else {
-        if (lateTupleStream != null) {
-          windowedOutputCollector.emit(lateTupleStream, input, new Values(input));
-        } else {
-          LOG.info(String.format(
-              "Received a late tuple %s with ts %d. This will not be " + "processed"
-                  + ".", input, ts));
-        }
-        windowedOutputCollector.ack(input);
-      }
+    if (TupleUtils.isTick(input)) {
+      long currTime = System.currentTimeMillis();
+      triggerPolicy.track(new TimerEvent<>(input, currTime));
+      evictionPolicy.track(new TimerEvent<>(input, currTime));
     } else {
-      windowManager.add(input);
+      if (isTupleTs()) {
+        long ts = timestampExtractor.extractTimestamp(input);
+        if (waterMarkEventGenerator.track(input.getSourceGlobalStreamId(), ts)) {
+          windowManager.add(input, ts);
+        } else {
+          if (lateTupleStream != null) {
+            windowedOutputCollector.emit(lateTupleStream, input, new Values(input));
+          } else {
+            LOG.info(String.format(
+                "Received a late tuple %s with ts %d. This will not be " + "processed"
+                    + ".", input, ts));
+          }
+          windowedOutputCollector.ack(input);
+        }
+      } else {
+        windowManager.add(input);
+      }
     }
   }
 

--- a/heron/api/src/java/com/twitter/heron/api/utils/TupleUtils.java
+++ b/heron/api/src/java/com/twitter/heron/api/utils/TupleUtils.java
@@ -11,39 +11,19 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-package com.twitter.heron.api.windowing;
+package com.twitter.heron.api.utils;
 
-public class EventImpl<T> implements Event<T> {
-  private final T event;
-  private long ts;
+import com.twitter.heron.api.Constants;
+import com.twitter.heron.api.tuple.Tuple;
 
-  EventImpl(T event, long ts) {
-    this.event = event;
-    this.ts = ts;
+public final class TupleUtils {
+  private TupleUtils() {
+    // No instantiation
   }
 
-  @Override
-  public long getTimestamp() {
-    return ts;
-  }
-
-  @Override
-  public T get() {
-    return event;
-  }
-
-  @Override
-  public boolean isWatermark() {
-    return false;
-  }
-
-  @Override
-  public boolean isTimer() {
-    return false;
-  }
-
-  @Override
-  public String toString() {
-    return "EventImpl{" + "event=" + event + ", ts=" + ts + '}';
+  public static boolean isTick(Tuple tuple) {
+    return tuple != null
+        && Constants.SYSTEM_COMPONENT_ID.equals(tuple.getSourceComponent())
+        && Constants.SYSTEM_TICK_STREAM_ID.equals(tuple.getSourceStreamId());
   }
 }

--- a/heron/api/src/java/com/twitter/heron/api/windowing/Event.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/Event.java
@@ -42,4 +42,10 @@ public interface Event<T> {
    * @return true if this is a watermark event
    */
   boolean isWatermark();
+
+  /**
+   * If this is a timer event or not.  Timer events use Tick Tuples to trigger
+   * @return true if this a timer event
+   */
+  boolean isTimer();
 }

--- a/heron/api/src/java/com/twitter/heron/api/windowing/TimerEvent.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/TimerEvent.java
@@ -13,37 +13,21 @@
 //  limitations under the License.
 package com.twitter.heron.api.windowing;
 
-public class EventImpl<T> implements Event<T> {
-  private final T event;
-  private long ts;
-
-  EventImpl(T event, long ts) {
-    this.event = event;
-    this.ts = ts;
-  }
-
-  @Override
-  public long getTimestamp() {
-    return ts;
-  }
-
-  @Override
-  public T get() {
-    return event;
-  }
-
-  @Override
-  public boolean isWatermark() {
-    return false;
+/**
+ * Timer event used to trigger actions in windowing that needs to occur on a set frequency
+ */
+public class TimerEvent<T> extends EventImpl<T> {
+  public TimerEvent(T event, long ts) {
+    super(event, ts);
   }
 
   @Override
   public boolean isTimer() {
-    return false;
+    return true;
   }
 
   @Override
   public String toString() {
-    return "EventImpl{" + "event=" + event + ", ts=" + ts + '}';
+    return "TimerEvent{} " + super.toString();
   }
 }

--- a/heron/api/src/java/com/twitter/heron/api/windowing/WindowManager.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/WindowManager.java
@@ -121,10 +121,12 @@ public class WindowManager<T> implements TriggerHandler {
    */
   public void add(Event<T> windowEvent) {
     // watermark events are not added to the queue.
-    if (!windowEvent.isWatermark()) {
-      queue.add(windowEvent);
-    } else {
+    if (windowEvent.isWatermark()) {
       LOG.fine(String.format("Got watermark event with ts %d", windowEvent.getTimestamp()));
+    } else if (windowEvent.isTimer()) {
+      LOG.fine(String.format("Got timer event with ts %d", windowEvent.getTimestamp()));
+    } else {
+      queue.add(windowEvent);
     }
     track(windowEvent);
     compactWindow();

--- a/heron/api/src/java/com/twitter/heron/api/windowing/evictors/CountEvictionPolicy.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/evictors/CountEvictionPolicy.java
@@ -56,7 +56,7 @@ public class CountEvictionPolicy<T> implements EvictionPolicy<T> {
 
   @Override
   public void track(Event<T> event) {
-    if (!event.isWatermark()) {
+    if (!event.isWatermark() && !event.isTimer()) {
       currentCount.incrementAndGet();
     }
   }

--- a/heron/api/src/java/com/twitter/heron/api/windowing/triggers/CountTriggerPolicy.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/triggers/CountTriggerPolicy.java
@@ -45,7 +45,7 @@ public class CountTriggerPolicy<T> implements TriggerPolicy<T> {
 
   @Override
   public void track(Event<T> event) {
-    if (started && !event.isWatermark()) {
+    if (started && !event.isWatermark() && !event.isTimer()) {
       if (currentCount.incrementAndGet() >= count) {
         evictionPolicy.setContext(new DefaultEvictionContext(System.currentTimeMillis()));
         handler.onTrigger();

--- a/heron/api/src/java/com/twitter/heron/api/windowing/triggers/TimeTriggerPolicy.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/triggers/TimeTriggerPolicy.java
@@ -13,14 +13,6 @@
 //  limitations under the License.
 package com.twitter.heron.api.windowing.triggers;
 
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
-
-import com.twitter.heron.api.exception.FailedException;
 import com.twitter.heron.api.windowing.DefaultEvictionContext;
 import com.twitter.heron.api.windowing.Event;
 import com.twitter.heron.api.windowing.EvictionPolicy;
@@ -31,13 +23,11 @@ import com.twitter.heron.api.windowing.TriggerPolicy;
  * Invokes {@link TriggerHandler#onTrigger()} after the duration.
  */
 public class TimeTriggerPolicy<T> implements TriggerPolicy<T> {
-  private static final Logger LOG = Logger.getLogger(TimeTriggerPolicy.class.getName());
 
   private long duration;
   private final TriggerHandler handler;
-  private final ScheduledExecutorService executor;
   private final EvictionPolicy<T> evictionPolicy;
-  private ScheduledFuture<?> executorFuture;
+  private boolean started = false;
 
   public TimeTriggerPolicy(long millis, TriggerHandler handler) {
     this(millis, handler, null);
@@ -47,37 +37,29 @@ public class TimeTriggerPolicy<T> implements TriggerPolicy<T> {
       evictionPolicy) {
     this.duration = millis;
     this.handler = handler;
-    this.executor = Executors.newSingleThreadScheduledExecutor();
     this.evictionPolicy = evictionPolicy;
   }
 
   @Override
   public void track(Event<T> event) {
-    checkFailures();
+    if (started && event.isTimer()) {
+      triggerTask();
+    }
   }
 
   @Override
   public void reset() {
-    checkFailures();
+
   }
 
   @Override
   public void start() {
-    executorFuture = executor.scheduleAtFixedRate(newTriggerTask(), duration, duration, TimeUnit
-        .MILLISECONDS);
+    started = true;
   }
 
   @Override
   public void shutdown() {
-    executor.shutdown();
-    try {
-      if (!executor.awaitTermination(2, TimeUnit.SECONDS)) {
-        executor.shutdownNow();
-      }
-    } catch (InterruptedException ie) {
-      executor.shutdownNow();
-      Thread.currentThread().interrupt();
-    }
+
   }
 
   @Override
@@ -85,50 +67,15 @@ public class TimeTriggerPolicy<T> implements TriggerPolicy<T> {
     return "TimeTriggerPolicy{" + "duration=" + duration + '}';
   }
 
-  /*
-  * Check for uncaught exceptions during the execution
-  * of the trigger and fail fast.
-  * The uncaught exceptions will be wrapped in
-  * ExecutionException and thrown when future.get() is invoked.
-  */
-  private void checkFailures() {
-    if (executorFuture != null && executorFuture.isDone()) {
-      try {
-        executorFuture.get();
-      } catch (InterruptedException ex) {
-        LOG.severe(String.format("Got exception\n%s", ex));
-        throw new FailedException(ex);
-      } catch (ExecutionException ex) {
-        LOG.severe(String.format("Got exception\n%s", ex));
-        throw new FailedException(ex.getCause());
-      }
-    }
-  }
+  private void triggerTask() {
+    // do not process current timestamp since tuples might arrive while the trigger is executing
+    long now = System.currentTimeMillis() - 1;
 
-  private Runnable newTriggerTask() {
-    return new Runnable() {
-
-      @Override
-      @SuppressWarnings("IllegalCatch")
-      public void run() {
-        // do not process current timestamp since tuples might arrive while the trigger is executing
-        long now = System.currentTimeMillis() - 1;
-        try {
-                    /*
-                     * set the current timestamp as the reference time for the eviction policy
-                     * to evict the events
-                     */
-          evictionPolicy.setContext(new DefaultEvictionContext(now, null, null, duration));
-          handler.onTrigger();
-        } catch (Throwable th) {
-          LOG.severe(String.format("handler.onTrigger failed\n%s", th));
-                    /*
-                     * propagate it so that task gets canceled and the exception
-                     * can be retrieved from executorFuture.get()
-                     */
-          throw th;
-        }
-      }
-    };
+    /*
+     * set the current timestamp as the reference time for the eviction policy
+     * to evict the events
+     */
+    evictionPolicy.setContext(new DefaultEvictionContext(now, null, null, duration));
+    handler.onTrigger();
   }
 }

--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
@@ -123,6 +123,9 @@ public class BoltInstance implements IInstance {
 
     // Re-prepare the CustomStreamGrouping since the downstream tasks can change
     physicalPlanHelper.prepareForCustomStreamGrouping();
+    // transfer potentially changed variables by topology code
+    physicalPlanHelper.getTopologyContext().getTopologyConfig()
+        .putAll(helper.getTopologyContext().getTopologyConfig());
     // Reset the helper
     helper = physicalPlanHelper;
   }
@@ -296,11 +299,11 @@ public class BoltInstance implements IInstance {
   }
 
   private void PrepareTickTupleTimer() {
-    Object tickTupleFreqSecs =
-        helper.getTopologyContext().getTopologyConfig().get(Config.TOPOLOGY_TICK_TUPLE_FREQ_SECS);
+    Object tickTupleFreqMs =
+        helper.getTopologyContext().getTopologyConfig().get(Config.TOPOLOGY_TICK_TUPLE_FREQ_MS);
 
-    if (tickTupleFreqSecs != null) {
-      Duration freq = TypeUtils.getDuration(tickTupleFreqSecs, ChronoUnit.SECONDS);
+    if (tickTupleFreqMs != null) {
+      Duration freq = TypeUtils.getDuration(tickTupleFreqMs, ChronoUnit.MILLIS);
 
       Runnable r = new Runnable() {
         public void run() {


### PR DESCRIPTION
TimeTriggerPolicy used an additional thread to run periodic tasks.  Tuple acking was conducted as part of these periodic tasks.  However, OutgoingTupleCollection isn't thread safe thus causing NPEs.  Thus I removed the separate thread to run periodic tasks and instead used tick tuples to trigger the tasks. 

I also changed Tick Tuple to frequency to milliseconds since windowing needs to support windows in milliseconds.  I left a backwards compatible api for seconds:

public static void setTickTupleFrequency(Map<String, Object> conf, int seconds) 

Which will translate to milliseconds

I also add logic in bolt instance to persist config changes done in topology logic when updates to the physical plan occurs