### PR TITLE
adding StormTopology compatibility

### DIFF
--- a/heron/api/src/java/com/twitter/heron/api/topology/GeneralTopologyContext.java
+++ b/heron/api/src/java/com/twitter/heron/api/topology/GeneralTopologyContext.java
@@ -31,16 +31,14 @@ public interface GeneralTopologyContext {
   String getTopologyId();
 
   /**
-   * Gets the Thrift object representing the topology.
-   *
-   * @return the Thrift definition representing the topology
+   * Gets the Protobuf object representing the topology.
+   * Deprecated.  Only for storm compatiblity purposes
+   * @return the Protobuf definition representing the topology
+   * @deprecated for backwards compatibility purposes
    */
-    /*
-    TODO:- This should not be exposed. Take this out
-    public HeronTopology getRawTopology() {
-        return _topology;
-    }
-    */
+  @Deprecated
+  TopologyAPI.Topology getRawTopology();
+
 
   /**
    * Gets the component id for the specified task id. The component id maps

--- a/heron/common/src/java/com/twitter/heron/common/utils/topology/GeneralTopologyContextImpl.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/topology/GeneralTopologyContextImpl.java
@@ -120,17 +120,11 @@ public class GeneralTopologyContextImpl implements GeneralTopologyContext {
     return topology.getId();
   }
 
-  /**
-   * Gets the Thrift object representing the topology.
-   *
-   * @return the Thrift definition representing the topology
-   */
-  /*
-  TODO:- This should not be exposed. Take this out
-  public HeronTopology getRawTopology() {
-      return _topology;
+  @Override
+  @SuppressWarnings("deprecation")
+  public TopologyAPI.Topology getRawTopology() {
+    return topology;
   }
-  */
 
   /**
    * Gets the component id for the specified task id. The component id maps

--- a/integration_test/src/java/com/twitter/heron/integration_test/core/TestTopologyContext.java
+++ b/integration_test/src/java/com/twitter/heron/integration_test/core/TestTopologyContext.java
@@ -126,6 +126,12 @@ public class TestTopologyContext implements TopologyContext {
   }
 
   @Override
+  @SuppressWarnings("deprecation")
+  public TopologyAPI.Topology getRawTopology() {
+    return delegate.getRawTopology();
+  }
+
+  @Override
   public String getComponentId(int taskId) {
     return this.delegate.getComponentId(taskId);
   }

--- a/storm-compatibility/src/java/org/apache/storm/generated/Bolt.java
+++ b/storm-compatibility/src/java/org/apache/storm/generated/Bolt.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.generated;
+
+import com.twitter.heron.api.generated.TopologyAPI;
+
+public class Bolt {
+  private final TopologyAPI.Bolt delegate;
+
+  public Bolt(TopologyAPI.Bolt bolt) {
+    this.delegate = bolt;
+  }
+}

--- a/storm-compatibility/src/java/org/apache/storm/generated/SpoutSpec.java
+++ b/storm-compatibility/src/java/org/apache/storm/generated/SpoutSpec.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.generated;
+
+import com.twitter.heron.api.generated.TopologyAPI;
+
+public class SpoutSpec {
+  private final TopologyAPI.Spout delegate;
+
+  public SpoutSpec(TopologyAPI.Spout spout) {
+    this.delegate = spout;
+  }
+}

--- a/storm-compatibility/src/java/org/apache/storm/generated/StormTopology.java
+++ b/storm-compatibility/src/java/org/apache/storm/generated/StormTopology.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,10 +18,14 @@
 
 package org.apache.storm.generated;
 
+import java.util.Map;
+
 import com.twitter.heron.api.HeronTopology;
 
 public class StormTopology {
   private HeronTopology topology;
+  private Map<String, SpoutSpec> spouts; // required
+  private Map<String, Bolt> bolts; // required
 
   public StormTopology() {
   }
@@ -32,5 +36,55 @@ public class StormTopology {
 
   public HeronTopology getStormTopology() {
     return topology;
+  }
+
+  public int get_bolts_size() {
+    return topology.getTopology().getBoltsCount();
+  }
+
+  public Map<String, Bolt> get_bolts() {
+    return bolts;
+  }
+
+  @SuppressWarnings("HiddenField")
+  public void set_bolts(Map<String, Bolt> bolts) {
+    this.bolts = bolts;
+  }
+
+  public int get_spouts_size() {
+    return this.spouts.size();
+  }
+
+  public Map<String, SpoutSpec> get_spouts() {
+    return this.spouts;
+  }
+
+  @SuppressWarnings("HiddenField")
+  public void set_spouts(Map<String, SpoutSpec> spouts) {
+    this.spouts = spouts;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder("StormTopology(");
+    boolean first = true;
+    sb.append("spouts:");
+    if (get_bolts() == null) {
+      sb.append("null");
+    } else {
+      sb.append(get_spouts());
+    }
+    first = false;
+    if (!first) {
+      sb.append(", ");
+    }
+    sb.append("bolts:");
+    if (get_bolts() == null) {
+      sb.append("null");
+    } else {
+      sb.append(get_bolts());
+    }
+    sb.append(")");
+    return sb.toString();
   }
 }

--- a/storm-compatibility/src/java/org/apache/storm/task/GeneralTopologyContext.java
+++ b/storm-compatibility/src/java/org/apache/storm/task/GeneralTopologyContext.java
@@ -18,13 +18,18 @@
 
 package org.apache.storm.task;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.storm.generated.Bolt;
+import org.apache.storm.generated.SpoutSpec;
 import org.apache.storm.generated.StormTopology;
 import org.apache.storm.tuple.Fields;
 import org.json.simple.JSONAware;
+
+import com.twitter.heron.api.generated.TopologyAPI;
 
 // import org.apache.storm.generated.ComponentCommon;
 // import org.apache.storm.generated.GlobalStreamId;
@@ -62,11 +67,25 @@ public class GeneralTopologyContext implements JSONAware {
    *
    * @return the Thrift definition representing the topology
    */
-  /*
+  @SuppressWarnings("deprecation")
   public StormTopology getRawTopology() {
-    return null;
+
+    StormTopology stormTopology = new StormTopology();
+    Map<String, SpoutSpec> spouts = new HashMap<>();
+    for (TopologyAPI.Spout spout : this.delegate.getRawTopology().getSpoutsList()) {
+      spouts.put(spout.getComp().getName(), new SpoutSpec(spout));
+    }
+
+    Map<String, Bolt> bolts = new HashMap<>();
+    for (TopologyAPI.Bolt bolt : this.delegate.getRawTopology().getBoltsList()) {
+      bolts.put(bolt.getComp().getName(), new Bolt(bolt));
+    }
+
+    stormTopology.set_spouts(spouts);
+    stormTopology.set_bolts(bolts);
+    return stormTopology;
   }
-  */
+
 
   /**
    * Gets the component id for the specified task id. The component id maps


### PR DESCRIPTION
Some users were directly using the StormTopology Thrift object to get info spouts and bolts.  Add some code to be compatible with that use case