### PR TITLE
Use builder pattern in Streamlet API

### DIFF
--- a/examples/src/java/com/twitter/heron/examples/streamlet/FilesystemSinkTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/streamlet/FilesystemSinkTopology.java
@@ -128,8 +128,9 @@ public final class FilesystemSinkTopology {
     // argument (or else the default of 2 will be used).
     int topologyParallelism = StreamletUtils.getParallelism(args, 2);
 
-    Config config = new Config();
-    config.setNumContainers(topologyParallelism);
+    Config config = new Config.Builder()
+        .setNumContainers(topologyParallelism)
+        .build();
 
     // Fetches the topology name from the first command-line argument
     String topologyName = StreamletUtils.getTopologyName(args);

--- a/examples/src/java/com/twitter/heron/examples/streamlet/FormattedOutputTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/streamlet/FormattedOutputTopology.java
@@ -105,7 +105,7 @@ public final class FormattedOutputTopology {
     // Fetches the topology name from the first command-line argument
     String topologyName = StreamletUtils.getTopologyName(args);
 
-    Config config = new Config();
+    Config config = Config.defaultConfig();
 
     // Finally, the processing graph and configuration are passed to the Runner, which converts
     // the graph into a Heron topology that can be run in a Heron cluster.

--- a/examples/src/java/com/twitter/heron/examples/streamlet/ImpressionsAndClicksTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/streamlet/ImpressionsAndClicksTopology.java
@@ -185,7 +185,7 @@ public final class ImpressionsAndClicksTopology {
               kw.getValue()));
         });
 
-    Config config = new Config();
+    Config config = Config.defaultConfig();
 
     // Fetches the topology name from the first command-line argument
     String topologyName = StreamletUtils.getTopologyName(args);

--- a/examples/src/java/com/twitter/heron/examples/streamlet/IntegerProcessingTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/streamlet/IntegerProcessingTopology.java
@@ -60,19 +60,21 @@ public final class IntegerProcessingTopology {
         .setName("remove-twos")
         .log();
 
-    Config conf = new Config();
-    conf.setNumContainers(NUM_CONTAINERS);
+    Resources resources = new Resources.Builder()
+        .setCpu(CPU)
+        .setRamInGB(GIGABYTES_OF_RAM)
+        .build();
 
-    Resources resources = new Resources();
-    resources.withCpu(CPU);
-    resources.withRam(ByteAmount.fromGigabytes(GIGABYTES_OF_RAM).asBytes());
-    conf.setContainerResources(resources);
+    Config config = new Config.Builder()
+        .setNumContainers(NUM_CONTAINERS)
+        .setContainerResources(resources)
+        .build();
 
     // Fetches the topology name from the first command-line argument
     String topologyName = StreamletUtils.getTopologyName(args);
 
     // Finally, the processing graph and configuration are passed to the Runner, which converts
     // the graph into a Heron topology that can be run in a Heron cluster.
-    new Runner().run(topologyName, conf, builder);
+    new Runner().run(topologyName, config, builder);
   }
 }

--- a/examples/src/java/com/twitter/heron/examples/streamlet/IntegerProcessingTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/streamlet/IntegerProcessingTopology.java
@@ -16,7 +16,6 @@ package com.twitter.heron.examples.streamlet;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.examples.streamlet.utils.StreamletUtils;
 import com.twitter.heron.streamlet.Builder;
 import com.twitter.heron.streamlet.Config;

--- a/examples/src/java/com/twitter/heron/examples/streamlet/RepartitionTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/streamlet/RepartitionTopology.java
@@ -103,8 +103,10 @@ public final class RepartitionTopology {
     // Fetches the topology name from the first command-line argument
     String topologyName = StreamletUtils.getTopologyName(args);
 
+    Config config = Config.defaultConfig();
+
     // Finally, the processing graph and configuration are passed to the Runner, which converts
     // the graph into a Heron topology that can be run in a Heron cluster.
-    new Runner().run(topologyName, new Config(), processingGraphBuilder);
+    new Runner().run(topologyName, config, processingGraphBuilder);
   }
 }

