### PR TITLE
Change EMPTY_STRING defn to be a plain string so that we are ok getting references

### DIFF
--- a/heron/common/src/cpp/basics/sptypes.h
+++ b/heron/common/src/cpp/basics/sptypes.h
@@ -105,6 +105,6 @@ typedef std::string sp_string;
 
 #endif  // SP_UNICODE
 
-constexpr char const* EMPTY_STRING = "";
+const std::string EMPTY_STRING = ""; // NOLINT
 
 #endif /* end of header file */

--- a/heron/common/src/cpp/config/physical-plan-helper.cpp
+++ b/heron/common/src/cpp/config/physical-plan-helper.cpp
@@ -59,8 +59,8 @@ void PhysicalPlanHelper::GetLocalSpouts(const proto::system::PhysicalPlan& _ppla
   return;
 }
 
-const std::string PhysicalPlanHelper::GetComponentName(const proto::system::PhysicalPlan& _pplan,
-                                                       int _task_id) {
+const std::string& PhysicalPlanHelper::GetComponentName(const proto::system::PhysicalPlan& _pplan,
+                                                        int _task_id) {
   for (auto instance : _pplan.instances()) {
     if (instance.info().task_id() == _task_id) {
       return instance.info().component_name();

--- a/heron/common/src/cpp/config/physical-plan-helper.h
+++ b/heron/common/src/cpp/config/physical-plan-helper.h
@@ -69,8 +69,8 @@ class PhysicalPlanHelper {
 
   // Returns the component name for the specified _task_id
   // If the _task_id is not part of the _pplan, return empty string
-  static const std::string GetComponentName(const proto::system::PhysicalPlan& _pplan,
-                                            int _task_id);
+  static const std::string& GetComponentName(const proto::system::PhysicalPlan& _pplan,
+                                             int _task_id);
 
   // For a particular _component, returns all the task_ids
   static void GetComponentTaskIds(const proto::system::PhysicalPlan& _pplan,

--- a/heron/common/src/cpp/network/httputils.cpp
+++ b/heron/common/src/cpp/network/httputils.cpp
@@ -237,7 +237,7 @@ IncomingHTTPRequest::~IncomingHTTPRequest() {}
 
 const sp_string& IncomingHTTPRequest::GetQuery() const { return query_; }
 
-const sp_string IncomingHTTPRequest::GetValue(const sp_string& _key) const {
+const sp_string& IncomingHTTPRequest::GetValue(const sp_string& _key) const {
   for (size_t i = 0; i < kv_.size(); ++i) {
     if (kv_[i].first == _key) {
       return kv_[i].second;

--- a/heron/common/src/cpp/network/httputils.h
+++ b/heron/common/src/cpp/network/httputils.h
@@ -70,7 +70,7 @@ class IncomingHTTPRequest : public BaseHTTPRequest {
   const HTTPKeyValuePairs& keyvalues() const { return kv_; }
 
   //! Get the value of a particular key
-  const sp_string GetValue(const sp_string& _key) const;
+  const sp_string& GetValue(const sp_string& _key) const;
 
   //! Get the all the values of a particular key
   bool GetAllValues(const sp_string& _key, std::vector<sp_string>& _values) const;

--- a/heron/tmaster/src/cpp/manager/stateful-controller.cpp
+++ b/heron/tmaster/src/cpp/manager/stateful-controller.cpp
@@ -174,7 +174,7 @@ void StatefulController::HandleCheckpointSave(
   }
 }
 
-const std::string StatefulController::GetNextInLineCheckpointId(const std::string& _ckpt_id) {
+const std::string& StatefulController::GetNextInLineCheckpointId(const std::string& _ckpt_id) {
   if (_ckpt_id.empty()) {
     // There cannot be any checkpoints that are older than empty checkpoint
     LOG(FATAL) << "Could not recover even from the empty state";

--- a/heron/tmaster/src/cpp/manager/stateful-controller.h
+++ b/heron/tmaster/src/cpp/manager/stateful-controller.h
@@ -80,7 +80,7 @@ class StatefulController {
 
  private:
   // Get the youngest ckpt id that is older than the given ckpt_id
-  const std::string GetNextInLineCheckpointId(const std::string& _ckpt_id);
+  const std::string& GetNextInLineCheckpointId(const std::string& _ckpt_id);
   // Creates a new ckpt record adding the latest one
   proto::ckptmgr::StatefulConsistentCheckpoints*
     AddNewConsistentCheckpoint(const std::string& _new_checkpoint,


### PR DESCRIPTION
This cleans up the code by allowing us to return references rather than values.