### PR TITLE
Explicity setting heron apiserver to run as cluster-admin

### DIFF
--- a/deploy/kubernetes/gcp/bookkeeper-apiserver.yaml
+++ b/deploy/kubernetes/gcp/bookkeeper-apiserver.yaml
@@ -1,20 +1,54 @@
 ##
 ## Heron API server deployment
 ##
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: heron-apiserver
+  name: heron-apiserver
+  namespace: default
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: heron-apiserver
+  labels:
+    app: heron-apiserver
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: heron-apiserver
+  namespace: default
+
+---
+
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: heron-apiserver
+  labels:
+      app: heron-apiserver
+    namespace: default
 spec:
+  selector:
+    matchLabels:
+      app: heron-apiserver
   replicas: 1
   template:
     metadata:
       labels:
         app: heron-apiserver
     spec:
+      serviceAccountName: heron-apiserver
       containers:
         - name: heron-apiserver
-          image: heron/heron:0.16.2
+          image: heron/heron:latest
           command: ["sh", "-c"]
           args:
             - >-
@@ -23,7 +57,7 @@ spec:
               --cluster kubernetes
               -D heron.statemgr.connection.string=zookeeper:2181
               -D heron.kubernetes.scheduler.uri=http://localhost:8001
-              -D heron.executor.docker.image=heron/heron:0.16.2
+              -D heron.executor.docker.image=heron/heron:latest
               -D heron.class.uploader=com.twitter.heron.uploader.dlog.DLUploader
               -D heron.uploader.dlog.topologies.namespace.uri=distributedlog://zookeeper:2181/distributedlog
         - name: kubectl-proxy

--- a/deploy/kubernetes/gcp/gcs-apiserver.yaml
+++ b/deploy/kubernetes/gcp/gcs-apiserver.yaml
@@ -1,17 +1,51 @@
 ##
 ## Heron API server deployment
 ##
-apiVersion: apps/v1beta1
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: heron-apiserver
+  name: heron-apiserver
+  namespace: default
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: heron-apiserver
+  labels:
+    app: heron-apiserver
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: heron-apiserver
+  namespace: default
+
+---
+
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: heron-apiserver
+  labels:
+    app: heron-apiserver
+  namespace: default
 spec:
+  selector:
+    matchLabels:
+      app: heron-apiserver
   replicas: 1
   template:
     metadata:
       labels:
         app: heron-apiserver
     spec:
+      serviceAccountName: heron-apiserver
       volumes:
         - name: google-cloud-key
           secret:

--- a/deploy/kubernetes/general/apiserver.yaml
+++ b/deploy/kubernetes/general/apiserver.yaml
@@ -48,7 +48,7 @@ spec:
       serviceAccountName: heron-apiserver
       containers:
         - name: heron-apiserver
-          image: heron/heron:0.16.2
+          image: heron/heron:latest
           command: ["sh", "-c"]
           args:
             - >-
@@ -57,7 +57,7 @@ spec:
               --cluster kubernetes
               -D heron.statemgr.connection.string=zookeeper:2181
               -D heron.kubernetes.scheduler.uri=http://localhost:8001
-              -D heron.executor.docker.image=heron/heron:0.16.2
+              -D heron.executor.docker.image=heron/heron:latest
               -D heron.class.uploader=com.twitter.heron.uploader.dlog.DLUploader
               -D heron.uploader.dlog.topologies.namespace.uri=distributedlog://zookeeper:2181/distributedlog
         - name: kubectl-proxy

--- a/deploy/kubernetes/general/apiserver.yaml
+++ b/deploy/kubernetes/general/apiserver.yaml
@@ -1,17 +1,51 @@
 ##
 ## Heron API server deployment
 ##
-apiVersion: apps/v1beta1
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: heron-apiserver
+  name: heron-apiserver
+  namespace: default
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: heron-apiserver
+  labels:
+    app: heron-apiserver
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: heron-apiserver
+  namespace: default
+
+---
+
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: heron-apiserver
+  labels:
+    app: heron-apiserver
+  namespace: default
 spec:
+  selector:
+    matchLabels:
+      app: heron-apiserver
   replicas: 1
   template:
     metadata:
       labels:
         app: heron-apiserver
     spec:
+      serviceAccountName: heron-apiserver
       containers:
         - name: heron-apiserver
           image: heron/heron:0.16.2

--- a/deploy/kubernetes/minikube/apiserver.yaml
+++ b/deploy/kubernetes/minikube/apiserver.yaml
@@ -1,17 +1,51 @@
 ##
 ## Heron API server deployment
 ##
-apiVersion: apps/v1beta1
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: heron-apiserver
+  name: heron-apiserver
+  namespace: default
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: heron-apiserver
+  labels:
+    app: heron-apiserver
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: heron-apiserver
+  namespace: default
+
+---
+
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: heron-apiserver
+  labels:
+    app: heron-apiserver
 spec:
+  selector:
+    matchLabels:
+      app: heron-apiserver
   replicas: 1
   template:
     metadata:
       labels:
         app: heron-apiserver
     spec:
+      serviceAccountName: heron-apiserver
       containers:
         - name: heron-apiserver
           image: heron/heron:latest


### PR DESCRIPTION
Since RBAC is enabled by default in Kubernetes 1.8