### PR TITLE
fix metricscache location bug

### DIFF
--- a/heron/metricscachemgr/src/java/com/twitter/heron/metricscachemgr/MetricsCacheManager.java
+++ b/heron/metricscachemgr/src/java/com/twitter/heron/metricscachemgr/MetricsCacheManager.java
@@ -374,7 +374,7 @@ public class MetricsCacheManager {
 
       Boolean b = statemgr.setMetricsCacheLocation(metricsCacheLocation, topologyName)
           .get(5000, TimeUnit.MILLISECONDS);
-      if (b != null && b == Boolean.TRUE) {
+      if (b != null && b) {
         LOG.info("metricsCacheLocation " + metricsCacheLocation.toString());
         LOG.info("topologyName " + topologyName.toString());
 
@@ -387,7 +387,7 @@ public class MetricsCacheManager {
         metricsCacheManagerServer.start();
         metricsCacheManagerServerLoop.loop();
       } else {
-        LOG.severe("statemgr metricscahe node failure, fail fast");
+        throw new RuntimeException("Failed to set metricscahe location. Exiting...");
       }
     } finally {
       // 3. Do post work basing on the result

--- a/heron/metricscachemgr/src/java/com/twitter/heron/metricscachemgr/MetricsCacheManager.java
+++ b/heron/metricscachemgr/src/java/com/twitter/heron/metricscachemgr/MetricsCacheManager.java
@@ -17,6 +17,7 @@ package com.twitter.heron.metricscachemgr;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -348,6 +349,10 @@ public class MetricsCacheManager {
     LOG.info("Loops terminated. MetricsCache Manager exits.");
   }
 
+  /**
+   * start zk_client, metricscache_server, http_server
+   * @throws Exception
+   */
   public void start() throws Exception {
     // 1. Do prepare work
     // create an instance of state manager
@@ -364,21 +369,26 @@ public class MetricsCacheManager {
 
     // Put it in a try block so that we can always clean resources
     try {
-      // initialize the statemgr
+      // initialize the statemgr: zk_client.start()
       statemgr.initialize(config);
 
-      statemgr.setMetricsCacheLocation(metricsCacheLocation, topologyName);
-      LOG.info("metricsCacheLocation " + metricsCacheLocation.toString());
-      LOG.info("topologyName " + topologyName.toString());
+      Boolean b = statemgr.setMetricsCacheLocation(metricsCacheLocation, topologyName)
+          .get(5000, TimeUnit.MILLISECONDS);
+      if (b != null && b == Boolean.TRUE) {
+        LOG.info("metricsCacheLocation " + metricsCacheLocation.toString());
+        LOG.info("topologyName " + topologyName.toString());
 
-      LOG.info("Starting Metrics Cache HTTP Server");
-      metricsCacheManagerHttpServer.start();
+        LOG.info("Starting Metrics Cache HTTP Server");
+        metricsCacheManagerHttpServer.start();
 
-      // 2. The MetricsCacheServer would run in the main thread
-      // We do it in the final step since it would await the main thread
-      LOG.info("Starting Metrics Cache Server");
-      metricsCacheManagerServer.start();
-      metricsCacheManagerServerLoop.loop();
+        // 2. The MetricsCacheServer would run in the main thread
+        // We do it in the final step since it would await the main thread
+        LOG.info("Starting Metrics Cache Server");
+        metricsCacheManagerServer.start();
+        metricsCacheManagerServerLoop.loop();
+      } else {
+        LOG.severe("statemgr metricscahe node failure, fail fast");
+      }
     } finally {
       // 3. Do post work basing on the result
       // Currently nothing to do here

--- a/heron/metricscachemgr/src/java/com/twitter/heron/metricscachemgr/MetricsCacheManager.java
+++ b/heron/metricscachemgr/src/java/com/twitter/heron/metricscachemgr/MetricsCacheManager.java
@@ -350,7 +350,7 @@ public class MetricsCacheManager {
   }
 
   /**
-   * start zk_client, metricscache_server, http_server
+   * start statemgr_client, metricscache_server, http_server
    * @throws Exception
    */
   public void start() throws Exception {
@@ -369,7 +369,7 @@ public class MetricsCacheManager {
 
     // Put it in a try block so that we can always clean resources
     try {
-      // initialize the statemgr: zk_client.start()
+      // initialize the statemgr
       statemgr.initialize(config);
 
       Boolean b = statemgr.setMetricsCacheLocation(metricsCacheLocation, topologyName)

--- a/heron/metricscachemgr/src/java/com/twitter/heron/metricscachemgr/MetricsCacheManager.java
+++ b/heron/metricscachemgr/src/java/com/twitter/heron/metricscachemgr/MetricsCacheManager.java
@@ -387,7 +387,7 @@ public class MetricsCacheManager {
         metricsCacheManagerServer.start();
         metricsCacheManagerServerLoop.loop();
       } else {
-        throw new RuntimeException("Failed to set metricscahe location. Exiting...");
+        throw new RuntimeException("Failed to set metricscahe location.");
       }
     } finally {
       // 3. Do post work basing on the result

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.logging.Logger;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -344,8 +345,18 @@ public class CuratorStateManager extends FileSystemStateManager {
       public void stateChanged(CuratorFramework arg0, ConnectionState arg1) {
         if (arg1 == ConnectionState.RECONNECTED || arg1 == ConnectionState.CONNECTED) {
           LOG.info("zk session state changed to " + arg1);
-          createNode(
+          ListenableFuture<Boolean> result = createNode(
               StateLocation.METRICSCACHE_LOCATION, topologyName, location.toByteArray(), true);
+          try {
+            Boolean b = result.get(5000, TimeUnit.MILLISECONDS);
+            if (b != Boolean.TRUE) {
+              LOG.severe("creating zk metricscache node failed, fail fast");
+              throw new RuntimeException();
+            }
+          } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            LOG.severe("creating zk metricscache node exception, fail fast");
+            throw new RuntimeException();
+          }
         }
       }
     });

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
@@ -344,8 +344,9 @@ public class CuratorStateManager extends FileSystemStateManager {
       public void stateChanged(CuratorFramework arg0, ConnectionState arg1) {
         if (arg1 == ConnectionState.LOST
             || arg1 == ConnectionState.SUSPENDED
-            || arg1 == ConnectionState.READ_ONLY) {
-          throw new RuntimeException();
+            || arg1 == ConnectionState.READ_ONLY
+            || arg1 == ConnectionState.RECONNECTED) {
+          throw new RuntimeException("Unexpected state change to: " + arg1.name());
         }
       }
     });

--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/zookeeper/curator/CuratorStateManager.java
@@ -342,10 +342,8 @@ public class CuratorStateManager extends FileSystemStateManager {
     client.getConnectionStateListenable().addListener(new ConnectionStateListener() {
       @Override
       public void stateChanged(CuratorFramework arg0, ConnectionState arg1) {
-        if (arg1 == ConnectionState.LOST
-            || arg1 == ConnectionState.SUSPENDED
-            || arg1 == ConnectionState.READ_ONLY
-            || arg1 == ConnectionState.RECONNECTED) {
+        if (arg1 != ConnectionState.CONNECTED) {
+          // if not the first time successful connection, fail fast
           throw new RuntimeException("Unexpected state change to: " + arg1.name());
         }
       }


### PR DESCRIPTION
the metricscache location is an ephemeral node in zk. 
when the zk session re-connection happens, the ephemeral node may need registration again.