### PR TITLE
improve FileSystemStateManager doMain print

### DIFF
--- a/heron/statemgrs/src/java/com/twitter/heron/statemgr/FileSystemStateManager.java
+++ b/heron/statemgrs/src/java/com/twitter/heron/statemgr/FileSystemStateManager.java
@@ -289,14 +289,42 @@ public abstract class FileSystemStateManager implements IStateManager {
 
     if (isTopologyRunning(topologyName).get()) {
       print("==> Topology %s found", topologyName);
-      print("==> Topology %s:", getTopology(null, topologyName).get());
-      print("==> ExecutionState:\n%s", getExecutionState(null, topologyName).get());
-      print("==> SchedulerLocation:\n%s",
-          getSchedulerLocation(null, topologyName).get());
-      print("==> TMasterLocation:\n%s", getTMasterLocation(null, topologyName).get());
-      print("==> MetricsCacheLocation:\n%s", getMetricsCacheLocation(null, topologyName).get());
-      print("==> PackingPlan:\n%s", getPackingPlan(null, topologyName).get());
-      print("==> PhysicalPlan:\n%s", getPhysicalPlan(null, topologyName).get());
+      try {
+        print("==> Topology %s:", getTopology(null, topologyName).get());
+      } catch (ExecutionException e) {
+        print("Topology node not found %s", e.getMessage());
+      }
+      try {
+        print("==> ExecutionState:\n%s", getExecutionState(null, topologyName).get());
+      } catch (ExecutionException e) {
+        print("ExecutionState node not found %s", e.getMessage());
+      }
+      try {
+        print("==> SchedulerLocation:\n%s",
+                getSchedulerLocation(null, topologyName).get());
+      } catch (ExecutionException e) {
+        print("SchedulerLocation node not found %s", e.getMessage());
+      }
+      try {
+        print("==> TMasterLocation:\n%s", getTMasterLocation(null, topologyName).get());
+      } catch (ExecutionException e) {
+        print("TMasterLocation node not found %s", e.getMessage());
+      }
+      try {
+        print("==> MetricsCacheLocation:\n%s", getMetricsCacheLocation(null, topologyName).get());
+      } catch (ExecutionException e) {
+        print("MetricsCacheLocation node not found %s", e.getMessage());
+      }
+      try {
+        print("==> PackingPlan:\n%s", getPackingPlan(null, topologyName).get());
+      } catch (ExecutionException e) {
+        print("PackingPlan node not found %s", e.getMessage());
+      }
+      try {
+        print("==> PhysicalPlan:\n%s", getPhysicalPlan(null, topologyName).get());
+      } catch (ExecutionException e) {
+        print("PhysicalPlan node not found %s", e.getMessage());
+      }
     } else {
       print("==> Topology %s not found under %s",
           topologyName, config.getStringValue(Key.STATEMGR_ROOT_PATH));


### PR DESCRIPTION
$ java -jar lib/statemgr/heron-zookeeper-statemgr.jar WordCountTopologyNew szookeeper.xxxx.com

Exception in thread "main" java.util.concurrent.ExecutionException: java.lang.RuntimeException: Failed to fetch data from path: /xxxxx/pplans/WordCountTopologyNew
at com.google.common.util.concurrent.AbstractFuture$Sync.getValue(AbstractFuture.java:299)
at com.google.common.util.concurrent.AbstractFuture$Sync.get(AbstractFuture.java:286)
at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:116)
at com.twitter.heron.statemgr.FileSystemStateManager.doMain(FileSystemStateManager.java:299)
at com.twitter.heron.statemgr.zookeeper.curator.CuratorStateManager.main(CuratorStateManager.java:443)
Caused by: java.lang.RuntimeException: Failed to fetch data from path: /storm/heron/states/pplans/WordCountTopologyNew
at com.twitter.heron.statemgr.zookeeper.curator.CuratorStateManager$1.processResult(CuratorStateManager.java:309)
at org.apache.curator.framework.imps.CuratorFrameworkImpl.sendToBackgroundCallback(CuratorFrameworkImpl.java:743)
at org.apache.curator.framework.imps.CuratorFrameworkImpl.processBackgroundOperation(CuratorFrameworkImpl.java:520)
at org.apache.curator.framework.imps.GetDataBuilderImpl$3.processResult(GetDataBuilderImpl.java:254)
at org.apache.zookeeper.ClientCnxn$EventThread.processEvent(ClientCnxn.java:564)
at org.apache.zookeeper.ClientCnxn$EventThread.run(ClientCnxn.java:498)

The command stopped printing the next nodes in zk when some node failed. it is better to bypass the exception and continue printing the next nodes.

This PR improve the above issue.