### PR TITLE
Add a config translation function for components and fix a typo.

### DIFF
--- a/storm-compatibility/src/java/backtype/storm/topology/BoltDeclarerImpl.java
+++ b/storm-compatibility/src/java/backtype/storm/topology/BoltDeclarerImpl.java
@@ -38,8 +38,8 @@ public class BoltDeclarerImpl implements BoltDeclarer {
   @SuppressWarnings({"rawtypes", "unchecked"})
   public BoltDeclarer addConfigurations(Map conf) {
     // Translate config to heron config and then apply.
-    Map<String, Object> henronConf = ConfigUtils.translateConfig(conf);
-    delegate.addConfigurations(henronConf);
+    Map<String, Object> heronConf = ConfigUtils.translateComponentConfig(conf);
+    delegate.addConfigurations(heronConf);
     return this;
   }
 

--- a/storm-compatibility/src/java/backtype/storm/topology/SpoutDeclarerImpl.java
+++ b/storm-compatibility/src/java/backtype/storm/topology/SpoutDeclarerImpl.java
@@ -34,8 +34,8 @@ public class SpoutDeclarerImpl implements SpoutDeclarer {
   @SuppressWarnings({"rawtypes", "unchecked"})
   public SpoutDeclarer addConfigurations(Map conf) {
     // Translate config to heron config and then apply.
-    Map<String, Object> henronConf = ConfigUtils.translateConfig(conf);
-    delegate.addConfigurations(henronConf);
+    Map<String, Object> heronConf = ConfigUtils.translateComponentConfig(conf);
+    delegate.addConfigurations(heronConf);
     return this;
   }
 

--- a/storm-compatibility/src/java/backtype/storm/utils/ConfigUtils.java
+++ b/storm-compatibility/src/java/backtype/storm/utils/ConfigUtils.java
@@ -44,7 +44,7 @@ public final class ConfigUtils {
     doSerializationTranslation(heronConfig);
 
     // Now look at supported apis
-    doStormTranslation(heronConfig, stormConfig);
+    doStormTranslation(heronConfig);
 
     doTaskHooksTranslation(heronConfig);
 
@@ -60,7 +60,7 @@ public final class ConfigUtils {
   public static Config translateComponentConfig(Map stormConfig) {
     Config heronConfig = new Config((Map<String, Object>) stormConfig);
 
-    doStormTranslation(heronConfig, stormConfig);
+    doStormTranslation(heronConfig);
 
     return heronConfig;
   }
@@ -114,11 +114,9 @@ public final class ConfigUtils {
 
   /**
    * Translate storm config into heron config
-   * @param stormConfig the storm config
    * @param heron the heron config object to receive the results.
    */
-  @SuppressWarnings({"rawtypes", "unchecked"})
-  private static void doStormTranslation(Config heronConfig, Map stormConfig) {
+  private static void doStormTranslation(Config heronConfig) {
     if (heronConfig.containsKey(backtype.storm.Config.TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS)) {
       heronConfig.put(backtype.storm.Config.TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS,
           heronConfig.get(backtype.storm.Config.TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS).toString());

--- a/storm-compatibility/src/java/backtype/storm/utils/ConfigUtils.java
+++ b/storm-compatibility/src/java/backtype/storm/utils/ConfigUtils.java
@@ -39,56 +39,28 @@ public final class ConfigUtils {
   @SuppressWarnings({"rawtypes", "unchecked"})
   public static Config translateConfig(Map stormConfig) {
     Config heronConfig = new Config((Map<String, Object>) stormConfig);
+
     // Look at serialization stuff first
     doSerializationTranslation(heronConfig);
 
     // Now look at supported apis
-    if (heronConfig.containsKey(backtype.storm.Config.TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS)) {
-      heronConfig.put(backtype.storm.Config.TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS,
-          heronConfig.get(backtype.storm.Config.TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS).toString());
-    }
-    if (heronConfig.containsKey(backtype.storm.Config.TOPOLOGY_WORKERS)) {
-      Integer nWorkers = Utils.getInt(heronConfig.get(backtype.storm.Config.TOPOLOGY_WORKERS));
-      com.twitter.heron.api.Config.setNumStmgrs(heronConfig, nWorkers);
-    }
-    if (heronConfig.containsKey(backtype.storm.Config.TOPOLOGY_ACKER_EXECUTORS)) {
-      Integer nAckers =
-          Utils.getInt(heronConfig.get(backtype.storm.Config.TOPOLOGY_ACKER_EXECUTORS));
-      if (nAckers > 0) {
-        com.twitter.heron.api.Config.setTopologyReliabilityMode(heronConfig,
-                 com.twitter.heron.api.Config.TopologyReliabilityMode.ATLEAST_ONCE);
-      } else {
-        com.twitter.heron.api.Config.setTopologyReliabilityMode(heronConfig,
-                 com.twitter.heron.api.Config.TopologyReliabilityMode.ATMOST_ONCE);
-      }
-    } else {
-      com.twitter.heron.api.Config.setTopologyReliabilityMode(heronConfig,
-               com.twitter.heron.api.Config.TopologyReliabilityMode.ATMOST_ONCE);
-    }
-    if (heronConfig.containsKey(backtype.storm.Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS)) {
-      Integer nSecs =
-          Utils.getInt(heronConfig.get(backtype.storm.Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS));
-      com.twitter.heron.api.Config.setMessageTimeoutSecs(heronConfig, nSecs);
-    }
-    if (heronConfig.containsKey(backtype.storm.Config.TOPOLOGY_MAX_SPOUT_PENDING)) {
-      Integer nPending =
-          Utils.getInt(
-              heronConfig.get(backtype.storm.Config.TOPOLOGY_MAX_SPOUT_PENDING).toString());
-      com.twitter.heron.api.Config.setMaxSpoutPending(heronConfig, nPending);
-    }
-    if (heronConfig.containsKey(backtype.storm.Config.TOPOLOGY_TICK_TUPLE_FREQ_SECS)) {
-      Integer tSecs =
-          Utils.getInt(
-              heronConfig.get(backtype.storm.Config.TOPOLOGY_TICK_TUPLE_FREQ_SECS).toString());
-      com.twitter.heron.api.Config.setTickTupleFrequency(heronConfig, tSecs);
-    }
-    if (heronConfig.containsKey(backtype.storm.Config.TOPOLOGY_DEBUG)) {
-      Boolean dBg =
-          Boolean.parseBoolean(heronConfig.get(backtype.storm.Config.TOPOLOGY_DEBUG).toString());
-      com.twitter.heron.api.Config.setDebug(heronConfig, dBg);
-    }
+    doStormTranslation(heronConfig, stormConfig);
 
     doTaskHooksTranslation(heronConfig);
+
+    return heronConfig;
+  }
+
+  /**
+   * Translate storm config to heron config for components
+   * @param stormConfig the storm config
+   * @return a heron config
+   */
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public static Config translateComponentConfig(Map stormConfig) {
+    Config heronConfig = new Config((Map<String, Object>) stormConfig);
+
+    doStormTranslation(heronConfig, stormConfig);
 
     return heronConfig;
   }
@@ -137,6 +109,59 @@ public final class ConfigUtils {
       List<String> translationHooks = new LinkedList<>();
       translationHooks.add(ITaskHookDelegate.class.getName());
       heronConfig.setAutoTaskHooks(translationHooks);
+    }
+  }
+
+  /**
+   * Translate storm config into heron config
+   * @param stormConfig the storm config
+   * @param heron the heron config object to receive the results.
+   */
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private static void doStormTranslation(Config heronConfig, Map stormConfig) {
+    if (heronConfig.containsKey(backtype.storm.Config.TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS)) {
+      heronConfig.put(backtype.storm.Config.TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS,
+          heronConfig.get(backtype.storm.Config.TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS).toString());
+    }
+    if (heronConfig.containsKey(backtype.storm.Config.TOPOLOGY_WORKERS)) {
+      Integer nWorkers = Utils.getInt(heronConfig.get(backtype.storm.Config.TOPOLOGY_WORKERS));
+      com.twitter.heron.api.Config.setNumStmgrs(heronConfig, nWorkers);
+    }
+    if (heronConfig.containsKey(backtype.storm.Config.TOPOLOGY_ACKER_EXECUTORS)) {
+      Integer nAckers =
+          Utils.getInt(heronConfig.get(backtype.storm.Config.TOPOLOGY_ACKER_EXECUTORS));
+      if (nAckers > 0) {
+        com.twitter.heron.api.Config.setTopologyReliabilityMode(heronConfig,
+                 com.twitter.heron.api.Config.TopologyReliabilityMode.ATLEAST_ONCE);
+      } else {
+        com.twitter.heron.api.Config.setTopologyReliabilityMode(heronConfig,
+                 com.twitter.heron.api.Config.TopologyReliabilityMode.ATMOST_ONCE);
+      }
+    } else {
+      com.twitter.heron.api.Config.setTopologyReliabilityMode(heronConfig,
+               com.twitter.heron.api.Config.TopologyReliabilityMode.ATMOST_ONCE);
+    }
+    if (heronConfig.containsKey(backtype.storm.Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS)) {
+      Integer nSecs =
+          Utils.getInt(heronConfig.get(backtype.storm.Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS));
+      com.twitter.heron.api.Config.setMessageTimeoutSecs(heronConfig, nSecs);
+    }
+    if (heronConfig.containsKey(backtype.storm.Config.TOPOLOGY_MAX_SPOUT_PENDING)) {
+      Integer nPending =
+          Utils.getInt(
+              heronConfig.get(backtype.storm.Config.TOPOLOGY_MAX_SPOUT_PENDING).toString());
+      com.twitter.heron.api.Config.setMaxSpoutPending(heronConfig, nPending);
+    }
+    if (heronConfig.containsKey(backtype.storm.Config.TOPOLOGY_TICK_TUPLE_FREQ_SECS)) {
+      Integer tSecs =
+          Utils.getInt(
+              heronConfig.get(backtype.storm.Config.TOPOLOGY_TICK_TUPLE_FREQ_SECS).toString());
+      com.twitter.heron.api.Config.setTickTupleFrequency(heronConfig, tSecs);
+    }
+    if (heronConfig.containsKey(backtype.storm.Config.TOPOLOGY_DEBUG)) {
+      Boolean dBg =
+          Boolean.parseBoolean(heronConfig.get(backtype.storm.Config.TOPOLOGY_DEBUG).toString());
+      com.twitter.heron.api.Config.setDebug(heronConfig, dBg);
     }
   }
 }

--- a/storm-compatibility/src/java/org/apache/storm/topology/BoltDeclarerImpl.java
+++ b/storm-compatibility/src/java/org/apache/storm/topology/BoltDeclarerImpl.java
@@ -38,8 +38,8 @@ public class BoltDeclarerImpl implements BoltDeclarer {
   @SuppressWarnings({"rawtypes", "unchecked"})
   public BoltDeclarer addConfigurations(Map conf) {
     // Translate config to heron config and then apply.
-    Map<String, Object> henronConf = ConfigUtils.translateConfig(conf);
-    delegate.addConfigurations(henronConf);
+    Map<String, Object> heronConf = ConfigUtils.translateComponentConfig(conf);
+    delegate.addConfigurations(heronConf);
     return this;
   }
 

--- a/storm-compatibility/src/java/org/apache/storm/topology/SpoutDeclarerImpl.java
+++ b/storm-compatibility/src/java/org/apache/storm/topology/SpoutDeclarerImpl.java
@@ -34,8 +34,8 @@ public class SpoutDeclarerImpl implements SpoutDeclarer {
   @SuppressWarnings({"rawtypes", "unchecked"})
   public SpoutDeclarer addConfigurations(Map conf) {
     // Translate config to heron config and then apply.
-    Map<String, Object> henronConf = ConfigUtils.translateConfig(conf);
-    delegate.addConfigurations(henronConf);
+    Map<String, Object> heronConf = ConfigUtils.translateComponentConfig(conf);
+    delegate.addConfigurations(heronConf);
     return this;
   }
 

--- a/storm-compatibility/src/java/org/apache/storm/utils/ConfigUtils.java
+++ b/storm-compatibility/src/java/org/apache/storm/utils/ConfigUtils.java
@@ -43,7 +43,7 @@ public final class ConfigUtils {
     doSerializationTranslation(heronConfig);
 
     // Now look at supported apis
-    doStormTranslation(heronConfig, stormConfig);
+    doStormTranslation(heronConfig);
 
     doTaskHooksTranslation(heronConfig);
 
@@ -56,10 +56,10 @@ public final class ConfigUtils {
    * @return a heron config
    */
   @SuppressWarnings({"rawtypes", "unchecked"})
-  public static Config translateConfig(Map stormConfig) {
+  public static Config translateComponentConfig(Map stormConfig) {
     Config heronConfig = new Config((Map<String, Object>) stormConfig);
 
-    doStormTranslation(heronConfig, stormConfig);
+    doStormTranslation(heronConfig);
 
     return heronConfig;
   }
@@ -114,10 +114,9 @@ public final class ConfigUtils {
 
   /**
    * Translate storm config into heron config
-   * @param stormConfig the storm config
    * @param heron the heron config object to receive the results.
    */
-  private static void doStormTranslation(Config heronConfig, Map stormConfig) {
+  private static void doStormTranslation(Config heronConfig) {
     if (heronConfig.containsKey(org.apache.storm.Config.TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS)) {
       heronConfig.put(org.apache.storm.Config.TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS,
           heronConfig.get(org.apache.storm.Config.TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS).toString());


### PR DESCRIPTION
Config translation needs to be different between topology and components, because of the serialization configs.