### PR TITLE
enhance heron-shell /killexecutor

### DIFF
--- a/heron/shell/src/python/handlers/killexecutorhandler.py
+++ b/heron/shell/src/python/handlers/killexecutorhandler.py
@@ -38,7 +38,7 @@ class KillExecutorHandler(tornado.web.RequestHandler):
       os.killpg(os.getppid(), signal.SIGTERM)
 
     logger = logging.getLogger(__file__)
-    logger.info("Received 'Killing parent executor' request")
+    logger.info("Received 'Killing process' request")
     data = dict(urlparse.parse_qsl(self.request.body))
 
     # check shared secret

--- a/heron/shell/src/python/handlers/killexecutorhandler.py
+++ b/heron/shell/src/python/handlers/killexecutorhandler.py
@@ -47,15 +47,17 @@ class KillExecutorHandler(tornado.web.RequestHandler):
       status_finish(403)
       return
 
-    processName = data.get('process')
-    if processName:
-      filepath = processName + '.pid'
+    instanceId = data.get('instance_id_to_restart')
+    if instanceId:
+      filepath = instanceId + '.pid'
       if os.path.isfile(filepath): # process found
-        if processName.startswith('heron-executor-'): # kill heron-executor
+        if instanceId.startswith('heron-executor-'): # kill heron-executor
           kill_parent()
         else: # kill other normal process
-          firstLine = int(open(filepath).readline())
-          logger.info("Killing process " + processName + " " + str(firstLine))
+          fh = open(filepath)
+          firstLine = int(fh.readline())
+          fh.close()
+          logger.info("Killing process " + instanceId + " " + str(firstLine))
           os.kill(firstLine, signal.SIGTERM)
           status_finish(200)
       else: # process not found

--- a/heron/shell/src/python/handlers/killexecutorhandler.py
+++ b/heron/shell/src/python/handlers/killexecutorhandler.py
@@ -53,9 +53,9 @@ class KillExecutorHandler(tornado.web.RequestHandler):
         if processName.startswith('heron-executor-'):
           kill_parent()
         else:
-          firstLine = open(filepath).readline()
-          logger.info("Killing process " + processName + " " + firstLine)
-          os.killpg(int(firstLine), signal.SIGTERM)
+          firstLine = int(open(filepath).readline())
+          logger.info("Killing process " + processName + " " + str(firstLine))
+          os.kill(firstLine, signal.SIGTERM)
           status_finish(200)
       else:
         logger.info(filepath + " not found")

--- a/heron/shell/src/python/handlers/killexecutorhandler.py
+++ b/heron/shell/src/python/handlers/killexecutorhandler.py
@@ -50,18 +50,18 @@ class KillExecutorHandler(tornado.web.RequestHandler):
     instanceId = data.get('instance_id_to_restart')
     if instanceId:
       filepath = instanceId + '.pid'
-      if os.path.isfile(filepath): # process found
+      if os.path.isfile(filepath): # instance_id found
         if instanceId.startswith('heron-executor-'): # kill heron-executor
           kill_parent()
-        else: # kill other normal process
+        else: # kill other normal instance
           fh = open(filepath)
           firstLine = int(fh.readline())
           fh.close()
           logger.info("Killing process " + instanceId + " " + str(firstLine))
           os.kill(firstLine, signal.SIGTERM)
           status_finish(200)
-      else: # process not found
+      else: # instance_id not found
         logger.info(filepath + " not found")
         status_finish(422)
-    else: # process name not given, which means kill the container
+    else: # instance_id not given, which means kill the container
       kill_parent()


### PR DESCRIPTION
During debug, we often need to kill/restart particular process in the container instead of restarting the whole container. This pr adds this feature.

Test on local Mac:
`curl -X POST -d "secret=WordCountTopology17912828-226c-463f-a9e1-76c6a5afd00b" -d "instance_id_to_restart=heron-metricscache" http://localhost:50071/killexecutor`