### PR TITLE
Do minor Metrics Cleanup

### DIFF
--- a/heron/common/src/cpp/metrics/metrics-mgr-st.cpp
+++ b/heron/common/src/cpp/metrics/metrics-mgr-st.cpp
@@ -55,10 +55,10 @@ MetricsMgrSt::~MetricsMgrSt() {
 }
 
 void MetricsMgrSt::Start(const sp_string& _my_hostname, sp_int32 _my_port,
-     const sp_string& _component, const sp_string& _task_id) {
+     const sp_string& _component_id, const sp_string& _instance_id) {
   CHECK(client_ == nullptr) << "MetricsMgrClient started already";
-  client_ = new MetricsMgrClient(_my_hostname, _my_port, _component, _task_id,
-                                 eventLoop_, options_);
+  client_ = new MetricsMgrClient(_my_hostname, _my_port, _component_id, _instance_id,
+                                 -1, eventLoop_, options_);
 }
 
 void MetricsMgrSt::RefreshTMasterLocation(const proto::tmaster::TMasterLocation& location) {

--- a/heron/common/src/cpp/metrics/metrics-mgr-st.h
+++ b/heron/common/src/cpp/metrics/metrics-mgr-st.h
@@ -60,10 +60,10 @@ class MetricsMgrSt {
       @param _my_hostname to build message proto::system::MetricPublisher.
       @param _my_port to build message proto::system::MetricPublisher.
       @param _component to build message proto::system::MetricPublisher.
-      @param _task_id to build message proto::system::MetricPublisher.
+      @param _instance_id to build message proto::system::MetricPublisher.
   */
   void Start(const sp_string& _my_hostname, sp_int32 _my_port,
-             const sp_string& _component, const sp_string& _task_id);
+             const sp_string& _component_id, const sp_string& _instance_id);
 
  private:
   void gather_metrics(EventLoop::Status);

--- a/heron/common/src/cpp/metrics/metricsmgr-client.cpp
+++ b/heron/common/src/cpp/metrics/metricsmgr-client.cpp
@@ -28,13 +28,15 @@ namespace heron {
 namespace common {
 
 MetricsMgrClient::MetricsMgrClient(const sp_string& _hostname, sp_int32 _port,
-                                   const sp_string& _component_id, const sp_string& _task_id,
+                                   const sp_string& _component_name, const sp_string& _instance_id,
+                                   int _instance_index,
                                    EventLoop* eventLoop, const NetworkOptions& _options)
     : Client(eventLoop, _options),
       hostname_(_hostname),
       port_(_port),
-      component_id_(_component_id),
-      task_id_(_task_id),
+      component_name_(_component_name),
+      instance_id_(_instance_id),
+      instance_index_(_instance_index),
       tmaster_location_(NULL),
       metricscache_location_(NULL),
       registered_(false) {
@@ -70,9 +72,9 @@ void MetricsMgrClient::SendRegisterRequest() {
   proto::system::MetricPublisher* publisher = request->mutable_publisher();
   publisher->set_hostname(hostname_);
   publisher->set_port(port_);
-  publisher->set_component_name(component_id_);
-  publisher->set_instance_id(task_id_);
-  publisher->set_instance_index(-1);
+  publisher->set_component_name(component_name_);
+  publisher->set_instance_id(instance_id_);
+  publisher->set_instance_index(instance_index_);
 
   SendRequest(request, NULL);
 }

--- a/heron/common/src/cpp/metrics/metricsmgr-client.h
+++ b/heron/common/src/cpp/metrics/metricsmgr-client.h
@@ -36,8 +36,9 @@ namespace common {
 
 class MetricsMgrClient : public Client {
  public:
-  MetricsMgrClient(const sp_string& _hostname, sp_int32 _port, const sp_string& _component_id,
-                   const sp_string& _task_id, EventLoop* eventLoop, const NetworkOptions& options);
+  MetricsMgrClient(const sp_string& _hostname, sp_int32 _port, const sp_string& _component_name,
+                   const sp_string& _instance_id, int instance_index,
+                   EventLoop* eventLoop, const NetworkOptions& options);
   ~MetricsMgrClient();
 
   void SendMetrics(proto::system::MetricPublisherPublishMessage* _message);
@@ -58,8 +59,9 @@ class MetricsMgrClient : public Client {
 
   sp_string hostname_;
   sp_int32 port_;
-  sp_string component_id_;
-  sp_string task_id_;
+  sp_string component_name_;
+  sp_string instance_id_;
+  int instance_index_;
   proto::tmaster::TMasterLocation* tmaster_location_;
   proto::tmaster::MetricsCacheLocation* metricscache_location_;
   // Tells if we have registered to metrics manager or not


### PR DESCRIPTION
1. Rename TaskId vars to instance id since thats what they are
2. Make MetricsMgrClient take instance_index as well