### PR TITLE
Fix the logging of System Config

### DIFF
--- a/heron/common/src/java/com/twitter/heron/common/config/SystemConfig.java
+++ b/heron/common/src/java/com/twitter/heron/common/config/SystemConfig.java
@@ -43,6 +43,11 @@ public final class SystemConfig {
     return Builder.create(loadDefaults);
   }
 
+  @Override
+  public String toString() {
+    return this.config.toString();
+  }
+
   public ByteAmount getInstanceNetworkOptionsMaximumPacketSize() {
     return getByteAmount(
         SystemConfigKey.INSTANCE_NETWORK_OPTIONS_MAXIMUM_PACKETSIZE_BYTES);
@@ -325,7 +330,7 @@ public final class SystemConfig {
     private static void convertAndAdd(Map<String, Object> config,
                                       SystemConfigKey key, Object value) {
       if (key != null) { // sometimes config have non-java configs without an enum SystemConfigKey
-        switch(key.getType()) {
+        switch (key.getType()) {
           case BOOLEAN:
             config.put(key.value(), TypeUtils.getBoolean(value));
             break;

--- a/heron/instance/src/java/com/twitter/heron/instance/HeronInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/HeronInstance.java
@@ -311,7 +311,7 @@ public class HeronInstance {
 
     LOG.info(logMsg);
 
-    LOG.info("System Config: " + systemConfig);
+    LOG.info("System Config: " + systemConfig.toString());
 
     HeronInstance heronInstance =
         new HeronInstance(topologyName, topologyId, instance, streamPort, metricsPort);


### PR DESCRIPTION
Currently, when heron-instance tries to log the System Config, it will only log the reference value,
since there is no correct override for SystemConfig.toString().

This pull request fixes this issue by overriding the SystemConfig.toString().

Tested with LocalScheduler.