### PR TITLE
add SCHEDULER_IS_SERVICE config for zk tool

### DIFF
--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
@@ -426,6 +426,7 @@ public class CuratorStateManager extends FileSystemStateManager {
     Config config = Config.newBuilder()
         .put(Key.STATEMGR_ROOT_PATH, "/storm/heron/states")
         .put(Key.STATEMGR_CONNECTION_STRING, zookeeperHostname)
+        .put(Key.SCHEDULER_IS_SERVICE, false)
         .build();
     CuratorStateManager stateManager = new CuratorStateManager();
     stateManager.doMain(args, config);


### PR DESCRIPTION
Fix null exception for zk tool


```
==> State Manager root path: /storm/heron/states
Exception in thread "main" java.lang.NullPointerException
at com.twitter.heron.statemgr.zookeeper.curator.CuratorStateManager.initialize(CuratorStateManager.java:73)
at com.twitter.heron.statemgr.FileSystemStateManager.doMain(FileSystemStateManager.java:288)
at com.twitter.heron.statemgr.zookeeper.curator.CuratorStateManager.main(CuratorStateManager.java:431)
```