### PR TITLE
Use heron home cluster defaults when running in a cluster.

### DIFF
--- a/docker/dist/Dockerfile.dist.centos7
+++ b/docker/dist/Dockerfile.dist.centos7
@@ -20,11 +20,11 @@ RUN /heron/heron-client-install.sh
 RUN /heron/heron-tools-install.sh
 
 RUN mkdir -p /opt/heron && \
-    tar --strip-components=1 -m -zxvf /heron/heron-core.tar.gz -C /opt/heron
+    tar --strip-components=1 -m -zxvf /heron/heron-core.tar.gz -C /heron
 
 RUN rm -f /heron/heron-tools-install.sh
 RUN rm -f /heron/heron-client-install.sh
 RUN rm -f /heron/heron-core.tar.gz
 
-ENV HERON_HOME /opt/heron/heron-core/
+ENV HERON_HOME /heron/heron-core/
 RUN export HERON_HOME

--- a/docker/dist/Dockerfile.dist.ubuntu14.04
+++ b/docker/dist/Dockerfile.dist.ubuntu14.04
@@ -21,14 +21,13 @@ WORKDIR /heron
 RUN /heron/heron-client-install.sh
 RUN /heron/heron-tools-install.sh
 
-RUN mkdir -p /opt/heron && \
-    tar --strip-components=1 -m -zxvf /heron/heron-core.tar.gz -C /opt/heron
+RUN tar --strip-components=1 -m -zxvf /heron/heron-core.tar.gz -C /heron
 
 RUN rm -f /heron/heron-tools-install.sh
 RUN rm -f /heron/heron-client-install.sh
 RUN rm -f /heron/heron-core.tar.gz
 
-ENV HERON_HOME /opt/heron/heron-core/
+ENV HERON_HOME /heron/heron-core/
 RUN export HERON_HOME
 
 # install zookeeper

--- a/docker/dist/Dockerfile.dist.ubuntu15.10
+++ b/docker/dist/Dockerfile.dist.ubuntu15.10
@@ -20,12 +20,11 @@ WORKDIR /heron
 RUN /heron/heron-client-install.sh
 RUN /heron/heron-tools-install.sh
 
-RUN mkdir -p /opt/heron && \
-    tar --strip-components=1 -m -zxvf /heron/heron-core.tar.gz -C /opt/heron
+RUN tar --strip-components=1 -m -zxvf /heron/heron-core.tar.gz -C /heron
 
 RUN rm -f /heron/heron-tools-install.sh
 RUN rm -f /heron/heron-client-install.sh
 RUN rm -f /heron/heron-core.tar.gz
 
-ENV HERON_HOME /opt/heron/heron-core/
+ENV HERON_HOME /heron/heron-core/
 RUN export HERON_HOME

--- a/docker/dist/Dockerfile.dist.ubuntu16.04
+++ b/docker/dist/Dockerfile.dist.ubuntu16.04
@@ -20,12 +20,11 @@ WORKDIR /heron
 RUN /heron/heron-client-install.sh
 RUN /heron/heron-tools-install.sh
 
-RUN mkdir -p /opt/heron && \
-    tar --strip-components=1 -m -zxvf /heron/heron-core.tar.gz -C /opt/heron
+RUN tar --strip-components=1 -m -zxvf /heron/heron-core.tar.gz -C /heron
 
 RUN rm -f /heron/heron-tools-install.sh
 RUN rm -f /heron/heron-client-install.sh
 RUN rm -f /heron/heron-core.tar.gz
 
-ENV HERON_HOME /opt/heron/heron-core/
+ENV HERON_HOME /heron/heron-core/
 RUN export HERON_HOME

--- a/heron/config/src/yaml/conf/kubernetes/scheduler.yaml
+++ b/heron/config/src/yaml/conf/kubernetes/scheduler.yaml
@@ -7,12 +7,6 @@ heron.class.launcher:                        com.twitter.heron.scheduler.kuberne
 # location of java - pick it up from shell environment
 heron.directory.sandbox.java.home:          $JAVA_HOME
 
-# kubernetes extracts the topology package at the entry point of the container
-# this will create a ./heron-conf/ directory
-heron.directory.conf:                       "./heron-conf/"
-
-heron.directory.home:                       $HERON_HOME
-
 # The URI of kubernetes API
 heron.kubernetes.scheduler.uri:             <kubernetes_api_addr>
 
@@ -20,4 +14,4 @@ heron.kubernetes.scheduler.uri:             <kubernetes_api_addr>
 heron.scheduler.is.service:                  False
 
 # docker repo for executor
-heron.executor.docker.image:                'ndustrialio/heron-core:latest'
+heron.executor.docker.image:                'heron/heron:latest'

--- a/heron/tools/apiserver/src/java/com/twitter/heron/apiserver/Constants.java
+++ b/heron/tools/apiserver/src/java/com/twitter/heron/apiserver/Constants.java
@@ -21,8 +21,6 @@ public final class Constants {
 
   static final String DEFAULT_HERON_LOCAL = "~/.heron";
 
-  static final String DEFAULT_HERON_CLUSTER = "$HERON_HOME";
-
   static final String DEFAULT_HERON_CONFIG_DIRECTORY = "conf";
 
   static final String DEFAULT_HERON_RELEASE_FILE = "release.yaml";

--- a/heron/tools/apiserver/src/java/com/twitter/heron/apiserver/Runtime.java
+++ b/heron/tools/apiserver/src/java/com/twitter/heron/apiserver/Runtime.java
@@ -38,6 +38,7 @@ import com.twitter.heron.apiserver.resources.HeronResource;
 import com.twitter.heron.apiserver.utils.ConfigUtils;
 import com.twitter.heron.apiserver.utils.Logging;
 import com.twitter.heron.spi.common.Config;
+import com.twitter.heron.spi.common.Key;
 
 public final class Runtime {
 
@@ -157,10 +158,15 @@ public final class Runtime {
         cmd.getOptionValue(Flag.Cluster.name)).toFile().getAbsolutePath();
   }
 
+  // Get the heron home directory
+  // In local mode this is ~/.heron
+  // If running in a cluster this is ./heron-core and assumes the
+  // heron has been installed in the container's working directory
+  // working-dir/heron-core
   private static String getHeronDirectory(CommandLine cmd) {
     final String cluster = cmd.getOptionValue(Flag.Cluster.name);
     return "local".equalsIgnoreCase(cluster)
-        ? Constants.DEFAULT_HERON_LOCAL : Constants.DEFAULT_HERON_CLUSTER;
+        ? Constants.DEFAULT_HERON_LOCAL : Key.HERON_CLUSTER_HOME.getDefaultString();
   }
 
   private static String getReleaseFile(String toolsHome, CommandLine cmd) {


### PR DESCRIPTION
This changes how the api server configures heron home when running in a cluster. Heron core will now be installed in the working directory of the container heron/heron-core. This simplifies the code and allows the heron api server to assume the default configuration value. Key.HERON_CLUSTER_HOME. 