### PR TITLE
changing commandline arguments to be passed in a key value fashion

### DIFF
--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -559,7 +559,7 @@ class HeronExecutor(object):
       instance_cmd.extend(['-Djava.net.preferIPv4Stack=true',
                            '-cp',
                            '%s:%s' % (self.instance_classpath, self.classpath),
-                           'com.twitter.heron.instance.HeronInstance'] + + instance_args)
+                           'com.twitter.heron.instance.HeronInstance'] + instance_args)
 
       retval[instance_id] = instance_cmd
     return retval

--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -540,24 +540,27 @@ class HeronExecutor(object):
                       '-XX:+UseConcMarkSweepGC',
                       '-XX:ParallelGCThreads=4',
                       '-Xloggc:log-files/gc.%s.log' % instance_id]
+
+      instance_args = ['-topology_name', self.topology_name,
+                       '-topology_id', self.topology_id,
+                       '-instance_id', instance_id,
+                       '-component_name', component_name,
+                       '-task_id', str(global_task_id),
+                       '-component_index', str(component_index),
+                       '-stmgr_id', self.stmgr_ids[self.shard],
+                       '-stmgr_port', self.tmaster_controller_port,
+                       '-metricsmgr_port', self.metricsmgr_port,
+                       '-system_config_file', self.heron_internals_config_file,
+                       '-override_config_file', self.override_config_file]
+
       instance_cmd = instance_cmd + self.instance_jvm_opts.split()
       if component_name in self.component_jvm_opts:
         instance_cmd = instance_cmd + self.component_jvm_opts[component_name].split()
       instance_cmd.extend(['-Djava.net.preferIPv4Stack=true',
                            '-cp',
                            '%s:%s' % (self.instance_classpath, self.classpath),
-                           'com.twitter.heron.instance.HeronInstance',
-                           self.topology_name,
-                           self.topology_id,
-                           instance_id,
-                           component_name,
-                           str(global_task_id),
-                           str(component_index),
-                           self.stmgr_ids[self.shard],
-                           self.tmaster_controller_port,
-                           self.metricsmgr_port,
-                           self.heron_internals_config_file,
-                           self.override_config_file])
+                           'com.twitter.heron.instance.HeronInstance'] + + instance_args)
+
       retval[instance_id] = instance_cmd
     return retval
 

--- a/heron/executor/tests/python/heron_executor_unittest.py
+++ b/heron/executor/tests/python/heron_executor_unittest.py
@@ -139,8 +139,8 @@ class HeronExecutorTest(unittest.TestCase):
            "-XX:+HeapDumpOnOutOfMemoryError -XX:+UseConcMarkSweepGC -XX:ParallelGCThreads=4 " \
            "-Xloggc:log-files/gc.%s.log -XX:+HeapDumpOnOutOfMemoryError " \
            "-Djava.net.preferIPv4Stack=true -cp instance_classpath:classpath " \
-           "com.twitter.heron.instance.HeronInstance topname topid %s %s %d 0 stmgr-%d " \
-           "tmaster_controller_port metricsmgr_port %s %s" \
+           "com.twitter.heron.instance.HeronInstance -topology_name topname -topology_id topid -instance_id %s -component_name %s -task_id %d -component_index 0 -stmgr_id stmgr-%d " \
+           "-stmgr_port tmaster_controller_port -metricsmgr_port metricsmgr_port -system_config_file %s -override_config_file %s" \
            % (instance_name, instance_name, component_name, instance_id,
               container_id, INTERNAL_CONF_PATH, OVERRIDE_PATH)
 
@@ -275,6 +275,9 @@ class HeronExecutorTest(unittest.TestCase):
 
     current_json = json.dumps(current_commands, sort_keys=True).split(' ')
     temp_json = json.dumps(temp_dict, sort_keys=True).split(' ')
+
+    print ("current_json: %s" % current_json)
+    print ("temp_json: %s" % temp_json)
 
     # better test error report
     for (s1, s2) in zip(current_json, temp_json):

--- a/heron/instance/src/java/BUILD
+++ b/heron/instance/src/java/BUILD
@@ -13,6 +13,7 @@ instance_deps_files =  \
         "//heron/common/src/java:config-java",
         "//heron/common/src/java:network-java",
         "//heron/common/src/java:utils-java",
