### PR TITLE
Add the ability to mount volumes for topologies in k8s.

### DIFF
--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/kubernetes/KubernetesConstants.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/kubernetes/KubernetesConstants.java
@@ -94,5 +94,5 @@ public final class KubernetesConstants {
       )
   );
 
-  static final String HOST_PATH_VOLUME = "hostPort";
+  static final String HOST_PATH_VOLUME = "hostPath";
 }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/kubernetes/KubernetesConstants.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/kubernetes/KubernetesConstants.java
@@ -93,4 +93,6 @@ public final class KubernetesConstants {
           "Never"
       )
   );
+
+  static final String HOST_PATH_VOLUME = "hostPort";
 }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/kubernetes/KubernetesContext.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/kubernetes/KubernetesContext.java
@@ -28,6 +28,17 @@ public final class KubernetesContext extends Context {
   public static final String HERON_KUBERNETES_SCHEDULER_IMAGE_PULL_POLICY =
       "heron.kubernetes.scheduler.imagePullPolicy";
 
+
+  public static final String HERON_KUBERNETES_VOLUME_NAME = "heron.kubernetes.volume.name";
+  public static final String HERON_KUBERNETES_VOLUME_TYPE = "heron.kubernetes.volume.type";
+  public static final String HERON_KUBERNETES_VOLUME_HOSTPATH_PATH =
+      "heron.kubernetes.volume.hostPath.path";
+
+  public static final String HERON_KUBERNETES_CONTAINER_VOLUME_MOUNT_NAME =
+      "heron.kubernetes.container.volumeMount.name";
+  public static final String HERON_KUBERNETES_CONTAINER_VOLUME_MOUNT_PATH =
+      "heron.kubernetes.container.volumeMount.path";
+
   private KubernetesContext() {
   }
 
@@ -49,6 +60,40 @@ public final class KubernetesContext extends Context {
 
   public static boolean hasImagePullPolicy(Config config) {
     final String imagePullPolicy = getKubernetesImagePullPolicy(config);
-    return imagePullPolicy != null && !imagePullPolicy.isEmpty();
+    return isNotEmpty(imagePullPolicy);
+  }
+
+  static String getVolumeType(Config config) {
+    return config.getStringValue(HERON_KUBERNETES_VOLUME_TYPE);
+  }
+
+  static String getVolumeName(Config config) {
+    return config.getStringValue(HERON_KUBERNETES_VOLUME_NAME);
+  }
+
+  static String getHostPathVolumePath(Config config) {
+    return config.getStringValue(HERON_KUBERNETES_VOLUME_HOSTPATH_PATH);
+  }
+
+  static boolean hasVolume(Config config) {
+    return isNotEmpty(getVolumeType(config));
+  }
+
+  static String getContainerVolumeName(Config config) {
+    return config.getStringValue(HERON_KUBERNETES_CONTAINER_VOLUME_MOUNT_NAME);
+  }
+
+  static String getContainerVolumeMountPath(Config config) {
+    return config.getStringValue(HERON_KUBERNETES_CONTAINER_VOLUME_MOUNT_PATH);
+  }
+
+  public static boolean hasContainerVolume(Config config) {
+    final String name = getContainerVolumeName(config);
+    final String path = getContainerVolumeMountPath(config);
+    return isNotEmpty(name) && isNotEmpty(path);
+  }
+
+  private static boolean isNotEmpty(String s) {
+    return s != null && !s.isEmpty();
   }
 }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/kubernetes/Volumes.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/kubernetes/Volumes.java
@@ -26,7 +26,7 @@ final class Volumes {
   private final Map<String, VolumeFactory> volumes = new HashMap<>();
 
   private Volumes() {
-    volumes.put("hostPath", new HostPathVolumeFactory());
+    volumes.put(KubernetesConstants.HOST_PATH_VOLUME, new HostPathVolumeFactory());
   }
 
   static Volumes get() {

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/kubernetes/Volumes.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/kubernetes/Volumes.java
@@ -1,0 +1,64 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.scheduler.kubernetes;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.twitter.heron.spi.common.Config;
+
+import io.kubernetes.client.models.V1HostPathVolumeSource;
+import io.kubernetes.client.models.V1Volume;
+
+final class Volumes {
+
+  private final Map<String, VolumeFactory> volumes = new HashMap<>();
+
+  private Volumes() {
+    volumes.put("hostPath", new HostPathVolumeFactory());
+  }
+
+  static Volumes get() {
+    return new Volumes();
+  }
+
+  V1Volume create(Config config) {
+    final String volumeType = KubernetesContext.getVolumeType(config);
+    if (volumes.containsKey(volumeType)) {
+      return volumes.get(volumeType).create(config);
+    }
+    return null;
+  }
+
+  interface VolumeFactory {
+    V1Volume create(Config config);
+  }
+
+  static class HostPathVolumeFactory implements VolumeFactory {
+    @Override
+    public V1Volume create(Config config) {
+      final String volumeName = KubernetesContext.getVolumeName(config);
+      final V1Volume volume = new V1Volume()
+          .name(volumeName);
+
+      final String path = KubernetesContext.getHostPathVolumePath(config);
+      final V1HostPathVolumeSource hostPathVolume =
+          new V1HostPathVolumeSource()
+              .path(path);
+      volume.hostPath(hostPathVolume);
+
+      return volume;
+    }
+  }
+}

--- a/heron/schedulers/tests/java/BUILD
+++ b/heron/schedulers/tests/java/BUILD
@@ -178,7 +178,8 @@ java_tests(
   test_classes = [
     "com.twitter.heron.scheduler.kubernetes.KubernetesSchedulerTest",
     "com.twitter.heron.scheduler.kubernetes.KubernetesControllerTest",
-    "com.twitter.heron.scheduler.kubernetes.KubernetesLauncherTest"
+    "com.twitter.heron.scheduler.kubernetes.KubernetesLauncherTest",
+    "com.twitter.heron.scheduler.kubernetes.VolumesTests",
   ],
   runtime_deps = [ ":kubernetes-tests" ],
   size = "small",

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/kubernetes/VolumesTests.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/kubernetes/VolumesTests.java
@@ -1,0 +1,45 @@
+//  Copyright 2017 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.scheduler.kubernetes;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.twitter.heron.spi.common.Config;
+
+import io.kubernetes.client.models.V1Volume;
+
+public class VolumesTests {
+
+  @Test
+  public void testNoVolume() {
+    final Config config = Config.newBuilder().build();
+    final V1Volume volume = Volumes.get().create(config);
+    Assert.assertNull(volume);
+  }
+
+  @Test
+  public void testHostPathVolume() {
+    final String path = "/test/dir1";
+    final Config config = Config.newBuilder()
+        .put(KubernetesContext.HERON_KUBERNETES_VOLUME_TYPE, "hostPath")
+        .put(KubernetesContext.HERON_KUBERNETES_VOLUME_HOSTPATH_PATH, path)
+        .build();
+
+    V1Volume volume = Volumes.get().create(config);
+    Assert.assertNotNull(volume);
+    Assert.assertNotNull(volume.getHostPath());
+    Assert.assertEquals(volume.getHostPath().getPath(), path);
+  }
+}

--- a/heron/tools/cli/src/python/main.py
+++ b/heron/tools/cli/src/python/main.py
@@ -178,6 +178,10 @@ def server_deployment_mode(command, parser, cluster, cl_args):
     Log.error('No service url for %s cluster in %s', cluster, config_file)
     sys.exit(1)
 
+  # get overrides
+  if 'config_property' in cl_args:
+    pass
+
   try:
     cluster_role_env = (cl_args['cluster'], cl_args['role'], cl_args['environ'])
     config.server_mode_cluster_role_env(cluster_role_env, client_confs)
@@ -212,7 +216,7 @@ def direct_deployment_mode(command, parser, cluster, cl_args):
   cluster = cl_args['cluster']
   try:
     config_path = cl_args['config_path']
-    override_config_file = config.parse_override_config(cl_args['config_property'])
+    override_config_file = config.parse_override_config_and_write_file(cl_args['config_property'])
   except KeyError:
     # if some of the arguments are not found, print error and exit
     subparser = config.get_subparser(parser, command)

--- a/heron/tools/cli/src/python/submit.py
+++ b/heron/tools/cli/src/python/submit.py
@@ -162,6 +162,14 @@ def launch_topology_server(cl_args, topology_file, topology_defn_file, topology_
       user=cl_args['submit_user'],
   )
 
+  Log.info("" + str(cl_args))
+  overrides = dict()
+  if 'config_property' in cl_args:
+    overrides = config.parse_override_config(cl_args['config_property'])
+
+  if overrides:
+    data.update(overrides)
+
   if cl_args['dry_run']:
     data["dry_run"] = True
 

--- a/heron/tools/cli/tests/python/client_command_unittest.py
+++ b/heron/tools/cli/tests/python/client_command_unittest.py
@@ -37,7 +37,7 @@ class ClientCommandTest(unittest.TestCase):
     config.get_heron_dir = MagicMock(return_value='/heron/home')
     config.get_java_path = MagicMock(return_value='/usr/lib/bin/java')
     config.get_heron_release_file = MagicMock(return_value='/heron/home/release.yaml')
-    config.parse_override_config = MagicMock(return_value='/heron/home/override.yaml')
+    config.parse_override_config_and_write_file = MagicMock(return_value='/heron/home/override.yaml')
     # Mock result module
     result.render = MagicMock(return_value=None)
     result.is_successful = MagicMock(return_value=True)

--- a/heron/tools/common/src/python/utils/config.py
+++ b/heron/tools/common/src/python/utils/config.py
@@ -382,18 +382,33 @@ def defaults_cluster_role_env(cluster_role_env):
 ################################################################################
 # Parse the command line for overriding the defaults
 ################################################################################
-def parse_override_config(namespace):
-  """Parse the command line for overriding the defaults"""
+def parse_override_config_and_write_file(namespace):
+  """
+  Parse the command line for overriding the defaults and 
+  create an override file.
+  """
+  overrides = parse_override_config(namespace)
   try:
     tmp_dir = tempfile.mkdtemp()
     override_config_file = os.path.join(tmp_dir, OVERRIDE_YAML)
     with open(override_config_file, 'w') as f:
-      for config in namespace:
-        f.write("%s\n" % config.replace('=', ': '))
+      for k, v in overrides.items():
+        f.write("%s:%s\n" % (k, v))
 
     return override_config_file
   except Exception as e:
     raise Exception("Failed to parse override config: %s" % str(e))
+
+
+def parse_override_config(namespace):
+  """Parse the command line for overriding the defaults"""
+  overrides = dict()
+  for config in namespace:
+    kv = config.split("=")
+    if len(kv) != 2:
+      raise Exception("Invalid config property format (%s) expected key=value" % kv)
+    overrides[kv[0]] = kv[1]
+  return overrides
 
 
 def get_java_path():

--- a/heron/tools/common/src/python/utils/config.py
+++ b/heron/tools/common/src/python/utils/config.py
@@ -384,7 +384,7 @@ def defaults_cluster_role_env(cluster_role_env):
 ################################################################################
 def parse_override_config_and_write_file(namespace):
   """
-  Parse the command line for overriding the defaults and 
+  Parse the command line for overriding the defaults and
   create an override file.
   """
   overrides = parse_override_config(namespace)

--- a/heron/tools/common/src/python/utils/config.py
+++ b/heron/tools/common/src/python/utils/config.py
@@ -406,7 +406,7 @@ def parse_override_config(namespace):
   for config in namespace:
     kv = config.split("=")
     if len(kv) != 2:
-      raise Exception("Invalid config property format (%s) expected key=value" % kv)
+      raise Exception("Invalid config property format (%s) expected key=value" % config)
     overrides[kv[0]] = kv[1]
   return overrides
 


### PR DESCRIPTION
This patch add the ability to mount volumes for topologies in kubernetes. It also fixes a couple of submit bugs with the apiserver and cli client. The cli was not sending the override params and the apiserver was not applying the overrides correctly.