--- a/examples/src/java/com/twitter/heron/examples/streamlet/SimplePulsarSourceTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/streamlet/SimplePulsarSourceTopology.java
@@ -114,7 +114,7 @@ public final class SimplePulsarSourceTopology {
         .setName("incoming-pulsar-messages")
         .consume(s -> LOG.info(String.format("Message received from Pulsar: \"%s\"", s)));
 
-    Config config = new Config();
+    Config config = Config.defaultConfig();
 
     // Fetches the topology name from the first command-line argument
     String topologyName = StreamletUtils.getTopologyName(args);

--- a/examples/src/java/com/twitter/heron/examples/streamlet/SmartWatchTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/streamlet/SmartWatchTopology.java
@@ -112,7 +112,7 @@ public final class SmartWatchTopology {
           LOG.info(logMessage);
         });
 
-    Config config = new Config();
+    Config config = Config.defaultConfig();
 
     // Fetches the topology name from the first command-line argument
     String topologyName = StreamletUtils.getTopologyName(args);

--- a/examples/src/java/com/twitter/heron/examples/streamlet/StreamletCloneTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/streamlet/StreamletCloneTopology.java
@@ -146,7 +146,7 @@ public final class StreamletCloneTopology {
     splitGameScoreStreamlet.get(1)
         .toSink(new FormattedLogSink());
 
-    Config config = new Config();
+    Config config = Config.defaultConfig();
 
     // Fetches the topology name from the first command-line argument
     String topologyName = StreamletUtils.getTopologyName(args);

--- a/examples/src/java/com/twitter/heron/examples/streamlet/TransformsTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/streamlet/TransformsTopology.java
@@ -110,7 +110,7 @@ public final class TransformsTopology {
         .transform(new IncrementTransformer(-3))
         .log();
 
-    Config config = new Config();
+    Config config = Config.defaultConfig();
 
     // Fetches the topology name from the first command-line argument
     String topologyName = StreamletUtils.getTopologyName(args);

--- a/examples/src/java/com/twitter/heron/examples/streamlet/WindowedWordCountTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/streamlet/WindowedWordCountTopology.java
@@ -82,8 +82,9 @@ public final class WindowedWordCountTopology {
     // argument (or else the default of 2 will be used).
     int topologyParallelism = StreamletUtils.getParallelism(args, 2);
 
-    Config config = new Config();
-    config.setNumContainers(topologyParallelism);
+    Config config = new Config.Builder()
+        .setNumContainers(topologyParallelism)
+        .build();
 
     // Fetches the topology name from the first command-line argument
     String topologyName = StreamletUtils.getTopologyName(args);

--- a/examples/src/java/com/twitter/heron/examples/streamlet/WireRequestsTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/streamlet/WireRequestsTopology.java
@@ -179,9 +179,10 @@ public final class WireRequestsTopology {
         .setName("all-branches-fraud-detect")
         .log();
 
-    Config config = new Config();
-    config.setDeliverySemantics(Config.DeliverySemantics.EFFECTIVELY_ONCE);
-    config.setNumContainers(2);
+    Config config = new Config.Builder()
+        .setDeliverySemantics(Config.DeliverySemantics.EFFECTIVELY_ONCE)
+        .setNumContainers(2)
+        .build();
 
     // Fetches the topology name from the first command-line argument
     String topologyName = StreamletUtils.getTopologyName(args);

--- a/heron/api/src/java/com/twitter/heron/streamlet/Config.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/Config.java
@@ -15,7 +15,6 @@
 package com.twitter.heron.streamlet;
 
 import java.io.Serializable;
-import java.util.Map;
 
 import com.twitter.heron.common.basics.ByteAmount;
 
@@ -81,7 +80,7 @@ public final class Config implements Serializable {
 
     /**
      * Sets resources used per container by this topology
-     * @param resources The resource per container to dedicate per container
+     * @param resources The resource to dedicate per container
      */
     public Builder setContainerResources(Resources resources) {
       config.setContainerCpuRequested(resources.getCpu());

--- a/heron/api/src/java/com/twitter/heron/streamlet/Config.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/Config.java
@@ -15,71 +15,41 @@
 package com.twitter.heron.streamlet;
 
 import java.io.Serializable;
+import java.util.Map;
 
 import com.twitter.heron.common.basics.ByteAmount;
 
 /**
  * Config is the way users configure the execution of the topology.
- * Things like tuple delivery semantics, resources used, as well as
- * user defined key/value pairs are passed on to the runner via
+ * Things like streamlet delivery semantics, resources used, as well as
+ * user-defined key/value pairs are passed on to the topology runner via
  * this class.
  */
 public final class Config implements Serializable {
   private static final long serialVersionUID = 6204498077403076352L;
+
   private com.twitter.heron.api.Config heronConfig;
+
   public enum DeliverySemantics {
     ATMOST_ONCE,
     ATLEAST_ONCE,
     EFFECTIVELY_ONCE
   }
 
-  public Config() {
-    heronConfig = new com.twitter.heron.api.Config();
+  private Config(Builder builder) {
+    heronConfig = builder.config;
   }
 
-  Config(com.twitter.heron.api.Config config) {
-    heronConfig = config;
+  public static Config defaultConfig() {
+    return new Builder()
+        .build();
   }
 
   com.twitter.heron.api.Config getHeronConfig() {
     return heronConfig;
   }
 
-  /**
-   * Sets the delivery semantics of the topology
-   * @param semantic The delivery semantic to be enforced
-   */
-  public void setDeliverySemantics(DeliverySemantics semantic) {
-    heronConfig.setTopologyReliabilityMode(translateSemantics(semantic));
-  }
-
-  /**
-   * Sets the number of containers to run this topology
-   * @param numContainers The number of containers to distribute this topology
-   */
-  public void setNumContainers(int numContainers) {
-    heronConfig.setNumStmgrs(numContainers);
-  }
-
-  /**
-   * Sets resources used per container by this topology
-   * @param resource The resource per container to dedicate per container
-   */
-  public void setContainerResources(Resources resource) {
-    heronConfig.setContainerCpuRequested(resource.getCpu());
-    heronConfig.setContainerRamRequested(ByteAmount.fromBytes(resource.getRam()));
-  }
-
-  /**
-   * Sets some user defined key value mapping
-   * @param key The user defined key
-   * @param value The user defined object
-   */
-  public void setUserConfig(String key, Object value) {
-    heronConfig.put(key, value);
-  }
-
-  private com.twitter.heron.api.Config.TopologyReliabilityMode translateSemantics(
+  private static com.twitter.heron.api.Config.TopologyReliabilityMode translateSemantics(
       DeliverySemantics semantics) {
     switch (semantics) {
       case ATMOST_ONCE:
@@ -90,6 +60,56 @@ public final class Config implements Serializable {
         return com.twitter.heron.api.Config.TopologyReliabilityMode.EFFECTIVELY_ONCE;
       default:
         return com.twitter.heron.api.Config.TopologyReliabilityMode.ATMOST_ONCE;
+    }
+  }
+
+  public static class Builder {
+    private com.twitter.heron.api.Config config;
+
+    public Builder() {
+      config = new com.twitter.heron.api.Config();
+    }
+
+    /**
+     * Sets the number of containers to run this topology
+     * @param numContainers The number of containers to distribute this topology
+     */
+    public Builder setNumContainers(int numContainers) {
+      config.setNumStmgrs(numContainers);
+      return this;
+    }
+
+    /**
+     * Sets resources used per container by this topology
+     * @param resources The resource per container to dedicate per container
+     */
+    public Builder setContainerResources(Resources resources) {
+      config.setContainerCpuRequested(resources.getCpu());
+      config.setContainerRamRequested(ByteAmount.fromBytes(resources.getRam()));
+      return this;
+    }
+
+    /**
+     * Sets the delivery semantics of the topology
+     * @param semantic The delivery semantic to be enforced
+     */
+    public Builder setDeliverySemantics(DeliverySemantics semantic) {
+      config.setTopologyReliabilityMode(Config.translateSemantics(semantic));
+      return this;
+    }
+
+    /**
+     * Sets some user-defined key/value mapping
+     * @param key The user-defined key
+     * @param value The user-defined value
+     */
+    public Builder setUserConfig(String key, Object value) {
+      config.put(key, value);
+      return this;
+    }
+
+    public Config build() {
+      return new Config(this);
     }
   }
 }

--- a/heron/api/src/java/com/twitter/heron/streamlet/Resources.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/Resources.java
@@ -18,12 +18,19 @@ import java.io.Serializable;
 
 /**
  * Resources needed by the topology are encapsulated in this class.
- * Currently we deal with cpu and ram. Others can be added later.
+ * Currently we deal with CPU and RAM. Others can be added later.
  */
 public final class Resources implements Serializable {
   private static final long serialVersionUID = 630451253428388496L;
+  private static float CPU_DEFAULT = 1.0f;
+  private static long RAM_DEFAULT = 104857600;
   private float cpu;
   private long ram;
+
+  public Resources(Builder builder) {
+    this.cpu = builder.cpu;
+    this.ram = builder.ram;
+  }
 
   public float getCpu() {
     return cpu;
@@ -33,31 +40,58 @@ public final class Resources implements Serializable {
     return ram;
   }
 
-  public Resources() {
-    this.cpu = 1.0f;
-    this.ram = 104857600;
-  }
-
-  public Resources withCpu(float ncpu) {
-    this.cpu = ncpu;
-    return this;
-  }
-
-  public Resources withRam(long nram) {
-    this.ram = nram;
-    return this;
-  }
-
-  public Resources withRamInMB(long nram) {
-    return withRam(nram * 1024 * 1024);
-  }
-
-  public Resources withRamInGB(long nram) {
-    return withRamInMB(nram * 1024);
-  }
-
   @Override
   public String toString() {
-    return "{ CPU: " + String.valueOf(cpu) + " RAM: " + String.valueOf(ram) + " }";
+    return String.format("{ CPU: %s RAM: %s }", String.valueOf(cpu), String.valueOf(ram));
+  }
+
+  public static class Builder {
+    private float cpu;
+    private long ram;
+
+    public Builder() {
+      this.cpu = CPU_DEFAULT;
+      this.ram = RAM_DEFAULT;
+    }
+
+    /**
+     * Sets the RAM to be used by the topology (in megabytes)
+     * @param nram The number of megabytes of RAM
+     */
+    public Builder setRamInMB(long nram) {
+      this.ram = nram * 1024;
+      return this;
+    }
+
+    /**
+     * Sets the RAM to be used by the topology (in gigabytes)
+     * @param nram The number of gigabytes of RAM
+     */
+    public Builder setRamInGB(long nram) {
+      this.ram = nram * 1024 * 1024;
+      return this;
+    }
+
+    /**
+     * Sets the total number of CPUs to be used by the topology
+     * @param cpu The number of CPUs (as a float)
+     */
+    public Builder setCpu(float cpu) {
+      this.cpu = cpu;
+      return this;
+    }
+
+    /**
+     * Sets the RAM to be used by the topology (in bytes)
+     * @param ram The number of bytes of RAM
+     */
+    public Builder setRam(long ram) {
+      this.ram = ram;
+      return this;
+    }
+
+    public Resources build() {
+      return new Resources(this);
+    }
   }
 }

--- a/heron/api/src/java/com/twitter/heron/streamlet/Resources.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/Resources.java
@@ -22,8 +22,6 @@ import java.io.Serializable;
  */
 public final class Resources implements Serializable {
   private static final long serialVersionUID = 630451253428388496L;
-  private static float CPU_DEFAULT = 1.0f;
-  private static long RAM_DEFAULT = 104857600;
   private float cpu;
   private long ram;
 
@@ -55,8 +53,8 @@ public final class Resources implements Serializable {
     private long ram;
 
     public Builder() {
-      this.cpu = CPU_DEFAULT;
-      this.ram = RAM_DEFAULT;
+      this.cpu = 1.0f;
+      this.ram = 104857600;
     }
 
     /**
@@ -81,8 +79,8 @@ public final class Resources implements Serializable {
      * Sets the total number of CPUs to be used by the topology
      * @param cpu The number of CPUs (as a float)
      */
-    public Builder setCpu(float cpu) {
-      this.cpu = cpu;
+    public Builder setCpu(float containerCpu) {
+      this.cpu = containerCpu;
       return this;
     }
 
@@ -90,8 +88,8 @@ public final class Resources implements Serializable {
      * Sets the RAM to be used by the topology (in bytes)
      * @param ram The number of bytes of RAM
      */
-    public Builder setRam(long ram) {
-      this.ram = ram;
+    public Builder setRam(long containerRam) {
+      this.ram = containerRam;
       return this;
     }
 

--- a/heron/api/src/java/com/twitter/heron/streamlet/Resources.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/Resources.java
@@ -27,9 +27,14 @@ public final class Resources implements Serializable {
   private float cpu;
   private long ram;
 
-  public Resources(Builder builder) {
+  private Resources(Builder builder) {
     this.cpu = builder.cpu;
     this.ram = builder.ram;
+  }
+
+  public static Resources defaultResources() {
+    return new Builder()
+        .build();
   }
 
   public float getCpu() {

--- a/heron/api/src/java/com/twitter/heron/streamlet/Resources.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/Resources.java
@@ -77,7 +77,7 @@ public final class Resources implements Serializable {
 
     /**
      * Sets the total number of CPUs to be used by the topology
-     * @param cpu The number of CPUs (as a float)
+     * @param containerCpu The number of CPUs (as a float)
      */
     public Builder setCpu(float containerCpu) {
       this.cpu = containerCpu;
@@ -86,7 +86,7 @@ public final class Resources implements Serializable {
 
     /**
      * Sets the RAM to be used by the topology (in bytes)
-     * @param ram The number of bytes of RAM
+     * @param containerRam The number of bytes of RAM
      */
     public Builder setRam(long containerRam) {
       this.ram = containerRam;

--- a/heron/api/tests/java/com/twitter/heron/streamlet/impl/StreamletImplTest.java
+++ b/heron/api/tests/java/com/twitter/heron/streamlet/impl/StreamletImplTest.java
@@ -261,10 +261,9 @@ public class StreamletImplTest {
 
   @Test
   public void testResourcesBuilder() {
-    Resources res1 = new Resources.Builder()
-        .build();
-    assertEquals(0, Float.compare(res1.getCpu(), 1.0f));
-    assertEquals(res1.getRam(), 104857600);
+    Resources defaultResoures = Resources.defaultResources();
+    assertEquals(0, Float.compare(defaultResoures.getCpu(), 1.0f));
+    assertEquals(defaultResoures.getRam(), 104857600);
 
     Resources res2 = new Resources.Builder()
         .setCpu(5.1f)

--- a/heron/api/tests/java/com/twitter/heron/streamlet/impl/StreamletImplTest.java
+++ b/heron/api/tests/java/com/twitter/heron/streamlet/impl/StreamletImplTest.java
@@ -23,7 +23,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.twitter.heron.api.topology.TopologyBuilder;
+import com.twitter.heron.streamlet.Config;
 import com.twitter.heron.streamlet.Context;
+import com.twitter.heron.streamlet.Resources;
 import com.twitter.heron.streamlet.SerializableTransformer;
 import com.twitter.heron.streamlet.Streamlet;
 import com.twitter.heron.streamlet.WindowConfig;
@@ -255,5 +257,20 @@ public class StreamletImplTest {
     jStreamlet =
         (JoinStreamlet<String, String, String, String>) fStreamlet.getChildren().get(0);
     assertEquals(jStreamlet.getChildren().size(), 0);
+  }
+
+  @Test
+  public void testResourcesBuilder() {
+    Resources res1 = new Resources.Builder()
+        .build();
+    assertEquals(0, Float.compare(res1.getCpu(), 1.0f));
+    assertEquals(res1.getRam(), 104857600);
+
+    Resources res2 = new Resources.Builder()
+        .setCpu(5.1f)
+        .setRamInGB(20)
+        .build();
+    assertEquals(0, Float.compare(res2.getCpu(), 5.1f));
+    assertEquals(res2.getRam(), 20 * 1024 * 1024);
   }
 }

--- a/heron/api/tests/java/com/twitter/heron/streamlet/impl/StreamletImplTest.java
+++ b/heron/api/tests/java/com/twitter/heron/streamlet/impl/StreamletImplTest.java
@@ -23,7 +23,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.twitter.heron.api.topology.TopologyBuilder;
-import com.twitter.heron.streamlet.Config;
 import com.twitter.heron.streamlet.Context;
 import com.twitter.heron.streamlet.Resources;
 import com.twitter.heron.streamlet.SerializableTransformer;


### PR DESCRIPTION
At the moment, there are two classes in the Streamlet API (`Config` and `Resources`) that could benefit from a more user-friendly builder pattern (I've also added constructors that explicitly use the defaults). I've updated these classes to use this pattern as well as existing Streamlet API examples. Here's an example:

```java
Resources resources = Resources.defaultResources();

Config config = new Config.Builder()
        .setNumContainers(3)
        .setContainerResources(resources)
        .build();
```