### PR TITLE
Log when stmgr broadcasts physical plan

### DIFF
--- a/heron/stmgr/src/cpp/manager/instance-server.cpp
+++ b/heron/stmgr/src/cpp/manager/instance-server.cpp
@@ -409,6 +409,7 @@ void InstanceServer::BroadcastNewPhysicalPlan(const proto::system::PhysicalPlan&
   proto::stmgr::NewInstanceAssignmentMessage new_assignment;
   new_assignment.mutable_pplan()->CopyFrom(_pplan);
   for (auto iter = active_instances_.begin(); iter != active_instances_.end(); ++iter) {
+    LOG(INFO) << "Sending new physical plan to instance with task_id: " << iter->second;
     SendMessage(iter->first, new_assignment);
   }
 }


### PR DESCRIPTION
Currently, it is hard to trace the destination instances that a stmgr sends new physical plan to,
especially during run-time scaling.
This pull request logs it down for better tracing and debug.

Tested with LocalScheduler.