### PR TITLE
Add batch support for AuroraScheduler to remove containers

### DIFF
--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraCLIController.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraCLIController.java
@@ -101,6 +101,8 @@ class AuroraCLIController implements AuroraController {
     //aurora job kill <cluster>/<role>/<env>/<name>/<instance_ids>
     List<String> auroraCmd = new ArrayList<>(Arrays.asList(
         "aurora", "job", "kill", jobSpec + "/" + instancesToKill));
+
+    appendAuroraCommandOptions(auroraCmd, isVerbose);
     LOG.info(String.format(
         "Killing %s aurora containers: %s", containersToRemove.size(), auroraCmd));
     if (!runProcess(auroraCmd)) {

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraCLIController.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraCLIController.java
@@ -116,6 +116,11 @@ class AuroraCLIController implements AuroraController {
     //clone instance 0
     List<String> auroraCmd = new ArrayList<>(Arrays.asList(
         "aurora", "job", "add", "--wait-until", "RUNNING", jobSpec + "/0", count.toString()));
+
+    if (isVerbose) {
+      auroraCmd.add("--verbose");
+    }
+
     LOG.info(String.format("Requesting %s new aurora containers %s", count, auroraCmd));
     if (!runProcess(auroraCmd)) {
       throw new RuntimeException("Failed to create " + count + " new aurora instances");

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraCLIControllerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraCLIControllerTest.java
@@ -71,7 +71,7 @@ public class AuroraCLIControllerTest {
   public void testCreateJob() throws Exception {
     Map<AuroraField, String> bindings = new HashMap<>();
     List<String> expectedCommand = asList("aurora job create --wait-until RUNNING %s %s %s",
-            JOB_SPEC, AURORA_FILENAME, VERBOSE_CONFIG);
+        JOB_SPEC, AURORA_FILENAME, VERBOSE_CONFIG);
 
     // Failed
     Mockito.doReturn(false).when(controller).runProcess(Matchers.anyListOf(String.class));
@@ -129,7 +129,8 @@ public class AuroraCLIControllerTest {
     containers.add(PackingTestUtils.testContainerPlan(3));
     containers.add(PackingTestUtils.testContainerPlan(5));
 
-    List<String> expectedCommand = asList("aurora job kill %s/3,5", JOB_SPEC);
+    List<String> expectedCommand = asList("aurora job kill %s/3,5 %s %s %d",
+        JOB_SPEC, VERBOSE_CONFIG, BATCH_CONFIG, Integer.MAX_VALUE);
 
     Mockito.doReturn(true).when(controller).runProcess(Matchers.anyListOf(String.class));
     controller.removeContainers(containers);
@@ -140,7 +141,8 @@ public class AuroraCLIControllerTest {
   public void testAddContainers() {
     Integer containersToAdd = 3;
     List<String> expectedCommand = asList(
-        "aurora job add --wait-until RUNNING %s/0 %s", JOB_SPEC, containersToAdd.toString());
+        "aurora job add --wait-until RUNNING %s/0 %s %s",
+        JOB_SPEC, containersToAdd.toString(), VERBOSE_CONFIG);
 
     Mockito.doReturn(true).when(controller).runProcess(Matchers.anyListOf(String.class));
     controller.addContainers(containersToAdd);


### PR DESCRIPTION
Currently, the AuroraScheduler will remove containers one by one, very slow.

This pull request allows AuroraScheduler to remove containers in one batch.
It also makes the verbose option effectively for adding containers.