### PR TITLE
RoundRobinPacking implements IRepacking

### DIFF
--- a/heron/api/src/java/com/twitter/heron/api/utils/TopologyUtils.java
+++ b/heron/api/src/java/com/twitter/heron/api/utils/TopologyUtils.java
@@ -127,13 +127,17 @@ public final class TopologyUtils {
     return getConfigWithDefault(topologyConfig, Config.TOPOLOGY_COMPONENT_JVMOPTS, "");
   }
 
-  public static int getTotalInstance(TopologyAPI.Topology topology) {
-    Map<String, Integer> parallelismMap = getComponentParallelism(topology);
+  public static int getTotalInstance(Map<String, Integer> parallelismMap) {
     int numInstances = 0;
     for (int parallelism : parallelismMap.values()) {
       numInstances += parallelism;
     }
     return numInstances;
+  }
+
+  public static int getTotalInstance(TopologyAPI.Topology topology) {
+    Map<String, Integer> parallelismMap = getComponentParallelism(topology);
+    return getTotalInstance(parallelismMap);
   }
 
   public static boolean shouldStartCkptMgr(TopologyAPI.Topology topology) {

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
@@ -373,7 +373,7 @@ public class RoundRobinPacking implements IPacking, IRepacking {
       Integer count = e.getValue();
 
       if (componentChanges.containsKey(componentName)) {
-        count += componentChanges.get(componentName);
+        count = componentChanges.get(componentName);
       }
 
       newComponentParallelism.put(componentName, count);

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -149,8 +150,8 @@ public class RoundRobinPacking implements IPacking, IRepacking {
       }
 
       Resource resource = new Resource(containerCpu, containerRam, containerDiskInBytes);
-      PackingPlan.ContainerPlan containerPlan = new PackingPlan.ContainerPlan(containerId,
-          new HashSet<>(instancePlanMap.values()), resource);
+      PackingPlan.ContainerPlan containerPlan = new PackingPlan.ContainerPlan(
+          containerId, new HashSet<>(instancePlanMap.values()), resource);
 
       containerPlans.add(containerPlan);
     }
@@ -244,10 +245,8 @@ public class RoundRobinPacking implements IPacking, IRepacking {
   private Map<Integer, List<InstanceId>> getRoundRobinAllocation(int numContainer,
       Map<String, Integer> parallelismMap) {
     Map<Integer, List<InstanceId>> allocation = new HashMap<>();
-    int totalInstance = 0;
-    for (int parallelism : parallelismMap.values()) {
-      totalInstance += parallelism;
-    }
+    int totalInstance =
+        parallelismMap.values().stream().collect(Collectors.summingInt(Integer::intValue));
     if (numContainer > totalInstance) {
       throw new RuntimeException("More containers allocated than instance.");
     }

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
@@ -111,10 +111,10 @@ public class RoundRobinPacking implements IPacking, IRepacking {
     int numContainer = TopologyUtils.getNumContainers(topology);
     Map<String, Integer> parallelismMap = TopologyUtils.getComponentParallelism(topology);
 
-    return pack(numContainer, parallelismMap);
+    return packInternal(numContainer, parallelismMap);
   }
 
-  public PackingPlan pack(int numContainer, Map<String, Integer> parallelismMap) {
+  private PackingPlan packInternal(int numContainer, Map<String, Integer> parallelismMap) {
     // Get the instances' round-robin allocation
     Map<Integer, List<InstanceId>> roundRobinAllocation =
         getRoundRobinAllocation(numContainer, parallelismMap);
@@ -379,6 +379,6 @@ public class RoundRobinPacking implements IPacking, IRepacking {
 
     int newNumContainer = (int) Math.ceil(newNumInstance / initialNumInstancePerContainer);
 
-    return pack(newNumContainer, newComponentParallelism);
+    return packInternal(newNumContainer, newComponentParallelism);
   }
 }

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
@@ -245,8 +245,7 @@ public class RoundRobinPacking implements IPacking, IRepacking {
   private Map<Integer, List<InstanceId>> getRoundRobinAllocation(
       int numContainer, Map<String, Integer> parallelismMap) {
     Map<Integer, List<InstanceId>> allocation = new HashMap<>();
-    int totalInstance =
-        parallelismMap.values().stream().collect(Collectors.summingInt(Integer::intValue));
+    int totalInstance = TopologyUtils.getTotalInstance(parallelismMap);
     if (numContainer > totalInstance) {
       throw new RuntimeException("More containers allocated than instance.");
     }
@@ -354,6 +353,11 @@ public class RoundRobinPacking implements IPacking, IRepacking {
     }
   }
 
+  /*
+   * read the current packing plan with update parallelism to calculate a new packing plan
+   * the packing algorithm packInternal() is shared with pack()
+   * delegate to packInternal() with the new container count and component parallelism
+   */
   @Override
   public PackingPlan repack(PackingPlan currentPackingPlan, Map<String, Integer> componentChanges)
       throws PackingException {

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
@@ -242,8 +242,8 @@ public class RoundRobinPacking implements IPacking, IRepacking {
    *
    * @return containerId -&gt; list of InstanceId belonging to this container
    */
-  private Map<Integer, List<InstanceId>> getRoundRobinAllocation(int numContainer,
-      Map<String, Integer> parallelismMap) {
+  private Map<Integer, List<InstanceId>> getRoundRobinAllocation(
+      int numContainer, Map<String, Integer> parallelismMap) {
     Map<Integer, List<InstanceId>> allocation = new HashMap<>();
     int totalInstance =
         parallelismMap.values().stream().collect(Collectors.summingInt(Integer::intValue));

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+//    http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -39,39 +39,42 @@ import com.twitter.heron.spi.packing.Resource;
 /**
  * Round-robin packing algorithm
  * <p>
- * This IPacking implementation generates PackingPlan: instances of the component are assigned to
- * each container one by one in circular order, without any priority. Each container is expected to
- * take equal number of instances if # of instances is multiple of # of containers.
+ * This IPacking implementation generates PackingPlan: instances of the component are assigned
+ * to each container one by one in circular order, without any priority. Each container is expected
+ * to take equal number of instances if # of instances is multiple of # of containers.
  * <p>
- * Following semantics are guaranteed: 1. Every container requires same size of resource, i.e. same
- * cpu, ram and disk. Consider that instances in different containers can be different, the value of
- * size will be aligned to the max one.
+ * Following semantics are guaranteed:
+ * 1. Every container requires same size of resource, i.e. same cpu, ram and disk.
+ * Consider that instances in different containers can be different, the value of size
+ * will be aligned to the max one.
  * <p>
- * 2. The size of resource required by the whole topology is equal to ((# of container specified in
- * config) + 1) * (size of resource required for a single container). The extra 1 is considered for
- * Heron internal container, i.e. the one containing Scheduler and TMaster.
+ * 2. The size of resource required by the whole topology is equal to
+ * ((# of container specified in config) + 1) * (size of resource required for a single container).
+ * The extra 1 is considered for Heron internal container,
+ * i.e. the one containing Scheduler and TMaster.
  * <p>
- * 3. The disk required for a container is calculated as: value for
- * com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_DISK_REQUESTED if exists, otherwise, (disk for
- * instances in container) + (disk padding for heron internal process)
+ * 3. The disk required for a container is calculated as:
+ * value for com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_DISK_REQUESTED if exists, otherwise,
+ * (disk for instances in container) + (disk padding for heron internal process)
  * <p>
- * 4. The cpu required for a container is calculated as: value for
- * com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_CPU_REQUESTED if exists, otherwise, (cpu for
- * instances in container) + (cpu padding for heron internal process)
+ * 4. The cpu required for a container is calculated as:
+ * value for com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_CPU_REQUESTED if exists, otherwise,
+ * (cpu for instances in container) + (cpu padding for heron internal process)
  * <p>
- * 5. The ram required for a container is calculated as: value for
- * com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED if exists, otherwise, (ram for
- * instances in container) + (ram padding for heron internal process)
+ * 5. The ram required for a container is calculated as:
+ * value for com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED if exists, otherwise,
+ * (ram for instances in container) + (ram padding for heron internal process)
  * <p>
- * 6. The ram required for one instance is calculated as: value in
- * com.twitter.heron.api.Config.TOPOLOGY_COMPONENT_RAMMAP if exists, otherwise, - if
- * com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED not exists: the default ram value
- * for one instance - if com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED exists:
- * ((TOPOLOGY_CONTAINER_RAM_REQUESTED) - (ram padding for heron internal process) - (ram used by
- * instances within TOPOLOGY_COMPONENT_RAMMAP config))) / (the # of instances in container not
- * specified in TOPOLOGY_COMPONENT_RAMMAP config) 7. The pack() return null if PackingPlan fails to
- * pass the safe check, for instance, the size of ram for an instance is less than the minimal
- * required value.
+ * 6. The ram required for one instance is calculated as:
+ * value in com.twitter.heron.api.Config.TOPOLOGY_COMPONENT_RAMMAP if exists, otherwise,
+ * - if com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED not exists:
+ * the default ram value for one instance
+ * - if com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED exists:
+ * ((TOPOLOGY_CONTAINER_RAM_REQUESTED) - (ram padding for heron internal process)
+ * - (ram used by instances within TOPOLOGY_COMPONENT_RAMMAP config))) /
+ * (the # of instances in container not specified in TOPOLOGY_COMPONENT_RAMMAP config)
+ * 7. The pack() return null if PackingPlan fails to pass the safe check, for instance,
+ * the size of ram for an instance is less than the minimal required value.
  */
 public class RoundRobinPacking implements IPacking, IRepacking {
   private static final Logger LOG = Logger.getLogger(RoundRobinPacking.class.getName());
@@ -215,7 +218,8 @@ public class RoundRobinPacking implements IPacking, IRepacking {
         // If container ram is specified
         if (!containerRamHint.equals(NOT_SPECIFIED_NUMBER_VALUE)) {
           // remove ram for heron internal process
-          ByteAmount remainingRam = containerRamHint.minus(containerRamPadding).minus(usedRam);
+          ByteAmount remainingRam =
+              containerRamHint.minus(containerRamPadding).minus(usedRam);
 
           // Split remaining ram evenly
           individualInstanceRam = remainingRam.divide(instancesToAllocate);
@@ -292,8 +296,8 @@ public class RoundRobinPacking implements IPacking, IRepacking {
     double defaultContainerCpu =
         DEFAULT_CPU_PADDING_PER_CONTAINER + getLargestContainerSize(allocation);
 
-    String cpuHint = TopologyUtils.getConfigWithDefault(topologyConfig,
-        com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_CPU_REQUESTED,
+    String cpuHint = TopologyUtils.getConfigWithDefault(
+        topologyConfig, com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_CPU_REQUESTED,
         Double.toString(defaultContainerCpu));
 
     return Double.parseDouble(cpuHint);
@@ -307,12 +311,14 @@ public class RoundRobinPacking implements IPacking, IRepacking {
    */
   private ByteAmount getContainerDiskHint(Map<Integer, List<InstanceId>> allocation) {
     ByteAmount defaultContainerDisk = instanceDiskDefault
-        .multiply(getLargestContainerSize(allocation)).plus(DEFAULT_DISK_PADDING_PER_CONTAINER);
+        .multiply(getLargestContainerSize(allocation))
+        .plus(DEFAULT_DISK_PADDING_PER_CONTAINER);
 
     List<TopologyAPI.Config.KeyValue> topologyConfig = topology.getTopologyConfig().getKvsList();
 
     return TopologyUtils.getConfigWithDefault(topologyConfig,
-        com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_DISK_REQUESTED, defaultContainerDisk);
+        com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_DISK_REQUESTED,
+        defaultContainerDisk);
   }
 
   /**
@@ -324,8 +330,9 @@ public class RoundRobinPacking implements IPacking, IRepacking {
   private ByteAmount getContainerRamHint(Map<Integer, List<InstanceId>> allocation) {
     List<TopologyAPI.Config.KeyValue> topologyConfig = topology.getTopologyConfig().getKvsList();
 
-    return TopologyUtils.getConfigWithDefault(topologyConfig,
-        com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED, NOT_SPECIFIED_NUMBER_VALUE);
+    return TopologyUtils.getConfigWithDefault(
+        topologyConfig, com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED,
+        NOT_SPECIFIED_NUMBER_VALUE);
   }
 
   /**
@@ -339,8 +346,7 @@ public class RoundRobinPacking implements IPacking, IRepacking {
       for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
         // Safe check
         if (instancePlan.getResource().getRam().lessThan(MIN_RAM_PER_INSTANCE)) {
-          throw new PackingException(String.format(
-              "Invalid packing plan generated. A minimum of "
+          throw new PackingException(String.format("Invalid packing plan generated. A minimum of "
                   + "%s ram is required, but InstancePlan for component '%s' has %s",
               MIN_RAM_PER_INSTANCE, instancePlan.getComponentName(),
               instancePlan.getResource().getRam()));

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
@@ -365,23 +365,14 @@ public class RoundRobinPacking implements IPacking, IRepacking {
     double initialNumInstancePerContainer = (double) initialNumInstance / initialNumContainer;
 
     Map<String, Integer> currentComponentParallelism = currentPackingPlan.getComponentCounts();
-    Map<String, Integer> newComponentParallelism = new HashMap<>();
-    int newNumInstance = 0;
 
-    for (Map.Entry<String, Integer> e : currentComponentParallelism.entrySet()) {
-      String componentName = e.getKey();
-      Integer count = e.getValue();
-
-      if (componentChanges.containsKey(componentName)) {
-        count = componentChanges.get(componentName);
-      }
-
-      newComponentParallelism.put(componentName, count);
-      newNumInstance += count;
+    for (Map.Entry<String, Integer> e : componentChanges.entrySet()) {
+      currentComponentParallelism.put(e.getKey(), e.getValue());
     }
 
+    int newNumInstance = TopologyUtils.getTotalInstance(currentComponentParallelism);
     int newNumContainer = (int) Math.ceil(newNumInstance / initialNumInstancePerContainer);
 
-    return packInternal(newNumContainer, newComponentParallelism);
+    return packInternal(newNumContainer, currentComponentParallelism);
   }
 }

--- a/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/RoundRobinPackingTest.java
+++ b/heron/packing/tests/java/com/twitter/heron/packing/roundrobin/RoundRobinPackingTest.java
@@ -375,7 +375,7 @@ public class RoundRobinPackingTest {
         if (SPOUT_NAME.equals(instancePlan.getComponentName())) {
           spoutCount++;
         } else if (BOLT_NAME.equals(instancePlan.getComponentName())) {
-          boltCount ++;
+          boltCount++;
         }
       }
     }

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
@@ -338,7 +338,7 @@ public class RuntimeManagerRunner {
         }
         String[] kvp = componentValuePair.split(":", 2);
         int val = Integer.parseInt(kvp[1]);
-        if (val <=0 ) {
+        if (val <= 0) {
           throw new IllegalArgumentException("parallelism should be positive, Found: " + val);
         }
         changes.put(kvp[0], val);

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
@@ -337,11 +337,7 @@ public class RuntimeManagerRunner {
           continue;
         }
         String[] kvp = componentValuePair.split(":", 2);
-        int val = Integer.parseInt(kvp[1]);
-        if (val <= 0) {
-          throw new IllegalArgumentException("parallelism should be positive, Found: " + val);
-        }
-        changes.put(kvp[0], val);
+        changes.put(kvp[0], Integer.parseInt(kvp[1]));
       }
     } catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
       throw new IllegalArgumentException("Invalid parallelism parameter found. Expected: "

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
@@ -337,7 +337,11 @@ public class RuntimeManagerRunner {
           continue;
         }
         String[] kvp = componentValuePair.split(":", 2);
-        changes.put(kvp[0], Integer.parseInt(kvp[1]));
+        int val = Integer.parseInt(kvp[1]);
+        if (val <=0 ) {
+          throw new IllegalArgumentException("parallelism should be positive, Found: " + val);
+        }
+        changes.put(kvp[0], val);
       }
     } catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
       throw new IllegalArgumentException("Invalid parallelism parameter found. Expected: "


### PR DESCRIPTION
Walk around https://github.com/twitter/heron/issues/2576
Some legacy topologies use RoundRobinPacking lacking configurations for neither ResourceCompliantRRPacking nor FirstFitDecreasingPacking, which results in exceptions.
This PR enables IRepacking implementation for RoundRobinPacking.

Tested with local scheduler
`~/bin/heron update --verbose --dry-run --config-property heron.class.repacking.algorithm=com.twitter.heron.packing.roundrobin.RoundRobinPacking local WordCountTopology --component-parallelism consumer:4`
