### PR TITLE
Fix log.error exception in check_direct_mode_cluster_definition()

### DIFF
--- a/heron/tools/cli/src/python/cdefs.py
+++ b/heron/tools/cli/src/python/cdefs.py
@@ -14,7 +14,6 @@
 ''' cdefs.py '''
 import os
 
-import heron.common.src.python.utils.log as Log
 import heron.tools.cli.src.python.cliconfig as cliconfig
 import heron.tools.common.src.python.utils.config as config
 
@@ -50,6 +49,5 @@ def check_direct_mode_cluster_definition(cluster, config_path):
   '''
   config_path = config.get_heron_cluster_conf_dir(cluster, config_path)
   if not os.path.isdir(config_path):
-    Log.error("Cluster config directory \'%s\' does not exist", config_path)
     return False
   return True

--- a/heron/tools/cli/src/python/main.py
+++ b/heron/tools/cli/src/python/main.py
@@ -221,6 +221,7 @@ def direct_deployment_mode(command, parser, cluster, cl_args):
 
   # check if the cluster config directory exists
   if not cdefs.check_direct_mode_cluster_definition(cluster, config_path):
+    Log.error("Cluster config directory \'%s\' does not exist", config_path)
     return dict()
 
   config_path = config.get_heron_cluster_conf_dir(cluster, config_path)


### PR DESCRIPTION
The Log.error() call is invalid in cdefs.py currently. Moving it out to main.py