### PR TITLE
Streamlet typing changes (removal of superfluous super-typing)

### DIFF
--- a/heron/api/src/java/com/twitter/heron/streamlet/KVStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/KVStreamlet.java
@@ -29,14 +29,14 @@ public interface KVStreamlet<K, V> extends BaseStreamlet<KVStreamlet<K, V>> {
    * Return a new KVStreamlet by applying mapFn to each element of this KVStreamlet
    * @param mapFn The Map Function that should be applied to each element
    */
-  <K1, V1> KVStreamlet<K1, V1> map(SerializableFunction<? super KeyValue<K, V>,
+  <K1, V1> KVStreamlet<K1, V1> map(SerializableFunction<KeyValue<K, V>,
       ? extends KeyValue<? extends K1, ? extends V1>> mapFn);
 
   /**
    * Return a new Streamlet by applying mapFn to each element of this KVStreamlet
    * @param mapFn The Map Function that should be applied to each element
    */
-  <R> Streamlet<R> mapToStreamlet(SerializableFunction<? super KeyValue<K, V>,
+  <R> Streamlet<R> mapToStreamlet(SerializableFunction<KeyValue<K, V>,
                                   ? extends R> mapFn);
 
   /**
@@ -45,7 +45,7 @@ public interface KVStreamlet<K, V> extends BaseStreamlet<KVStreamlet<K, V>> {
    * @param flatMapFn The FlatMap Function that should be applied to each element
    */
   <K1, V1> KVStreamlet<K1, V1> flatMap(
-      SerializableFunction<? super KeyValue<? super K, ? super V>,
+      SerializableFunction<KeyValue<K, V>,
           ? extends Iterable<KeyValue<? extends K1, ? extends V1>>> flatMapFn);
 
   /**
@@ -53,7 +53,7 @@ public interface KVStreamlet<K, V> extends BaseStreamlet<KVStreamlet<K, V>> {
    * and including only those elements that satisfy the filterFn
    * @param filterFn The filter Function that should be applied to each element
    */
-  KVStreamlet<K, V> filter(SerializablePredicate<? super KeyValue<? super K, ? super V>> filterFn);
+  KVStreamlet<K, V> filter(SerializablePredicate<KeyValue<K, V>> filterFn);
 
   /**
    * Same as filter(filterFn).setNumPartitions(nPartitions) where filterFn is identity
@@ -65,7 +65,7 @@ public interface KVStreamlet<K, V> extends BaseStreamlet<KVStreamlet<K, V>> {
    * any particular tuple should go to
    */
   KVStreamlet<K, V> repartition(int numPartitions,
-                                SerializableBiFunction<? super KeyValue<? super K, ? super V>,
+                                SerializableBiFunction<KeyValue<K, V>,
                                     Integer, List<Integer>> partitionFn);
 
   /**
@@ -89,7 +89,7 @@ public interface KVStreamlet<K, V> extends BaseStreamlet<KVStreamlet<K, V>> {
    * @return Streamlet containing the output of the transformFunction
    */
   <K1, V1> KVStreamlet<K1, V1> transform(
-      SerializableTransformer<? super KeyValue<? super K, ? super V>,
+      SerializableTransformer<KeyValue<K, V>,
           ? extends KeyValue<? extends K1, ? extends V1>> serializableTransformer);
 
   /**
@@ -104,7 +104,7 @@ public interface KVStreamlet<K, V> extends BaseStreamlet<KVStreamlet<K, V>> {
    * @param consumer The user supplied consumer function that is invoked for each element
    * of this streamlet.
    */
-  void consume(SerializableConsumer<? super KeyValue<? super K, ? super V>> consumer);
+  void consume(SerializableConsumer<KeyValue<K, V>> consumer);
 
   /**
    * Applies the sink's put function to every element of the stream
@@ -112,7 +112,7 @@ public interface KVStreamlet<K, V> extends BaseStreamlet<KVStreamlet<K, V>> {
    * @param sink The Sink whose put method consumes each element
    * of this streamlet.
    */
-  void toSink(Sink<? super KeyValue<? super K, ? super V>> sink);
+  void toSink(Sink<KeyValue<K, V>> sink);
 
   /**
    * Return a new KVStreamlet by inner joining 'this streamlet with ‘other’ streamlet.
@@ -124,7 +124,7 @@ public interface KVStreamlet<K, V> extends BaseStreamlet<KVStreamlet<K, V>> {
    */
   <V2, VR> KVStreamlet<KeyedWindow<K>, VR>
         join(KVStreamlet<K, V2> other, WindowConfig windowCfg,
-             SerializableBiFunction<? super V, ? super V2, ? extends VR> joinFunction);
+             SerializableBiFunction<V, V2, ? extends VR> joinFunction);
 
 
   /**
@@ -140,7 +140,7 @@ public interface KVStreamlet<K, V> extends BaseStreamlet<KVStreamlet<K, V>> {
    */
   <V2, VR> KVStreamlet<KeyedWindow<K>, VR>
         join(KVStreamlet<K, V2> other, WindowConfig windowCfg, JoinType joinType,
-             SerializableBiFunction<? super V, ? super V2, ? extends VR> joinFunction);
+             SerializableBiFunction<V, V2, ? extends VR> joinFunction);
 
   /**
    * Return a new Streamlet in which for each time_window, all elements are belonging to the
@@ -164,5 +164,5 @@ public interface KVStreamlet<K, V> extends BaseStreamlet<KVStreamlet<K, V>> {
    */
   <VR> KVStreamlet<KeyedWindow<K>, VR> reduceByKeyAndWindow(WindowConfig windowCfg,
                             VR identity,
-                            SerializableBiFunction<? super VR, ? super V, ? extends VR> reduceFn);
+                            SerializableBiFunction<VR, V, ? extends VR> reduceFn);
 }

