### PR TITLE
Add `prometheus-sink` default configs to all base templates

### DIFF
--- a/heron/config/src/yaml/conf/aurora/metrics_sinks.yaml
+++ b/heron/config/src/yaml/conf/aurora/metrics_sinks.yaml
@@ -56,6 +56,16 @@ tmaster-sink:
     "__server/__time_spent_back_pressure_initiated": SUM
     "__time_spent_back_pressure_by_compid": SUM
 
+### Config for prometheus-sink
+# prometheus-sink:
+#   class: "com.twitter.heron.metricsmgr.sink.PrometheusSink"
+#   port: 8080 # The port on which to run (either port or port-file are mandatory)
+#   path: /metrics # The path on which to publish the metrics (mandatory)
+#   flat-metrics: true # By default the web-sink will publish a flat "name -> value" json map
+#   include-topology-name: true # Include topology name in metric name (default false)
+#   metrics-cache-max-size: 1000000 # Max number of metrics cached and published (default 1000000)
+#   metrics-cache-ttl-sec: 600 # Time in seconds after which a metric that was collected will stopped being published (default 600)
+
 ### Config for scribe-sink
 # scribe-sink:
 #   class: "com.twitter.heron.metricsmgr.sink.ScribeSink"

--- a/heron/config/src/yaml/conf/examples/metrics_sinks.yaml
+++ b/heron/config/src/yaml/conf/examples/metrics_sinks.yaml
@@ -88,6 +88,16 @@ metricscache-sink:
     "__server/__time_spent_back_pressure_initiated": SUM
     "__time_spent_back_pressure_by_compid": SUM
 
+### Config for prometheus-sink
+# prometheus-sink:
+#   class: "com.twitter.heron.metricsmgr.sink.PrometheusSink"
+#   port: 8080 # The port on which to run (either port or port-file are mandatory)
+#   path: /metrics # The path on which to publish the metrics (mandatory)
+#   flat-metrics: true # By default the web-sink will publish a flat "name -> value" json map
+#   include-topology-name: true # Include topology name in metric name (default false)
+#   metrics-cache-max-size: 1000000 # Max number of metrics cached and published (default 1000000)
+#   metrics-cache-ttl-sec: 600 # Time in seconds after which a metric that was collected will stopped being published (default 600)
+
 ### Config for scribe-sink
 # scribe-sink:
 #   class: "com.twitter.heron.metricsmgr.sink.ScribeSink"

--- a/heron/config/src/yaml/conf/local/metrics_sinks.yaml
+++ b/heron/config/src/yaml/conf/local/metrics_sinks.yaml
@@ -88,6 +88,16 @@ metricscache-sink:
     "__server/__time_spent_back_pressure_initiated": SUM
     "__time_spent_back_pressure_by_compid": SUM
 
+### Config for prometheus-sink
+# prometheus-sink:
+#   class: "com.twitter.heron.metricsmgr.sink.PrometheusSink"
+#   port: 8080 # The port on which to run (either port or port-file are mandatory)
+#   path: /metrics # The path on which to publish the metrics (mandatory)
+#   flat-metrics: true # By default the web-sink will publish a flat "name -> value" json map
+#   include-topology-name: true # Include topology name in metric name (default false)
+#   metrics-cache-max-size: 1000000 # Max number of metrics cached and published (default 1000000)
+#   metrics-cache-ttl-sec: 600 # Time in seconds after which a metric that was collected will stopped being published (default 600)
+
 ### Config for scribe-sink
 # scribe-sink:
 #   class: "com.twitter.heron.metricsmgr.sink.ScribeSink"

--- a/heron/config/src/yaml/conf/localzk/metrics_sinks.yaml
+++ b/heron/config/src/yaml/conf/localzk/metrics_sinks.yaml
@@ -56,6 +56,16 @@ tmaster-sink:
     "__server/__time_spent_back_pressure_initiated": SUM
     "__time_spent_back_pressure_by_compid": SUM
 