+        "@commons_cli_commons_cli//jar"
     ]
 
 java_library(

--- a/heron/instance/src/java/com/twitter/heron/instance/HeronInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/HeronInstance.java
@@ -28,6 +28,14 @@ import java.util.logging.Logger;
 
 import com.google.protobuf.Message;
 
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
 import com.twitter.heron.common.basics.Communicator;
 import com.twitter.heron.common.basics.NIOLooper;
 import com.twitter.heron.common.basics.SingletonRegistry;
@@ -75,6 +83,21 @@ public class HeronInstance {
   private final ExecutorService threadsPool;
 
   private final SystemConfig systemConfig;
+
+  private static class CommandLineOptions {
+    private static final String TOPOLOGY_NAME_OPTION = "topology_name";
+    private static final String TOPOLOGY_ID_OPTION = "topology_id";
+    private static final String INSTANCE_ID_OPTION = "instance_id";
+    private static final String COMPONENT_NAME_OPTION = "component_name";
+    private static final String TASK_ID_OPTION = "task_id";
+    private static final String COMPONENT_INDEX_OPTION = "component_index";
+    private static final String STMGR_ID_OPTION = "stmgr_id";
+    private static final String STMGR_PORT_OPTION = "stmgr_port";
+    private static final String METRICS_MGR_PORT_OPTION = "metricsmgr_port";
+    private static final String SYSTEM_CONFIG_FILE = "system_config_file";
+    private static final String OVERRIDE_CONFIG_FILE = "override_config_file";
+    private static final String REMOTE_DEBUGGER_PORT = "remote_debugger_port";
+  }
 
   /**
    * Heron instance constructor
@@ -128,25 +151,116 @@ public class HeronInstance {
     threadsPool = Executors.newFixedThreadPool(NUM_THREADS);
   }
 
-  public static void main(String[] args) throws IOException {
-    if (args.length < 10) {
-      throw new RuntimeException(
-          "Invalid arguments; Usage is java com.twitter.heron.instance.HeronInstance "
-              + "<topology_name> <topology_id> <instance_id> <component_name> <task_id> "
-              + "<component_index> <stmgr_id> <stmgr_port> <metricsmgr_port> "
-              + "<heron_internals_config_filename>");
-    }
+  private static CommandLine parseCommandLineArgs(String[] args) {
+    Options options = new Options();
 
-    String topologyName = args[0];
-    String topologyId = args[1];
-    String instanceId = args[2];
-    String componentName = args[3];
-    int taskId = Integer.parseInt(args[4]);
-    int componentIndex = Integer.parseInt(args[5]);
-    String streamId = args[6];
-    int streamPort = Integer.parseInt(args[7]);
-    int metricsPort = Integer.parseInt(args[8]);
-    SystemConfig systemConfig = SystemConfig.newBuilder(true).putAll(args[9], true).build();
+    Option topologyNameOption = new Option(
+        CommandLineOptions.TOPOLOGY_NAME_OPTION, true, "Topology Name");
+    topologyNameOption.setRequired(true);
+    topologyNameOption.setType(String.class);
+    options.addOption(topologyNameOption);
+
+    Option topologyIdOption = new Option(
+        CommandLineOptions.TOPOLOGY_ID_OPTION, true, "Topology ID");
+    topologyIdOption.setRequired(true);
+    topologyIdOption.setType(String.class);
+    options.addOption(topologyIdOption);
+
+    Option instanceIdOption = new Option(
+        CommandLineOptions.INSTANCE_ID_OPTION, true, "Instance ID");
+    instanceIdOption.setRequired(true);
+    instanceIdOption.setType(String.class);
+    options.addOption(instanceIdOption);
+
+    Option componentNameOption = new Option(
+        CommandLineOptions.COMPONENT_NAME_OPTION, true, "Component Name");
+    componentNameOption.setRequired(true);
+    componentNameOption.setType(String.class);
+    options.addOption(componentNameOption);
+
+    Option taskIdOption = new Option(CommandLineOptions.TASK_ID_OPTION, true, "Task ID");
+    taskIdOption.setRequired(true);
+    taskIdOption.setType(Integer.class);
+    options.addOption(taskIdOption);
+
+    Option componentIndexOption = new Option(
+        CommandLineOptions.COMPONENT_INDEX_OPTION, true, "Component Index");
+    componentIndexOption.setRequired(true);
+    componentIndexOption.setType(Integer.class);
+    options.addOption(componentIndexOption);
+
+    Option stmgrIdOption = new Option(
+        CommandLineOptions.STMGR_ID_OPTION, true, "Stream Manager ID");
+    stmgrIdOption.setType(String.class);
+    stmgrIdOption.setRequired(true);
+    options.addOption(stmgrIdOption);
+
+    Option stmgrPortOption = new Option(
+        CommandLineOptions.STMGR_PORT_OPTION, true, "Stream Manager Port");
+    stmgrPortOption.setType(Integer.class);
+    stmgrPortOption.setRequired(true);
+    options.addOption(stmgrPortOption);
+
+    Option metricsmgrPortOption
+        = new Option(
+        CommandLineOptions.METRICS_MGR_PORT_OPTION, true, "Metrics Manager Port");
+    metricsmgrPortOption.setType(Integer.class);
+    metricsmgrPortOption.setRequired(true);
+    options.addOption(metricsmgrPortOption);
+
+    Option systemConfigFileOption
+        = new Option(
+        CommandLineOptions.SYSTEM_CONFIG_FILE, true, "Heron Internals Config Filename");
+    systemConfigFileOption.setType(String.class);
+    systemConfigFileOption.setRequired(true);
+    options.addOption(systemConfigFileOption);
+
+    Option overrideConfigFileOption
+        = new Option(CommandLineOptions.OVERRIDE_CONFIG_FILE,
+        true, "Override Config File");
+    overrideConfigFileOption.setType(String.class);
+    overrideConfigFileOption.setRequired(true);
+    options.addOption(overrideConfigFileOption);
+
+    CommandLineParser parser = new DefaultParser();
+    HelpFormatter formatter = new HelpFormatter();
+    CommandLine cmd = null;
+    try {
+      cmd = parser.parse(options, args);
+    } catch (ParseException e) {
+      System.out.println(e.getMessage());
+      formatter.printHelp("Heron Instance", options);
+      throw new RuntimeException("Incorrect Usage");
+    }
+    return cmd;
+  }
+
+  public static void main(String[] args) throws IOException {
+    CommandLine commandLine = parseCommandLineArgs(args);
+
+    String topologyName = commandLine.getOptionValue(CommandLineOptions.TOPOLOGY_NAME_OPTION);
+    String topologyId = commandLine.getOptionValue(CommandLineOptions.TOPOLOGY_ID_OPTION);
+    String instanceId = commandLine.getOptionValue(CommandLineOptions.INSTANCE_ID_OPTION);
+    String componentName = commandLine.getOptionValue(CommandLineOptions.COMPONENT_NAME_OPTION);
+    Integer taskId = Integer.parseInt(
+        commandLine.getOptionValue(CommandLineOptions.TASK_ID_OPTION));
+    Integer componentIndex
+        = Integer.parseInt(commandLine.getOptionValue(CommandLineOptions.COMPONENT_INDEX_OPTION));
+    String streamId = commandLine.getOptionValue(CommandLineOptions.STMGR_ID_OPTION);
+    Integer streamPort
+        = Integer.parseInt(commandLine.getOptionValue(CommandLineOptions.STMGR_PORT_OPTION));
+    Integer metricsPort
+        = Integer.parseInt(
+        commandLine.getOptionValue(CommandLineOptions.METRICS_MGR_PORT_OPTION));
+    String systemConfigFile
+        = commandLine.getOptionValue(CommandLineOptions.SYSTEM_CONFIG_FILE);
+    String overrideConfigFile
+        = commandLine.getOptionValue(CommandLineOptions.OVERRIDE_CONFIG_FILE);
+
+    SystemConfig systemConfig = SystemConfig.newBuilder(true)
+        .putAll(systemConfigFile, true)
+        .putAll(overrideConfigFile, true)
+        .build();
 
     // Add the SystemConfig into SingletonRegistry
     SingletonRegistry.INSTANCE.registerSingleton(SystemConfig.HERON_SYSTEM_CONFIG, systemConfig);

--- a/heron/instance/src/java/shade.conf
+++ b/heron/instance/src/java/shade.conf
@@ -1,3 +1,4 @@
 rule com.google.protobuf** com.twitter.heron.shaded.@0
 rule org.yaml.snakeyaml** com.twitter.heron.shaded.@0
 rule com.esotericsoftware.kryo** com.twitter.heron.shaded.@0
+rule org.apache.commons** com.twitter.heron.shaded.@0


### PR DESCRIPTION
- changing commandline arguments to be passed in a key value fashion
- allow override config in heron_executor.py to actually override heron internal configs in HeronInstance

Splitting up PR: https://github.com/twitter/heron/pull/2468