--- a/heron/api/src/java/com/twitter/heron/streamlet/KVStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/KVStreamlet.java
@@ -29,14 +29,14 @@ public interface KVStreamlet<K, V> extends BaseStreamlet<KVStreamlet<K, V>> {
    * Return a new KVStreamlet by applying mapFn to each element of this KVStreamlet
    * @param mapFn The Map Function that should be applied to each element
    */
-  <K1, V1> KVStreamlet<K1, V1> map(SerializableFunction<? super KeyValue<? super K, ? super V>,
+  <K1, V1> KVStreamlet<K1, V1> map(SerializableFunction<? super KeyValue<K, V>,
       ? extends KeyValue<? extends K1, ? extends V1>> mapFn);
 
   /**
    * Return a new Streamlet by applying mapFn to each element of this KVStreamlet
    * @param mapFn The Map Function that should be applied to each element
    */
-  <R> Streamlet<R> mapToStreamlet(SerializableFunction<? super KeyValue<? super K, ? super V>,
+  <R> Streamlet<R> mapToStreamlet(SerializableFunction<? super KeyValue<K, V>,
                                   ? extends R> mapFn);
 
   /**

--- a/heron/api/src/java/com/twitter/heron/streamlet/Streamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/Streamlet.java
@@ -44,7 +44,7 @@ public interface Streamlet<R> extends BaseStreamlet<Streamlet<R>> {
    * Return a new Streamlet by applying mapFn to each element of this Streamlet
    * @param mapFn The Map Function that should be applied to each element
   */
-  <T> Streamlet<T> map(SerializableFunction<? super R, ? extends T> mapFn);
+  <T> Streamlet<T> map(SerializableFunction<R, ? extends T> mapFn);
 
   /**
    * Return a new KVStreamlet by applying mapFn to each element of this Streamlet.
@@ -52,7 +52,7 @@ public interface Streamlet<R> extends BaseStreamlet<Streamlet<R>> {
    * instead of a plain Streamlet.
    * @param mapFn The Map function that should be applied to each element
    */
-  <K, V> KVStreamlet<K, V> mapToKV(SerializableFunction<? super R, ? extends KeyValue<K, V>> mapFn);
+  <K, V> KVStreamlet<K, V> mapToKV(SerializableFunction<R, ? extends KeyValue<K, V>> mapFn);
 
   /**
    * Return a new Streamlet by applying flatMapFn to each element of this Streamlet and
@@ -60,14 +60,14 @@ public interface Streamlet<R> extends BaseStreamlet<Streamlet<R>> {
    * @param flatMapFn The FlatMap Function that should be applied to each element
    */
   <T> Streamlet<T> flatMap(
-      SerializableFunction<? super R, ? extends Iterable<? extends T>> flatMapFn);
+      SerializableFunction<R, ? extends Iterable<? extends T>> flatMapFn);
 
   /**
    * Return a new Streamlet by applying the filterFn on each element of this streamlet
    * and including only those elements that satisfy the filterFn
    * @param filterFn The filter Function that should be applied to each element
   */
-  Streamlet<R> filter(SerializablePredicate<? super R> filterFn);
+  Streamlet<R> filter(SerializablePredicate<R> filterFn);
 
   /**
    * Same as filter(filterFn).setNumPartitions(nPartitions) where filterFn is identity
@@ -83,7 +83,7 @@ public interface Streamlet<R> extends BaseStreamlet<Streamlet<R>> {
    * this element should be routed to.
    */
   Streamlet<R> repartition(int numPartitions,
-                           SerializableBiFunction<? super R, Integer, List<Integer>> partitionFn);
+                           SerializableBiFunction<R, Integer, List<Integer>> partitionFn);
 
   /**
    * Clones the current Streamlet. It returns an array of numClones Streamlets where each
@@ -113,7 +113,7 @@ public interface Streamlet<R> extends BaseStreamlet<Streamlet<R>> {
    * and the next element of the stream. It returns a new partial result.
    */
   <T> KVStreamlet<Window, T> reduceByWindow(WindowConfig windowConfig, T identity,
-                               SerializableBiFunction<? super T, ? super R, ? extends T> reduceFn);
+                               SerializableBiFunction<T, R, ? extends T> reduceFn);
 
   /**
    * Returns a new Streamlet thats the union of this and the ‘other’ streamlet. Essentially
@@ -130,7 +130,7 @@ public interface Streamlet<R> extends BaseStreamlet<Streamlet<R>> {
    * @return Streamlet containing the output of the transformFunction
    */
   <T> Streamlet<T> transform(
-      SerializableTransformer<? super R, ? extends T> serializableTransformer);
+      SerializableTransformer<R, ? extends T> serializableTransformer);
 
   /**
    * Logs every element of the streamlet using String.valueOf function

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/KVStreamletImpl.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/KVStreamletImpl.java
@@ -86,8 +86,8 @@ public abstract class KVStreamletImpl<K, V> extends BaseStreamletImpl<KVStreamle
    */
   @Override
   public <K1, V1> KVStreamlet<K1, V1> map(
-      SerializableFunction<? super KeyValue<K, V>,
-      ? extends KeyValue<? extends K1, ? extends V1>> mapFn) {
+      SerializableFunction<KeyValue<K, V>,
+        ? extends KeyValue<? extends K1, ? extends V1>> mapFn) {
     KVMapStreamlet<K, V, K1, V1> retval = new KVMapStreamlet<>(this, mapFn);
     addChild(retval);
     return retval;
@@ -99,7 +99,7 @@ public abstract class KVStreamletImpl<K, V> extends BaseStreamletImpl<KVStreamle
    */
   @Override
   public <R> Streamlet<R> mapToStreamlet(
-      SerializableFunction<? super KeyValue<K, V>, ? extends R> mapFn) {
+      SerializableFunction<KeyValue<K, V>, ? extends R> mapFn) {
     KVToStreamlet<K, V, R> retval = new KVToStreamlet<>(this, mapFn);
     addChild(retval);
     return retval;
@@ -112,7 +112,7 @@ public abstract class KVStreamletImpl<K, V> extends BaseStreamletImpl<KVStreamle
    */
   @Override
   public <K1, V1> KVStreamlet<K1, V1> flatMap(
-      SerializableFunction<? super KeyValue<? super K, ? super V>,
+      SerializableFunction<KeyValue<K, V>,
           ? extends Iterable<KeyValue<? extends K1, ? extends V1>>> flatMapFn) {
     KVFlatMapStreamlet<K, V, K1, V1> retval = new KVFlatMapStreamlet<>(this, flatMapFn);
     addChild(retval);
@@ -126,7 +126,7 @@ public abstract class KVStreamletImpl<K, V> extends BaseStreamletImpl<KVStreamle
    */
   @Override
   public KVStreamlet<K, V> filter(
-      SerializablePredicate<? super KeyValue<? super K, ? super V>> filterFn) {
+      SerializablePredicate<KeyValue<K, V>> filterFn) {
     KVFilterStreamlet<K, V> retval = new KVFilterStreamlet<>(this, filterFn);
     addChild(retval);
     return retval;
@@ -149,8 +149,8 @@ public abstract class KVStreamletImpl<K, V> extends BaseStreamletImpl<KVStreamle
    */
   @Override
   public KVStreamlet<K, V> repartition(int numPartitions,
-                                     SerializableBiFunction<? super KeyValue<? super K, ? super V>,
-                                      Integer, List<Integer>> partitionFn) {
+                                     SerializableBiFunction<KeyValue<K, V>,
+                                     Integer, List<Integer>> partitionFn) {
     KVRemapStreamlet<K, V> retval = new KVRemapStreamlet<>(this, partitionFn);
     retval.setNumPartitions(numPartitions);
     addChild(retval);
@@ -202,7 +202,7 @@ public abstract class KVStreamletImpl<K, V> extends BaseStreamletImpl<KVStreamle
    * @param consumer The user supplied consumer function that is invoked for each element
    */
   @Override
-  public void consume(SerializableConsumer<? super KeyValue<? super K, ? super V>> consumer) {
+  public void consume(SerializableConsumer<KeyValue<K, V>> consumer) {
     KVConsumerStreamlet<K, V> consumerStreamlet = new KVConsumerStreamlet<>(this, consumer);
     addChild(consumerStreamlet);
     return;
@@ -213,7 +213,7 @@ public abstract class KVStreamletImpl<K, V> extends BaseStreamletImpl<KVStreamle
    * @param sink The Sink that consumes
    */
   @Override
-  public void toSink(Sink<? super KeyValue<? super K, ? super V>> sink) {
+  public void toSink(Sink<KeyValue<K, V>> sink) {
     KVSinkStreamlet<K, V> sinkStreamlet = new KVSinkStreamlet<>(this, sink);
     addChild(sinkStreamlet);
     return;
@@ -228,7 +228,7 @@ public abstract class KVStreamletImpl<K, V> extends BaseStreamletImpl<KVStreamle
    */
   @Override
   public <K1, V1> KVStreamlet<K1, V1> transform(
-      SerializableTransformer<? super KeyValue<? super K, ? super V>,
+      SerializableTransformer<KeyValue<K, V>,
           ? extends KeyValue<? extends K1, ? extends V1>> serializableTransformer) {
     KVTransformStreamlet<K, V, K1, V1> transformStreamlet =
         new KVTransformStreamlet<>(this, serializableTransformer);
@@ -247,7 +247,7 @@ public abstract class KVStreamletImpl<K, V> extends BaseStreamletImpl<KVStreamle
   @Override
   public <V2, VR> KVStreamlet<KeyedWindow<K>, VR>
       join(KVStreamlet<K, V2> other, WindowConfig windowCfg,
-           SerializableBiFunction<? super V, ? super V2, ? extends VR> joinFunction) {
+           SerializableBiFunction<V, V2, ? extends VR> joinFunction) {
     return join(other, windowCfg, JoinType.INNER, joinFunction);
   }
 
@@ -266,7 +266,7 @@ public abstract class KVStreamletImpl<K, V> extends BaseStreamletImpl<KVStreamle
   public <V2, VR> KVStreamlet<KeyedWindow<K>, VR>
         join(KVStreamlet<K, V2> other,
              WindowConfig windowCfg, JoinType joinType,
-             SerializableBiFunction<? super V, ? super V2, ? extends VR> joinFunction) {
+             SerializableBiFunction<V, V2, ? extends VR> joinFunction) {
 
     KVStreamletImpl<K, V2> joinee = (KVStreamletImpl<K, V2>) other;
     JoinStreamlet<K, V, V2, VR> retval = JoinStreamlet.createJoinStreamlet(
@@ -305,7 +305,7 @@ public abstract class KVStreamletImpl<K, V> extends BaseStreamletImpl<KVStreamle
   @Override
   public <VR> KVStreamlet<KeyedWindow<K>, VR>
       reduceByKeyAndWindow(WindowConfig windowCfg, VR identity,
-                           SerializableBiFunction<? super VR, ? super V, ? extends VR> reduceFn) {
+                           SerializableBiFunction<VR, V, ? extends VR> reduceFn) {
     GeneralReduceByKeyAndWindowStreamlet<K, V, VR> retval =
         new GeneralReduceByKeyAndWindowStreamlet<>(this, windowCfg, identity, reduceFn);
     addChild(retval);

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/KVStreamletImpl.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/KVStreamletImpl.java
@@ -86,7 +86,7 @@ public abstract class KVStreamletImpl<K, V> extends BaseStreamletImpl<KVStreamle
    */
   @Override
   public <K1, V1> KVStreamlet<K1, V1> map(
-      SerializableFunction<? super KeyValue<? super K, ? super V>,
+      SerializableFunction<? super KeyValue<K, V>,
       ? extends KeyValue<? extends K1, ? extends V1>> mapFn) {
     KVMapStreamlet<K, V, K1, V1> retval = new KVMapStreamlet<>(this, mapFn);
     addChild(retval);
@@ -99,7 +99,7 @@ public abstract class KVStreamletImpl<K, V> extends BaseStreamletImpl<KVStreamle
    */
   @Override
   public <R> Streamlet<R> mapToStreamlet(
-      SerializableFunction<? super KeyValue<? super K, ? super V>, ? extends R> mapFn) {
+      SerializableFunction<? super KeyValue<K, V>, ? extends R> mapFn) {
     KVToStreamlet<K, V, R> retval = new KVToStreamlet<>(this, mapFn);
     addChild(retval);
     return retval;

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/StreamletImpl.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/StreamletImpl.java
@@ -96,7 +96,7 @@ public abstract class StreamletImpl<R> extends BaseStreamletImpl<Streamlet<R>>
    * @param mapFn The Map Function that should be applied to each element
   */
   @Override
-  public <T> Streamlet<T> map(SerializableFunction<? super R, ? extends T> mapFn) {
+  public <T> Streamlet<T> map(SerializableFunction<R, ? extends T> mapFn) {
     MapStreamlet<R, T> retval = new MapStreamlet<>(this, mapFn);
     addChild(retval);
     return retval;
@@ -109,7 +109,7 @@ public abstract class StreamletImpl<R> extends BaseStreamletImpl<Streamlet<R>>
    * @param mapFn The Map function that should be applied to each element
    */
   @Override
-  public <K, V> KVStreamlet<K, V> mapToKV(SerializableFunction<? super R,
+  public <K, V> KVStreamlet<K, V> mapToKV(SerializableFunction<R,
       ? extends KeyValue<K, V>> mapFn) {
     MapToKVStreamlet<R, K, V> retval = new MapToKVStreamlet<>(this, mapFn);
     addChild(retval);
@@ -123,7 +123,7 @@ public abstract class StreamletImpl<R> extends BaseStreamletImpl<Streamlet<R>>
    */
   @Override
   public <T> Streamlet<T> flatMap(
-      SerializableFunction<? super R, ? extends Iterable<? extends T>> flatMapFn) {
+      SerializableFunction<R, ? extends Iterable<? extends T>> flatMapFn) {
     FlatMapStreamlet<R, T> retval = new FlatMapStreamlet<>(this, flatMapFn);
     addChild(retval);
     return retval;
@@ -135,7 +135,7 @@ public abstract class StreamletImpl<R> extends BaseStreamletImpl<Streamlet<R>>
    * @param filterFn The filter Function that should be applied to each element
   */
   @Override
-  public Streamlet<R> filter(SerializablePredicate<? super R> filterFn) {
+  public Streamlet<R> filter(SerializablePredicate<R> filterFn) {
     FilterStreamlet<R> retval = new FilterStreamlet<>(this, filterFn);
     addChild(retval);
     return retval;
@@ -155,7 +155,7 @@ public abstract class StreamletImpl<R> extends BaseStreamletImpl<Streamlet<R>>
    */
   @Override
   public Streamlet<R> repartition(int numPartitions,
-                           SerializableBiFunction<? super R, Integer, List<Integer>> partitionFn) {
+                           SerializableBiFunction<R, Integer, List<Integer>> partitionFn) {
     RemapStreamlet<R> retval = new RemapStreamlet<>(this, partitionFn);
     retval.setNumPartitions(numPartitions);
     addChild(retval);
@@ -203,7 +203,7 @@ public abstract class StreamletImpl<R> extends BaseStreamletImpl<Streamlet<R>>
    */
   @Override
   public <T> KVStreamlet<Window, T> reduceByWindow(WindowConfig windowConfig, T identity,
-                             SerializableBiFunction<? super T, ? super R, ? extends T> reduceFn) {
+                             SerializableBiFunction<T, R, ? extends T> reduceFn) {
     GeneralReduceByWindowStreamlet<R, T> retval = new GeneralReduceByWindowStreamlet<>(this,
         windowConfig, identity, reduceFn);
     addChild(retval);
@@ -267,7 +267,7 @@ public abstract class StreamletImpl<R> extends BaseStreamletImpl<Streamlet<R>>
    */
   @Override
   public <T> Streamlet<T> transform(
-      SerializableTransformer<? super R, ? extends T> serializableTransformer) {
+      SerializableTransformer<R, ? extends T> serializableTransformer) {
     TransformStreamlet<R, T> transformStreamlet =
         new TransformStreamlet<>(this, serializableTransformer);
     addChild(transformStreamlet);

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/KVConsumerStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/KVConsumerStreamlet.java
@@ -29,10 +29,10 @@ import com.twitter.heron.streamlet.impl.sinks.ConsumerSink;
  */
 public class KVConsumerStreamlet<K, V> extends KVStreamletImpl<K, V> {
   private KVStreamletImpl<K, V> parent;
-  private SerializableConsumer<? super KeyValue<? super K, ? super V>> consumer;
+  private SerializableConsumer<KeyValue<K, V>> consumer;
 
   public KVConsumerStreamlet(KVStreamletImpl<K, V> parent,
-                            SerializableConsumer<? super KeyValue<? super K, ? super V>> consumer) {
+                            SerializableConsumer<KeyValue<K, V>> consumer) {
     this.parent = parent;
     this.consumer = consumer;
     setNumPartitions(parent.getNumPartitions());

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/KVFilterStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/KVFilterStreamlet.java
@@ -28,10 +28,10 @@ import com.twitter.heron.streamlet.impl.operators.FilterOperator;
  */
 public class KVFilterStreamlet<K, V> extends KVStreamletImpl<K, V> {
   private KVStreamletImpl<K, V> parent;
-  private SerializablePredicate<? super KeyValue<? super K, ? super V>> filterFn;
+  private SerializablePredicate<KeyValue<K, V>> filterFn;
 
   public KVFilterStreamlet(KVStreamletImpl<K, V> parent,
-                           SerializablePredicate<? super KeyValue<? super K, ? super V>> filterFn) {
+                           SerializablePredicate<KeyValue<K, V>> filterFn) {
     this.parent = parent;
     this.filterFn = filterFn;
     setNumPartitions(parent.getNumPartitions());

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/KVFlatMapStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/KVFlatMapStreamlet.java
@@ -29,11 +29,11 @@ import com.twitter.heron.streamlet.impl.operators.FlatMapOperator;
  */
 public class KVFlatMapStreamlet<K, V, K1, V1> extends KVStreamletImpl<K1, V1> {
   private KVStreamletImpl<K, V> parent;
-  private SerializableFunction<? super KeyValue<? super K, ? super V>,
+  private SerializableFunction<KeyValue<K, V>,
       ? extends Iterable<KeyValue<? extends K1, ? extends V1>>> flatMapFn;
 
   public KVFlatMapStreamlet(KVStreamletImpl<K, V> parent,
-                            SerializableFunction<? super KeyValue<? super K, ? super V>,
+                            SerializableFunction<KeyValue<K, V>,
                               ? extends Iterable<KeyValue<? extends K1, ? extends V1>>> flatMapFn) {
     this.parent = parent;
     this.flatMapFn = flatMapFn;
@@ -49,7 +49,7 @@ public class KVFlatMapStreamlet<K, V, K1, V1> extends KVStreamletImpl<K1, V1> {
       throw new RuntimeException("Duplicate Names");
     }
     stageNames.add(getName());
-    bldr.setBolt(getName(), new FlatMapOperator<KeyValue<? super K, ? super V>,
+    bldr.setBolt(getName(), new FlatMapOperator<KeyValue<K, V>,
             KeyValue<? extends K1, ? extends V1>>(flatMapFn),
         getNumPartitions()).shuffleGrouping(parent.getName());
     return true;

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/KVMapStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/KVMapStreamlet.java
@@ -28,11 +28,11 @@ import com.twitter.heron.streamlet.impl.operators.MapOperator;
  */
 public class KVMapStreamlet<K, V, K1, V1> extends KVStreamletImpl<K1, V1> {
   private KVStreamletImpl<K, V> parent;
-  private SerializableFunction<? super KeyValue<? super K, ? super V>,
+  private SerializableFunction<? super KeyValue<K, V>,
       ? extends KeyValue<? extends K1, ? extends V1>> mapFn;
 
   public KVMapStreamlet(KVStreamletImpl<K, V> parent,
-                        SerializableFunction<? super KeyValue<? super K, ? super V>,
+                        SerializableFunction<? super KeyValue<K, V>,
       ? extends KeyValue<? extends K1, ? extends V1>> mapFn) {
     this.parent = parent;
     this.mapFn = mapFn;
@@ -48,7 +48,7 @@ public class KVMapStreamlet<K, V, K1, V1> extends KVStreamletImpl<K1, V1> {
       throw new RuntimeException("Duplicate Names");
     }
     stageNames.add(getName());
-    bldr.setBolt(getName(), new MapOperator<KeyValue<? super K, ? super V>,
+    bldr.setBolt(getName(), new MapOperator<KeyValue<K, V>,
             KeyValue<? extends K1, ? extends V1>>(mapFn),
         getNumPartitions()).shuffleGrouping(parent.getName());
     return true;

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/KVRemapStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/KVRemapStreamlet.java
@@ -33,11 +33,11 @@ import com.twitter.heron.streamlet.impl.operators.MapOperator;
  */
 public class KVRemapStreamlet<K, V> extends KVStreamletImpl<K, V> {
   private KVStreamletImpl<K, V> parent;
-  private SerializableBiFunction<? super KeyValue<? super K, ? super V>,
+  private SerializableBiFunction<KeyValue<K, V>,
       Integer, List<Integer>> remapFn;
 
   public KVRemapStreamlet(KVStreamletImpl<K, V> parent,
-                          SerializableBiFunction<? super KeyValue<? super K, ? super V>,
+                          SerializableBiFunction<KeyValue<K, V>,
                               Integer, List<Integer>> remapFn) {
     this.parent = parent;
     this.remapFn = remapFn;

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/KVSinkStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/KVSinkStreamlet.java
@@ -29,10 +29,10 @@ import com.twitter.heron.streamlet.impl.sinks.ComplexSink;
  */
 public class KVSinkStreamlet<K, V> extends KVStreamletImpl<K, V> {
   private KVStreamletImpl<K, V> parent;
-  private Sink<? super KeyValue<? super K, ? super V>> sink;
+  private Sink<KeyValue<K, V>> sink;
 
   public KVSinkStreamlet(KVStreamletImpl<K, V> parent,
-                         Sink<? super KeyValue<? super K, ? super V>> sink) {
+                         Sink<KeyValue<K, V>> sink) {
     this.parent = parent;
     this.sink = sink;
     setNumPartitions(parent.getNumPartitions());

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/KVToStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/KVToStreamlet.java
@@ -29,10 +29,10 @@ import com.twitter.heron.streamlet.impl.operators.MapOperator;
  */
 public class KVToStreamlet<K, V, R> extends StreamletImpl<R> {
   private KVStreamletImpl<K, V> parent;
-  private SerializableFunction<? super KeyValue<? super K, ? super V>, ? extends R> mapFn;
+  private SerializableFunction<? super KeyValue<K, V>, ? extends R> mapFn;
 
   public KVToStreamlet(KVStreamletImpl<K, V> parent,
-                       SerializableFunction<? super KeyValue<? super K, ? super V>,
+                       SerializableFunction<? super KeyValue<K, V>,
                            ? extends R> mapFn) {
     this.parent = parent;
     this.mapFn = mapFn;
@@ -48,7 +48,7 @@ public class KVToStreamlet<K, V, R> extends StreamletImpl<R> {
       throw new RuntimeException("Duplicate Names");
     }
     stageNames.add(getName());
-    bldr.setBolt(getName(), new MapOperator<KeyValue<? super K, ? super V>, R>(mapFn),
+    bldr.setBolt(getName(), new MapOperator<KeyValue<K, V>, R>(mapFn),
         getNumPartitions()).shuffleGrouping(parent.getName());
     return true;
   }

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/KVTransformStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/KVTransformStreamlet.java
@@ -30,11 +30,11 @@ import com.twitter.heron.streamlet.impl.operators.TransformOperator;
  */
 public class KVTransformStreamlet<K, V, K1, V1> extends KVStreamletImpl<K1, V1> {
   private KVStreamletImpl<K, V> parent;
-  private SerializableTransformer<? super KeyValue<? super K, ? super V>,
+  private SerializableTransformer<KeyValue<K, V>,
       ? extends KeyValue<? extends K1, ? extends V1>> serializableTransformer;
 
   public KVTransformStreamlet(KVStreamletImpl<K, V> parent,
-                         SerializableTransformer<? super KeyValue<? super K, ? super V>,
+                         SerializableTransformer<KeyValue<K, V>,
                          ? extends KeyValue<? extends K1, ? extends V1>> serializableTransformer) {
     this.parent = parent;
     this.serializableTransformer = serializableTransformer;
@@ -50,7 +50,7 @@ public class KVTransformStreamlet<K, V, K1, V1> extends KVStreamletImpl<K1, V1> 
       throw new RuntimeException("Duplicate Names");
     }
     stageNames.add(getName());
-    bldr.setBolt(getName(), new TransformOperator<KeyValue<? super K, ? super V>,
+    bldr.setBolt(getName(), new TransformOperator<KeyValue<K, V>,
             KeyValue<? extends K1, ? extends V1>>(serializableTransformer),
         getNumPartitions()).shuffleGrouping(parent.getName());
     return true;


### PR DESCRIPTION
There are a number of places in the Streamlet API for Java where `super`ing is being used but unnecessarily, which has created some identifiable issues, such as this one:

```java
KVStreamlet<String, Integer> kvs = builder.newKVSource(() -> new KeyValue<>("foo", 1))
        .map(kv -> new KeyValue<>(kv.getKey(), kv.getValue()));
```

This should work but instead throws an error due to an unnecessary `? super V` in the type signature for the `map` method of `KVStreamlet`. This led me to investigate the type system in general. The more general issue here is that `super`ing is not necessary when the input to a function type can *only* be of type `T`. In a map operation, for example, that means that this should be used...

```java
SerializableFunction<R, ? extends T>
```

...instead of this:

```java
SerializableFunction<? extends R, ? extends T>
```

I've made changes across the API where I found the same thing.

I've successfully re-built the Streamlet API library and all tests have passed:

```bash
$ bazel test --config=darwin heron/api/tests/java/...
```