+### Config for prometheus-sink
+# prometheus-sink:
+#   class: "com.twitter.heron.metricsmgr.sink.PrometheusSink"
+#   port: 8080 # The port on which to run (either port or port-file are mandatory)
+#   path: /metrics # The path on which to publish the metrics (mandatory)
+#   flat-metrics: true # By default the web-sink will publish a flat "name -> value" json map
+#   include-topology-name: true # Include topology name in metric name (default false)
+#   metrics-cache-max-size: 1000000 # Max number of metrics cached and published (default 1000000)
+#   metrics-cache-ttl-sec: 600 # Time in seconds after which a metric that was collected will stopped being published (default 600)
+
 ### Config for scribe-sink
 # scribe-sink:
 #   class: "com.twitter.heron.metricsmgr.sink.ScribeSink"

--- a/heron/config/src/yaml/conf/marathon/metrics_sinks.yaml
+++ b/heron/config/src/yaml/conf/marathon/metrics_sinks.yaml
@@ -56,6 +56,16 @@ tmaster-sink:
     "__server/__time_spent_back_pressure_initiated": SUM
     "__time_spent_back_pressure_by_compid": SUM
 
+### Config for prometheus-sink
+# prometheus-sink:
+#   class: "com.twitter.heron.metricsmgr.sink.PrometheusSink"
+#   port: 8080 # The port on which to run (either port or port-file are mandatory)
+#   path: /metrics # The path on which to publish the metrics (mandatory)
+#   flat-metrics: true # By default the web-sink will publish a flat "name -> value" json map
+#   include-topology-name: true # Include topology name in metric name (default false)
+#   metrics-cache-max-size: 1000000 # Max number of metrics cached and published (default 1000000)
+#   metrics-cache-ttl-sec: 600 # Time in seconds after which a metric that was collected will stopped being published (default 600)
+
 ### Config for scribe-sink
 # scribe-sink:
 #   class: "com.twitter.heron.metricsmgr.sink.ScribeSink"

--- a/heron/config/src/yaml/conf/mesos/metrics_sinks.yaml
+++ b/heron/config/src/yaml/conf/mesos/metrics_sinks.yaml
@@ -56,6 +56,16 @@ tmaster-sink:
     "__server/__time_spent_back_pressure_initiated": SUM
     "__time_spent_back_pressure_by_compid": SUM
 
+### Config for prometheus-sink
+# prometheus-sink:
+#   class: "com.twitter.heron.metricsmgr.sink.PrometheusSink"
+#   port: 8080 # The port on which to run (either port or port-file are mandatory)
+#   path: /metrics # The path on which to publish the metrics (mandatory)
+#   flat-metrics: true # By default the web-sink will publish a flat "name -> value" json map
+#   include-topology-name: true # Include topology name in metric name (default false)
+#   metrics-cache-max-size: 1000000 # Max number of metrics cached and published (default 1000000)
+#   metrics-cache-ttl-sec: 600 # Time in seconds after which a metric that was collected will stopped being published (default 600)
+
 ### Config for scribe-sink
 # scribe-sink:
 #   class: "com.twitter.heron.metricsmgr.sink.ScribeSink"

--- a/heron/config/src/yaml/conf/sandbox/metrics_sinks.yaml
+++ b/heron/config/src/yaml/conf/sandbox/metrics_sinks.yaml
@@ -88,6 +88,16 @@ metricscache-sink:
     "__server/__time_spent_back_pressure_initiated": SUM
     "__time_spent_back_pressure_by_compid": SUM
 
+### Config for prometheus-sink
+# prometheus-sink:
+#   class: "com.twitter.heron.metricsmgr.sink.PrometheusSink"
+#   port: 8080 # The port on which to run (either port or port-file are mandatory)
+#   path: /metrics # The path on which to publish the metrics (mandatory)
+#   flat-metrics: true # By default the web-sink will publish a flat "name -> value" json map
+#   include-topology-name: true # Include topology name in metric name (default false)
+#   metrics-cache-max-size: 1000000 # Max number of metrics cached and published (default 1000000)
+#   metrics-cache-ttl-sec: 600 # Time in seconds after which a metric that was collected will stopped being published (default 600)
+
 ### Config for scribe-sink
 # scribe-sink:
 #   class: "com.twitter.heron.metricsmgr.sink.ScribeSink"

