### PR TITLE
[Uploaders] Extend LocalFileSystemUploader UT Coverage

### DIFF
--- a/heron/spi/tests/java/com/twitter/heron/spi/utils/ShellUtilsTest.java
+++ b/heron/spi/tests/java/com/twitter/heron/spi/utils/ShellUtilsTest.java
@@ -23,14 +23,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 
 import org.junit.Assert;
 import org.junit.Test;
 
 public class ShellUtilsTest {
-
-  private static final Logger LOG = Logger.getLogger(ShellUtilsTest.class.getName());
 
   private static String generateRandomLongString(int size) {
     StringBuilder builder = new StringBuilder();

--- a/website/content/docs/operators/deployment/uploaders/localfs.md
+++ b/website/content/docs/operators/deployment/uploaders/localfs.md
@@ -27,7 +27,7 @@ to `com.twitter.heron.uploader.localfs.LocalFileSystemUploader`
 * `heron.uploader.localfs.file.system.directory` --- Provides the name of the directory where
 the topology jar should be uploaded. The name of the directory should be unique per cluster
 You could use the Heron environment variables `${CLUSTER}` that will be substituted by cluster
-name.
+name. If this is not set, `${HOME}/.herondata/repository/${CLUSTER}/${ROLE}/${TOPOLOGY}` will be set as default.
 
 ### Example Local File System Uploader Configuration
 


### PR DESCRIPTION
This PR aims the following changes:

- Extends Unit Test coverages of `LocalFileSystemUploader` and `UploaderUtils`
- Documentation update about setting default `heron.uploader.localfs.file.system.directory` value if it is not set by the user. _This behaviour information can be useful for user._