### PR TITLE
Handle Older jars more gracefully

### DIFF
--- a/heron/common/src/java/com/twitter/heron/common/utils/misc/PhysicalPlanHelper.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/misc/PhysicalPlanHelper.java
@@ -305,6 +305,9 @@ public class PhysicalPlanHelper {
 
   public boolean isTopologyStateful() {
     Map<String, Object> config = topologyContext.getTopologyConfig();
+    if (config.get(Config.TOPOLOGY_RELIABILITY_MODE) == null) {
+      return false;
+    }
     Config.TopologyReliabilityMode mode =
         Config.TopologyReliabilityMode.valueOf(
             String.valueOf(config.get(Config.TOPOLOGY_RELIABILITY_MODE)));


### PR DESCRIPTION
For topologies submitted with older jars, topologuy reliability mode will not exist.