### PR TITLE
Increase state manager reachability timeout.

### DIFF
--- a/heron/statemgrs/src/python/statemanager.py
+++ b/heron/statemgrs/src/python/statemanager.py
@@ -35,6 +35,8 @@ class StateManager:
 
   __metaclass__ = abc.ABCMeta
 
+  TIMEOUT_SECONDS = 5
+
   @property
   def name(self):
     return self.__name
@@ -81,7 +83,7 @@ class StateManager:
     """
     for hostport in self.hostportlist:
       try:
-        socket.create_connection(hostport, 2)
+        socket.create_connection(hostport, TIMEOUT_SECONDS)
         return True
       except:
         LOG.info("StateManager %s Unable to connect to host: %s port %i"

--- a/heron/statemgrs/src/python/statemanager.py
+++ b/heron/statemgrs/src/python/statemanager.py
@@ -83,7 +83,7 @@ class StateManager:
     """
     for hostport in self.hostportlist:
       try:
-        socket.create_connection(hostport, TIMEOUT_SECONDS)
+        socket.create_connection(hostport, StateManager.TIMEOUT_SECONDS)
         return True
       except:
         LOG.info("StateManager %s Unable to connect to host: %s port %i"


### PR DESCRIPTION
The state manager currently has a 2 second timeout and then it will try to tunnel. We ran into some issues with containers in kubernetes failing and then the tunnel failed to because ssh was not installed on the container. This is the first step in trying to make the state manager more resilient. This change increases the timeout to 5 seconds.

Error from container:
Traceback (most recent call last):
  File "heron/executor/src/python/heron_executor.py", line 912, in start_state_manager_watches
  File "heron/statemgrs/src/python/zkstatemanager.py", line 65, in start
    localhostports = self.establish_ssh_tunnel()
  File "heron/statemgrs/src/python/statemanager.py", line 110, in establish_ssh_tunnel
    ('ssh', self.tunnelhost, '-NL127.0.0.1:%d:%s:%d' % (localport, host, port))))
  File "/usr/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1327, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
