### PR TITLE
Modify local scheduler to work without a core uri.

### DIFF
--- a/heron/common/src/java/com/twitter/heron/common/basics/FileUtils.java
+++ b/heron/common/src/java/com/twitter/heron/common/basics/FileUtils.java
@@ -121,6 +121,15 @@ public final class FileUtils {
   }
 
   public static boolean deleteDir(File dir, boolean deleteSelf) {
+    if (Files.isSymbolicLink(dir.toPath())) {
+      try {
+        Files.delete(dir.toPath());
+        return true;
+      } catch (IOException e) {
+        return false;
+      }
+    }
+
     if (dir.isDirectory()) {
       String[] children = dir.list();
 

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/SchedulerUtils.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/SchedulerUtils.java
@@ -369,26 +369,13 @@ public final class SchedulerUtils {
   }
 
   /**
-   * Setup the working directory:
-   * <br> 1. Download heron core and the topology packages into topology working directory,
-   * <br> 2. Extract heron core and the topology packages
-   * <br> 3. Remove the downloaded heron core and the topology packages
+   * Setup the working directory: Create the directory if it does not exist
+   * otherwise clean the directory.
    *
    * @param workingDirectory the working directory to setup
-   * @param coreReleasePackageURL the URL of core release package
-   * @param coreReleaseDestination the destination of the core release package fetched
-   * @param topologyPackageURL the URL of heron topology release package
-   * @param topologyPackageDestination the destination of heron topology release package fetched
-   * @param isVerbose display verbose output or not
    * @return true if successful
    */
-  public static boolean setupWorkingDirectory(
-      String workingDirectory,
-      String coreReleasePackageURL,
-      String coreReleaseDestination,
-      String topologyPackageURL,
-      String topologyPackageDestination,
-      boolean isVerbose) {
+  public static boolean setupWorkingDirectory(String workingDirectory) {
     // if the working directory does not exist, create it.
     if (!FileUtils.isDirectoryExists(workingDirectory)) {
       LOG.fine("The working directory does not exist; creating it.");
@@ -404,16 +391,13 @@ public final class SchedulerUtils {
       return false;
     }
 
-    // Curl and extract heron core release package and topology package
-    // And then delete the downloaded release package
-    boolean ret =
-        curlAndExtractPackage(
-            workingDirectory, coreReleasePackageURL, coreReleaseDestination, true, isVerbose)
-            &&
-            curlAndExtractPackage(
-                workingDirectory, topologyPackageURL, topologyPackageDestination, true, isVerbose);
+    return true;
+  }
 
-    return ret;
+  public static boolean extractPackage(String workingDirectory, String packageURI,
+        String packageDestination, boolean deletePackage, boolean verbose) {
+    return curlAndExtractPackage(workingDirectory, packageURI, packageDestination,
+        deletePackage, verbose);
   }
 
   /**

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/SchedulerUtils.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/SchedulerUtils.java
@@ -369,25 +369,24 @@ public final class SchedulerUtils {
   }
 
   /**
-   * Setup the working directory: Create the directory if it does not exist
-   * otherwise clean the directory.
+   * Create the directory if it does not exist otherwise clean the directory.
    *
-   * @param workingDirectory the working directory to setup
+   * @param directory the working directory to setup
    * @return true if successful
    */
-  public static boolean setupWorkingDirectory(String workingDirectory) {
-    // if the working directory does not exist, create it.
-    if (!FileUtils.isDirectoryExists(workingDirectory)) {
-      LOG.fine("The working directory does not exist; creating it.");
-      if (!FileUtils.createDirectory(workingDirectory)) {
-        LOG.severe("Failed to create directory: " + workingDirectory);
+  public static boolean createOrCleanDirectory(String directory) {
+    // if the directory does not exist, create it.
+    if (!FileUtils.isDirectoryExists(directory)) {
+      LOG.fine("The directory does not exist; creating it.");
+      if (!FileUtils.createDirectory(directory)) {
+        LOG.severe("Failed to create directory: " + directory);
         return false;
       }
     }
 
     // Cleanup the directory
-    if (!FileUtils.cleanDir(workingDirectory)) {
-      LOG.severe("Failed to clean directory: " + workingDirectory);
+    if (!FileUtils.cleanDir(directory)) {
+      LOG.severe("Failed to clean directory: " + directory);
       return false;
     }
 

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/utils/SchedulerUtilsTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/utils/SchedulerUtilsTest.java
@@ -116,7 +116,7 @@ public class SchedulerUtilsTest {
   }
 
   /**
-   * Test method setupWorkingDirectory()
+   * Test method createOrCleanDirectory()
    */
   @Test
   public void testSetupWorkingDirectory() throws Exception {
@@ -128,17 +128,17 @@ public class SchedulerUtilsTest {
 
     // Failed to create dir
     PowerMockito.when(FileUtils.createDirectory(Mockito.anyString())).thenReturn(false);
-    Assert.assertFalse(SchedulerUtils.setupWorkingDirectory(WORKING_DIR));
+    Assert.assertFalse(SchedulerUtils.createOrCleanDirectory(WORKING_DIR));
     // OK to create dir
     PowerMockito.when(FileUtils.createDirectory(Mockito.anyString())).thenReturn(true);
 
     // Fail to cleanup
     PowerMockito.when(FileUtils.cleanDir(Mockito.anyString())).thenReturn(false);
-    Assert.assertFalse(SchedulerUtils.setupWorkingDirectory(WORKING_DIR));
+    Assert.assertFalse(SchedulerUtils.createOrCleanDirectory(WORKING_DIR));
 
     // Ok to cleanup
     PowerMockito.when(FileUtils.cleanDir(Mockito.anyString())).thenReturn(true);
-    Assert.assertTrue(SchedulerUtils.setupWorkingDirectory(WORKING_DIR));
+    Assert.assertTrue(SchedulerUtils.createOrCleanDirectory(WORKING_DIR));
   }
 
   @Test

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/utils/SchedulerUtilsTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/utils/SchedulerUtilsTest.java
@@ -128,43 +128,17 @@ public class SchedulerUtilsTest {
 
     // Failed to create dir
     PowerMockito.when(FileUtils.createDirectory(Mockito.anyString())).thenReturn(false);
-    Assert.assertFalse(SchedulerUtils.setupWorkingDirectory(
-            WORKING_DIR, CORE_RELEASE_URI, CORE_RELEASE_DEST,
-            TOPOLOGY_URI, TOPOLOGY_DEST, isVerbose));
-
+    Assert.assertFalse(SchedulerUtils.setupWorkingDirectory(WORKING_DIR));
     // OK to create dir
     PowerMockito.when(FileUtils.createDirectory(Mockito.anyString())).thenReturn(true);
 
     // Fail to cleanup
     PowerMockito.when(FileUtils.cleanDir(Mockito.anyString())).thenReturn(false);
-    Assert.assertFalse(SchedulerUtils.setupWorkingDirectory(
-            WORKING_DIR, CORE_RELEASE_URI, CORE_RELEASE_DEST,
-            TOPOLOGY_URI, TOPOLOGY_DEST, isVerbose));
+    Assert.assertFalse(SchedulerUtils.setupWorkingDirectory(WORKING_DIR));
 
     // Ok to cleanup
     PowerMockito.when(FileUtils.cleanDir(Mockito.anyString())).thenReturn(true);
-
-    PowerMockito.spy(SchedulerUtils.class);
-    // OK to curl and extract core-release-package
-    PowerMockito.doReturn(true).when(SchedulerUtils.class, "curlAndExtractPackage",
-        Mockito.eq(WORKING_DIR), Mockito.eq(CORE_RELEASE_URI),
-        Mockito.eq(CORE_RELEASE_DEST), Mockito.eq(true), Mockito.eq(isVerbose));
-
-    // Failed to curl and extract topology-package
-    PowerMockito.doReturn(false).when(SchedulerUtils.class, "curlAndExtractPackage",
-        Mockito.eq(WORKING_DIR), Mockito.eq(TOPOLOGY_URI),
-        Mockito.eq(TOPOLOGY_DEST), Mockito.anyBoolean(), Mockito.anyBoolean());
-    Assert.assertFalse(SchedulerUtils.setupWorkingDirectory(
-            WORKING_DIR, CORE_RELEASE_URI, CORE_RELEASE_DEST,
-            TOPOLOGY_URI, TOPOLOGY_DEST, isVerbose));
-
-    // OK to curl and extract topology-package
-    PowerMockito.doReturn(true).when(SchedulerUtils.class, "curlAndExtractPackage",
-        Mockito.eq(WORKING_DIR), Mockito.eq(TOPOLOGY_URI),
-        Mockito.eq(TOPOLOGY_DEST), Mockito.anyBoolean(), Mockito.anyBoolean());
-    Assert.assertTrue(SchedulerUtils.setupWorkingDirectory(
-            WORKING_DIR, CORE_RELEASE_URI, CORE_RELEASE_DEST,
-            TOPOLOGY_URI, TOPOLOGY_DEST, isVerbose));
+    Assert.assertTrue(SchedulerUtils.setupWorkingDirectory(WORKING_DIR));
   }
 
   @Test

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/kubernetes/KubernetesController.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/kubernetes/KubernetesController.java
@@ -142,7 +142,7 @@ public class KubernetesController {
       try {
         deployContainer(appConf);
       } catch (IOException ioe) {
-        LOG.log(Level.SEVERE, "Problem deploying container with config: " + appConf, ioe);
+        LOG.log(Level.SEVERE, "Problem deploying container with config: " + appConf);
         return false;
       }
     }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/kubernetes/KubernetesController.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/kubernetes/KubernetesController.java
@@ -142,7 +142,7 @@ public class KubernetesController {
       try {
         deployContainer(appConf);
       } catch (IOException ioe) {
-        LOG.log(Level.SEVERE, "Problem deploying container with config: " + appConf);
+        LOG.log(Level.SEVERE, "Problem deploying container with config: " + appConf, ioe);
         return false;
       }
     }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalKey.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalKey.java
@@ -21,7 +21,9 @@ import com.twitter.heron.spi.common.Key;
 public enum LocalKey {
   // config key for specifying the working directory of a topology
   WORKING_DIRECTORY("heron.scheduler.local.working.directory",
-      "${HOME}/.herondata/topologies/${CLUSTER}/${ROLE}/${TOPOLOGY}");
+      "${HOME}/.herondata/topologies/${CLUSTER}/${ROLE}/${TOPOLOGY}"),
+
+  USE_HERON_CORE_URI("heron.scheduler.local.use_core_uri", true);
 
   private final String value;
   private final Key.Type type;
@@ -33,12 +35,26 @@ public enum LocalKey {
     this.defaultValue = defaultValue;
   }
 
+  LocalKey(String value, boolean defaultValue) {
+    this.value = value;
+    this.type = Key.Type.BOOLEAN;
+    this.defaultValue = defaultValue;
+  }
+
   public String value() {
     return value;
   }
 
   public Object getDefault() {
     return defaultValue;
+  }
+
+  public Boolean getDefaultBoolean() {
+    if (type != Key.Type.BOOLEAN) {
+      throw new IllegalAccessError(String.format(
+          "Config Key %s is type %s, getDefaultBoolean() not supported", this.name(), this.type));
+    }
+    return (Boolean) this.defaultValue;
   }
 
   public String getDefaultString() {

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalLauncher.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalLauncher.java
@@ -15,6 +15,9 @@
 package com.twitter.heron.scheduler.local;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,6 +30,7 @@ import com.twitter.heron.scheduler.utils.Runtime;
 import com.twitter.heron.scheduler.utils.SchedulerUtils;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Context;
+import com.twitter.heron.spi.common.Key;
 import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.scheduler.ILauncher;
 import com.twitter.heron.spi.utils.ShellUtils;
@@ -66,7 +70,7 @@ public class LocalLauncher implements ILauncher {
 
     // setup the working directory
     // mainly it downloads and extracts the heron-core-release and topology package
-    if (!setupWorkingDirectory()) {
+    if (!setupWorkingDirectoryAndExtractPackages()) {
       LOG.severe("Failed to setup working directory");
       return false;
     }
@@ -99,9 +103,11 @@ public class LocalLauncher implements ILauncher {
     return SchedulerUtils.schedulerCommand(config, runtime, freePorts);
   }
 
-  protected boolean setupWorkingDirectory() {
+  protected boolean setupWorkingDirectoryAndExtractPackages() {
     // get the path of core release URI
     String coreReleasePackageURI = LocalContext.corePackageUri(config);
+
+    LOG.info("core release package uri: " + coreReleasePackageURI);
 
     // form the target dest core release file name
     String coreReleaseFileDestination = Paths.get(
@@ -114,13 +120,36 @@ public class LocalLauncher implements ILauncher {
     String topologyPackageDestination = Paths.get(
         topologyWorkingDirectory, "topology.tar.gz").toString();
 
-    return SchedulerUtils.setupWorkingDirectory(
-        topologyWorkingDirectory,
-        coreReleasePackageURI,
-        coreReleaseFileDestination,
-        topologyPackageURI,
-        topologyPackageDestination,
-        Context.verbose(config));
+    if (!SchedulerUtils.setupWorkingDirectory(topologyWorkingDirectory)) {
+      return false;
+    }
+
+    final boolean isVerbose =  Context.verbose(config);
+
+    // Check if the config is set to use the heron core uri (this is the default behavior)
+    // If set to false we will try to create a symlink to the install heron-core. This is used
+    // in the sandbox config to avoid installing the heron client on the docker image.
+    if (config.getBooleanValue(LocalKey.USE_HERON_CORE_URI.value(),
+        LocalKey.USE_HERON_CORE_URI.getDefaultBoolean())) {
+      if (!SchedulerUtils.extractPackage(topologyWorkingDirectory, coreReleasePackageURI,
+          coreReleaseFileDestination, true, isVerbose)) {
+        return false;
+      }
+    } else {
+      // check for heron home
+      Path heronCore = Paths.get(config.getStringValue(Key.HERON_HOME), "heron-core");
+      Path heronCoreLink = Paths.get(topologyWorkingDirectory, "heron-core");
+      try {
+        Files.createSymbolicLink(heronCoreLink, heronCore);
+      } catch (IOException ioe) {
+        LOG.log(Level.SEVERE, "Unable to create heron core link from "
+            + heronCoreLink + " to " + heronCore, ioe);
+      }
+    }
+
+    // extract the topology package and then delete the downloaded release package
+    return SchedulerUtils.extractPackage(topologyWorkingDirectory, topologyPackageURI,
+        topologyPackageDestination, true, isVerbose);
   }
 
   protected Process startScheduler(String[] schedulerCmd) {

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalLauncher.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalLauncher.java
@@ -136,7 +136,6 @@ public class LocalLauncher implements ILauncher {
         return false;
       }
     } else {
-      // check for heron home
       Path heronCore = Paths.get(config.getStringValue(Key.HERON_HOME), "heron-core");
       Path heronCoreLink = Paths.get(topologyWorkingDirectory, "heron-core");
       try {
@@ -144,6 +143,7 @@ public class LocalLauncher implements ILauncher {
       } catch (IOException ioe) {
         LOG.log(Level.SEVERE, "Unable to create heron core link from "
             + heronCoreLink + " to " + heronCore, ioe);
+        return false;
       }
     }
 

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalLauncher.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/local/LocalLauncher.java
@@ -120,7 +120,7 @@ public class LocalLauncher implements ILauncher {
     String topologyPackageDestination = Paths.get(
         topologyWorkingDirectory, "topology.tar.gz").toString();
 
-    if (!SchedulerUtils.setupWorkingDirectory(topologyWorkingDirectory)) {
+    if (!SchedulerUtils.createOrCleanDirectory(topologyWorkingDirectory)) {
       return false;
     }
 

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/slurm/SlurmLauncher.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/slurm/SlurmLauncher.java
@@ -92,12 +92,17 @@ public class SlurmLauncher implements ILauncher {
     String topologyPackageDestination = Paths.get(
         topologyWorkingDirectory, "topology.tar.gz").toString();
 
-    return SchedulerUtils.setupWorkingDirectory(
-        topologyWorkingDirectory,
-        coreReleasePackageURI,
-        coreReleaseFileDestination,
-        topologyPackageURI,
-        topologyPackageDestination,
-        Context.verbose(config));
+    if (!SchedulerUtils.setupWorkingDirectory(topologyWorkingDirectory)) {
+      return false;
+    }
+
+    final boolean isVerbose = Context.verbose(config);
+    if (!SchedulerUtils.extractPackage(topologyWorkingDirectory, coreReleasePackageURI,
+        coreReleaseFileDestination, true, isVerbose)) {
+      return false;
+    }
+
+    return SchedulerUtils.extractPackage(topologyWorkingDirectory, topologyPackageURI,
+        topologyPackageDestination, true, isVerbose);
   }
 }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/slurm/SlurmLauncher.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/slurm/SlurmLauncher.java
@@ -92,7 +92,7 @@ public class SlurmLauncher implements ILauncher {
     String topologyPackageDestination = Paths.get(
         topologyWorkingDirectory, "topology.tar.gz").toString();
 
-    if (!SchedulerUtils.setupWorkingDirectory(topologyWorkingDirectory)) {
+    if (!SchedulerUtils.createOrCleanDirectory(topologyWorkingDirectory)) {
       return false;
     }
 

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/local/LocalLauncherTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/local/LocalLauncherTest.java
@@ -62,11 +62,11 @@ public class LocalLauncherTest {
     localLauncher.initialize(config, runtime);
 
     // Failed to setup working directory
-    Mockito.doReturn(false).when(localLauncher).setupWorkingDirectory();
+    Mockito.doReturn(false).when(localLauncher).setupWorkingDirectoryAndExtractPackages();
     Assert.assertFalse(localLauncher.launch(packingPlan));
 
     // setup successfully
-    Mockito.doReturn(true).when(localLauncher).setupWorkingDirectory();
+    Mockito.doReturn(true).when(localLauncher).setupWorkingDirectoryAndExtractPackages();
     String[] expectedSchedulerCommand = {"expected", "scheduler", "command"};
     Mockito.doReturn(expectedSchedulerCommand).when(localLauncher).getSchedulerCommand();
 


### PR DESCRIPTION
This adds a config option to use an installed version of
heron so we don't need to package the heron client within
a docker image to run the sandbox.