### PR TITLE
Seperate out the low level api examples and higher level dsl examples

### DIFF
--- a/examples/src/java/BUILD
+++ b/examples/src/java/BUILD
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
 java_binary(
-    name='examples-unshaded',
-    srcs = glob(["**/*.java"]),
+    name='api-examples-unshaded',
+    srcs = glob(["com/twitter/heron/examples/api/**/*.java"]),
     deps = [
         "//heron/api/src/java:api-java",
         "//heron/common/src/java:basics-java",
@@ -12,8 +12,26 @@ java_binary(
 )
 
 genrule(
-    name = 'heron-examples',
-    srcs = [":examples-unshaded_deploy.jar"],
-    outs = ["heron-examples.jar"],
+    name = 'heron-api-examples',
+    srcs = [":api-examples-unshaded_deploy.jar"],
+    outs = ["heron-api-examples.jar"],
+    cmd  = "cp $< $@",
+)
+
+java_binary(
+    name='dsl-examples-unshaded',
+    srcs = glob(["com/twitter/heron/examples/dsl/**/*.java"]),
+    deps = [
+        "//heron/api/src/java:api-java",
+        "//heron/common/src/java:basics-java",
+        "//heron/simulator/src/java:simulator-java"
+    ],
+    create_executable = 0,
+)
+
+genrule(
+    name = 'heron-dsl-examples',
+    srcs = [":dsl-examples-unshaded_deploy.jar"],
+    outs = ["heron-dsl-examples.jar"],
     cmd  = "cp $< $@",
 )

--- a/examples/src/java/com/twitter/heron/examples/api/AckingTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/api/AckingTopology.java
@@ -1,18 +1,18 @@
-// Copyright 2016 Twitter. All rights reserved.
+//  Copyright 2017 Twitter. All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 
-package com.twitter.heron.examples;
+package com.twitter.heron.examples.api;
 
 import java.util.Map;
 import java.util.Random;
@@ -31,28 +31,27 @@ import com.twitter.heron.api.tuple.Fields;
 import com.twitter.heron.api.tuple.Tuple;
 import com.twitter.heron.api.tuple.Values;
 import com.twitter.heron.api.utils.Utils;
-import com.twitter.heron.simulator.Simulator;
+
 
 /**
- * This is three stage topology. Spout emits to bolt to bolt.
+ * This is a basic example of a Heron topology with acking enable.
  */
-public final class MultiStageAckingTopology {
+public final class AckingTopology {
 
-  private MultiStageAckingTopology() {
+  private AckingTopology() {
   }
 
   public static void main(String[] args) throws Exception {
     if (args.length != 1) {
-      throw new RuntimeException("Please specify the name of the topology");
+      throw new RuntimeException("Specify topology name");
     }
     TopologyBuilder builder = new TopologyBuilder();
 
-    int parallelism = 2;
-    builder.setSpout("word", new AckingTestWordSpout(), parallelism);
-    builder.setBolt("exclaim1", new ExclamationBolt(true), parallelism)
+    int spouts = 2;
+    int bolts = 2;
+    builder.setSpout("word", new AckingTestWordSpout(), spouts);
+    builder.setBolt("exclaim1", new ExclamationBolt(), bolts)
         .shuffleGrouping("word");
-    builder.setBolt("exclaim2", new ExclamationBolt(false), parallelism)
-        .shuffleGrouping("exclaim1");
 
     Config conf = new Config();
     conf.setDebug(true);
@@ -60,40 +59,30 @@ public final class MultiStageAckingTopology {
     // Put an arbitrary large number here if you don't want to slow the topology down
     conf.setMaxSpoutPending(1000 * 1000 * 1000);
 
-    // To enable acking, we need to setEnableAcking true
+    // To enable acking
     conf.setTopologyReliabilityMode(Config.TopologyReliabilityMode.ATLEAST_ONCE);
-
     conf.put(Config.TOPOLOGY_WORKER_CHILDOPTS, "-XX:+HeapDumpOnOutOfMemoryError");
 
     // component resource configuration
-    com.twitter.heron.api.Config.setComponentRam(conf, "word",
-        ExampleResources.getComponentRam());
+    com.twitter.heron.api.Config.setComponentRam(conf, "word", ExampleResources.getComponentRam());
     com.twitter.heron.api.Config.setComponentRam(conf, "exclaim1",
-        ExampleResources.getComponentRam());
-    com.twitter.heron.api.Config.setComponentRam(conf, "exclaim2",
         ExampleResources.getComponentRam());
 
     // container resource configuration
     com.twitter.heron.api.Config.setContainerDiskRequested(conf,
-        ExampleResources.getContainerDisk(3 * parallelism, parallelism));
+        ExampleResources.getContainerDisk(spouts + bolts, 2));
     com.twitter.heron.api.Config.setContainerRamRequested(conf,
-        ExampleResources.getContainerRam(3 * parallelism, parallelism));
+        ExampleResources.getContainerRam(spouts + bolts, 2));
     com.twitter.heron.api.Config.setContainerCpuRequested(conf, 1);
 
-    if (args != null && args.length > 0) {
-      conf.setNumStmgrs(parallelism);
-      HeronSubmitter.submitTopology(args[0], conf, builder.createTopology());
-    } else {
-      Simulator simulator = new Simulator();
-      simulator.submitTopology("test", conf, builder.createTopology());
-      Utils.sleep(10000);
-      simulator.killTopology("test");
-      simulator.shutdown();
-    }
+    // Set the number of workers or stream managers
+    conf.setNumStmgrs(2);
+    HeronSubmitter.submitTopology(args[0], conf, builder.createTopology());
   }
 
   public static class AckingTestWordSpout extends BaseRichSpout {
-    private static final long serialVersionUID = -5972291205871728684L;
+
+    private static final long serialVersionUID = -630307949908406294L;
     private SpoutOutputCollector collector;
     private String[] words;
     private Random rand;
@@ -117,7 +106,9 @@ public final class MultiStageAckingTopology {
     public void nextTuple() {
       // We explicitly slow down the spout to avoid the stream mgr to be the bottleneck
       Utils.sleep(1);
+
       final String word = words[rand.nextInt(words.length)];
+
       // To enable acking, we need to emit tuple with MessageId, which is an object
       collector.emit(new Values(word), "MESSAGE_ID");
     }
@@ -134,22 +125,14 @@ public final class MultiStageAckingTopology {
   }
 
   public static class ExclamationBolt extends BaseRichBolt {
-    private static final long serialVersionUID = -3226618846531432832L;
+    private static final long serialVersionUID = -2267338658317778214L;
     private OutputCollector collector;
     private long nItems;
     private long startTime;
-    private boolean emit;
-
-    public ExclamationBolt(boolean emit) {
-      this.emit = emit;
-    }
 
     @Override
     @SuppressWarnings("rawtypes")
-    public void prepare(
-        Map conf,
-        TopologyContext context,
-        OutputCollector acollector) {
+    public void prepare(Map conf, TopologyContext context, OutputCollector acollector) {
       collector = acollector;
       nItems = 0;
       startTime = System.currentTimeMillis();
@@ -160,25 +143,24 @@ public final class MultiStageAckingTopology {
       // We need to ack a tuple when we consider it is done successfully
       // Or we could fail it by invoking collector.fail(tuple)
       // If we do not do the ack or fail explicitly
-      // After the MessageTimeout Seconds, which could be set in Config,
-      // the spout will fail this tuple
+      // After the MessageTimeout Seconds, which could be set in Config, the spout will
+      // fail this tuple
       ++nItems;
       if (nItems % 10000 == 0) {
         long latency = System.currentTimeMillis() - startTime;
         System.out.println("Bolt processed " + nItems + " tuples in " + latency + " ms");
         GlobalMetrics.incr("selected_items");
+        // Here we explicitly forget to do the ack or fail
+        // It would trigger fail on this tuple on spout end after MessageTimeout Seconds
+      } else if (nItems % 2 == 0) {
+        collector.fail(tuple);
+      } else {
+        collector.ack(tuple);
       }
-      if (emit) {
-        collector.emit(tuple, new Values(tuple.getString(0) + "!!!"));
-      }
-      collector.ack(tuple);
     }
 
     @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
-      if (emit) {
-        declarer.declare(new Fields("word"));
-      }
     }
   }
 }

--- a/examples/src/java/com/twitter/heron/examples/api/ComponentJVMOptionsTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/api/ComponentJVMOptionsTopology.java
@@ -1,18 +1,18 @@
-// Copyright 2016 Twitter. All rights reserved.
+//  Copyright 2017 Twitter. All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 
-package com.twitter.heron.examples;
+package com.twitter.heron.examples.api;
 
 import java.util.Map;
 
@@ -27,51 +27,48 @@ import com.twitter.heron.api.topology.TopologyContext;
 import com.twitter.heron.api.tuple.Tuple;
 import com.twitter.heron.api.utils.Utils;
 import com.twitter.heron.common.basics.ByteAmount;
-import com.twitter.heron.examples.spout.TestWordSpout;
+import com.twitter.heron.examples.api.spout.TestWordSpout;
 import com.twitter.heron.simulator.Simulator;
 
 
 /**
  * This is a basic example of a Storm topology.
  */
-public final class MultiSpoutExclamationTopology {
+public final class ComponentJVMOptionsTopology {
 
-  private MultiSpoutExclamationTopology() {
+  private ComponentJVMOptionsTopology() {
   }
 
   public static void main(String[] args) throws Exception {
     TopologyBuilder builder = new TopologyBuilder();
 
-    builder.setSpout("word0", new TestWordSpout(), 2);
-    builder.setSpout("word1", new TestWordSpout(), 2);
-    builder.setSpout("word2", new TestWordSpout(), 2);
+    builder.setSpout("word", new TestWordSpout(), 2);
     builder.setBolt("exclaim1", new ExclamationBolt(), 2)
-        .shuffleGrouping("word0")
-        .shuffleGrouping("word1")
-        .shuffleGrouping("word2");
+        .shuffleGrouping("word");
 
     Config conf = new Config();
     conf.setDebug(true);
     conf.setMaxSpoutPending(10);
+
+    // TOPOLOGY_WORKER_CHILDOPTS will be a global one
     conf.put(Config.TOPOLOGY_WORKER_CHILDOPTS, "-XX:+HeapDumpOnOutOfMemoryError");
 
+    // For each component, both the global and if any the component one will be appended.
+    // And the component one will take precedence
+    com.twitter.heron.api.Config.setComponentJvmOptions(conf, "word", "-XX:NewSize=300m");
+    com.twitter.heron.api.Config.setComponentJvmOptions(conf, "exclaim1", "-XX:NewSize=800m");
+
     // component resource configuration
-    com.twitter.heron.api.Config.setComponentRam(conf, "word0",
-        ExampleResources.getComponentRam());
-    com.twitter.heron.api.Config.setComponentRam(conf, "word1",
-        ExampleResources.getComponentRam());
-    com.twitter.heron.api.Config.setComponentRam(conf, "word2",
-        ExampleResources.getComponentRam());
-    com.twitter.heron.api.Config.setComponentRam(conf, "exclaim1",
-        ExampleResources.getComponentRam());
+    com.twitter.heron.api.Config.setComponentRam(conf, "word", ByteAmount.fromMegabytes(512));
+    com.twitter.heron.api.Config.setComponentRam(conf, "exclaim1", ByteAmount.fromMegabytes(512));
 
     // container resource configuration
-    com.twitter.heron.api.Config.setContainerDiskRequested(conf, ByteAmount.fromGigabytes(3));
+    com.twitter.heron.api.Config.setContainerDiskRequested(conf, ByteAmount.fromGigabytes(2));
     com.twitter.heron.api.Config.setContainerRamRequested(conf, ByteAmount.fromGigabytes(2));
-    com.twitter.heron.api.Config.setContainerCpuRequested(conf, 1);
+    com.twitter.heron.api.Config.setContainerCpuRequested(conf, 2);
 
     if (args != null && args.length > 0) {
-      conf.setNumStmgrs(3);
+      conf.setNumStmgrs(2);
       HeronSubmitter.submitTopology(args[0], conf, builder.createTopology());
     } else {
       Simulator simulator = new Simulator();
@@ -80,26 +77,27 @@ public final class MultiSpoutExclamationTopology {
       simulator.killTopology("test");
       simulator.shutdown();
     }
+
+
   }
 
   public static class ExclamationBolt extends BaseRichBolt {
-    private static final long serialVersionUID = 6945654705222426596L;
+    private static final long serialVersionUID = 2165326630789117557L;
     private long nItems;
     private long startTime;
 
     @Override
     @SuppressWarnings("rawtypes")
-    public void prepare(Map conf,
-                        TopologyContext context, OutputCollector collector) {
+    public void prepare(
+        Map conf,
+        TopologyContext context,
+        OutputCollector collector) {
       nItems = 0;
       startTime = System.currentTimeMillis();
     }
 
     @Override
     public void execute(Tuple tuple) {
-      // System.out.println(tuple.getString(0));
-      // collector.emit(tuple, new Values(tuple.getString(0) + "!!!"));
-      // collector.ack(tuple);
       if (++nItems % 100000 == 0) {
         long latency = System.currentTimeMillis() - startTime;
         System.out.println("Bolt processed " + nItems + " tuples in " + latency + " ms");
@@ -109,7 +107,6 @@ public final class MultiSpoutExclamationTopology {
 
     @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
-      // declarer.declare(new Fields("word"));
     }
   }
 }

--- a/examples/src/java/com/twitter/heron/examples/api/CustomGroupingTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/api/CustomGroupingTopology.java
@@ -1,18 +1,18 @@
-// Copyright 2016 Twitter. All rights reserved.
+//  Copyright 2017 Twitter. All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 
-package com.twitter.heron.examples;
+package com.twitter.heron.examples.api;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,7 +28,7 @@ import com.twitter.heron.api.topology.TopologyBuilder;
 import com.twitter.heron.api.topology.TopologyContext;
 import com.twitter.heron.api.tuple.Tuple;
 import com.twitter.heron.common.basics.ByteAmount;
-import com.twitter.heron.examples.spout.TestWordSpout;
+import com.twitter.heron.examples.api.spout.TestWordSpout;
 /**
  * This is a basic example of a Storm topology.
  */

--- a/examples/src/java/com/twitter/heron/examples/api/ExampleResources.java
+++ b/examples/src/java/com/twitter/heron/examples/api/ExampleResources.java
@@ -11,7 +11,7 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-package com.twitter.heron.examples;
+package com.twitter.heron.examples.api;
 
 import com.twitter.heron.common.basics.ByteAmount;
 

--- a/examples/src/java/com/twitter/heron/examples/api/ExclamationTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/api/ExclamationTopology.java
@@ -1,18 +1,18 @@
-// Copyright 2016 Twitter. All rights reserved.
+//  Copyright 2017 Twitter. All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 
-package com.twitter.heron.examples;
+package com.twitter.heron.examples.api;
 
 import java.time.Duration;
 import java.util.List;
@@ -29,7 +29,7 @@ import com.twitter.heron.api.topology.TopologyBuilder;
 import com.twitter.heron.api.topology.TopologyContext;
 import com.twitter.heron.api.tuple.Tuple;
 import com.twitter.heron.api.utils.Utils;
-import com.twitter.heron.examples.spout.TestWordSpout;
+import com.twitter.heron.examples.api.spout.TestWordSpout;
 import com.twitter.heron.simulator.Simulator;
 
 /**

--- a/examples/src/java/com/twitter/heron/examples/api/SentenceWordCountTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/api/SentenceWordCountTopology.java
@@ -1,18 +1,18 @@
-// Copyright 2016 Twitter. All rights reserved.
+//  Copyright 2017 Twitter. All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 
-package com.twitter.heron.examples;
+package com.twitter.heron.examples.api;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/examples/src/java/com/twitter/heron/examples/api/SlidingWindowTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/api/SlidingWindowTopology.java
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package com.twitter.heron.examples;
+package com.twitter.heron.examples.api;
 
 import java.util.List;
 import java.util.Map;
@@ -30,9 +30,9 @@ import com.twitter.heron.api.tuple.Tuple;
 import com.twitter.heron.api.tuple.Values;
 import com.twitter.heron.api.windowing.TupleWindow;
 import com.twitter.heron.common.basics.ByteAmount;
-import com.twitter.heron.examples.bolt.PrinterBolt;
-import com.twitter.heron.examples.bolt.SlidingWindowSumBolt;
-import com.twitter.heron.examples.spout.RandomIntegerSpout;
+import com.twitter.heron.examples.api.bolt.PrinterBolt;
+import com.twitter.heron.examples.api.bolt.SlidingWindowSumBolt;
+import com.twitter.heron.examples.api.spout.RandomIntegerSpout;
 
 /**
  * A sample topology that demonstrates the usage of {@link com.twitter.heron.api.bolt.IWindowedBolt}

--- a/examples/src/java/com/twitter/heron/examples/api/StatefulWordCountTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/api/StatefulWordCountTopology.java
@@ -1,18 +1,18 @@
-// Copyright 2016 Twitter. All rights reserved.
+//  Copyright 2017 Twitter. All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 
-package com.twitter.heron.examples;
+package com.twitter.heron.examples.api;
 
 import java.util.Map;
 import java.util.Random;

--- a/examples/src/java/com/twitter/heron/examples/api/TaskHookTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/api/TaskHookTopology.java
@@ -1,18 +1,18 @@
-// Copyright 2016 Twitter. All rights reserved.
+//  Copyright 2017 Twitter. All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 
-package com.twitter.heron.examples;
+package com.twitter.heron.examples.api;
 
 import java.util.LinkedList;
 import java.util.List;

--- a/examples/src/java/com/twitter/heron/examples/api/WordCountTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/api/WordCountTopology.java
@@ -1,18 +1,18 @@
-// Copyright 2016 Twitter. All rights reserved.
+//  Copyright 2017 Twitter. All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 
-package com.twitter.heron.examples;
+package com.twitter.heron.examples.api;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/examples/src/java/com/twitter/heron/examples/api/bolt/PrinterBolt.java
+++ b/examples/src/java/com/twitter/heron/examples/api/bolt/PrinterBolt.java
@@ -11,7 +11,7 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-package com.twitter.heron.examples.bolt;
+package com.twitter.heron.examples.api.bolt;
 
 import com.twitter.heron.api.bolt.BaseBasicBolt;
 import com.twitter.heron.api.bolt.BasicOutputCollector;

--- a/examples/src/java/com/twitter/heron/examples/api/bolt/SlidingWindowSumBolt.java
+++ b/examples/src/java/com/twitter/heron/examples/api/bolt/SlidingWindowSumBolt.java
@@ -11,7 +11,7 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-package com.twitter.heron.examples.bolt;
+package com.twitter.heron.examples.api.bolt;
 
 import java.util.List;
 import java.util.Map;

--- a/examples/src/java/com/twitter/heron/examples/api/spout/RandomIntegerSpout.java
+++ b/examples/src/java/com/twitter/heron/examples/api/spout/RandomIntegerSpout.java
@@ -11,7 +11,7 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-package com.twitter.heron.examples.spout;
+package com.twitter.heron.examples.api.spout;
 
 import java.util.Map;
 import java.util.Random;

--- a/examples/src/java/com/twitter/heron/examples/api/spout/TestWordSpout.java
+++ b/examples/src/java/com/twitter/heron/examples/api/spout/TestWordSpout.java
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package com.twitter.heron.examples.spout;
+package com.twitter.heron.examples.api.spout;
 
 import java.time.Duration;
 import java.util.Map;

--- a/examples/src/java/com/twitter/heron/examples/dsl/WordCountDslTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/dsl/WordCountDslTopology.java
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package com.twitter.heron.examples;
+package com.twitter.heron.examples.dsl;
 
 import java.util.Arrays;
 

--- a/scripts/centos/BUILD
+++ b/scripts/centos/BUILD
@@ -120,7 +120,7 @@ genrule(
         "--cp $(location conf-local-statemgr)        conf/local/statemgr.yaml",
         "--cp $(location conf-local-uploader)        conf/local/uploader.yaml",
         "--cp $(location heron-core)                 dist/heron-core.tar.gz",
-        "--cp $(location hexamples)                  examples/heron-examples.jar",
+        "--cp $(location hexamples)                  examples/heron-api-examples.jar",
         "--cp $(location hscheduler)                 lib/scheduler/heron-scheduler.jar",
         "--cp $(location hscheduler-aurora)          lib/scheduler/heron-aurora-scheduler.jar",
         "--cp $(location hscheduler-local)           lib/scheduler/heron-local-scheduler.jar",
@@ -230,7 +230,7 @@ filegroup(
 
 filegroup(
     name = "hexamples",
-    srcs = ["//examples/src/java:heron-examples"],
+    srcs = ["//examples/src/java:heron-api-examples"],
 )
 
 filegroup(

--- a/tools/rules/heron_examples.bzl
+++ b/tools/rules/heron_examples.bzl
@@ -14,5 +14,6 @@ def heron_examples_conf_files():
 
 def heron_examples_lib_files():
     return [
-        "//examples/src/java:heron-examples",
+        "//examples/src/java:heron-api-examples",
+        "//examples/src/java:heron-dsl-examples",
     ]


### PR DESCRIPTION
Currently both the low level(spouts/bolts) and high level(dsl) examples are lumped together in one directory. As we continue to add more examples, this directory will get crowded and confusing.
This pr separates out the two kind