### PR TITLE
Move examples to updated config system

### DIFF
--- a/examples/src/java/com/twitter/heron/examples/api/AckingTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/api/AckingTopology.java
@@ -64,16 +64,15 @@ public final class AckingTopology {
     conf.put(Config.TOPOLOGY_WORKER_CHILDOPTS, "-XX:+HeapDumpOnOutOfMemoryError");
 
     // component resource configuration
-    com.twitter.heron.api.Config.setComponentRam(conf, "word", ExampleResources.getComponentRam());
-    com.twitter.heron.api.Config.setComponentRam(conf, "exclaim1",
-        ExampleResources.getComponentRam());
+    conf.setComponentRam("word", ExampleResources.getComponentRam());
+    conf.setComponentRam("exclaim1", ExampleResources.getComponentRam());
 
     // container resource configuration
-    com.twitter.heron.api.Config.setContainerDiskRequested(conf,
+    conf.setContainerDiskRequested(
         ExampleResources.getContainerDisk(spouts + bolts, 2));
-    com.twitter.heron.api.Config.setContainerRamRequested(conf,
+    conf.setContainerRamRequested(
         ExampleResources.getContainerRam(spouts + bolts, 2));
-    com.twitter.heron.api.Config.setContainerCpuRequested(conf, 1);
+    conf.setContainerCpuRequested(conf, 1);
 
     // Set the number of workers or stream managers
     conf.setNumStmgrs(2);

--- a/examples/src/java/com/twitter/heron/examples/api/AckingTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/api/AckingTopology.java
@@ -72,7 +72,7 @@ public final class AckingTopology {
         ExampleResources.getContainerDisk(spouts + bolts, 2));
     conf.setContainerRamRequested(
         ExampleResources.getContainerRam(spouts + bolts, 2));
-    conf.setContainerCpuRequested(conf, 1);
+    conf.setContainerCpuRequested(1);
 
     // Set the number of workers or stream managers
     conf.setNumStmgrs(2);

--- a/examples/src/java/com/twitter/heron/examples/api/ComponentJVMOptionsTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/api/ComponentJVMOptionsTopology.java
@@ -55,17 +55,17 @@ public final class ComponentJVMOptionsTopology {
 
     // For each component, both the global and if any the component one will be appended.
     // And the component one will take precedence
-    com.twitter.heron.api.Config.setComponentJvmOptions(conf, "word", "-XX:NewSize=300m");
-    com.twitter.heron.api.Config.setComponentJvmOptions(conf, "exclaim1", "-XX:NewSize=800m");
+    conf.setComponentJvmOptions("word", "-XX:NewSize=300m");
+    conf.setComponentJvmOptions("exclaim1", "-XX:NewSize=800m");
 
     // component resource configuration
-    com.twitter.heron.api.Config.setComponentRam(conf, "word", ByteAmount.fromMegabytes(512));
-    com.twitter.heron.api.Config.setComponentRam(conf, "exclaim1", ByteAmount.fromMegabytes(512));
+    conf.setComponentRam("word", ByteAmount.fromMegabytes(512));
+    conf.setComponentRam("exclaim1", ByteAmount.fromMegabytes(512));
 
     // container resource configuration
-    com.twitter.heron.api.Config.setContainerDiskRequested(conf, ByteAmount.fromGigabytes(2));
-    com.twitter.heron.api.Config.setContainerRamRequested(conf, ByteAmount.fromGigabytes(2));
-    com.twitter.heron.api.Config.setContainerCpuRequested(conf, 2);
+    conf.setContainerDiskRequested(ByteAmount.fromGigabytes(2));
+    conf.setContainerRamRequested(ByteAmount.fromGigabytes(2));
+    conf.setContainerCpuRequested(2);
 
     if (args != null && args.length > 0) {
       conf.setNumStmgrs(2);

--- a/examples/src/java/com/twitter/heron/examples/api/CustomGroupingTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/api/CustomGroupingTopology.java
@@ -47,15 +47,13 @@ public final class CustomGroupingTopology {
     Config conf = new Config();
 
     // component resource configuration
-    com.twitter.heron.api.Config
-        .setComponentRam(conf, "word", ByteAmount.fromMegabytes(512));
-    com.twitter.heron.api
-        .Config.setComponentRam(conf, "mybolt", ByteAmount.fromMegabytes(512));
+    conf.setComponentRam("word", ByteAmount.fromMegabytes(512));
+    conf.setComponentRam("mybolt", ByteAmount.fromMegabytes(512));
 
     // container resource configuration
-    com.twitter.heron.api.Config.setContainerDiskRequested(conf, ByteAmount.fromGigabytes(2));
-    com.twitter.heron.api.Config.setContainerRamRequested(conf, ByteAmount.fromGigabytes(2));
-    com.twitter.heron.api.Config.setContainerCpuRequested(conf, 2);
+    conf.setContainerDiskRequested(ByteAmount.fromGigabytes(2));
+    conf.setContainerRamRequested(ByteAmount.fromGigabytes(2));
+    conf.setContainerCpuRequested(2);
 
     conf.setNumStmgrs(2);
 

--- a/examples/src/java/com/twitter/heron/examples/api/ExclamationTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/api/ExclamationTopology.java
@@ -57,15 +57,15 @@ public final class ExclamationTopology {
     conf.put(Config.TOPOLOGY_WORKER_CHILDOPTS, "-XX:+HeapDumpOnOutOfMemoryError");
 
     // resources configuration
-    com.twitter.heron.api.Config.setComponentRam(conf, "word", ExampleResources.getComponentRam());
-    com.twitter.heron.api.Config.setComponentRam(conf, "exclaim1",
+    conf.setComponentRam("word", ExampleResources.getComponentRam());
+    conf.setComponentRam("exclaim1",
         ExampleResources.getComponentRam());
 
-    com.twitter.heron.api.Config.setContainerDiskRequested(conf,
+    conf.setContainerDiskRequested(
         ExampleResources.getContainerDisk(spouts + bolts, parallelism));
-    com.twitter.heron.api.Config.setContainerRamRequested(conf,
+    conf.setContainerRamRequested(
         ExampleResources.getContainerRam(spouts + bolts, parallelism));
-    com.twitter.heron.api.Config.setContainerCpuRequested(conf, 1);
+    conf.setContainerCpuRequested(1);
 
     if (args != null && args.length > 0) {
       conf.setNumStmgrs(parallelism);

--- a/examples/src/java/com/twitter/heron/examples/api/MultiSpoutExclamationTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/api/MultiSpoutExclamationTopology.java
@@ -56,19 +56,19 @@ public final class MultiSpoutExclamationTopology {
     conf.put(Config.TOPOLOGY_WORKER_CHILDOPTS, "-XX:+HeapDumpOnOutOfMemoryError");
 
     // component resource configuration
-    com.twitter.heron.api.Config.setComponentRam(conf, "word0",
+    conf.setComponentRam("word0",
         ExampleResources.getComponentRam());
-    com.twitter.heron.api.Config.setComponentRam(conf, "word1",
+        conf.setComponentRam("word1",
         ExampleResources.getComponentRam());
-    com.twitter.heron.api.Config.setComponentRam(conf, "word2",
+        conf.setComponentRam("word2",
         ExampleResources.getComponentRam());
-    com.twitter.heron.api.Config.setComponentRam(conf, "exclaim1",
+        conf.setComponentRam("exclaim1",
         ExampleResources.getComponentRam());
 
     // container resource configuration
-    com.twitter.heron.api.Config.setContainerDiskRequested(conf, ByteAmount.fromGigabytes(3));
-    com.twitter.heron.api.Config.setContainerRamRequested(conf, ByteAmount.fromGigabytes(2));
-    com.twitter.heron.api.Config.setContainerCpuRequested(conf, 1);
+    conf.setContainerDiskRequested(ByteAmount.fromGigabytes(3));
+    conf.setContainerRamRequested(ByteAmount.fromGigabytes(2));
+    conf.setContainerCpuRequested(1);
 
     if (args != null && args.length > 0) {
       conf.setNumStmgrs(3);

--- a/examples/src/java/com/twitter/heron/examples/api/MultiStageAckingTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/api/MultiStageAckingTopology.java
@@ -66,19 +66,19 @@ public final class MultiStageAckingTopology {
     conf.put(Config.TOPOLOGY_WORKER_CHILDOPTS, "-XX:+HeapDumpOnOutOfMemoryError");
 
     // component resource configuration
-    com.twitter.heron.api.Config.setComponentRam(conf, "word",
+    conf.setComponentRam("word",
         ExampleResources.getComponentRam());
-    com.twitter.heron.api.Config.setComponentRam(conf, "exclaim1",
+    conf.setComponentRam("exclaim1",
         ExampleResources.getComponentRam());
-    com.twitter.heron.api.Config.setComponentRam(conf, "exclaim2",
+    conf.setComponentRam("exclaim2",
         ExampleResources.getComponentRam());
 
     // container resource configuration
-    com.twitter.heron.api.Config.setContainerDiskRequested(conf,
+    conf.setContainerDiskRequested(
         ExampleResources.getContainerDisk(3 * parallelism, parallelism));
-    com.twitter.heron.api.Config.setContainerRamRequested(conf,
+    conf.setContainerRamRequested(
         ExampleResources.getContainerRam(3 * parallelism, parallelism));
-    com.twitter.heron.api.Config.setContainerCpuRequested(conf, 1);
+    conf.setContainerCpuRequested(1);
 
     if (args != null && args.length > 0) {
       conf.setNumStmgrs(parallelism);

--- a/examples/src/java/com/twitter/heron/examples/api/SentenceWordCountTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/api/SentenceWordCountTopology.java
@@ -174,14 +174,14 @@ public final class SentenceWordCountTopology {
     Config conf = new Config();
 
     // component resource configuration
-    com.twitter.heron.api.Config.setComponentRam(conf, "spout", ByteAmount.fromMegabytes(512));
-    com.twitter.heron.api.Config.setComponentRam(conf, "split", ByteAmount.fromMegabytes(512));
-    com.twitter.heron.api.Config.setComponentRam(conf, "count", ByteAmount.fromMegabytes(512));
+    conf.setComponentRam("spout", ByteAmount.fromMegabytes(512));
+    conf.setComponentRam("split", ByteAmount.fromMegabytes(512));
+    conf.setComponentRam("count", ByteAmount.fromMegabytes(512));
 
     // container resource configuration
-    com.twitter.heron.api.Config.setContainerDiskRequested(conf, ByteAmount.fromGigabytes(3));
-    com.twitter.heron.api.Config.setContainerRamRequested(conf, ByteAmount.fromGigabytes(3));
-    com.twitter.heron.api.Config.setContainerCpuRequested(conf, 2);
+    conf.setContainerDiskRequested(ByteAmount.fromGigabytes(3));
+    conf.setContainerRamRequested(ByteAmount.fromGigabytes(3));
+    conf.setContainerCpuRequested(2);
 
     conf.setNumStmgrs(2);
 

--- a/examples/src/java/com/twitter/heron/examples/api/SlidingWindowTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/api/SlidingWindowTopology.java
@@ -97,13 +97,13 @@ public final class SlidingWindowTopology {
     conf.setDebug(true);
     String topoName = "test";
 
-    Config.setComponentRam(conf, "integer", ByteAmount.fromGigabytes(1));
-    Config.setComponentRam(conf, "slidingsum", ByteAmount.fromGigabytes(1));
-    Config.setComponentRam(conf, "tumblingavg", ByteAmount.fromGigabytes(1));
-    Config.setComponentRam(conf, "printer", ByteAmount.fromGigabytes(1));
+    conf.setComponentRam("integer", ByteAmount.fromGigabytes(1));
+    conf.setComponentRam("slidingsum", ByteAmount.fromGigabytes(1));
+    conf.setComponentRam("tumblingavg", ByteAmount.fromGigabytes(1));
+    conf.setComponentRam("printer", ByteAmount.fromGigabytes(1));
 
-    Config.setContainerDiskRequested(conf, ByteAmount.fromGigabytes(5));
-    Config.setContainerCpuRequested(conf, 4);
+    conf.setContainerDiskRequested(ByteAmount.fromGigabytes(5));
+    conf.setContainerCpuRequested(4);
 
     if (args != null && args.length > 0) {
       topoName = args[0];

--- a/examples/src/java/com/twitter/heron/examples/api/StatefulWordCountTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/api/StatefulWordCountTopology.java
@@ -198,17 +198,17 @@ public final class StatefulWordCountTopology {
     conf.setTopologyStatefulCheckpointIntervalSecs(20);
 
     // configure component resources
-    com.twitter.heron.api.Config.setComponentRam(conf, "word",
+    conf.setComponentRam("word",
         ByteAmount.fromMegabytes(ExampleResources.COMPONENT_RAM_MB * 2));
-    com.twitter.heron.api.Config.setComponentRam(conf, "consumer",
+    conf.setComponentRam("consumer",
         ByteAmount.fromMegabytes(ExampleResources.COMPONENT_RAM_MB * 2));
 
     // configure container resources
-    com.twitter.heron.api.Config.setContainerDiskRequested(conf,
+    conf.setContainerDiskRequested(
         ExampleResources.getContainerDisk(2 * parallelism, parallelism));
-    com.twitter.heron.api.Config.setContainerRamRequested(conf,
+    conf.setContainerRamRequested(
         ExampleResources.getContainerRam(2 * parallelism, parallelism));
-    com.twitter.heron.api.Config.setContainerCpuRequested(conf, 2);
+    conf.setContainerCpuRequested(2);
 
     HeronSubmitter.submitTopology(args[0], conf, builder.createTopology());
   }

--- a/examples/src/java/com/twitter/heron/examples/api/TaskHookTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/api/TaskHookTopology.java
@@ -69,16 +69,16 @@ public final class TaskHookTopology {
     // Set the task hook
     List<String> taskHooks = new LinkedList<>();
     taskHooks.add("com.twitter.heron.examples.TaskHookTopology$TestTaskHook");
-    com.twitter.heron.api.Config.setAutoTaskHooks(conf, taskHooks);
+    conf.setAutoTaskHooks(taskHooks);
 
     // component resource configuration
-    com.twitter.heron.api.Config.setComponentRam(conf, "word", ByteAmount.fromMegabytes(512));
-    com.twitter.heron.api.Config.setComponentRam(conf, "count", ByteAmount.fromMegabytes(512));
+    conf.setComponentRam("word", ByteAmount.fromMegabytes(512));
+    conf.setComponentRam("count", ByteAmount.fromMegabytes(512));
 
     // container resource configuration
-    com.twitter.heron.api.Config.setContainerDiskRequested(conf, ByteAmount.fromGigabytes(2));
-    com.twitter.heron.api.Config.setContainerRamRequested(conf, ByteAmount.fromGigabytes(2));
-    com.twitter.heron.api.Config.setContainerCpuRequested(conf, 2);
+    conf.setContainerDiskRequested(ByteAmount.fromGigabytes(2));
+    conf.setContainerRamRequested(ByteAmount.fromGigabytes(2));
+    conf.setContainerCpuRequested(2);
 
 
     conf.setNumStmgrs(2);

--- a/examples/src/java/com/twitter/heron/examples/api/WordCountTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/api/WordCountTopology.java
@@ -177,17 +177,17 @@ public final class WordCountTopology {
     conf.setNumStmgrs(parallelism);
 
     // configure component resources
-    com.twitter.heron.api.Config.setComponentRam(conf, "word",
+    conf.setComponentRam("word",
         ByteAmount.fromMegabytes(ExampleResources.COMPONENT_RAM_MB * 2));
-    com.twitter.heron.api.Config.setComponentRam(conf, "consumer",
+    conf.setComponentRam("consumer",
         ByteAmount.fromMegabytes(ExampleResources.COMPONENT_RAM_MB * 2));
 
     // configure container resources
-    com.twitter.heron.api.Config.setContainerDiskRequested(conf,
+    conf.setContainerDiskRequested(
         ExampleResources.getContainerDisk(2 * parallelism, parallelism));
-    com.twitter.heron.api.Config.setContainerRamRequested(conf,
+    conf.setContainerRamRequested(
         ExampleResources.getContainerRam(2 * parallelism, parallelism));
-    com.twitter.heron.api.Config.setContainerCpuRequested(conf, 2);
+    conf.setContainerCpuRequested(2);
 
     HeronSubmitter.submitTopology(args[0], conf, builder.createTopology());
   }


### PR DESCRIPTION
With changes to `com.twitter.heron.api.Config` that were completed a while back, it's no longer necessary to configure topologies using the quite unwieldy `com.twitter.heron.api.Config.setSomeConfig(configObject, "foo", "bar");`. This PR updates the existing Java examples for the old Topology API to reflect this change.