--- a/heron/config/src/yaml/conf/slurm/metrics_sinks.yaml
+++ b/heron/config/src/yaml/conf/slurm/metrics_sinks.yaml
@@ -56,6 +56,16 @@ tmaster-sink:
     "__server/__time_spent_back_pressure_initiated": SUM
     "__time_spent_back_pressure_by_compid": SUM
 
+### Config for prometheus-sink
+# prometheus-sink:
+#   class: "com.twitter.heron.metricsmgr.sink.PrometheusSink"
+#   port: 8080 # The port on which to run (either port or port-file are mandatory)
+#   path: /metrics # The path on which to publish the metrics (mandatory)
+#   flat-metrics: true # By default the web-sink will publish a flat "name -> value" json map
+#   include-topology-name: true # Include topology name in metric name (default false)
+#   metrics-cache-max-size: 1000000 # Max number of metrics cached and published (default 1000000)
+#   metrics-cache-ttl-sec: 600 # Time in seconds after which a metric that was collected will stopped being published (default 600)
+
 ### Config for scribe-sink
 # scribe-sink:
 #   class: "com.twitter.heron.metricsmgr.sink.ScribeSink"

--- a/heron/config/src/yaml/conf/test/test_metrics_sinks.yaml
+++ b/heron/config/src/yaml/conf/test/test_metrics_sinks.yaml
@@ -85,6 +85,16 @@ metricscache-sink:
     "__server/__time_spent_back_pressure_initiated": SUM
     "__time_spent_back_pressure_by_compid": SUM
 
+### Config for prometheus-sink
+# prometheus-sink:
+#   class: "com.twitter.heron.metricsmgr.sink.PrometheusSink"
+#   port: 8080 # The port on which to run (either port or port-file are mandatory)
+#   path: /metrics # The path on which to publish the metrics (mandatory)
+#   flat-metrics: true # By default the web-sink will publish a flat "name -> value" json map
+#   include-topology-name: true # Include topology name in metric name (default false)
+#   metrics-cache-max-size: 1000000 # Max number of metrics cached and published (default 1000000)
+#   metrics-cache-ttl-sec: 600 # Time in seconds after which a metric that was collected will stopped being published (default 600)
+
 ### Config for scribe-sink
 # scribe-sink:
 #   class: "com.twitter.heron.metricsmgr.sink.ScribeSink"

--- a/heron/config/src/yaml/conf/yarn/metrics_sinks.yaml
+++ b/heron/config/src/yaml/conf/yarn/metrics_sinks.yaml
@@ -56,6 +56,16 @@ tmaster-sink:
     "__server/__time_spent_back_pressure_initiated": SUM
     "__time_spent_back_pressure_by_compid": SUM
 
+### Config for prometheus-sink
+# prometheus-sink:
+#   class: "com.twitter.heron.metricsmgr.sink.PrometheusSink"
+#   port: 8080 # The port on which to run (either port or port-file are mandatory)
+#   path: /metrics # The path on which to publish the metrics (mandatory)
+#   flat-metrics: true # By default the web-sink will publish a flat "name -> value" json map
+#   include-topology-name: true # Include topology name in metric name (default false)
+#   metrics-cache-max-size: 1000000 # Max number of metrics cached and published (default 1000000)
+#   metrics-cache-ttl-sec: 600 # Time in seconds after which a metric that was collected will stopped being published (default 600)
+
 ### Config for scribe-sink
 # scribe-sink:
 #   class: "com.twitter.heron.metricsmgr.sink.ScribeSink"


### PR DESCRIPTION
Currently, there are default metrics sinks configs for Scribe and Graphite in *all* `metrics_sinks.yaml` config files in all base templates. They are commented out and thus not mandatory. This PR does the same except adds `prometheus-sink` configs to each template.