### PR TITLE
[Streamlet] Support abstraction and type safety more

### DIFF
--- a/heron/api/src/java/com/twitter/heron/streamlet/SerializableFunction.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/SerializableFunction.java
@@ -19,7 +19,7 @@ import java.util.function.Function;
 
 /**
  * All user supplied transformation functions have to be serializable.
- * Thus all Strealmet transformation definitions take Serializable
+ * Thus all Streamlet transformation definitions take Serializable
  * Functions as their input. We simply decorate java.util. function
  * definitions with a Serializable tag to ensure that any supplied
  * lambda functions automatically become serializable.

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/StreamletImpl.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/StreamletImpl.java
@@ -151,6 +151,12 @@ public abstract class StreamletImpl<R> implements Streamlet<R> {
     return name;
   }
 
+  /**
+   * Sets a default unique name to the Streamlet by type if it is not set.
+   * If it is already set, just checks its uniqueness.
+   * @param prefix The name prefix type of this streamlet
+   * @param stageNames The collections of created streamlet/stage names
+   */
   protected void setDefaultNameIfNone(String prefix, Set<String> stageNames) {
     if (getName() == null) {
       setName(defaultNameCalculator(prefix, stageNames));
@@ -159,6 +165,7 @@ public abstract class StreamletImpl<R> implements Streamlet<R> {
       throw new RuntimeException(String.format(
           "The stage name %s is used multiple times in the same topology", getName()));
     }
+    stageNames.add(getName());
   }
 
   /**
@@ -213,7 +220,7 @@ public abstract class StreamletImpl<R> implements Streamlet<R> {
     children.add(child);
   }
 
-  protected String defaultNameCalculator(String prefix, Set<String> stageNames) {
+  private String defaultNameCalculator(String prefix, Set<String> stageNames) {
     int index = 1;
     String calculatedName;
     while (true) {

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/StreamletImpl.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/StreamletImpl.java
@@ -153,7 +153,7 @@ public abstract class StreamletImpl<R> implements Streamlet<R> {
 
   /**
    * Sets a default unique name to the Streamlet by type if it is not set.
-   * If it is already set, just checks its uniqueness.
+   * Otherwise, just checks its uniqueness.
    * @param prefix The name prefix type of this streamlet
    * @param stageNames The collections of created streamlet/stage names
    */

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/StreamletImpl.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/StreamletImpl.java
@@ -154,7 +154,7 @@ public abstract class StreamletImpl<R> implements Streamlet<R> {
   /**
    * Sets a default unique name to the Streamlet by type if it is not set.
    * Otherwise, just checks its uniqueness.
-   * @param prefix The name prefix type of this streamlet
+   * @param prefix The name prefix of this streamlet
    * @param stageNames The collections of created streamlet/stage names
    */
   protected void setDefaultNameIfNone(String prefix, Set<String> stageNames) {

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/ConsumerStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/ConsumerStreamlet.java
@@ -29,7 +29,6 @@ import com.twitter.heron.streamlet.impl.sinks.ConsumerSink;
 public class ConsumerStreamlet<R> extends StreamletImpl<R> {
   private StreamletImpl<R> parent;
   private SerializableConsumer<R> consumer;
-  private static final String NAMEPREFIX = "consumer";
 
   public ConsumerStreamlet(StreamletImpl<R> parent, SerializableConsumer<R> consumer) {
     this.parent = parent;
@@ -40,7 +39,6 @@ public class ConsumerStreamlet<R> extends StreamletImpl<R> {
   @Override
   public boolean doBuild(TopologyBuilder bldr, Set<String> stageNames) {
     setDefaultNameIfNone(StreamletNamePrefixes.CONSUMER.toString(), stageNames);
-    stageNames.add(getName());
     bldr.setBolt(getName(), new ConsumerSink<>(consumer),
         getNumPartitions()).shuffleGrouping(parent.getName());
     return true;

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/FilterStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/FilterStreamlet.java
@@ -28,7 +28,6 @@ import com.twitter.heron.streamlet.impl.operators.FilterOperator;
 public class FilterStreamlet<R> extends StreamletImpl<R> {
   private StreamletImpl<R> parent;
   private SerializablePredicate<? super R> filterFn;
-  private static final String NAMEPREFIX = "filter";
 
   public FilterStreamlet(StreamletImpl<R> parent, SerializablePredicate<? super R> filterFn) {
     this.parent = parent;
@@ -39,7 +38,6 @@ public class FilterStreamlet<R> extends StreamletImpl<R> {
   @Override
   public boolean doBuild(TopologyBuilder bldr, Set<String> stageNames) {
     setDefaultNameIfNone(StreamletNamePrefixes.FILTER.toString(), stageNames);
-    stageNames.add(getName());
     bldr.setBolt(getName(), new FilterOperator<R>(filterFn),
         getNumPartitions()).shuffleGrouping(parent.getName());
     return true;

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/FlatMapStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/FlatMapStreamlet.java
@@ -29,7 +29,6 @@ import com.twitter.heron.streamlet.impl.operators.FlatMapOperator;
 public class FlatMapStreamlet<R, T> extends StreamletImpl<T> {
   private StreamletImpl<R> parent;
   private SerializableFunction<? super R, ? extends Iterable<? extends T>> flatMapFn;
-  private static final String NAMEPREFIX = "flatmap";
 
   public FlatMapStreamlet(StreamletImpl<R> parent,
                           SerializableFunction<? super R,
@@ -42,7 +41,6 @@ public class FlatMapStreamlet<R, T> extends StreamletImpl<T> {
   @Override
   public boolean doBuild(TopologyBuilder bldr, Set<String> stageNames) {
     setDefaultNameIfNone(StreamletNamePrefixes.FLATMAP.toString(), stageNames);
-    stageNames.add(getName());
     bldr.setBolt(getName(), new FlatMapOperator<R, T>(flatMapFn),
         getNumPartitions()).shuffleGrouping(parent.getName());
     return true;

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/GeneralReduceByKeyAndWindowStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/GeneralReduceByKeyAndWindowStreamlet.java
@@ -41,7 +41,6 @@ public class GeneralReduceByKeyAndWindowStreamlet<K, V, VR>
   private WindowConfigImpl windowCfg;
   private VR identity;
   private SerializableBiFunction<VR, V, ? extends VR> reduceFn;
-  private static final String NAMEPREFIX = "reduceByKeyAndWindow";
 
   public GeneralReduceByKeyAndWindowStreamlet(StreamletImpl<V> parent,
                             SerializableFunction<V, K> keyExtractor,
@@ -59,7 +58,6 @@ public class GeneralReduceByKeyAndWindowStreamlet<K, V, VR>
   @Override
   public boolean doBuild(TopologyBuilder bldr, Set<String> stageNames) {
     setDefaultNameIfNone(StreamletNamePrefixes.REDUCE.toString(), stageNames);
-    stageNames.add(getName());
     GeneralReduceByKeyAndWindowOperator<K, V, VR> bolt =
         new GeneralReduceByKeyAndWindowOperator<K, V, VR>(keyExtractor, identity, reduceFn);
     windowCfg.attachWindowConfig(bolt);

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/JoinStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/JoinStreamlet.java
@@ -43,7 +43,6 @@ public final class JoinStreamlet<K, R, S, T> extends StreamletImpl<KeyValue<Keye
   private SerializableFunction<S, K> rightKeyExtractor;
   private WindowConfigImpl windowCfg;
   private SerializableBiFunction<R, S, ? extends T> joinFn;
-  private static final String NAMEPREFIX = "join";
 
   public static <A, B, C, D> JoinStreamlet<A, B, C, D>
       createJoinStreamlet(StreamletImpl<B> left,
@@ -83,7 +82,6 @@ public final class JoinStreamlet<K, R, S, T> extends StreamletImpl<KeyValue<Keye
       return false;
     }
     setDefaultNameIfNone(StreamletNamePrefixes.JOIN.toString(), stageNames);
-    stageNames.add(getName());
     JoinOperator<K, R, S, T> bolt = new JoinOperator<>(joinType, left.getName(),
         right.getName(), leftKeyExtractor, rightKeyExtractor, joinFn);
     windowCfg.attachWindowConfig(bolt);

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/LogStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/LogStreamlet.java
@@ -27,7 +27,6 @@ import com.twitter.heron.streamlet.impl.sinks.LogSink;
  */
 public class LogStreamlet<R> extends StreamletImpl<R> {
   private StreamletImpl<R> parent;
-  private static final String NAMEPREFIX = "logger";
 
   public LogStreamlet(StreamletImpl<R> parent) {
     this.parent = parent;
@@ -37,7 +36,6 @@ public class LogStreamlet<R> extends StreamletImpl<R> {
   @Override
   public boolean doBuild(TopologyBuilder bldr, Set<String> stageNames) {
     setDefaultNameIfNone(StreamletNamePrefixes.LOGGER.toString(), stageNames);
-    stageNames.add(getName());
     bldr.setBolt(getName(), new LogSink<R>(),
         getNumPartitions()).shuffleGrouping(parent.getName());
     return true;

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/MapStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/MapStreamlet.java
@@ -28,7 +28,6 @@ import com.twitter.heron.streamlet.impl.operators.MapOperator;
 public class MapStreamlet<R, T> extends StreamletImpl<T> {
   private StreamletImpl<R> parent;
   private SerializableFunction<? super R, ? extends T> mapFn;
-  private static final String NAMEPREFIX = "map";
 
   public MapStreamlet(StreamletImpl<R> parent, SerializableFunction<? super R, ? extends T> mapFn) {
     this.parent = parent;
@@ -39,7 +38,6 @@ public class MapStreamlet<R, T> extends StreamletImpl<T> {
   @Override
   public boolean doBuild(TopologyBuilder bldr, Set<String> stageNames) {
     setDefaultNameIfNone(StreamletNamePrefixes.MAP.toString(), stageNames);
-    stageNames.add(getName());
     bldr.setBolt(getName(), new MapOperator<R, T>(mapFn),
         getNumPartitions()).shuffleGrouping(parent.getName());
     return true;

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/ReduceByKeyAndWindowStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/ReduceByKeyAndWindowStreamlet.java
@@ -41,7 +41,6 @@ public class ReduceByKeyAndWindowStreamlet<K, V, R>
   private SerializableFunction<R, V> valueExtractor;
   private WindowConfigImpl windowCfg;
   private SerializableBinaryOperator<V> reduceFn;
-  private static final String NAMEPREFIX = "reduceByKeyAndWindow";
 
   public ReduceByKeyAndWindowStreamlet(StreamletImpl<R> parent,
                        SerializableFunction<R, K> keyExtractor,
@@ -59,7 +58,6 @@ public class ReduceByKeyAndWindowStreamlet<K, V, R>
   @Override
   public boolean doBuild(TopologyBuilder bldr, Set<String> stageNames) {
     setDefaultNameIfNone(StreamletNamePrefixes.REDUCE.toString(), stageNames);
-    stageNames.add(getName());
     ReduceByKeyAndWindowOperator<K, V, R> bolt = new ReduceByKeyAndWindowOperator<>(keyExtractor,
         valueExtractor, reduceFn);
     windowCfg.attachWindowConfig(bolt);

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/RemapStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/RemapStreamlet.java
@@ -33,7 +33,6 @@ import com.twitter.heron.streamlet.impl.operators.MapOperator;
 public class RemapStreamlet<R> extends StreamletImpl<R> {
   private StreamletImpl<R> parent;
   private SerializableBiFunction<? super R, Integer, List<Integer>> remapFn;
-  private static final String NAMEPREFIX = "remap";
 
   public RemapStreamlet(StreamletImpl<R> parent,
                         SerializableBiFunction<? super R, Integer, List<Integer>> remapFn) {
@@ -45,7 +44,6 @@ public class RemapStreamlet<R> extends StreamletImpl<R> {
   @Override
   public boolean doBuild(TopologyBuilder bldr, Set<String> stageNames) {
     setDefaultNameIfNone(StreamletNamePrefixes.REMAP.toString(), stageNames);
-    stageNames.add(getName());
     bldr.setBolt(getName(), new MapOperator<R, R>((a) -> a),
         getNumPartitions())
         .customGrouping(parent.getName(), new RemapCustomGrouping<R>(remapFn));

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/SinkStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/SinkStreamlet.java
@@ -29,7 +29,6 @@ import com.twitter.heron.streamlet.impl.sinks.ComplexSink;
 public class SinkStreamlet<R> extends StreamletImpl<R> {
   private StreamletImpl<R> parent;
   private Sink<R> sink;
-  private static final String NAMEPREFIX = "sink";
 
   public SinkStreamlet(StreamletImpl<R> parent, Sink<R> sink) {
     this.parent = parent;
@@ -40,7 +39,6 @@ public class SinkStreamlet<R> extends StreamletImpl<R> {
   @Override
   public boolean doBuild(TopologyBuilder bldr, Set<String> stageNames) {
     setDefaultNameIfNone(StreamletNamePrefixes.SINK.toString(), stageNames);
-    stageNames.add(getName());
     bldr.setBolt(getName(), new ComplexSink<>(sink),
         getNumPartitions()).shuffleGrouping(parent.getName());
     return true;

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/SourceStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/SourceStreamlet.java
@@ -28,7 +28,6 @@ import com.twitter.heron.streamlet.impl.sources.ComplexSource;
  */
 public class SourceStreamlet<R> extends StreamletImpl<R> {
   private Source<R> generator;
-  private static final String NAMEPREFIX = "generator";
 
   public SourceStreamlet(Source<R> generator) {
     this.generator = generator;
@@ -38,7 +37,6 @@ public class SourceStreamlet<R> extends StreamletImpl<R> {
   @Override
   public boolean doBuild(TopologyBuilder bldr, Set<String> stageNames) {
     setDefaultNameIfNone(StreamletNamePrefixes.SOURCE.toString(), stageNames);
-    stageNames.add(getName());
     bldr.setSpout(getName(), new ComplexSource<R>(generator), getNumPartitions());
     return true;
   }

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/SupplierStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/SupplierStreamlet.java
@@ -28,7 +28,6 @@ import com.twitter.heron.streamlet.impl.sources.SupplierSource;
  */
 public class SupplierStreamlet<R> extends StreamletImpl<R> {
   private SerializableSupplier<R> supplier;
-  private static final String NAMEPREFIX = "supplier";
 
   public SupplierStreamlet(SerializableSupplier<R> supplier) {
     this.supplier = supplier;
@@ -38,7 +37,6 @@ public class SupplierStreamlet<R> extends StreamletImpl<R> {
   @Override
   public boolean doBuild(TopologyBuilder bldr, Set<String> stageNames) {
     setDefaultNameIfNone(StreamletNamePrefixes.SUPPLIER.toString(), stageNames);
-    stageNames.add(getName());
     bldr.setSpout(getName(), new SupplierSource<R>(supplier), getNumPartitions());
     return true;
   }

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/TransformStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/TransformStreamlet.java
@@ -30,7 +30,6 @@ import com.twitter.heron.streamlet.impl.operators.TransformOperator;
 public class TransformStreamlet<R, T> extends StreamletImpl<T> {
   private StreamletImpl<R> parent;
   private SerializableTransformer<? super R, ? extends T> serializableTransformer;
-  private static final String NAMEPREFIX = "transform";
 
   public TransformStreamlet(StreamletImpl<R> parent,
                        SerializableTransformer<? super R, ? extends T> serializableTransformer) {
@@ -42,7 +41,6 @@ public class TransformStreamlet<R, T> extends StreamletImpl<T> {
   @Override
   public boolean doBuild(TopologyBuilder bldr, Set<String> stageNames) {
     setDefaultNameIfNone(StreamletNamePrefixes.TRANSFORM.toString(), stageNames);
-    stageNames.add(getName());
     bldr.setBolt(getName(), new TransformOperator<R, T>(serializableTransformer),
         getNumPartitions()).shuffleGrouping(parent.getName());
     return true;

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/UnionStreamlet.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/streamlets/UnionStreamlet.java
@@ -27,7 +27,6 @@ import com.twitter.heron.streamlet.impl.operators.UnionOperator;
 public class UnionStreamlet<I> extends StreamletImpl<I> {
   private StreamletImpl<I> left;
   private StreamletImpl<? extends I> right;
-  private static final String NAMEPREFIX = "union";
 
   public UnionStreamlet(StreamletImpl<I> left, StreamletImpl<? extends I> right) {
     this.left = left;
@@ -43,7 +42,6 @@ public class UnionStreamlet<I> extends StreamletImpl<I> {
       return false;
     }
     setDefaultNameIfNone(StreamletNamePrefixes.UNION.toString(), stageNames);
-    stageNames.add(getName());
     bldr.setBolt(getName(), new UnionOperator<I>(),
         getNumPartitions()).shuffleGrouping(left.getName()).shuffleGrouping(right.getName());
     return true;

--- a/heron/api/tests/java/com/twitter/heron/streamlet/impl/StreamletImplTest.java
+++ b/heron/api/tests/java/com/twitter/heron/streamlet/impl/StreamletImplTest.java
@@ -314,6 +314,62 @@ public class StreamletImplTest {
   }
 
   @Test
+  public void testDefaultStreamletNameIfNotSet() {
+    // create SupplierStreamlet
+    Streamlet<String> baseStreamlet = StreamletImpl.createSupplierStreamlet(() ->
+        "This is test content");
+    SupplierStreamlet<String> supplierStreamlet = (SupplierStreamlet<String>) baseStreamlet;
+    Set<String> stageNames = new HashSet<>();
+
+    // set default name by streamlet name prefix
+    supplierStreamlet.setDefaultNameIfNone(
+        StreamletImpl.StreamletNamePrefixes.SUPPLIER.toString(), stageNames);
+
+    // verify stageNames
+    assertEquals(1, stageNames.size());
+    assertTrue(stageNames.containsAll(Arrays.asList("supplier1")));
+  }
+
+  @Test
+  public void testStreamletNameIfAlreadySet() {
+    String supplierName = "MyStringSupplier";
+    // create SupplierStreamlet
+    Streamlet<String> baseStreamlet = StreamletImpl.createSupplierStreamlet(() ->
+        "This is test content");
+    SupplierStreamlet<String> supplierStreamlet = (SupplierStreamlet<String>) baseStreamlet;
+    supplierStreamlet.setName(supplierName);
+    Set<String> stageNames = new HashSet<>();
+
+    // set default name by streamlet name prefix
+    supplierStreamlet.setDefaultNameIfNone(
+        StreamletImpl.StreamletNamePrefixes.SUPPLIER.toString(), stageNames);
+
+    // verify stageNames
+    assertEquals(1, stageNames.size());
+    assertTrue(stageNames.containsAll(Arrays.asList(supplierName)));
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testStreamletNameIfDuplicateNameIsSet() {
+    // create SupplierStreamlet
+    Streamlet<String> baseStreamlet = StreamletImpl.createSupplierStreamlet(() ->
+        "This is test content");
+
+    SupplierStreamlet<String> supplierStreamlet = (SupplierStreamlet<String>) baseStreamlet;
+
+    // set duplicate streamlet name and expect thrown exception
+    supplierStreamlet
+        .map((content) -> content.toUpperCase()).setName("MyMapStreamlet")
+        .map((content) -> content + "_test_suffix").setName("MyMapStreamlet");
+
+    // build SupplierStreamlet
+    assertFalse(supplierStreamlet.isBuilt());
+    TopologyBuilder builder = new TopologyBuilder();
+    Set<String> stageNames = new HashSet<>();
+    supplierStreamlet.build(builder, stageNames);
+  }
+
+  @Test
   public void testSetNameWithInvalidValues() {
     Streamlet<Double> streamlet = StreamletImpl.createSupplierStreamlet(() -> Math.random());
     Function<String, Streamlet<Double>> function = streamlet::setName;

--- a/heron/api/tests/java/com/twitter/heron/streamlet/impl/StreamletImplTest.java
+++ b/heron/api/tests/java/com/twitter/heron/streamlet/impl/StreamletImplTest.java
@@ -292,12 +292,12 @@ public class StreamletImplTest {
     assertEquals(0, consumerStreamlet.getChildren().size());
   }
 
-
+  @Test
   public void testConfigBuilder() {
     Config defaultConfig = Config.defaultConfig();
     assertEquals(defaultConfig.getSerializer(), Config.Serializer.KRYO);
     assertEquals(0, Float.compare(defaultConfig.getPerContainerCpu(), 1.0f));
-    assertEquals(defaultConfig.getPerContainerRam(), ByteAmount.fromMegabytes(100));
+    assertEquals(defaultConfig.getPerContainerRam(), ByteAmount.fromMegabytes(100).asBytes());
     assertEquals(defaultConfig.getDeliverySemantics(), Config.DeliverySemantics.ATMOST_ONCE);
     Config nonDefaultConfig = Config.newBuilder()
         .setDeliverySemantics(Config.DeliverySemantics.EFFECTIVELY_ONCE)


### PR DESCRIPTION
This PR aims the following changes:

- Abstraction and type safety are supported more
- UT coverage is added for `Streamlet` name logic(creating **default** name, checking **duplicate** etc...)