### PR TITLE
Small fix for Streamlet name and extending UT coverages

### DIFF
--- a/heron/api/src/java/com/twitter/heron/streamlet/SerializablePredicate.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/SerializablePredicate.java
@@ -19,7 +19,7 @@ import java.util.function.Predicate;
 
 /**
  * All user supplied transformation functions have to be serializable.
- * Thus all Strealmet transformation definitions take Serializable
+ * Thus all Streamlet transformation definitions take Serializable
  * Functions as their input. We simply decorate java.util. function
  * definitions with a Serializable tag to ensure that any supplied
  * lambda functions automatically become serializable.

--- a/heron/api/src/java/com/twitter/heron/streamlet/Sink.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/Sink.java
@@ -18,7 +18,7 @@ import java.io.Serializable;
 
 /**
  * Sink is how Streamlet's end. The put method
- * invokation consumes the tuple into say external database/cache, etc.
+ * invocation consumes the tuple into say external database/cache, etc.
  * setup/cleanup is where the sink can do any one time setup work, like
  * establishing/closing connection to sources, etc.
  */

--- a/heron/api/src/java/com/twitter/heron/streamlet/Source.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/Source.java
@@ -19,7 +19,7 @@ import java.util.Collection;
 
 /**
  * Source is how Streamlet's originate. The get method
- * invokation returns new element that form the tuples of the streamlet.
+ * invocation returns new element that form the tuples of the streamlet.
  * setup/cleanup is where the generator can do any one time setup work, like
  * establishing/closing connection to sources, etc.
  */

--- a/heron/api/src/java/com/twitter/heron/streamlet/Streamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/Streamlet.java
@@ -34,7 +34,7 @@ import com.twitter.heron.classification.InterfaceStability;
  * Streamlet. One can think of a transformation attaching itself to the stream and processing
  * each tuple as they go by. Thus the parallelism of any operator is implicitly determined
  * by the number of partitions of the stream that it is operating on. If a particular
- * tranformation wants to operate at a different parallelism, one can repartition the
+ * transformation wants to operate at a different parallelism, one can repartition the
  * Streamlet before doing the transformation.
  */
 @InterfaceStability.Evolving
@@ -180,7 +180,7 @@ public interface Streamlet<R> {
       T identity, SerializableBiFunction<T, R, ? extends T> reduceFn);
 
   /**
-   * Returns a new Streamlet thats the union of this and the ‘other’ streamlet. Essentially
+   * Returns a new Streamlet that is the union of this and the ‘other’ streamlet. Essentially
    * the new streamlet will contain tuples belonging to both Streamlets
   */
   Streamlet<R> union(Streamlet<? extends R> other);

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/StreamletImpl.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/StreamletImpl.java
@@ -66,7 +66,7 @@ import com.twitter.heron.streamlet.impl.streamlets.UnionStreamlet;
  * Streamlet. One can think of a transformation attaching itself to the stream and processing
  * each tuple as they go by. Thus the parallelism of any operator is implicitly determined
  * by the number of partitions of the stream that it is operating on. If a particular
