### PR TITLE
Add null protection in config translation code

### DIFF
--- a/storm-compatibility/src/java/backtype/storm/utils/ConfigUtils.java
+++ b/storm-compatibility/src/java/backtype/storm/utils/ConfigUtils.java
@@ -38,7 +38,12 @@ public final class ConfigUtils {
    */
   @SuppressWarnings({"rawtypes", "unchecked"})
   public static Config translateConfig(Map stormConfig) {
-    Config heronConfig = new Config((Map<String, Object>) stormConfig);
+    Config heronConfig;
+    if (stormConfig != null) {
+      heronConfig = new Config((Map<String, Object>) stormConfig);
+    } else {
+      heronConfig = new Config();
+    }
 
     // Look at serialization stuff first
     doSerializationTranslation(heronConfig);
@@ -60,7 +65,12 @@ public final class ConfigUtils {
    */
   @SuppressWarnings({"rawtypes", "unchecked"})
   public static Config translateComponentConfig(Map stormConfig) {
-    Config heronConfig = new Config((Map<String, Object>) stormConfig);
+    Config heronConfig;
+    if (stormConfig != null) {
+      heronConfig = new Config((Map<String, Object>) stormConfig);
+    } else {
+      heronConfig = new Config();
+    }
 
     doStormTranslation(heronConfig);
 

--- a/storm-compatibility/src/java/org/apache/storm/utils/ConfigUtils.java
+++ b/storm-compatibility/src/java/org/apache/storm/utils/ConfigUtils.java
@@ -38,7 +38,13 @@ public final class ConfigUtils {
    */
   @SuppressWarnings({"rawtypes", "unchecked"})
   public static Config translateConfig(Map stormConfig) {
-    Config heronConfig = new Config((Map<String, Object>) stormConfig);
+    Config heronConfig;
+    if (stormConfig != null) {
+      heronConfig = new Config((Map<String, Object>) stormConfig);
+    } else {
+      heronConfig = new Config();
+    }
+
     // Look at serialization stuff first
     doSerializationTranslation(heronConfig);
 
@@ -59,7 +65,12 @@ public final class ConfigUtils {
    */
   @SuppressWarnings({"rawtypes", "unchecked"})
   public static Config translateComponentConfig(Map stormConfig) {
-    Config heronConfig = new Config((Map<String, Object>) stormConfig);
+    Config heronConfig;
+    if (stormConfig != null) {
+      heronConfig = new Config((Map<String, Object>) stormConfig);
+    } else {
+      heronConfig = new Config();
+    }
 
     doStormTranslation(heronConfig);
 


### PR DESCRIPTION
Got report from user and a null pointer protection is needed.

INFO: [Tail.5-FlatMap] summer builder: Sync(CacheSize(20,0.2),FlushFrequency(1.seconds),SoftMemoryFlushPercent(80.0))
Exception in thread "main" java.lang.NullPointerException
	at java.util.HashMap.putMapEntries(HashMap.java:500)
	at java.util.HashMap.<init>(HashMap.java:489)
	at com.twitter.heron.api.Config.<init>(Config.java:326)
	at org.apache.storm.utils.ConfigUtils.translateComponentConfig(ConfigUtils.java:62)
	at org.apache.storm.topology.IRichBoltDelegate.getComponentConfiguration(IRichBoltDelegate.java:78)