### PR TITLE
allow users to set topology environment properties

### DIFF
--- a/heron/api/src/java/com/twitter/heron/api/Config.java
+++ b/heron/api/src/java/com/twitter/heron/api/Config.java
@@ -473,7 +473,7 @@ public class Config extends HashMap<String, Object> {
   public static void setTopologyStatefulStartClean(Map<String, Object> conf, boolean clean) {
     conf.put(Config.TOPOLOGY_STATEFUL_START_CLEAN, String.valueOf(clean));
   }
-  public static void setEnvironment(Map<String, Object> conf, Map<String, String> env) {
+  public static void setEnvironment(Map<String, Object> conf, Map env) {
     conf.put(Config.TOPOLOGY_ENVIRONMENT, env);
   }
 

--- a/heron/api/src/java/com/twitter/heron/api/Config.java
+++ b/heron/api/src/java/com/twitter/heron/api/Config.java
@@ -235,6 +235,13 @@ public class Config extends HashMap<String, Object> {
   public static final String TOPOLOGY_UPDATE_REACTIVATE_WAIT_SECS =
       "topology.update.reactivate.wait.secs";
 
+  /**
+   * Topology-specific environment variables for the worker child process.
+   * This is added to the existing environment (that of the supervisor).
+   * This variable contains Map<String, String>
+   */
+  public static final String TOPOLOGY_ENVIRONMENT = "topology.environment";
+
   private static final long serialVersionUID = 2550967708478837032L;
   // We maintain a list of all user exposed vars
   private static Set<String> apiVars = new HashSet<>();
@@ -465,6 +472,9 @@ public class Config extends HashMap<String, Object> {
 
   public static void setTopologyStatefulStartClean(Map<String, Object> conf, boolean clean) {
     conf.put(Config.TOPOLOGY_STATEFUL_START_CLEAN, String.valueOf(clean));
+  }
+  public static void setEnvironment(Map<String, Object> conf, Map<String, String> env) {
+    conf.put(Config.TOPOLOGY_ENVIRONMENT, env);
   }
 
   public void setDebug(boolean isOn) {

--- a/heron/api/src/java/com/twitter/heron/api/Config.java
+++ b/heron/api/src/java/com/twitter/heron/api/Config.java
@@ -236,8 +236,8 @@ public class Config extends HashMap<String, Object> {
       "topology.update.reactivate.wait.secs";
 
   /**
-   * Topology-specific environment variables for the worker child process.
-   * This is added to the existing environment (that of the supervisor).
+   * Topology-specific environment properties to be added to an Heron instance.
+   * This is added to the existing environment (that of the Heron instance).
    * This variable contains Map<String, String>
    */
   public static final String TOPOLOGY_ENVIRONMENT = "topology.environment";

--- a/heron/api/src/java/com/twitter/heron/api/Config.java
+++ b/heron/api/src/java/com/twitter/heron/api/Config.java
@@ -473,6 +473,8 @@ public class Config extends HashMap<String, Object> {
   public static void setTopologyStatefulStartClean(Map<String, Object> conf, boolean clean) {
     conf.put(Config.TOPOLOGY_STATEFUL_START_CLEAN, String.valueOf(clean));
   }
+
+  @SuppressWarnings("rawtypes")
   public static void setEnvironment(Map<String, Object> conf, Map env) {
     conf.put(Config.TOPOLOGY_ENVIRONMENT, env);
   }

--- a/storm-compatibility/src/java/org/apache/storm/Config.java
+++ b/storm-compatibility/src/java/org/apache/storm/Config.java
@@ -357,6 +357,12 @@ public class Config extends HashMap<String, Object> {
       = "topology.bolts.watermark.event.interval.ms";
 
   /**
+   * Topology-specific environment variables for the worker child process.
+   * This is added to the existing environment (that of the supervisor)
+   */
+  public static final String TOPOLOGY_ENVIRONMENT="topology.environment";
+
+  /**
    * ----  DO NOT USE -----
    * This variable is used to rewrite the TOPOLOGY_AUTO_TASK_HOOKS variable.
    * As such this is a strictly internal config variable that is not exposed the user
@@ -460,6 +466,10 @@ public class Config extends HashMap<String, Object> {
     }
     conf.put(Config.TOPOLOGY_KRYO_DECORATORS, ret);
     return ret;
+  }
+
+  public static void setEnvironment(Map<String, Object> conf, Map env) {
+    conf.put(Config.TOPOLOGY_ENVIRONMENT, env);
   }
 
   public void setDebug(boolean isOn) {

--- a/storm-compatibility/src/java/org/apache/storm/Config.java
+++ b/storm-compatibility/src/java/org/apache/storm/Config.java
@@ -360,7 +360,7 @@ public class Config extends HashMap<String, Object> {
    * Topology-specific environment variables for the worker child process.
    * This is added to the existing environment (that of the supervisor)
    */
-  public static final String TOPOLOGY_ENVIRONMENT="topology.environment";
+  public static final String TOPOLOGY_ENVIRONMENT = "topology.environment";
 
   /**
    * ----  DO NOT USE -----

--- a/storm-compatibility/src/java/org/apache/storm/utils/ConfigUtils.java
+++ b/storm-compatibility/src/java/org/apache/storm/utils/ConfigUtils.java
@@ -87,6 +87,10 @@ public final class ConfigUtils {
           Boolean.parseBoolean(heronConfig.get(org.apache.storm.Config.TOPOLOGY_DEBUG).toString());
       com.twitter.heron.api.Config.setDebug(heronConfig, dBg);
     }
+    if (heronConfig.containsKey(org.apache.storm.Config.TOPOLOGY_ENVIRONMENT)) {
+      com.twitter.heron.api.Config.setEnvironment(heronConfig,
+          (Map) heronConfig.get(org.apache.storm.Config.TOPOLOGY_ENVIRONMENT));
+    }
 
     doTaskHooksTranslation(heronConfig);
 


### PR DESCRIPTION
I added TOPOLOGY_ENVIRONMENT to make heron more compatible with Storm since Storm has this feature.

We can use TOPOLOGY_WORKER_CHILDOPTS to set these environment properties but it might not be an elegant way of doing it. We would essentially have to put all the user defined environment properties on the java command line that starts the heron instance in a format: -Denv.variable=foo . If the user has many environment properties, this could cause the java command line to start the heron instance to be very large. I don't know if that is a good idea. Doing a System.setProperty in the start of the heron instance seems like a more eloquent approach