### PR TITLE
Fix for "Marathon scheduler generates json based on "old method""

### DIFF
--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/marathon/MarathonScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/marathon/MarathonScheduler.java
@@ -127,7 +127,7 @@ public class MarathonScheduler implements IScheduler {
     for (int i = 0; i < Runtime.numContainers(runtime); i++) {
       ObjectNode instance = mapper.createObjectNode();
 
-      instance.put(MarathonConstants.ID, "/"+Runtime.topologyName(runtime)+"/"+Integer.toString(i));
+      instance.put(MarathonConstants.ID, "/" + Runtime.topologyName(runtime) + "/" + Integer.toString(i));
       instance.put(MarathonConstants.COMMAND, getExecutorCommand(i));
       instance.put(MarathonConstants.CPU, containerResource.getCpu());
       instance.set(MarathonConstants.CONTAINER, getContainer(mapper));
@@ -142,7 +142,7 @@ public class MarathonScheduler implements IScheduler {
 
     // Create marathon group for a topology
     ObjectNode appConf = mapper.createObjectNode();
-    appConf.put(MarathonConstants.ID, "/"+Runtime.topologyName(runtime));
+    appConf.put(MarathonConstants.ID, "/" + Runtime.topologyName(runtime));
     appConf.set(MarathonConstants.APPS, instances);
 
     return appConf.toString();

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/marathon/MarathonScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/marathon/MarathonScheduler.java
@@ -127,7 +127,7 @@ public class MarathonScheduler implements IScheduler {
     for (int i = 0; i < Runtime.numContainers(runtime); i++) {
       ObjectNode instance = mapper.createObjectNode();
 
-      instance.put(MarathonConstants.ID, Integer.toString(i));
+      instance.put(MarathonConstants.ID, "/"+Runtime.topologyName(runtime)+"/"+Integer.toString(i)); //Absolute paths need to go.
       instance.put(MarathonConstants.COMMAND, getExecutorCommand(i));
       instance.put(MarathonConstants.CPU, containerResource.getCpu());
       instance.set(MarathonConstants.CONTAINER, getContainer(mapper));
@@ -142,7 +142,7 @@ public class MarathonScheduler implements IScheduler {
 
     // Create marathon group for a topology
     ObjectNode appConf = mapper.createObjectNode();
-    appConf.put(MarathonConstants.ID, Runtime.topologyName(runtime));
+    appConf.put(MarathonConstants.ID, "/"+Runtime.topologyName(runtime));
     appConf.set(MarathonConstants.APPS, instances);
 
     return appConf.toString();

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/marathon/MarathonScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/marathon/MarathonScheduler.java
@@ -127,7 +127,8 @@ public class MarathonScheduler implements IScheduler {
     for (int i = 0; i < Runtime.numContainers(runtime); i++) {
       ObjectNode instance = mapper.createObjectNode();
 
-      instance.put(MarathonConstants.ID, "/" + Runtime.topologyName(runtime) + "/" + Integer.toString(i));
+      instance.put(MarathonConstants.ID,
+                   "/" + Runtime.topologyName(runtime) + "/" + Integer.toString(i));
       instance.put(MarathonConstants.COMMAND, getExecutorCommand(i));
       instance.put(MarathonConstants.CPU, containerResource.getCpu());
       instance.set(MarathonConstants.CONTAINER, getContainer(mapper));

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/marathon/MarathonScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/marathon/MarathonScheduler.java
@@ -127,7 +127,7 @@ public class MarathonScheduler implements IScheduler {
     for (int i = 0; i < Runtime.numContainers(runtime); i++) {
       ObjectNode instance = mapper.createObjectNode();
 
-      instance.put(MarathonConstants.ID, "/"+Runtime.topologyName(runtime)+"/"+Integer.toString(i)); //Absolute paths need to go.
+      instance.put(MarathonConstants.ID, "/"+Runtime.topologyName(runtime)+"/"+Integer.toString(i));
       instance.put(MarathonConstants.COMMAND, getExecutorCommand(i));
       instance.put(MarathonConstants.CPU, containerResource.getCpu());
       instance.set(MarathonConstants.CONTAINER, getContainer(mapper));


### PR DESCRIPTION
See issue: https://github.com/twitter/heron/issues/2581

This works around the current errors on marathon.


I figured it might be optimal to allow for a self-declared "headgroup"/"topology"/"0...1" but did not implement this for the current pull request as that change would be more intrusive.

This is merely a bugfix for upcoming versions of marathon that will enforce absolute pathing in the POST message as per example: https://github.com/mesosphere/marathon/commit/261880df99113f0e1b3e03791e0850b1da2457d1