### PR TITLE
keep topology defn during update

### DIFF
--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -149,8 +150,8 @@ public class RoundRobinPacking implements IPacking, IRepacking {
       }
 
       Resource resource = new Resource(containerCpu, containerRam, containerDiskInBytes);
-      PackingPlan.ContainerPlan containerPlan = new PackingPlan.ContainerPlan(containerId,
-          new HashSet<>(instancePlanMap.values()), resource);
+      PackingPlan.ContainerPlan containerPlan = new PackingPlan.ContainerPlan(
+          containerId, new HashSet<>(instancePlanMap.values()), resource);
 
       containerPlans.add(containerPlan);
     }
@@ -244,10 +245,8 @@ public class RoundRobinPacking implements IPacking, IRepacking {
   private Map<Integer, List<InstanceId>> getRoundRobinAllocation(int numContainer,
       Map<String, Integer> parallelismMap) {
     Map<Integer, List<InstanceId>> allocation = new HashMap<>();
-    int totalInstance = 0;
-    for (int parallelism : parallelismMap.values()) {
-      totalInstance += parallelism;
-    }
+    int totalInstance =
+        parallelismMap.values().stream().collect(Collectors.summingInt(Integer::intValue));
     if (numContainer > totalInstance) {
       throw new RuntimeException("More containers allocated than instance.");
     }

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
@@ -111,10 +111,10 @@ public class RoundRobinPacking implements IPacking, IRepacking {
     int numContainer = TopologyUtils.getNumContainers(topology);
     Map<String, Integer> parallelismMap = TopologyUtils.getComponentParallelism(topology);
 
-    return pack(numContainer, parallelismMap);
+    return packInternal(numContainer, parallelismMap);
   }
 
-  public PackingPlan pack(int numContainer, Map<String, Integer> parallelismMap) {
+  private PackingPlan packInternal(int numContainer, Map<String, Integer> parallelismMap) {
     // Get the instances' round-robin allocation
     Map<Integer, List<InstanceId>> roundRobinAllocation =
         getRoundRobinAllocation(numContainer, parallelismMap);
@@ -379,6 +379,6 @@ public class RoundRobinPacking implements IPacking, IRepacking {
 
     int newNumContainer = (int) Math.ceil(newNumInstance / initialNumInstancePerContainer);
 
-    return pack(newNumContainer, newComponentParallelism);
+    return packInternal(newNumContainer, newComponentParallelism);
   }
 }

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
@@ -242,8 +242,8 @@ public class RoundRobinPacking implements IPacking, IRepacking {
    *
    * @return containerId -&gt; list of InstanceId belonging to this container
    */
-  private Map<Integer, List<InstanceId>> getRoundRobinAllocation(int numContainer,
-      Map<String, Integer> parallelismMap) {
+  private Map<Integer, List<InstanceId>> getRoundRobinAllocation(
+      int numContainer, Map<String, Integer> parallelismMap) {
     Map<Integer, List<InstanceId>> allocation = new HashMap<>();
     int totalInstance =
         parallelismMap.values().stream().collect(Collectors.summingInt(Integer::intValue));

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/RoundRobinPacking.java
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+//    http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -39,39 +39,42 @@ import com.twitter.heron.spi.packing.Resource;
 /**
  * Round-robin packing algorithm
  * <p>
- * This IPacking implementation generates PackingPlan: instances of the component are assigned to
- * each container one by one in circular order, without any priority. Each container is expected to
- * take equal number of instances if # of instances is multiple of # of containers.
+ * This IPacking implementation generates PackingPlan: instances of the component are assigned
+ * to each container one by one in circular order, without any priority. Each container is expected
+ * to take equal number of instances if # of instances is multiple of # of containers.
  * <p>
- * Following semantics are guaranteed: 1. Every container requires same size of resource, i.e. same
- * cpu, ram and disk. Consider that instances in different containers can be different, the value of
- * size will be aligned to the max one.
+ * Following semantics are guaranteed:
+ * 1. Every container requires same size of resource, i.e. same cpu, ram and disk.
+ * Consider that instances in different containers can be different, the value of size
+ * will be aligned to the max one.
  * <p>
- * 2. The size of resource required by the whole topology is equal to ((# of container specified in
- * config) + 1) * (size of resource required for a single container). The extra 1 is considered for
- * Heron internal container, i.e. the one containing Scheduler and TMaster.
+ * 2. The size of resource required by the whole topology is equal to
+ * ((# of container specified in config) + 1) * (size of resource required for a single container).
+ * The extra 1 is considered for Heron internal container,
+ * i.e. the one containing Scheduler and TMaster.
  * <p>
- * 3. The disk required for a container is calculated as: value for
- * com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_DISK_REQUESTED if exists, otherwise, (disk for
- * instances in container) + (disk padding for heron internal process)
+ * 3. The disk required for a container is calculated as:
+ * value for com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_DISK_REQUESTED if exists, otherwise,
+ * (disk for instances in container) + (disk padding for heron internal process)
  * <p>
- * 4. The cpu required for a container is calculated as: value for
- * com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_CPU_REQUESTED if exists, otherwise, (cpu for
- * instances in container) + (cpu padding for heron internal process)
+ * 4. The cpu required for a container is calculated as:
+ * value for com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_CPU_REQUESTED if exists, otherwise,
+ * (cpu for instances in container) + (cpu padding for heron internal process)
  * <p>
- * 5. The ram required for a container is calculated as: value for
- * com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED if exists, otherwise, (ram for
- * instances in container) + (ram padding for heron internal process)
+ * 5. The ram required for a container is calculated as:
+ * value for com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED if exists, otherwise,
+ * (ram for instances in container) + (ram padding for heron internal process)
  * <p>
- * 6. The ram required for one instance is calculated as: value in
- * com.twitter.heron.api.Config.TOPOLOGY_COMPONENT_RAMMAP if exists, otherwise, - if
- * com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED not exists: the default ram value
- * for one instance - if com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED exists:
- * ((TOPOLOGY_CONTAINER_RAM_REQUESTED) - (ram padding for heron internal process) - (ram used by
- * instances within TOPOLOGY_COMPONENT_RAMMAP config))) / (the # of instances in container not
- * specified in TOPOLOGY_COMPONENT_RAMMAP config) 7. The pack() return null if PackingPlan fails to
- * pass the safe check, for instance, the size of ram for an instance is less than the minimal
- * required value.
+ * 6. The ram required for one instance is calculated as:
+ * value in com.twitter.heron.api.Config.TOPOLOGY_COMPONENT_RAMMAP if exists, otherwise,
+ * - if com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED not exists:
+ * the default ram value for one instance
+ * - if com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED exists:
+ * ((TOPOLOGY_CONTAINER_RAM_REQUESTED) - (ram padding for heron internal process)
+ * - (ram used by instances within TOPOLOGY_COMPONENT_RAMMAP config))) /
+ * (the # of instances in container not specified in TOPOLOGY_COMPONENT_RAMMAP config)
+ * 7. The pack() return null if PackingPlan fails to pass the safe check, for instance,
+ * the size of ram for an instance is less than the minimal required value.
  */
 public class RoundRobinPacking implements IPacking, IRepacking {
   private static final Logger LOG = Logger.getLogger(RoundRobinPacking.class.getName());
@@ -215,7 +218,8 @@ public class RoundRobinPacking implements IPacking, IRepacking {
         // If container ram is specified
         if (!containerRamHint.equals(NOT_SPECIFIED_NUMBER_VALUE)) {
           // remove ram for heron internal process
-          ByteAmount remainingRam = containerRamHint.minus(containerRamPadding).minus(usedRam);
+          ByteAmount remainingRam =
+              containerRamHint.minus(containerRamPadding).minus(usedRam);
 
           // Split remaining ram evenly
           individualInstanceRam = remainingRam.divide(instancesToAllocate);
@@ -292,8 +296,8 @@ public class RoundRobinPacking implements IPacking, IRepacking {
     double defaultContainerCpu =
         DEFAULT_CPU_PADDING_PER_CONTAINER + getLargestContainerSize(allocation);
 
-    String cpuHint = TopologyUtils.getConfigWithDefault(topologyConfig,
-        com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_CPU_REQUESTED,
+    String cpuHint = TopologyUtils.getConfigWithDefault(
+        topologyConfig, com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_CPU_REQUESTED,
         Double.toString(defaultContainerCpu));
 
     return Double.parseDouble(cpuHint);
@@ -307,12 +311,14 @@ public class RoundRobinPacking implements IPacking, IRepacking {
    */
   private ByteAmount getContainerDiskHint(Map<Integer, List<InstanceId>> allocation) {
     ByteAmount defaultContainerDisk = instanceDiskDefault
-        .multiply(getLargestContainerSize(allocation)).plus(DEFAULT_DISK_PADDING_PER_CONTAINER);
+        .multiply(getLargestContainerSize(allocation))
+        .plus(DEFAULT_DISK_PADDING_PER_CONTAINER);
 
     List<TopologyAPI.Config.KeyValue> topologyConfig = topology.getTopologyConfig().getKvsList();
 
     return TopologyUtils.getConfigWithDefault(topologyConfig,
-        com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_DISK_REQUESTED, defaultContainerDisk);
+        com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_DISK_REQUESTED,
+        defaultContainerDisk);
   }
 
   /**
@@ -324,8 +330,9 @@ public class RoundRobinPacking implements IPacking, IRepacking {
   private ByteAmount getContainerRamHint(Map<Integer, List<InstanceId>> allocation) {
     List<TopologyAPI.Config.KeyValue> topologyConfig = topology.getTopologyConfig().getKvsList();
 
-    return TopologyUtils.getConfigWithDefault(topologyConfig,
-        com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED, NOT_SPECIFIED_NUMBER_VALUE);
+    return TopologyUtils.getConfigWithDefault(
+        topologyConfig, com.twitter.heron.api.Config.TOPOLOGY_CONTAINER_RAM_REQUESTED,
+        NOT_SPECIFIED_NUMBER_VALUE);
   }
 
   /**
@@ -339,8 +346,7 @@ public class RoundRobinPacking implements IPacking, IRepacking {
       for (PackingPlan.InstancePlan instancePlan : containerPlan.getInstances()) {
         // Safe check
         if (instancePlan.getResource().getRam().lessThan(MIN_RAM_PER_INSTANCE)) {
-          throw new PackingException(String.format(
-              "Invalid packing plan generated. A minimum of "
+          throw new PackingException(String.format("Invalid packing plan generated. A minimum of "
                   + "%s ram is required, but InstancePlan for component '%s' has %s",
               MIN_RAM_PER_INSTANCE, instancePlan.getComponentName(),
               instancePlan.getResource().getRam()));

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
@@ -147,37 +147,26 @@ public class UpdateTopologyManager implements Closeable {
     TopologyAPI.Topology topology = getTopology(stateManager, topologyName);
     boolean initiallyRunning = topology.getState() == TopologyAPI.TopologyState.RUNNING;
 
-    System.out.println("debug - getUpdatedTopology");
     // fetch the topology, which will need to be updated
     TopologyAPI.Topology updatedTopology =
         getUpdatedTopology(topologyName, proposedPackingPlan, stateManager);
 
-    System.out.println("debug - deactivateTopology");
     // deactivate and sleep
     if (initiallyRunning) {
       // Update the topology since the state should have changed from RUNNING to PAUSED
       updatedTopology = deactivateTopology(stateManager, updatedTopology, proposedPackingPlan);
     }
 
-    System.out.println("debug - addContainers");
     // request new resources if necessary. Once containers are allocated we should make the changes
     // to state manager quickly, otherwise the scheduler might penalize for thrashing on start-up
     if (newContainerCount > 0 && scalableScheduler.isPresent()) {
       scalableScheduler.get().addContainers(containerDelta.getContainersToAdd());
     }
 
-    // update parallelism in updatedTopology since TMaster checks that
-    // Sum(parallelism) == Sum(instances)
-    // debug: check if topo defn update needed
-// logInfo("Update new Topology: %s",
-//stateManager.updateTopology(updatedTopology, topologyName));
-
-    System.out.println("debug - updatePackingPlan");
     // update packing plan to trigger the scaling event
     logInfo("Update new PackingPlan: %s",
         stateManager.updatePackingPlan(proposedProtoPackingPlan, topologyName));
 
-    System.out.println("debug - reactivateTopology");
     // reactivate topology
     if (initiallyRunning) {
       // wait before reactivating to give the tmaster a chance to receive the packing update and
@@ -187,7 +176,6 @@ public class UpdateTopologyManager implements Closeable {
       reactivateTopology(stateManager, updatedTopology, removableContainerCount);
     }
 
-    System.out.println("debug - removeContainers");
     if (removableContainerCount > 0 && scalableScheduler.isPresent()) {
       scalableScheduler.get().removeContainers(containerDelta.getContainersToRemove());
     }

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
@@ -148,6 +148,7 @@ public class UpdateTopologyManager implements Closeable {
     // deactivate and sleep
     if (initiallyRunning) {
       // Update the topology since the state should have changed from RUNNING to PAUSED
+      // Will throw exceptions internally if tmaster fails to deactivate
       deactivateTopology(stateManager, topology, proposedPackingPlan);
     }
 
@@ -167,6 +168,7 @@ public class UpdateTopologyManager implements Closeable {
       // delete the packing plan. Instead we could message tmaster to invalidate the physical plan
       // and/or possibly even update the packing plan directly
       SysUtils.sleep(Duration.ofSeconds(10));
+      // Will throw exceptions internally if tmaster fails to deactivate
       reactivateTopology(stateManager, topology, removableContainerCount);
     }
 

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
@@ -147,16 +147,19 @@ public class UpdateTopologyManager implements Closeable {
     TopologyAPI.Topology topology = getTopology(stateManager, topologyName);
     boolean initiallyRunning = topology.getState() == TopologyAPI.TopologyState.RUNNING;
 
+    System.out.println("debug - getUpdatedTopology");
     // fetch the topology, which will need to be updated
     TopologyAPI.Topology updatedTopology =
         getUpdatedTopology(topologyName, proposedPackingPlan, stateManager);
 
+    System.out.println("debug - deactivateTopology");
     // deactivate and sleep
     if (initiallyRunning) {
       // Update the topology since the state should have changed from RUNNING to PAUSED
       updatedTopology = deactivateTopology(stateManager, updatedTopology, proposedPackingPlan);
     }
 
+    System.out.println("debug - addContainers");
     // request new resources if necessary. Once containers are allocated we should make the changes
     // to state manager quickly, otherwise the scheduler might penalize for thrashing on start-up
     if (newContainerCount > 0 && scalableScheduler.isPresent()) {
@@ -165,12 +168,16 @@ public class UpdateTopologyManager implements Closeable {
 
     // update parallelism in updatedTopology since TMaster checks that
     // Sum(parallelism) == Sum(instances)
-    logInfo("Update new Topology: %s", stateManager.updateTopology(updatedTopology, topologyName));
+    // debug: check if topo defn update needed
+// logInfo("Update new Topology: %s",
+//stateManager.updateTopology(updatedTopology, topologyName));
 
+    System.out.println("debug - updatePackingPlan");
     // update packing plan to trigger the scaling event
     logInfo("Update new PackingPlan: %s",
         stateManager.updatePackingPlan(proposedProtoPackingPlan, topologyName));
 
+    System.out.println("debug - reactivateTopology");
     // reactivate topology
     if (initiallyRunning) {
       // wait before reactivating to give the tmaster a chance to receive the packing update and
@@ -180,6 +187,7 @@ public class UpdateTopologyManager implements Closeable {
       reactivateTopology(stateManager, updatedTopology, removableContainerCount);
     }
 
+    System.out.println("debug - removeContainers");
     if (removableContainerCount > 0 && scalableScheduler.isPresent()) {
       scalableScheduler.get().removeContainers(containerDelta.getContainersToRemove());
     }

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
@@ -19,7 +19,6 @@ import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -32,7 +31,6 @@ import java.util.logging.Logger;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
-import com.google.protobuf.Descriptors;
 
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.api.utils.TopologyUtils;
@@ -147,14 +145,10 @@ public class UpdateTopologyManager implements Closeable {
     TopologyAPI.Topology topology = getTopology(stateManager, topologyName);
     boolean initiallyRunning = topology.getState() == TopologyAPI.TopologyState.RUNNING;
 
-    // fetch the topology, which will need to be updated
-    TopologyAPI.Topology updatedTopology =
-        getUpdatedTopology(topologyName, proposedPackingPlan, stateManager);
-
     // deactivate and sleep
     if (initiallyRunning) {
       // Update the topology since the state should have changed from RUNNING to PAUSED
-      updatedTopology = deactivateTopology(stateManager, updatedTopology, proposedPackingPlan);
+      deactivateTopology(stateManager, topology, proposedPackingPlan);
     }
 
     // request new resources if necessary. Once containers are allocated we should make the changes
@@ -173,7 +167,7 @@ public class UpdateTopologyManager implements Closeable {
       // delete the packing plan. Instead we could message tmaster to invalidate the physical plan
       // and/or possibly even update the packing plan directly
       SysUtils.sleep(Duration.ofSeconds(10));
-      reactivateTopology(stateManager, updatedTopology, removableContainerCount);
+      reactivateTopology(stateManager, topology, removableContainerCount);
     }
 
     if (removableContainerCount > 0 && scalableScheduler.isPresent()) {
@@ -182,7 +176,7 @@ public class UpdateTopologyManager implements Closeable {
   }
 
   @VisibleForTesting
-  TopologyAPI.Topology deactivateTopology(SchedulerStateManagerAdaptor stateManager,
+  void deactivateTopology(SchedulerStateManagerAdaptor stateManager,
                           final TopologyAPI.Topology topology,
                           PackingPlan proposedPackingPlan)
       throws InterruptedException, TMasterException {
@@ -204,8 +198,6 @@ public class UpdateTopologyManager implements Closeable {
     } else {
       logInfo("Deactivated topology %s.", topology.getName());
     }
-
-    return getUpdatedTopology(topology.getName(), proposedPackingPlan, stateManager);
   }
 
   @VisibleForTesting
@@ -310,14 +302,6 @@ public class UpdateTopologyManager implements Closeable {
     }
   }
 
-  private TopologyAPI.Topology getUpdatedTopology(String topologyName,
-                                                  PackingPlan proposedPackingPlan,
-                                                  SchedulerStateManagerAdaptor stateManager) {
-    TopologyAPI.Topology updatedTopology = getTopology(stateManager, topologyName);
-    Map<String, Integer> proposedComponentCounts = proposedPackingPlan.getComponentCounts();
-    return mergeTopology(updatedTopology, proposedComponentCounts);
-  }
-
   @VisibleForTesting
   PackingPlans.PackingPlan getPackingPlan(SchedulerStateManagerAdaptor stateManager,
                                           String topologyName) {
@@ -382,75 +366,6 @@ public class UpdateTopologyManager implements Closeable {
     Set<PackingPlan.ContainerPlan> getContainersToAdd() {
       return containersToAdd;
     }
-  }
-
-  /**
-   * For each of the components with changed parallelism we need to update the Topology configs to
-   * represent the change.
-   */
-  @VisibleForTesting
-  static TopologyAPI.Topology mergeTopology(TopologyAPI.Topology topology,
-                                            Map<String, Integer> proposedComponentCounts) {
-    TopologyAPI.Topology.Builder builder = TopologyAPI.Topology.newBuilder().mergeFrom(topology);
-    for (String componentName : proposedComponentCounts.keySet()) {
-      Integer parallelism = proposedComponentCounts.get(componentName);
-
-      boolean updated = false;
-      for (TopologyAPI.Bolt.Builder boltBuilder : builder.getBoltsBuilderList()) {
-        if (updateComponent(boltBuilder.getCompBuilder(), componentName, parallelism)) {
-          updated = true;
-          break;
-        }
-      }
-
-      if (!updated) {
-        for (TopologyAPI.Spout.Builder spoutBuilder : builder.getSpoutsBuilderList()) {
-          if (updateComponent(spoutBuilder.getCompBuilder(), componentName, parallelism)) {
-            break;
-          }
-        }
-      }
-    }
-
-    return builder.build();
-  }
-
-  /**
-   * Go through all fields in the component builder until one is found where "name=componentName".
-   * When found, go through the confs in the conf builder to find the parallelism field and update
-   * that.
-   *
-   * @return true if the component was found and updated, which might not always happen. For example
-   * if the component is a spout, it won't be found if a bolt builder is passed.
-   */
-  private static boolean updateComponent(TopologyAPI.Component.Builder compBuilder,
-                                         String componentName,
-                                         int parallelism) {
-    for (Map.Entry<Descriptors.FieldDescriptor, Object> entry
-        : compBuilder.getAllFields().entrySet()) {
-      if (entry.getKey().getName().equals("name") && componentName.equals(entry.getValue())) {
-        TopologyAPI.Config.Builder confBuilder = compBuilder.getConfigBuilder();
-        boolean keyFound = false;
-        // no way to get a KeyValue builder with a get(key) so we have to iterate until found.
-        for (TopologyAPI.Config.KeyValue.Builder kvBuilder : confBuilder.getKvsBuilderList()) {
-          if (kvBuilder.getKey().equals(
-              com.twitter.heron.api.Config.TOPOLOGY_COMPONENT_PARALLELISM)) {
-            kvBuilder.setValue(Integer.toString(parallelism));
-            keyFound = true;
-            break;
-          }
-        }
-        if (!keyFound) {
-          TopologyAPI.Config.KeyValue.Builder kvBuilder =
-              TopologyAPI.Config.KeyValue.newBuilder();
-          kvBuilder.setKey(com.twitter.heron.api.Config.TOPOLOGY_COMPONENT_PARALLELISM);
-          kvBuilder.setValue(Integer.toString(parallelism));
-          confBuilder.addKvs(kvBuilder);
-        }
-        return true;
-      }
-    }
-    return false;
   }
 
   private static Set<Integer> toIdSet(Set<PackingPlan.ContainerPlan> containers) {

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/UpdateTopologyManagerTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/UpdateTopologyManagerTest.java
@@ -223,13 +223,6 @@ public class UpdateTopologyManagerTest {
     Map<String, Integer> updates = new HashMap<>();
     updates.putAll(boltUpdates);
     updates.putAll(spoutUpdates);
-
-    // assert that the updated topology config settings are as expected
-    topology = UpdateTopologyManager.mergeTopology(topology, updates);
-    bolts.putAll(boltUpdates);
-    spouts.putAll(spoutUpdates);
-
-    assertParallelism(topology, spouts, bolts);
   }
 
   private void assertParallelism(TopologyAPI.Topology topology,

--- a/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
+++ b/heron/stmgr/tests/cpp/server/stmgr_unittest.cpp
@@ -131,8 +131,8 @@ static heron::proto::api::Topology* GenerateDummyTopology(
 
 static heron::proto::system::PackingPlan* GenerateDummyPackingPlan(int num_stmgrs_, int num_spouts,
     int num_spout_instances, int num_bolts, int num_bolt_instances) {
-  size_t spouts_size = num_spout_instances;
-  size_t bolts_size = num_bolt_instances;
+  size_t spouts_size = num_spouts * num_spout_instances;
+  size_t bolts_size = num_bolts * num_bolt_instances;
 
   heron::proto::system::Resource* instanceResource = new heron::proto::system::Resource();
   instanceResource->set_ram(1);

--- a/heron/tmaster/src/cpp/manager/tmaster.cpp
+++ b/heron/tmaster/src/cpp/manager/tmaster.cpp
@@ -710,9 +710,9 @@ void TMaster::DoPhysicalPlan(EventLoop::Status) {
   CHECK_NOTNULL(pplan);
   DCHECK(pplan->IsInitialized());
 
-  if (!ValidateStMgrsWithTopology(pplan->topology())) {
+  if (!ValidateStMgrsWithPackingPlan()) {
     // TODO(kramasamy): Do Something better here
-    LOG(ERROR) << "Topology and StMgr mismatch... Dying\n";
+    LOG(ERROR) << "Packing plan and StMgr mismatch... Dying\n";
     ::exit(1);
   }
 
@@ -915,18 +915,13 @@ bool TMaster::ValidateTopology(proto::api::Topology _topology) {
   return true;
 }
 
-bool TMaster::ValidateStMgrsWithTopology(proto::api::Topology _topology) {
+bool TMaster::ValidateStMgrsWithPackingPlan() {
   // here we check to see if the total number of instances
   // across all stmgrs match up to all the spout/bolt
-  // parallelism the topology has specified
+  // parallelism the packing plan has specified
   sp_int32 ntasks = 0;
-  for (sp_int32 i = 0; i < _topology.spouts_size(); ++i) {
-    ntasks +=
-        config::TopologyConfigHelper::GetComponentParallelism(_topology.spouts(i).comp().config());
-  }
-  for (sp_int32 i = 0; i < _topology.bolts_size(); ++i) {
-    ntasks +=
-        config::TopologyConfigHelper::GetComponentParallelism(_topology.bolts(i).comp().config());
+  for (sp_int32 i = 0; i < packing_plan_->container_plans_size(); ++i) {
+    ntasks += packing_plan_->container_plans(i).instance_plans_size();
   }
 
   sp_int32 ninstances = 0;

--- a/heron/tmaster/src/cpp/manager/tmaster.h
+++ b/heron/tmaster/src/cpp/manager/tmaster.h
@@ -119,7 +119,7 @@ class TMaster {
 
   // Check to see if the topology and stmgrs match
   // in terms of workers
-  bool ValidateStMgrsWithTopology(proto::api::Topology _topology);
+  bool ValidateStMgrsWithPackingPlan();
 
   // Check to see if the stmgrs and pplan match
   // in terms of workers

--- a/heron/tmaster/tests/cpp/server/tmaster_unittest.cpp
+++ b/heron/tmaster/tests/cpp/server/tmaster_unittest.cpp
@@ -126,8 +126,8 @@ static heron::proto::api::Topology* GenerateDummyTopology(
 
 static heron::proto::system::PackingPlan* GenerateDummyPackingPlan(int num_stmgrs_, int num_spouts,
     int num_spout_instances, int num_bolts, int num_bolt_instances) {
-  size_t spouts_size = num_spout_instances;
-  size_t bolts_size = num_bolt_instances;
+  size_t spouts_size = num_spouts * num_spout_instances;
+  size_t bolts_size = num_bolts * num_bolt_instances;
 
   heron::proto::system::Resource* instanceResource = new heron::proto::system::Resource();
   instanceResource->set_ram(1);


### PR DESCRIPTION
We found that the topology defn is changed during update process, which causes the messy state. The original topology definition should remain same during the whole topology lifecycle, while the packing plan shows the latest topology information during update/repack.

This PR keeps topology defn during update.

Tested in local scheduler with #2600.
