### PR TITLE
Generic Integer Convention when submitting a topology

### DIFF
--- a/storm-compatibility/src/java/backtype/storm/utils/ConfigUtils.java
+++ b/storm-compatibility/src/java/backtype/storm/utils/ConfigUtils.java
@@ -48,11 +48,12 @@ public final class ConfigUtils {
           heronConfig.get(backtype.storm.Config.TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS).toString());
     }
     if (heronConfig.containsKey(backtype.storm.Config.TOPOLOGY_WORKERS)) {
-      Integer nWorkers = (Integer) heronConfig.get(backtype.storm.Config.TOPOLOGY_WORKERS);
+      Integer nWorkers = Utils.getInt(heronConfig.get(backtype.storm.Config.TOPOLOGY_WORKERS));
       com.twitter.heron.api.Config.setNumStmgrs(heronConfig, nWorkers);
     }
     if (heronConfig.containsKey(backtype.storm.Config.TOPOLOGY_ACKER_EXECUTORS)) {
-      Integer nAckers = (Integer) heronConfig.get(backtype.storm.Config.TOPOLOGY_ACKER_EXECUTORS);
+      Integer nAckers =
+          Utils.getInt(heronConfig.get(backtype.storm.Config.TOPOLOGY_ACKER_EXECUTORS));
       if (nAckers > 0) {
         com.twitter.heron.api.Config.setTopologyReliabilityMode(heronConfig,
                  com.twitter.heron.api.Config.TopologyReliabilityMode.ATLEAST_ONCE);
@@ -66,18 +67,18 @@ public final class ConfigUtils {
     }
     if (heronConfig.containsKey(backtype.storm.Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS)) {
       Integer nSecs =
-          (Integer) heronConfig.get(backtype.storm.Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS);
+          Utils.getInt(heronConfig.get(backtype.storm.Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS));
       com.twitter.heron.api.Config.setMessageTimeoutSecs(heronConfig, nSecs);
     }
     if (heronConfig.containsKey(backtype.storm.Config.TOPOLOGY_MAX_SPOUT_PENDING)) {
       Integer nPending =
-          Integer.parseInt(
+          Utils.getInt(
               heronConfig.get(backtype.storm.Config.TOPOLOGY_MAX_SPOUT_PENDING).toString());
       com.twitter.heron.api.Config.setMaxSpoutPending(heronConfig, nPending);
     }
     if (heronConfig.containsKey(backtype.storm.Config.TOPOLOGY_TICK_TUPLE_FREQ_SECS)) {
       Integer tSecs =
-          Integer.parseInt(
+          Utils.getInt(
               heronConfig.get(backtype.storm.Config.TOPOLOGY_TICK_TUPLE_FREQ_SECS).toString());
       com.twitter.heron.api.Config.setTickTupleFrequency(heronConfig, tSecs);
     }

--- a/storm-compatibility/src/java/org/apache/storm/utils/ConfigUtils.java
+++ b/storm-compatibility/src/java/org/apache/storm/utils/ConfigUtils.java
@@ -48,12 +48,12 @@ public final class ConfigUtils {
           heronConfig.get(org.apache.storm.Config.TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS).toString());
     }
     if (heronConfig.containsKey(org.apache.storm.Config.TOPOLOGY_WORKERS)) {
-      Integer nWorkers = (Integer) heronConfig.get(org.apache.storm.Config.TOPOLOGY_WORKERS);
+      Integer nWorkers = Utils.getInt(heronConfig.get(org.apache.storm.Config.TOPOLOGY_WORKERS));
       com.twitter.heron.api.Config.setNumStmgrs(heronConfig, nWorkers);
     }
     if (heronConfig.containsKey(org.apache.storm.Config.TOPOLOGY_ACKER_EXECUTORS)) {
       Integer nAckers =
-          (Integer) heronConfig.get(org.apache.storm.Config.TOPOLOGY_ACKER_EXECUTORS);
+          Utils.getInt(heronConfig.get(org.apache.storm.Config.TOPOLOGY_ACKER_EXECUTORS));
       if (nAckers > 0) {
         com.twitter.heron.api.Config.setTopologyReliabilityMode(heronConfig,
                  com.twitter.heron.api.Config.TopologyReliabilityMode.ATLEAST_ONCE);
@@ -67,18 +67,18 @@ public final class ConfigUtils {
     }
     if (heronConfig.containsKey(org.apache.storm.Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS)) {
       Integer nSecs =
-          (Integer) heronConfig.get(org.apache.storm.Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS);
+          Utils.getInt(heronConfig.get(org.apache.storm.Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS));
       com.twitter.heron.api.Config.setMessageTimeoutSecs(heronConfig, nSecs);
     }
     if (heronConfig.containsKey(org.apache.storm.Config.TOPOLOGY_MAX_SPOUT_PENDING)) {
       Integer nPending =
-          Integer.parseInt(
+          Utils.getInt(
               heronConfig.get(org.apache.storm.Config.TOPOLOGY_MAX_SPOUT_PENDING).toString());
       com.twitter.heron.api.Config.setMaxSpoutPending(heronConfig, nPending);
     }
     if (heronConfig.containsKey(org.apache.storm.Config.TOPOLOGY_TICK_TUPLE_FREQ_SECS)) {
       Integer tSecs =
-          Integer.parseInt(
+          Utils.getInt(
               heronConfig.get(org.apache.storm.Config.TOPOLOGY_TICK_TUPLE_FREQ_SECS).toString());
       com.twitter.heron.api.Config.setTickTupleFrequency(heronConfig, tSecs);
     }


### PR DESCRIPTION
Currently, Storm and Heron have different encoding styles for Integer in `api.Confg`.

Storm will put the `Integer` object directly while Heron will put the `Integer.toString()` object.
So if the config is put via Heron style, like: `com.twitter.heron.api.Config.setMessageTimeoutSecs(conf: Storm Config, 1200);`
and submit with a StormSubmitter. The StormSubmitter will fail to parse the Integer value from the Config and throw:
```
Exception in thread "main" java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Integer
 at org.apache.storm.utils.ConfigUtils.translateConfig(ConfigUtils.java:70)
```

This pull request uses a more generic Integer convention method in ConfigUtils.translateConfig(..),
so the StormSubmitter could submit with different styles config. 
It also unifies the ways to get Integer from an Object in the Config, rather than a mixture of `(Integer)...` and `Integer.parseInt(...)`

Tested with LocalScheduler.