### PR TITLE
fixes bookeeper statefulset's deployment url

### DIFF
--- a/deploy/kubernetes/general/README.md
+++ b/deploy/kubernetes/general/README.md
@@ -32,7 +32,7 @@ In some environments like K8S on DC/OS, `hostPort` is not well supported. You ca
 a `StatefulSet` with `Persistent Volumes` as below. Please see [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) for more details.
 
 ```shell
-$ kubectl create -f https://raw.githubusercontent.com/twitter/heron/master/deploy/kubernetes/general/bookkeeper.stateful.yaml
+$ kubectl create -f https://raw.githubusercontent.com/twitter/heron/master/deploy/kubernetes/general/bookkeeper.statefulset.yaml
 ```
 
 3. Start heron tools:


### PR DESCRIPTION
should be https://raw.githubusercontent.com/twitter/heron/master/deploy/kubernetes/general/bookkeeper.statefulset.yaml otherwise 404 will occur