### PR TITLE
Allow users to register timer tasks in topologies

### DIFF
--- a/heron/api/src/java/com/twitter/heron/api/Config.java
+++ b/heron/api/src/java/com/twitter/heron/api/Config.java
@@ -666,14 +666,14 @@ public class Config extends HashMap<String, Object> {
    * Registers a timer event that executes periodically
    * @param conf the map with the existing topology configs
    * @param name the name of the timer
-   * @param timerDuration the frequency in which to run the task
+   * @param interval the frequency in which to run the task
    * @param task the task to run
    */
   @SuppressWarnings("unchecked")
   public static void registerTopologyTimerEvents(Map<String, Object> conf,
-                                                 String name, Duration timerDuration,
+                                                 String name, Duration interval,
                                                  Runnable task) {
-    if (timerDuration.isZero() || timerDuration.isNegative()) {
+    if (interval.isZero() || interval.isNegative()) {
       throw new IllegalArgumentException("Timer duration needs to be positive");
     }
     if (!conf.containsKey(Config.TOPOLOGY_TIMER_EVENTS)) {
@@ -686,6 +686,6 @@ public class Config extends HashMap<String, Object> {
     if (timers.containsKey(name)) {
       throw new IllegalArgumentException("Timer with name " + name + " already exists");
     }
-    timers.put(name, Pair.of(timerDuration, task));
+    timers.put(name, Pair.of(interval, task));
   }
 }

--- a/heron/api/src/java/com/twitter/heron/api/Config.java
+++ b/heron/api/src/java/com/twitter/heron/api/Config.java
@@ -34,6 +34,7 @@
 package com.twitter.heron.api;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -265,6 +266,8 @@ public class Config extends HashMap<String, Object> {
    * This variable contains Map<String, String>
    */
   public static final String TOPOLOGY_ENVIRONMENT = "topology.environment";
+
+  public static final String TOPOLOGY_TIMER_EVENTS = "topology.timer.events";
 
   private static final long serialVersionUID = 2550967708478837032L;
   // We maintain a list of all user exposed vars
@@ -651,5 +654,22 @@ public class Config extends HashMap<String, Object> {
 
   public void setTopologyStatefulStartClean(boolean clean) {
     setTopologyStatefulStartClean(this, clean);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static void registerTopologyTimerEvents(Map<String, Object> conf,
+                                                 String name, Duration timerDuration,
+                                                 Runnable task) {
+    if (!conf.containsKey(Config.TOPOLOGY_TIMER_EVENTS)) {
+      conf.put(Config.TOPOLOGY_TIMER_EVENTS, new HashMap<String, Pair<Duration, Runnable>>());
+    }
+
+    Map<String, Pair<Duration, Runnable>> timers
+        = (Map<String, Pair<Duration, Runnable>>) conf.get(Config.TOPOLOGY_TIMER_EVENTS);
+
+    if (timers.containsKey(name)) {
+      throw new IllegalArgumentException("Timer with name " + name + " already exists");
+    }
+    timers.put(name, Pair.of(timerDuration, task));
   }
 }

--- a/heron/api/src/java/com/twitter/heron/api/Config.java
+++ b/heron/api/src/java/com/twitter/heron/api/Config.java
@@ -673,6 +673,9 @@ public class Config extends HashMap<String, Object> {
   public static void registerTopologyTimerEvents(Map<String, Object> conf,
                                                  String name, Duration timerDuration,
                                                  Runnable task) {
+    if (timerDuration.isZero() || timerDuration.isNegative()) {
+      throw new IllegalArgumentException("Timer duration needs to be positive");
+    }
     if (!conf.containsKey(Config.TOPOLOGY_TIMER_EVENTS)) {
       conf.put(Config.TOPOLOGY_TIMER_EVENTS, new HashMap<String, Pair<Duration, Runnable>>());
     }

--- a/heron/api/src/java/com/twitter/heron/api/Config.java
+++ b/heron/api/src/java/com/twitter/heron/api/Config.java
@@ -267,6 +267,12 @@ public class Config extends HashMap<String, Object> {
    */
   public static final String TOPOLOGY_ENVIRONMENT = "topology.environment";
 
+  /**
+   * Timer events registered for a topology.
+   * This is a Map<String, Pair<Duration, Runnable>>.
+   * Where the key is the name and the value contains the frequency of the event
+   * and the task to run.
+   */
   public static final String TOPOLOGY_TIMER_EVENTS = "topology.timer.events";
 
   private static final long serialVersionUID = 2550967708478837032L;
@@ -656,6 +662,13 @@ public class Config extends HashMap<String, Object> {
     setTopologyStatefulStartClean(this, clean);
   }
 
+  /**
+   * Registers a timer event that executes periodically
+   * @param conf the map with the existing topology configs
+   * @param name the name of the timer
+   * @param timerDuration the frequency in which to run the task
+   * @param task the task to run
+   */
   @SuppressWarnings("unchecked")
   public static void registerTopologyTimerEvents(Map<String, Object> conf,
                                                  String name, Duration timerDuration,

--- a/heron/api/tests/java/BUILD
+++ b/heron/api/tests/java/BUILD
@@ -34,7 +34,8 @@ java_tests(
     "com.twitter.heron.streamlet.impl.operators.ReduceByKeyAndWindowOperatorTest",
     "com.twitter.heron.streamlet.impl.operators.GeneralReduceByWindowOperatorTest",
     "com.twitter.heron.streamlet.impl.operators.GeneralReduceByKeyAndWindowOperatorTest",
-    "com.twitter.heron.api.HeronSubmitterTest"
+    "com.twitter.heron.api.HeronSubmitterTest",
+    "com.twitter.heron.api.ConfigTest"
   ],
   runtime_deps = [ ":api-tests" ],
   size = "small",

--- a/heron/api/tests/java/BUILD
+++ b/heron/api/tests/java/BUILD
@@ -34,8 +34,8 @@ java_tests(
     "com.twitter.heron.streamlet.impl.operators.ReduceByKeyAndWindowOperatorTest",
     "com.twitter.heron.streamlet.impl.operators.GeneralReduceByWindowOperatorTest",
     "com.twitter.heron.streamlet.impl.operators.GeneralReduceByKeyAndWindowOperatorTest",
-    "com.twitter.heron.api.HeronSubmitterTest",
-    "com.twitter.heron.api.ConfigTest"
+    "com.twitter.heron.api.ConfigTest",
+    "com.twitter.heron.api.HeronSubmitterTest"
   ],
   runtime_deps = [ ":api-tests" ],
   size = "small",

--- a/heron/api/tests/java/com/twitter/heron/api/ConfigTest.java
+++ b/heron/api/tests/java/com/twitter/heron/api/ConfigTest.java
@@ -1,0 +1,48 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.api;
+
+import java.time.Duration;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class ConfigTest {
+
+  @Test
+  public void testRegisterTimerEvent() {
+    Config conf = new Config();
+    try {
+      Config.registerTopologyTimerEvents(conf, "timer", Duration.ofSeconds(0), () -> {
+      });
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+    }
+
+    try {
+      Config.registerTopologyTimerEvents(conf, "timer", Duration.ofSeconds(-1), () -> {
+      });
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+    }
+
+    try {
+      Config.registerTopologyTimerEvents(conf, "timer", Duration.ofSeconds(1), () -> {
+      });
+    } catch (IllegalArgumentException e) {
+      Assert.fail();
+    }
+  }
+}

--- a/heron/api/tests/java/com/twitter/heron/api/ConfigTest.java
+++ b/heron/api/tests/java/com/twitter/heron/api/ConfigTest.java
@@ -1,16 +1,17 @@
-//  Copyright 2017 Twitter. All rights reserved.
+// Copyright 2017 Twitter. All rights reserved.
 //
-//  Licensed under the Apache License, Version 2.0 (the "License");
-//  you may not use this file except in compliance with the License.
-//  You may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  http://www.apache.org/licenses/LICENSE-2.0
+//    http://www.apache.org/licenses/LICENSE-2.0
 //
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.twitter.heron.api;
 
 import java.time.Duration;

--- a/heron/common/src/java/com/twitter/heron/common/basics/WakeableLooper.java
+++ b/heron/common/src/java/com/twitter/heron/common/basics/WakeableLooper.java
@@ -119,6 +119,16 @@ public abstract class WakeableLooper {
     timers.add(new TimerTask(expiration, task));
   }
 
+  public void registerPeriodicEvent(Duration frequency, Runnable task) {
+    registerTimerEvent(frequency, new Runnable() {
+      @Override
+      public void run() {
+        task.run();
+        registerPeriodicEvent(frequency, task);
+      }
+    });
+  }
+
   public void exitLoop() {
     exitLoop = true;
     wakeUp();

--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
@@ -300,7 +300,7 @@ public class BoltInstance implements IInstance {
   public void deactivate() {
   }
 
-  public void PrepareTickTupleTimer() {
+  private void PrepareTickTupleTimer() {
     Object tickTupleFreqMs =
         helper.getTopologyContext().getTopologyConfig().get(Config.TOPOLOGY_TICK_TUPLE_FREQ_MS);
 

--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
@@ -310,7 +310,7 @@ public class BoltInstance implements IInstance {
         Duration duration = entry.getValue().getFirst();
         Runnable task = entry.getValue().getSecond();
 
-       looper.registerPeriodicEvent(duration, task);
+        looper.registerPeriodicEvent(duration, task);
       }
     }
 

--- a/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutInstance.java
@@ -44,6 +44,7 @@ import com.twitter.heron.common.utils.misc.PhysicalPlanHelper;
 import com.twitter.heron.common.utils.misc.SerializeDeSerializeHelper;
 import com.twitter.heron.common.utils.topology.TopologyContextImpl;
 import com.twitter.heron.instance.IInstance;
+import com.twitter.heron.instance.util.InstanceUtils;
 import com.twitter.heron.proto.ckptmgr.CheckpointManager;
 import com.twitter.heron.proto.system.HeronTuples;
 
@@ -264,6 +265,8 @@ public class SpoutInstance implements IInstance {
     if (enableMessageTimeouts) {
       lookForTimeouts();
     }
+
+    InstanceUtils.prepareTimerEvents(looper, helper);
   }
 
   /**

--- a/heron/instance/src/java/com/twitter/heron/instance/util/InstanceUtils.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/util/InstanceUtils.java
@@ -1,0 +1,43 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.instance.util;
+
+import java.time.Duration;
+import java.util.Map;
+
+import com.twitter.heron.api.Config;
+import com.twitter.heron.api.Pair;
+import com.twitter.heron.common.basics.SlaveLooper;
+import com.twitter.heron.common.utils.misc.PhysicalPlanHelper;
+
+public final class InstanceUtils {
+  private InstanceUtils() {
+  }
+
+  @SuppressWarnings("unchecked")
+  public static void prepareTimerEvents(SlaveLooper looper, PhysicalPlanHelper helper) {
+    Map<String, Pair<Duration, Runnable>> timerEvents =
+        (Map<String, Pair<Duration, Runnable>>) helper.getTopologyContext()
+            .getTopologyConfig().get(Config.TOPOLOGY_TIMER_EVENTS);
+
+    if (timerEvents != null) {
+      for (Map.Entry<String, Pair<Duration, Runnable>> entry : timerEvents.entrySet()) {
+        Duration duration = entry.getValue().getFirst();
+        Runnable task = entry.getValue().getSecond();
+
+        looper.registerPeriodicEvent(duration, task);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is done sone that:
1. Users don't have to use additional threads in their topology to use a timers.
2. Collectors are not thread safe so use other threads to emit tuples will cause race conditions.  Using timer events part of the slave event loop with prevent that since its the same thread.
3. Tick tuples are cumbersome to use to trigger events and you can only have tick tuples emitted at one frequency.