### PR TITLE
Retry when failing to kill an Aurora topology

### DIFF
--- a/heron/config/src/yaml/conf/aurora/scheduler.yaml
+++ b/heron/config/src/yaml/conf/aurora/scheduler.yaml
@@ -10,6 +10,15 @@ heron.directory.sandbox.java.home:           /usr/lib/jvm/java-1.8.0-openjdk-amd
 # Invoke the IScheduler as a library directly
 heron.scheduler.is.service:                  False
 
+####################################################################
+# Following are Aurora-specific
+####################################################################
+# The maximum retry attempts when trying to kill an Aurora job
+heron.scheduler.job.max.kill.attempts:       5
+
+# The interval in ms between two retry-attempts to kill an Aurora job
+heron.scheduler.job.kill.retry.interval.ms:  2000
+
 # Aurora Controller Class
 # heron.class.scheduler.aurora.controller.cli:     False
 

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
@@ -150,7 +150,8 @@ public class RuntimeManagerRunner {
 
     if (!schedulerClient.killTopology(killTopologyRequest)) {
       throw new TopologyRuntimeManagementException(
-          String.format("Failed to kill topology '%s' with scheduler", topologyName));
+          String.format("Failed to kill topology '%s' with scheduler, "
+              + "please re-try the kill command later", topologyName));
     }
 
     // clean up the state of the topology in state manager
@@ -176,7 +177,7 @@ public class RuntimeManagerRunner {
     if (!changeDetected(currentPlan, changeRequests)) {
       throw new TopologyRuntimeManagementException(
           String.format("The component parallelism request (%s) is the same as the "
-          + "current topology parallelism. Not taking action.", newParallelism));
+              + "current topology parallelism. Not taking action.", newParallelism));
     }
 
     PackingPlans.PackingPlan proposedPlan = buildNewPackingPlan(currentPlan, changeRequests,
@@ -199,7 +200,7 @@ public class RuntimeManagerRunner {
     if (!schedulerClient.updateTopology(updateTopologyRequest)) {
       throw new TopologyRuntimeManagementException(String.format(
           "Failed to update topology with Scheduler, updateTopologyRequest="
-          + updateTopologyRequest));
+              + updateTopologyRequest));
     }
 
     // Clean the connection when we are done.
@@ -242,25 +243,25 @@ public class RuntimeManagerRunner {
     result = statemgr.deletePhysicalPlan(topologyName);
     if (result == null || !result) {
       throw new TopologyRuntimeManagementException(
-        "Failed to clear physical plan. Check whether TMaster set it correctly.");
+          "Failed to clear physical plan. Check whether TMaster set it correctly.");
     }
 
     result = statemgr.deleteSchedulerLocation(topologyName);
     if (result == null || !result) {
       throw new TopologyRuntimeManagementException(
-        "Failed to clear scheduler location. Check whether Scheduler set it correctly.");
+          "Failed to clear scheduler location. Check whether Scheduler set it correctly.");
     }
 
     result = statemgr.deleteLocks(topologyName);
     if (result == null || !result) {
       throw new TopologyRuntimeManagementException(
-        "Failed to delete locks. It's possible that the topology never created any.");
+          "Failed to delete locks. It's possible that the topology never created any.");
     }
 
     result = statemgr.deleteExecutionState(topologyName);
     if (result == null || !result) {
       throw new TopologyRuntimeManagementException(
-        "Failed to clear execution state");
+          "Failed to clear execution state");
     }
 
     // Set topology def at last since we determine whether a topology is running
@@ -268,7 +269,7 @@ public class RuntimeManagerRunner {
     result = statemgr.deleteTopology(topologyName);
     if (result == null || !result) {
       throw new TopologyRuntimeManagementException(
-        "Failed to clear topology definition");
+          "Failed to clear topology definition");
     }
 
     LOG.fine("Cleaned up topology state");
@@ -346,7 +347,7 @@ public class RuntimeManagerRunner {
   }
 
   private static boolean changeDetected(PackingPlans.PackingPlan currentProtoPlan,
-                                 Map<String, Integer> changeRequests) {
+                                        Map<String, Integer> changeRequests) {
     PackingPlanProtoDeserializer deserializer = new PackingPlanProtoDeserializer();
     PackingPlan currentPlan = deserializer.fromProto(currentProtoPlan);
     for (String component : changeRequests.keySet()) {

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraContext.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraContext.java
@@ -22,6 +22,9 @@ import com.twitter.heron.spi.common.Context;
 public final class AuroraContext extends Context {
   public static final String JOB_LINK_TEMPLATE = "heron.scheduler.job.link.template";
   public static final String JOB_TEMPLATE = "heron.scheduler.job.template";
+  public static final String JOB_MAX_KILL_ATTEMPTS = "heron.scheduler.job.max.kill.attempts";
+  public static final String JOB_KILL_RETRY_INTERVAL_MS =
+      "heron.scheduler.job.kill.retry.interval.ms";
 
   private AuroraContext() {
   }
@@ -33,5 +36,13 @@ public final class AuroraContext extends Context {
   public static String getHeronAuroraPath(Config config) {
     return config.getStringValue(JOB_TEMPLATE,
         new File(Context.heronConf(config), "heron.aurora").getPath());
+  }
+
+  public static int getJobMaxKillAttempts(Config config) {
+    return config.getIntegerValue(JOB_MAX_KILL_ATTEMPTS, 5);
+  }
+
+  public static long getJobKillRetryIntervalMs(Config config) {
+    return config.getLongValue(JOB_KILL_RETRY_INTERVAL_MS, 2000);
   }
 }


### PR DESCRIPTION
A lot of Twitter internal topology owners complained heron failing to kill an aurora topology because
the Aurora service can be unavailable or unstable for a while, or it can sometimes provide a false negative response.

This pull request adds retry mechanism to kill an Aurora topology with more confidence. It can increase the robustness of AuroraScheduler regardless of the Aurora Service People can also specify the retry attempts and interval via config.

This pull request also re-format some coding-styles for `RuntimeManagerRunner.java`.