### PR TITLE
Remove unused Kubernetes config

### DIFF
--- a/heron/config/src/yaml/conf/kubernetes/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/kubernetes/heron_internals.yaml
@@ -254,8 +254,6 @@ heron.instance.reconnect.metricsmgr.times: 60
 # The interval in second for an instance to sample its system metrics, for instance, cpu load.
 heron.instance.metrics.system.sample.interval.sec: 10
 
-heron.instance.slave.fetch.pplan.interval.sec: 1
-
 # For efficient acknowledgement
 heron.instance.acknowledgement.nbuckets: 10
 


### PR DESCRIPTION
This config isn't actually being used anywhere in the Heron codebase. Best to remove it for the sake of reducing cognitive load.