### PR TITLE
Fix wrong stmgr log

### DIFF
--- a/heron/stmgr/src/cpp/manager/stmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr.cpp
@@ -549,8 +549,8 @@ void StMgr::NewPhysicalPlan(proto::system::PhysicalPlan* _pplan) {
   if (!pplan_) {
     LOG(INFO) << "This is the first time we received the physical plan";
   } else if (_pplan->topology().state() != pplan_->topology().state()) {
-    LOG(INFO) << "Topology state changed from " << _pplan->topology().state() << " to "
-              << pplan_->topology().state();
+    LOG(INFO) << "Topology state changed from " << pplan_->topology().state() << " to "
+              << _pplan->topology().state();
   }
   proto::api::TopologyState st = _pplan->topology().state();
   _pplan->clear_topology();


### PR DESCRIPTION
Currently, the stmgr logs incorrectly for state change: it logs the new state to old state.
This pull requests fixes it by logging the old state to new state.