### PR TITLE
fix map inconsistency

### DIFF
--- a/storm-compatibility-examples/src/java/org/apache/storm/examples/ExclamationTopology.java
+++ b/storm-compatibility-examples/src/java/org/apache/storm/examples/ExclamationTopology.java
@@ -77,8 +77,8 @@ public final class ExclamationTopology {
     private OutputCollector collector;
 
     @Override
-    @SuppressWarnings("HiddenField")
-    public void prepare(Map<String, Object> stormConf, TopologyContext context,
+    @SuppressWarnings({"HiddenField", "rawtypes"})
+    public void prepare(Map stormConf, TopologyContext context,
                         OutputCollector collector) {
       this.collector = collector;
 

--- a/storm-compatibility/src/java/org/apache/storm/task/IBolt.java
+++ b/storm-compatibility/src/java/org/apache/storm/task/IBolt.java
@@ -55,7 +55,7 @@ public interface IBolt extends Serializable {
    * @param collector The collector is used to emit tuples from this bolt. Tuples can be emitted at any time, including the prepare and cleanup methods. The collector is thread-safe and should be saved as an instance variable of this bolt object.
    */
   @SuppressWarnings("rawtypes")
-  void prepare(Map<String, Object> stormConf, TopologyContext context, OutputCollector collector);
+  void prepare(Map stormConf, TopologyContext context, OutputCollector collector);
 
   /**
    * Process a single tuple of input. The Tuple object contains metadata on it


### PR DESCRIPTION
1. The Map in api is inconsistent with our some topologies. Our topologies use raw map. Here is an example:
```
import java.util.{Date, Map => JMap}
class xBolt extends BaseRichBolt {
  override def prepare(conf: JMap[_, _], context: TopologyContext, collector: OutputCollector) {
```
here is the compiling error

```
[error] xBolt.scala: class xBolt needs to be abstract, since method prepare in trait IBolt of type (x$1: java.util.Map[String,Object], x$2: org.apache.storm.task.TopologyContext, x$3: org.apache.storm.task.OutputCollector)Unit is not defined
[error] (Note that java.util.Map[String,Object] does not match java.util.Map[_, _]: their type parameters differ)
[error] class xBolt extends BaseRichBolt {
[error]       ^
[error] xBolt.scala: method prepare overrides nothing.
[error] Note: the super classes of class xBolt contain the following, non final members named prepare:
[error] def prepare(x$1: java.util.Map[String,Object],x$2: org.apache.storm.task.TopologyContext,x$3: org.apache.storm.task.OutputCollector): Unit
[error]   override def prepare(conf: JMap[_, _], context: TopologyContext, collector: OutputCollector) {
[error]                ^
[error] two errors found
```
2. This PR change the Map in api to raw Map.
