### PR TITLE
Change heron api dependency

### DIFF
--- a/examples/src/java/BUILD
+++ b/examples/src/java/BUILD
@@ -4,7 +4,7 @@ java_binary(
     name='api-examples-unshaded',
     srcs = glob(["com/twitter/heron/examples/api/**/*.java"]),
     deps = [
-        "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "//heron/common/src/java:basics-java",
         "//heron/simulator/src/java:simulator-java"
     ],

--- a/examples/src/java/com/twitter/heron/examples/streamlet/FilesystemSinkTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/streamlet/FilesystemSinkTopology.java
@@ -23,7 +23,6 @@ import java.nio.file.StandardOpenOption;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.logging.Logger;
 
-import com.twitter.heron.api.utils.Utils;
 import com.twitter.heron.examples.streamlet.utils.StreamletUtils;
 import com.twitter.heron.streamlet.Builder;
 import com.twitter.heron.streamlet.Config;
@@ -115,7 +114,7 @@ public final class FilesystemSinkTopology {
         .newSource(() -> {
           // This applies a "brake" that makes the processing graph write
           // to the temporary file at a reasonable, readable pace.
-          Utils.sleep(500);
+          StreamletUtils.sleep(500);
           return ThreadLocalRandom.current().nextInt(100);
         })
         .setName("incoming-integers")

--- a/examples/src/java/com/twitter/heron/examples/streamlet/FormattedOutputTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/streamlet/FormattedOutputTopology.java
@@ -21,7 +21,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import com.twitter.heron.api.utils.Utils;
 import com.twitter.heron.examples.streamlet.utils.StreamletUtils;
 import com.twitter.heron.streamlet.Builder;
 import com.twitter.heron.streamlet.Config;
@@ -63,7 +62,7 @@ public final class FormattedOutputTopology {
 
     SensorReading() {
       // Readings are produced only every two seconds
-      Utils.sleep(2000);
+      StreamletUtils.sleep(2000);
       this.deviceId = StreamletUtils.randomFromList(DEVICES);
       // Each temperature reading is a double between 70 and 100
       this.temperature = 70 + 30 * new Random().nextDouble();

--- a/examples/src/java/com/twitter/heron/examples/streamlet/RepartitionTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/streamlet/RepartitionTopology.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.logging.Logger;
 
-import com.twitter.heron.api.utils.Utils;
 import com.twitter.heron.examples.streamlet.utils.StreamletUtils;
 import com.twitter.heron.streamlet.Builder;
 import com.twitter.heron.streamlet.Config;
@@ -83,7 +82,7 @@ public final class RepartitionTopology {
     Streamlet<Integer> randomIntegers = processingGraphBuilder
         .newSource(() -> {
           // Random integers are emitted every 50 milliseconds
-          Utils.sleep(50);
+          StreamletUtils.sleep(50);
           return ThreadLocalRandom.current().nextInt(100);
         })
         .setNumPartitions(2)

--- a/examples/src/java/com/twitter/heron/examples/streamlet/SmartWatchTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/streamlet/SmartWatchTopology.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.logging.Logger;
 
-import com.twitter.heron.api.utils.Utils;
 import com.twitter.heron.examples.streamlet.utils.StreamletUtils;
 import com.twitter.heron.streamlet.Builder;
 import com.twitter.heron.streamlet.Config;
@@ -55,7 +54,7 @@ public final class SmartWatchTopology {
     private final int feetRun;
 
     SmartWatchReading() {
-      Utils.sleep(1000);
+      StreamletUtils.sleep(1000);
       this.joggerId = StreamletUtils.randomFromList(JOGGERS);
       this.feetRun = ThreadLocalRandom.current().nextInt(200, 400);
     }

--- a/examples/src/java/com/twitter/heron/examples/streamlet/WireRequestsTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/streamlet/WireRequestsTopology.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.logging.Logger;
 
-import com.twitter.heron.api.utils.Utils;
 import com.twitter.heron.examples.streamlet.utils.StreamletUtils;
 import com.twitter.heron.streamlet.Builder;
 import com.twitter.heron.streamlet.Config;
@@ -80,7 +79,7 @@ public final class WireRequestsTopology {
     WireRequest(long delay) {
       // The pace at which requests are generated is throttled. Different
       // throttles are applied to different bank branches.
-      Utils.sleep(delay);
+      StreamletUtils.sleep(delay);
       this.customerId = StreamletUtils.randomFromList(CUSTOMERS);
       this.amount = ThreadLocalRandom.current().nextInt(1000);
       LOG.info(String.format("New wire request: %s", this));

--- a/examples/src/java/com/twitter/heron/examples/streamlet/utils/StreamletUtils.java
+++ b/examples/src/java/com/twitter/heron/examples/streamlet/utils/StreamletUtils.java
@@ -25,6 +25,14 @@ public final class StreamletUtils {
   private StreamletUtils() {
   }
 
+  public static void sleep(long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   /**
    * Fetches the topology's name from the first command-line argument or
    * throws an exception if not present.

--- a/heron/api/src/java/BUILD
+++ b/heron/api/src/java/BUILD
@@ -20,7 +20,7 @@ api_deps_files =  \
         "//heron/common/src/java:basics-java",
     ]
 
-# Legacy Low Level Api
+# Low Level Api
 java_library(
     name = "api-java-low-level",
     srcs = glob(["com/twitter/heron/api/**/*.java"]),
@@ -28,7 +28,7 @@ java_library(
     deps = api_deps_files,
 )
 
-# External Api
+# Functional Api
 java_library(
     name = "api-java",
     srcs = glob(["com/twitter/heron/streamlet/**/*.java"]),

--- a/heron/api/src/java/BUILD
+++ b/heron/api/src/java/BUILD
@@ -20,11 +20,20 @@ api_deps_files =  \
         "//heron/common/src/java:basics-java",
     ]
 
+# Legacy Low Level Api
 java_library(
-    name = "api-java",
-    srcs = glob(["com/twitter/heron/api/**/*.java", "com/twitter/heron/streamlet/**/*.java"]),
+    name = "api-java-low-level",
+    srcs = glob(["com/twitter/heron/api/**/*.java"]),
     javacopts = DOCLINT_HTML_AND_SYNTAX,
     deps = api_deps_files,
+)
+
+# External Api
+java_library(
+    name = "api-java",
+    srcs = glob(["com/twitter/heron/streamlet/**/*.java"]),
+    javacopts = DOCLINT_HTML_AND_SYNTAX,
+    deps = api_deps_files + [":api-java-low-level"]
 )
 
 java_binary(

--- a/heron/api/tests/java/BUILD
+++ b/heron/api/tests/java/BUILD
@@ -2,6 +2,7 @@ load("/tools/rules/heron_deps", "heron_java_api_proto_files")
 
 api_deps_files = [
     "//heron/api/src/java:api-java-low-level",
+    "//heron/api/src/java:api-java",
     "//heron/common/src/java:utils-java",
     "//heron/common/src/java:basics-java",
     "//third_party/java:junit4",

--- a/heron/api/tests/java/BUILD
+++ b/heron/api/tests/java/BUILD
@@ -1,7 +1,7 @@
 load("/tools/rules/heron_deps", "heron_java_api_proto_files")
 
 api_deps_files = [
-    "//heron/api/src/java:api-java",
+    "//heron/api/src/java:api-java-low-level",
     "//heron/common/src/java:utils-java",
     "//heron/common/src/java:basics-java",
     "//third_party/java:junit4",

--- a/heron/ckptmgr/src/java/BUILD
+++ b/heron/ckptmgr/src/java/BUILD
@@ -28,7 +28,7 @@ java_binary(
     deps = [
         ":ckptmgr-java",
         "//heron/spi/src/java:statefulstorage-spi-java",
-        "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "//heron/common/src/java:basics-java",
         "//heron/common/src/java:config-java",
         "//heron/common/src/java:network-java",

--- a/heron/common/src/java/BUILD
+++ b/heron/common/src/java/BUILD
@@ -46,7 +46,7 @@ java_library(
     deps = heron_java_proto_files() + [
         ":basics-java",
         ":config-java",
-        "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "//heron/api/src/java:classification",
     ]
 )

--- a/heron/common/tests/java/BUILD
+++ b/heron/common/tests/java/BUILD
@@ -3,7 +3,7 @@ java_library(
     srcs = glob(["**/*.java"]),
     deps = [
         "//heron/proto:proto_topology_java",
-        "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "//heron/common/src/java:basics-java",
         "//heron/common/src/java:config-java",
         "//heron/common/src/java:network-java",

--- a/heron/healthmgr/src/java/BUILD
+++ b/heron/healthmgr/src/java/BUILD
@@ -5,7 +5,7 @@ package(default_visibility = ["//visibility:public"])
 load("/tools/rules/heron_deps", "heron_java_proto_files")
 
 healthmgr_deps_files = [
-    "//heron/api/src/java:api-java",
+    "//heron/api/src/java:api-java-low-level",
     "//heron/api/src/java:classification",
     "//heron/common/src/java:basics-java",
     "//heron/common/src/java:config-java",

--- a/heron/instance/src/java/BUILD
+++ b/heron/instance/src/java/BUILD
@@ -7,7 +7,7 @@ load("/tools/rules/heron_deps", "heron_java_proto_files")
 
 instance_deps_files =  \
     heron_java_proto_files() + [
-        "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "//heron/api/src/java:classification",
         "//heron/common/src/java:basics-java",
         "//heron/common/src/java:config-java",

--- a/heron/instance/tests/java/BUILD
+++ b/heron/instance/tests/java/BUILD
@@ -2,7 +2,7 @@ load("/tools/rules/heron_deps", "heron_java_proto_files")
 
 test_deps_files = \
     heron_java_proto_files() + [
-        "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "//heron/common/src/java:basics-java",
         "//heron/common/src/java:config-java",
         "//heron/common/src/java:network-java",

--- a/heron/metricscachemgr/src/java/BUILD
+++ b/heron/metricscachemgr/src/java/BUILD
@@ -10,7 +10,7 @@ metricscachemgr_deps_files = heron_java_proto_files() + [
            "//heron/spi/src/java:utils-spi-java",
            "//heron/spi/src/java:statemgr-spi-java",
            "//heron/spi/src/java:packing-spi-java",
-           "//heron/api/src/java:api-java",
+           "//heron/api/src/java:api-java-low-level",
            "//heron/common/src/java:basics-java",
            "//heron/common/src/java:config-java",
            "//heron/common/src/java:network-java",

--- a/heron/metricsmgr/src/java/BUILD
+++ b/heron/metricsmgr/src/java/BUILD
@@ -9,7 +9,7 @@ java_library(
         exclude = ["**/MetricManager.java"],
     ),
     deps = [
-        "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "//heron/common/src/java:basics-java",
         "//heron/common/src/java:config-java",
         "//heron/common/src/java:network-java",
@@ -33,7 +33,7 @@ java_binary(
     srcs = glob(["**/MetricsManager.java"]),
     deps = [
         ":metricsmgr-java",
-        "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "//heron/common/src/java:basics-java",
         "//heron/common/src/java:config-java",
         "//heron/common/src/java:network-java",

--- a/heron/metricsmgr/tests/java/BUILD
+++ b/heron/metricsmgr/tests/java/BUILD
@@ -2,7 +2,7 @@ java_library(
     name = "metricsmgr-tests",
     srcs = glob(["**/*.java"]),
     deps = [
-        "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "//heron/common/src/java:basics-java",
         "//heron/common/src/java:network-java",
         "//heron/common/src/java:config-java",

--- a/heron/packing/src/java/BUILD
+++ b/heron/packing/src/java/BUILD
@@ -15,7 +15,7 @@ packing_deps_files = [
 roundrobin_deps_files = \
     heron_java_proto_files() + \
     packing_deps_files + [
-        "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "//heron/spi/src/java:statemgr-spi-java",
         "//heron/spi/src/java:utils-spi-java",
     ]
@@ -23,7 +23,7 @@ roundrobin_deps_files = \
 binpacking_deps_files = \
     heron_java_proto_files() + \
     packing_deps_files + [
-        "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "//heron/spi/src/java:statemgr-spi-java",
         "//heron/spi/src/java:utils-spi-java",
     ]
@@ -37,7 +37,7 @@ java_library(
         "//heron/spi/src/java:common-spi-java",
         "//heron/spi/src/java:packing-spi-java",
         "//heron/spi/src/java:utils-spi-java",
-        "//heron/api/src/java:api-java"
+        "//heron/api/src/java:api-java-low-level"
     ],
 )
 

--- a/heron/packing/tests/java/BUILD
+++ b/heron/packing/tests/java/BUILD
@@ -20,7 +20,7 @@ roundrobin_deps_files = \
     heron_java_proto_files() + \
     packing_deps_files + \
     test_deps_files + [
-        "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-levela",
         "//heron/spi/src/java:utils-spi-java",
     ]
 
@@ -28,7 +28,7 @@ binpacking_deps_files = \
     heron_java_proto_files() + \
     packing_deps_files + \
     test_deps_files + [
-        "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "//heron/spi/src/java:utils-spi-java",
     ]
 
@@ -36,7 +36,7 @@ packing_utils_deps_files = \
      heron_java_proto_files() + \
         packing_deps_files + \
         test_deps_files + [
-            "//heron/api/src/java:api-java",
+            "//heron/api/src/java:api-java-low-level",
             "//heron/spi/src/java:utils-spi-java",
         ]
 
@@ -54,7 +54,7 @@ java_library(
         "//heron/packing/src/java:utils",
         "//heron/spi/src/java:packing-spi-java",
         "//third_party/java:junit4",
-        "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "//heron/proto:proto_topology_java",
         "//heron/spi/src/java:common-spi-java",
         "//heron/spi/src/java:utils-spi-java",

--- a/heron/packing/tests/java/BUILD
+++ b/heron/packing/tests/java/BUILD
@@ -20,7 +20,7 @@ roundrobin_deps_files = \
     heron_java_proto_files() + \
     packing_deps_files + \
     test_deps_files + [
-        "//heron/api/src/java:api-java-low-levela",
+        "//heron/api/src/java:api-java-low-level",
         "//heron/spi/src/java:utils-spi-java",
     ]
 

--- a/heron/scheduler-core/src/java/BUILD
+++ b/heron/scheduler-core/src/java/BUILD
@@ -12,7 +12,7 @@ common_deps_files = [
 ]
 
 spi_deps_files = [
-    "//heron/api/src/java:api-java",
+    "//heron/api/src/java:api-java-low-level",
     "//heron/spi/src/java:common-spi-java",
     "//heron/spi/src/java:statemgr-spi-java",
     "//heron/spi/src/java:uploader-spi-java",

--- a/heron/scheduler-core/tests/java/BUILD
+++ b/heron/scheduler-core/tests/java/BUILD
@@ -4,7 +4,7 @@ common_deps_files = [
     "@com_google_guava_guava//jar",
     "@commons_io_commons_io//jar",
     "//third_party/java:powermock",
-    "//heron/api/src/java:api-java",
+    "//heron/api/src/java:api-java-low-level",
     "//heron/common/src/java:basics-java",
     "//heron/common/src/java:utils-java",
     "//heron/scheduler-core/src/java:scheduler-java",

--- a/heron/schedulers/src/java/BUILD
+++ b/heron/schedulers/src/java/BUILD
@@ -18,7 +18,7 @@ spi_deps_files = [
 ]
 
 api_deps_files = [
-    "//heron/api/src/java:api-java",
+    "//heron/api/src/java:api-java-low-level",
 ]
 
 scheduler_deps_files = \

--- a/heron/schedulers/tests/java/BUILD
+++ b/heron/schedulers/tests/java/BUILD
@@ -3,7 +3,7 @@ load("/tools/rules/heron_deps", "heron_java_proto_files")
 common_deps_files = [
     "@com_google_guava_guava//jar",
     "//third_party/java:powermock",
-    "//heron/api/src/java:api-java",
+    "//heron/api/src/java:api-java-low-level",
     "//heron/common/src/java:basics-java",
     "//heron/common/src/java:utils-java",
     "//heron/scheduler-core/src/java:scheduler-java",

--- a/heron/simulator/src/java/BUILD
+++ b/heron/simulator/src/java/BUILD
@@ -6,7 +6,7 @@ load("/tools/rules/heron_deps", "heron_java_proto_files")
 
 simulator_deps_files = \
     heron_java_proto_files() + [
-        "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "//heron/common/src/java:basics-java",
         "//heron/common/src/java:config-java",
         "//heron/common/src/java:utils-java",

--- a/heron/simulator/tests/java/BUILD
+++ b/heron/simulator/tests/java/BUILD
@@ -4,7 +4,7 @@ java_library(
     name = "simulator-tests",
     srcs = glob(["**/*.java"]),
     deps =  heron_java_proto_files() + [
-        "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "//heron/common/src/java:basics-java",
         "//heron/common/src/java:config-java",
         "//heron/common/src/java:utils-java",

--- a/heron/spi/src/java/BUILD
+++ b/heron/spi/src/java/BUILD
@@ -26,7 +26,7 @@ java_library(
     ]),
     javacopts = DOCLINT_HTML_AND_SYNTAX,
     deps = [
-        "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "//heron/api/src/java:classification",
         "//heron/common/src/java:basics-java",
         "//heron/common/src/java:config-java",
@@ -56,7 +56,7 @@ utils_deps_files = \
         "//heron/common/src/java:basics-java",
         "//heron/common/src/java:config-java",
         "//heron/common/src/java:utils-java",
-        "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "@com_google_guava_guava//jar",
     ]
 
@@ -76,7 +76,7 @@ statefulstorage_deps_files = \
     ]
 
 packing_deps_files = [
-    "//heron/api/src/java:api-java",
+    "//heron/api/src/java:api-java-low-level",
     ":common-spi-java",
     "//heron/api/src/java:classification",
     "//heron/common/src/java:basics-java",

--- a/heron/statemgrs/src/java/BUILD
+++ b/heron/statemgrs/src/java/BUILD
@@ -12,11 +12,11 @@ common_deps_files = \
 
 localfs_deps_files = \
     common_deps_files + [
-        "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "//heron/common/src/java:basics-java",
         "//heron/spi/src/java:heron-spi",
     ]
-    
+
 zookeeper_deps_files = \
     localfs_deps_files + [
         "@org_apache_curator_curator_client//jar",
@@ -31,7 +31,7 @@ java_library(
     srcs = glob(
         ["**/*.java"],
     ),
-    deps = zookeeper_deps_files, 
+    deps = zookeeper_deps_files,
 )
 
 java_library(

--- a/heron/tools/apiserver/src/java/BUILD
+++ b/heron/tools/apiserver/src/java/BUILD
@@ -6,7 +6,7 @@ api_deps_files = [
   "//heron/spi/src/java:heron-spi",
   "//heron/common/src/java:basics-java",
   "//heron/common/src/java:utils-java",
-  "//heron/api/src/java:api-java"
+  "//heron/api/src/java:api-java-low-level"
 ]
 
 scheduler_deps_files = [

--- a/integration_test/src/java/BUILD
+++ b/integration_test/src/java/BUILD
@@ -14,6 +14,7 @@ java_library(
     ),
     deps = [
         "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "//storm-compatibility/src/java:storm-compatibility-java",
         "//heron/proto:proto_topology_java",
         "//third_party/java:jackson",
@@ -31,6 +32,7 @@ java_library(
     ),
     deps = [
         "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "//storm-compatibility/src/java:storm-compatibility-java",
         "//third_party/java:hadoop-core",
         "//third_party/java:jackson",
@@ -46,6 +48,7 @@ java_library(
     ),
     deps = [
         "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "//storm-compatibility/src/java:storm-compatibility-java",
         "@com_googlecode_json_simple_json_simple//jar",
         "@commons_cli_commons_cli//jar",
@@ -61,6 +64,7 @@ java_library(
     ),
     deps = [
         "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "//storm-compatibility/src/java:storm-compatibility-java",
         ":common",
         ":core"
@@ -74,6 +78,7 @@ java_binary(
     ),
     deps = [
         "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "//storm-compatibility/src/java:storm-compatibility-java",
         "@commons_cli_commons_cli//jar",
         "@com_googlecode_json_simple_json_simple//jar",
@@ -96,6 +101,7 @@ java_binary(
     ),
     deps = [
         "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "//storm-compatibility/src/java:storm-compatibility-java",
         ":common",
         ":core"

--- a/storm-compatibility-examples/src/java/BUILD
+++ b/storm-compatibility-examples/src/java/BUILD
@@ -4,7 +4,7 @@ java_binary(
     name='heron-storm-compatibility-examples-unshaded',
     srcs = glob(["**/*.java"]),
     deps = [
-        "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level",
         "//heron/common/src/java:basics-java",
         "//storm-compatibility/src/java:storm-compatibility-java",
     ],

--- a/storm-compatibility/src/java/BUILD
+++ b/storm-compatibility/src/java/BUILD
@@ -5,7 +5,7 @@ load("/tools/rules/build_defs", "DOCLINT_HTML_AND_SYNTAX")
 load("/tools/rules/javadoc", "java_doc")
 
 storm_deps_files = [
-    "//heron/api/src/java:api-java",
+    "//heron/api/src/java:api-java-low-level",
     "//heron/common/src/java:basics-java",
     "//heron/simulator/src/java:simulator-java",
     "//heron/proto:proto_topology_java",


### PR DESCRIPTION
This change separates the core low level ui(the ui that the instance targets) and the high level streamlet interface. The aim of this is to ensure that dependent librarires(like heron-storm) only deal with the core api and the higher level streamlet api can morph pretty rapidly without worrying compatibility issues.