### PR TITLE
Apply config translation for Bolt and Spout

### DIFF
--- a/storm-compatibility/src/java/backtype/storm/StormSubmitter.java
+++ b/storm-compatibility/src/java/backtype/storm/StormSubmitter.java
@@ -53,7 +53,8 @@ public final class StormSubmitter {
       Map stormConfig,
       StormTopology topology) throws AlreadyAliveException, InvalidTopologyException {
 
-    // First do config translation
+    // First do topology config translation. Bolt and Spout config translation is handled
+    // in their own DeclarerImpl classes.
     com.twitter.heron.api.Config heronConfig = ConfigUtils.translateConfig(stormConfig);
 
     // Now submit a heron topology

--- a/storm-compatibility/src/java/backtype/storm/topology/BoltDeclarerImpl.java
+++ b/storm-compatibility/src/java/backtype/storm/topology/BoltDeclarerImpl.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import backtype.storm.grouping.CustomStreamGrouping;
 import backtype.storm.grouping.CustomStreamGroupingDelegate;
 import backtype.storm.tuple.Fields;
+import backtype.storm.utils.ConfigUtils;
 import backtype.storm.utils.Utils;
 
 public class BoltDeclarerImpl implements BoltDeclarer {
@@ -36,7 +37,7 @@ public class BoltDeclarerImpl implements BoltDeclarer {
   @SuppressWarnings({"rawtypes", "unchecked"})
   public BoltDeclarer addConfigurations(Map conf) {
     // Translate config to heron config and then apply.
-    Map<String, Object> henronConf = Utils.ConfigUtils.translateConfig(conf);
+    Map<String, Object> henronConf = ConfigUtils.translateConfig(conf);
     delegate.addConfigurations(henronConf);
     return this;
   }

--- a/storm-compatibility/src/java/backtype/storm/topology/BoltDeclarerImpl.java
+++ b/storm-compatibility/src/java/backtype/storm/topology/BoltDeclarerImpl.java
@@ -35,13 +35,18 @@ public class BoltDeclarerImpl implements BoltDeclarer {
   @Override
   @SuppressWarnings({"rawtypes", "unchecked"})
   public BoltDeclarer addConfigurations(Map conf) {
-    delegate.addConfigurations((Map<String, Object>) conf);
+    // Translate config to heron config and then apply.
+    Map<String, Object> henronConf = Utils.ConfigUtils.translateConfig(conf);
+    delegate.addConfigurations(henronConf);
     return this;
   }
 
   @Override
   public BoltDeclarer addConfiguration(String config, Object value) {
-    delegate.addConfiguration(config, value);
+    Map<String, Object> configMap = new Map<String, Object>();
+    configMap.put(config, value);
+
+    addConfigurations(configMap);
     return this;
   }
 

--- a/storm-compatibility/src/java/backtype/storm/topology/BoltDeclarerImpl.java
+++ b/storm-compatibility/src/java/backtype/storm/topology/BoltDeclarerImpl.java
@@ -18,6 +18,7 @@
 
 package backtype.storm.topology;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import backtype.storm.grouping.CustomStreamGrouping;
@@ -44,7 +45,7 @@ public class BoltDeclarerImpl implements BoltDeclarer {
 
   @Override
   public BoltDeclarer addConfiguration(String config, Object value) {
-    Map<String, Object> configMap = new Map<String, Object>();
+    Map<String, Object> configMap = new HashMap<String, Object>();
     configMap.put(config, value);
 
     addConfigurations(configMap);

--- a/storm-compatibility/src/java/backtype/storm/topology/SpoutDeclarerImpl.java
+++ b/storm-compatibility/src/java/backtype/storm/topology/SpoutDeclarerImpl.java
@@ -18,6 +18,7 @@
 
 package backtype.storm.topology;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import backtype.storm.utils.ConfigUtils;
@@ -40,7 +41,7 @@ public class SpoutDeclarerImpl implements SpoutDeclarer {
 
   @Override
   public SpoutDeclarer addConfiguration(String config, Object value) {
-    Map<String, Object> configMap = new Map<String, Object>();
+    Map<String, Object> configMap = new HashMap<String, Object>();
     configMap.put(config, value);
 
     addConfigurations(configMap);

--- a/storm-compatibility/src/java/backtype/storm/topology/SpoutDeclarerImpl.java
+++ b/storm-compatibility/src/java/backtype/storm/topology/SpoutDeclarerImpl.java
@@ -30,13 +30,18 @@ public class SpoutDeclarerImpl implements SpoutDeclarer {
   @Override
   @SuppressWarnings({"rawtypes", "unchecked"})
   public SpoutDeclarer addConfigurations(Map conf) {
-    delegate.addConfigurations((Map<String, Object>) conf);
+    // Translate config to heron config and then apply.
+    Map<String, Object> henronConf = Utils.ConfigUtils.translateConfig(conf);
+    delegate.addConfigurations(henronConf);
     return this;
   }
 
   @Override
   public SpoutDeclarer addConfiguration(String config, Object value) {
-    delegate.addConfiguration(config, value);
+    Map<String, Object> configMap = new Map<String, Object>();
+    configMap.put(config, value);
+
+    addConfigurations(configMap);
     return this;
   }
 

--- a/storm-compatibility/src/java/backtype/storm/topology/SpoutDeclarerImpl.java
+++ b/storm-compatibility/src/java/backtype/storm/topology/SpoutDeclarerImpl.java
@@ -20,6 +20,8 @@ package backtype.storm.topology;
 
 import java.util.Map;
 
+import backtype.storm.utils.ConfigUtils;
+
 public class SpoutDeclarerImpl implements SpoutDeclarer {
   private com.twitter.heron.api.topology.SpoutDeclarer delegate;
 
@@ -31,7 +33,7 @@ public class SpoutDeclarerImpl implements SpoutDeclarer {
   @SuppressWarnings({"rawtypes", "unchecked"})
   public SpoutDeclarer addConfigurations(Map conf) {
     // Translate config to heron config and then apply.
-    Map<String, Object> henronConf = Utils.ConfigUtils.translateConfig(conf);
+    Map<String, Object> henronConf = ConfigUtils.translateConfig(conf);
     delegate.addConfigurations(henronConf);
     return this;
   }

--- a/storm-compatibility/src/java/org/apache/storm/StormSubmitter.java
+++ b/storm-compatibility/src/java/org/apache/storm/StormSubmitter.java
@@ -53,7 +53,8 @@ public final class StormSubmitter {
       Map stormConfig,
       StormTopology topology) throws AlreadyAliveException, InvalidTopologyException {
 
-    // First do config translation
+    // First do topology config translation. Bolt and Spout config translation is handled
+    // in their own DeclarerImpl classes.
     com.twitter.heron.api.Config heronConfig = ConfigUtils.translateConfig(stormConfig);
 
     // Now submit a heron topology

--- a/storm-compatibility/src/java/org/apache/storm/topology/BoltDeclarerImpl.java
+++ b/storm-compatibility/src/java/org/apache/storm/topology/BoltDeclarerImpl.java
@@ -18,6 +18,7 @@
 
 package org.apache.storm.topology;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.storm.grouping.CustomStreamGrouping;
@@ -44,7 +45,7 @@ public class BoltDeclarerImpl implements BoltDeclarer {
 
   @Override
   public BoltDeclarer addConfiguration(String config, Object value) {
-    Map<String, Object> configMap = new Map<String, Object>();
+    Map<String, Object> configMap = new HashMap<String, Object>();
     configMap.put(config, value);
 
     addConfigurations(configMap);

--- a/storm-compatibility/src/java/org/apache/storm/topology/BoltDeclarerImpl.java
+++ b/storm-compatibility/src/java/org/apache/storm/topology/BoltDeclarerImpl.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.storm.grouping.CustomStreamGrouping;
 import org.apache.storm.grouping.CustomStreamGroupingDelegate;
 import org.apache.storm.tuple.Fields;
+import org.apache.storm.utils.ConfigUtils;
 import org.apache.storm.utils.Utils;
 
 public class BoltDeclarerImpl implements BoltDeclarer {
@@ -36,8 +37,8 @@ public class BoltDeclarerImpl implements BoltDeclarer {
   @SuppressWarnings({"rawtypes", "unchecked"})
   public BoltDeclarer addConfigurations(Map conf) {
     // Translate config to heron config and then apply.
-    Map<String, Object> henronConf = Utils.ConfigUtils.translateConfig(conf);
-    delegate.addConfigurations((Map<String, Object>) henronConf);
+    Map<String, Object> henronConf = ConfigUtils.translateConfig(conf);
+    delegate.addConfigurations(henronConf);
     return this;
   }
 

--- a/storm-compatibility/src/java/org/apache/storm/topology/BoltDeclarerImpl.java
+++ b/storm-compatibility/src/java/org/apache/storm/topology/BoltDeclarerImpl.java
@@ -35,13 +35,18 @@ public class BoltDeclarerImpl implements BoltDeclarer {
   @Override
   @SuppressWarnings({"rawtypes", "unchecked"})
   public BoltDeclarer addConfigurations(Map conf) {
-    delegate.addConfigurations((Map<String, Object>) conf);
+    // Translate config to heron config and then apply.
+    Map<String, Object> henronConf = Utils.ConfigUtils.translateConfig(conf);
+    delegate.addConfigurations((Map<String, Object>) henronConf);
     return this;
   }
 
   @Override
   public BoltDeclarer addConfiguration(String config, Object value) {
-    delegate.addConfiguration(config, value);
+    Map<String, Object> configMap = new Map<String, Object>();
+    configMap.put(config, value);
+
+    addConfigurations(configMap);
     return this;
   }
 

--- a/storm-compatibility/src/java/org/apache/storm/topology/SpoutDeclarerImpl.java
+++ b/storm-compatibility/src/java/org/apache/storm/topology/SpoutDeclarerImpl.java
@@ -18,6 +18,7 @@
 
 package org.apache.storm.topology;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.storm.utils.ConfigUtils;
@@ -40,7 +41,7 @@ public class SpoutDeclarerImpl implements SpoutDeclarer {
 
   @Override
   public SpoutDeclarer addConfiguration(String config, Object value) {
-    Map<String, Object> configMap = new Map<String, Object>();
+    Map<String, Object> configMap = new HashMap<String, Object>();
     configMap.put(config, value);
 
     addConfigurations(configMap);

--- a/storm-compatibility/src/java/org/apache/storm/topology/SpoutDeclarerImpl.java
+++ b/storm-compatibility/src/java/org/apache/storm/topology/SpoutDeclarerImpl.java
@@ -30,13 +30,18 @@ public class SpoutDeclarerImpl implements SpoutDeclarer {
   @Override
   @SuppressWarnings({"rawtypes", "unchecked"})
   public SpoutDeclarer addConfigurations(Map conf) {
-    delegate.addConfigurations((Map<String, Object>) conf);
+    // Translate config to heron config and then apply.
+    Map<String, Object> henronConf = Utils.ConfigUtils.translateConfig(conf);
+    delegate.addConfigurations(henronConf);
     return this;
   }
 
   @Override
   public SpoutDeclarer addConfiguration(String config, Object value) {
-    delegate.addConfiguration(config, value);
+    Map<String, Object> configMap = new Map<String, Object>();
+    configMap.put(config, value);
+
+    addConfigurations(configMap);
     return this;
   }
 

--- a/storm-compatibility/src/java/org/apache/storm/topology/SpoutDeclarerImpl.java
+++ b/storm-compatibility/src/java/org/apache/storm/topology/SpoutDeclarerImpl.java
@@ -20,6 +20,8 @@ package org.apache.storm.topology;
 
 import java.util.Map;
 
+import org.apache.storm.utils.ConfigUtils;
+
 public class SpoutDeclarerImpl implements SpoutDeclarer {
   private com.twitter.heron.api.topology.SpoutDeclarer delegate;
 
@@ -31,7 +33,7 @@ public class SpoutDeclarerImpl implements SpoutDeclarer {
   @SuppressWarnings({"rawtypes", "unchecked"})
   public SpoutDeclarer addConfigurations(Map conf) {
     // Translate config to heron config and then apply.
-    Map<String, Object> henronConf = Utils.ConfigUtils.translateConfig(conf);
+    Map<String, Object> henronConf = ConfigUtils.translateConfig(conf);
     delegate.addConfigurations(henronConf);
     return this;
   }


### PR DESCRIPTION
Bolt and Spout configs need to be translated first before assigning to Heron components.