### PR TITLE
Remove unnecessary import statement

### DIFF
--- a/examples/src/java/com/twitter/heron/examples/api/AckingTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/api/AckingTopology.java
@@ -30,8 +30,6 @@ import com.twitter.heron.api.topology.TopologyContext;
 import com.twitter.heron.api.tuple.Fields;
 import com.twitter.heron.api.tuple.Tuple;
 import com.twitter.heron.api.tuple.Values;
-import com.twitter.heron.api.utils.Utils;
-
 
 /**
  * This is a basic example of a Heron topology with acking enable.


### PR DESCRIPTION
I added an unnecessary import statement to an example topology that accidentally broke the `master` build. This PR removes that statement.