- * tranformation wants to operate at a different parallelism, one can repartition the
+ * transformation wants to operate at a different parallelism, one can repartition the
  * Streamlet before doing the transformation.
  */
 public abstract class StreamletImpl<R> implements Streamlet<R> {
@@ -109,8 +109,8 @@ public abstract class StreamletImpl<R> implements Streamlet<R> {
    */
   @Override
   public Streamlet<R> setName(String sName) {
-    if (sName == null || sName.isEmpty()) {
-      throw new IllegalArgumentException("Streamlet name cannot be null/empty");
+    if (sName == null || sName.trim().isEmpty()) {
+      throw new IllegalArgumentException("Streamlet name cannot be null/blank");
     }
     this.name = sName;
     return this;

--- a/heron/api/tests/java/com/twitter/heron/streamlet/impl/StreamletImplTest.java
+++ b/heron/api/tests/java/com/twitter/heron/streamlet/impl/StreamletImplTest.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -260,9 +261,9 @@ public class StreamletImplTest {
 
   @Test
   public void testResourcesBuilder() {
-    Resources defaultResoures = Resources.defaultResources();
-    assertEquals(0, Float.compare(defaultResoures.getCpu(), 1.0f));
-    assertEquals(defaultResoures.getRam(), 104857600);
+    Resources defaultResources = Resources.defaultResources();
+    assertEquals(0, Float.compare(defaultResources.getCpu(), 1.0f));
+    assertEquals(defaultResources.getRam(), 104857600);
 
     Resources res2 = new Resources.Builder()
         .setCpu(5.1f)
@@ -271,4 +272,23 @@ public class StreamletImplTest {
     assertEquals(0, Float.compare(res2.getCpu(), 5.1f));
     assertEquals(res2.getRam(), 20 * 1024 * 1024);
   }
+
+  @Test
+  public void testSetNameWithInvalidValues() {
+    Streamlet<Double> sample = StreamletImpl.createSupplierStreamlet(() -> Math.random());
+    Function<String, Streamlet<Double>> function = sample::setName;
+    testByFunction(function, null);
+    testByFunction(function, "");
+    testByFunction(function, "  ");
+  }
+
+  private void testByFunction(Function<String, Streamlet<Double>> function, String sName) {
+    try {
+      function.apply(sName);
+      fail("Should have thrown an IllegalArgumentException because streamlet name is invalid");
+    } catch (IllegalArgumentException e) {
+      assertEquals("Streamlet name cannot be null/blank", e.getMessage());
+    }
+  }
+
 }

--- a/heron/uploaders/src/java/com/twitter/heron/uploader/localfs/LocalFileSystemContext.java
+++ b/heron/uploaders/src/java/com/twitter/heron/uploader/localfs/LocalFileSystemContext.java
@@ -18,8 +18,10 @@ import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Context;
 
 public class LocalFileSystemContext extends Context {
-  public static String fileSystemDirectory(Config config) {
+
+  public static String getFileSystemDirectory(Config config) {
     return config.getStringValue(LocalFileSystemKey.FILE_SYSTEM_DIRECTORY.value(),
         LocalFileSystemKey.FILE_SYSTEM_DIRECTORY.getDefaultString());
   }
+
 }

--- a/heron/uploaders/src/java/com/twitter/heron/uploader/localfs/LocalFileSystemUploader.java
+++ b/heron/uploaders/src/java/com/twitter/heron/uploader/localfs/LocalFileSystemUploader.java
@@ -43,7 +43,7 @@ public class LocalFileSystemUploader implements IUploader {
   public void initialize(Config ipconfig) {
     this.config = ipconfig;
 
-    this.destTopologyDirectory = LocalFileSystemContext.fileSystemDirectory(config);
+    this.destTopologyDirectory = LocalFileSystemContext.getFileSystemDirectory(config);
 
     // name of the destination file is the same as the base name of the topology package file
     String fileName =

--- a/heron/uploaders/tests/java/BUILD
+++ b/heron/uploaders/tests/java/BUILD
@@ -49,6 +49,7 @@ java_library(
 java_tests(
   test_classes = [
     "com.twitter.heron.uploader.localfs.LocalFileSystemConfigTest",
+    "com.twitter.heron.uploader.localfs.LocalFileSystemContextTest",
     "com.twitter.heron.uploader.localfs.LocalFileSystemUploaderTest",
   ],
   runtime_deps = [ ":localfs-tests" ],

--- a/heron/uploaders/tests/java/com/twitter/heron/uploader/localfs/LocalFileSystemConfigTest.java
+++ b/heron/uploaders/tests/java/com/twitter/heron/uploader/localfs/LocalFileSystemConfigTest.java
@@ -43,7 +43,7 @@ public class LocalFileSystemConfigTest {
     Config config = Config.toLocalMode(getDefaultConfig());
 
     Assert.assertEquals(
-        LocalFileSystemContext.fileSystemDirectory(config),
+        LocalFileSystemContext.getFileSystemDirectory(config),
         TokenSub.substitute(config, LocalFileSystemKey.FILE_SYSTEM_DIRECTORY.getDefaultString())
     );
   }
@@ -59,7 +59,7 @@ public class LocalFileSystemConfigTest {
             .build());
 
     Assert.assertEquals(
-        LocalFileSystemContext.fileSystemDirectory(config),
+        LocalFileSystemContext.getFileSystemDirectory(config),
         overrideDirectory
     );
   }
@@ -84,7 +84,7 @@ public class LocalFileSystemConfigTest {
 
     Assert.assertEquals(
         Paths.get(uploader.getTopologyFile()).getParent().toString(),
-        LocalFileSystemContext.fileSystemDirectory(config)
+        LocalFileSystemContext.getFileSystemDirectory(config)
     );
   }
 

--- a/heron/uploaders/tests/java/com/twitter/heron/uploader/localfs/LocalFileSystemContextTest.java
+++ b/heron/uploaders/tests/java/com/twitter/heron/uploader/localfs/LocalFileSystemContextTest.java
@@ -1,0 +1,62 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.uploader.localfs;
+
+import java.nio.file.Paths;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.twitter.heron.spi.common.Config;
+import com.twitter.heron.spi.common.Key;
+
+public class LocalFileSystemContextTest {
+
+  @Test
+  public void testGetDefaultFileSystemDirectory() {
+    Config config = Config.newBuilder()
+        .put(Key.CLUSTER, "cluster")
+        .put(Key.ROLE, "role")
+        .put(Key.TOPOLOGY_NAME, "topology")
+        .build();
+
+    String actualFileSystemDirectory = LocalFileSystemContext.getFileSystemDirectory(config);
+
+    // get default file system directory
+    String defaultFileSystemDirectory = Paths.get("${HOME}",
+        ".herondata", "repository", "${CLUSTER}", "${ROLE}", "${TOPOLOGY}").toString();
+
+    Assert.assertEquals(defaultFileSystemDirectory, actualFileSystemDirectory);
+  }
+
+  @Test
+  public void testGetFileSystemDirectory() {
+    String fileSystemDirectory = "${HOME}/.herondata/topologies/${CLUSTER}";
+
+    Config config = Config.newBuilder()
+        .put(Key.CLUSTER, "cluster")
+        .put(Key.ROLE, "role")
+        .put(LocalFileSystemKey.FILE_SYSTEM_DIRECTORY.value(), fileSystemDirectory)
+        .build();
+
+    // get actual file system directory set by the user
+    String actualFileSystemDirectory = LocalFileSystemContext.getFileSystemDirectory(config);
+
+    String expectedFileSystemDirectory = Paths.get("${HOME}",
+        ".herondata", "topologies", "${CLUSTER}").toString();
+
+    Assert.assertEquals(expectedFileSystemDirectory, actualFileSystemDirectory);
+  }
+
+}


### PR DESCRIPTION
This PR aims the following changes:

- `Streamlet`.`setName` can be robust for **blank** values. Also UT coverage is added for invalid cases.
- `LocalFileSystemContextTest` UT coverage is added (to avoid changing hardcoded fileSystemDirectory default value.)
- Minor javadoc updates.