### PR TITLE
[Streamlet] Add ConsumerStreamlet name to stageNames Set to avoid duplication

### DIFF
--- a/heron/api/src/java/com/twitter/heron/streamlet/SerializableConsumer.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/SerializableConsumer.java
@@ -19,7 +19,7 @@ import java.util.function.Consumer;
 
 /**
  * All user supplied transformation functions have to be serializable.
- * Thus all Strealmet transformation definitions take Serializable
+ * Thus all Streamlet transformation definitions take Serializable
  * Functions as their input. We simply decorate java.util. function
  * definitions with a Serializable tag to ensure that any supplied
  * lambda functions automatically become serializable.

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/ConsumerStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/ConsumerStreamlet.java
@@ -22,7 +22,7 @@ import com.twitter.heron.streamlet.impl.StreamletImpl;
 import com.twitter.heron.streamlet.impl.sinks.ConsumerSink;
 
 /**
- * ConsumerStreamlet represents en empty Streamlet that is made up of elements from the parent
+ * ConsumerStreamlet represents an empty Streamlet that is made up of elements from the parent
  * streamlet after consuming every element. Since elements of the parents are just consumed
  * by the user passed consumer function, nothing is emitted, thus this streamlet is empty.
  */
@@ -40,6 +40,7 @@ public class ConsumerStreamlet<R> extends StreamletImpl<R> {
   @Override
   public boolean doBuild(TopologyBuilder bldr, Set<String> stageNames) {
     setDefaultNameIfNone(NAMEPREFIX, stageNames);
+    stageNames.add(getName());
     bldr.setBolt(getName(), new ConsumerSink<>(consumer),
         getNumPartitions()).shuffleGrouping(parent.getName());
     return true;


### PR DESCRIPTION
This PR aims the following changes:

- Adding `ConsumerStreamlet` name to `stageNames` Set to avoid duplication
- UT coverage is added for **default** calculated Streamlet name
- Adding minor javadoc updates