### PR TITLE
Fix sample ComponentJVMOptionsTopology

### DIFF
--- a/examples/src/java/com/twitter/heron/examples/api/ComponentJVMOptionsTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/api/ComponentJVMOptionsTopology.java
@@ -44,7 +44,7 @@ public final class ComponentJVMOptionsTopology {
 
     builder.setSpout("word", new TestWordSpout(), 2);
     builder.setBolt("exclaim1", new ExclamationBolt(), 2)
-        .shuffleGrouping("word");
+        .shuffleGrouping("word").addConfiguration("heron-test-config", "heron-test-key");
 
     Config conf = new Config();
     conf.setDebug(true);
@@ -56,7 +56,7 @@ public final class ComponentJVMOptionsTopology {
     // For each component, both the global and if any the component one will be appended.
     // And the component one will take precedence
     conf.setComponentJvmOptions("word", "-XX:NewSize=300m");
-    conf.setComponentJvmOptions("exclaim1", "-XX:NewSize=800m");
+    conf.setComponentJvmOptions("exclaim1", "-XX:NewSize=300m");
 
     // component resource configuration
     conf.setComponentRam("word", ByteAmount.fromMegabytes(512));

--- a/examples/src/java/com/twitter/heron/examples/api/ComponentJVMOptionsTopology.java
+++ b/examples/src/java/com/twitter/heron/examples/api/ComponentJVMOptionsTopology.java
@@ -44,7 +44,8 @@ public final class ComponentJVMOptionsTopology {
 
     builder.setSpout("word", new TestWordSpout(), 2);
     builder.setBolt("exclaim1", new ExclamationBolt(), 2)
-        .shuffleGrouping("word").addConfiguration("heron-test-config", "heron-test-key");
+        .shuffleGrouping("word")
+        .addConfiguration("test-config", "test-key"); // Sample adding component-specific config
 
     Config conf = new Config();
     conf.setDebug(true);


### PR DESCRIPTION
Currently, ComponentJVMOptionsTopology specifies a NewSize greater than the heap size.
This pull request:
- fixes it
- add the sample to add component-level config for a particular component

Tested with LocalScheduler.