### PR TITLE
 Refactoring and improving standalone mode

### DIFF
--- a/heron/config/src/yaml/BUILD
+++ b/heron/config/src/yaml/BUILD
@@ -18,7 +18,6 @@ filegroup(
         ["conf/**/*.aurora"]
         + ["conf/**/*.hcl"]
         + ["conf/**/*.sh"]
-        + ["conf/**/*.txt"]
         + ["conf/**/*.yaml"]),
 )
 

--- a/heron/config/src/yaml/conf/standalone/inventory.yaml
+++ b/heron/config/src/yaml/conf/standalone/inventory.yaml
@@ -1,0 +1,4 @@
+cluster:
+    - 127.0.0.1
+zookeepers:
+    - 127.0.0.1

--- a/heron/config/src/yaml/conf/standalone/roles/master_servers.txt
+++ b/heron/config/src/yaml/conf/standalone/roles/master_servers.txt
@@ -1,2 +1,0 @@
-# Please provide a list of Master servers. Please provide at least one server.
-127.0.0.1

--- a/heron/config/src/yaml/conf/standalone/roles/slave_servers.txt
+++ b/heron/config/src/yaml/conf/standalone/roles/slave_servers.txt
@@ -1,2 +1,0 @@
-# Please provide a list of slave servers. Please provide at least one server.
-127.0.0.1

--- a/heron/config/src/yaml/conf/standalone/roles/zookeeper_servers.txt
+++ b/heron/config/src/yaml/conf/standalone/roles/zookeeper_servers.txt
@@ -1,2 +1,0 @@
-# Please provide a list of zookeeper servers (optionally with the port to contact ZK on. Default if 2181).
-127.0.0.1:2181

--- a/heron/config/src/yaml/conf/standalone/scheduler.yaml
+++ b/heron/config/src/yaml/conf/standalone/scheduler.yaml
@@ -11,7 +11,7 @@ heron.scheduler.local.working.directory:     ${HOME}/.herondata/topologies/${CLU
 heron.directory.sandbox.java.home:           ${JAVA_HOME}
 
 # The URI of Nomad API
-heron.nomad.scheduler.uri:             http://127.0.0.1:4646
+::             http://127.0.0.1:4646
 
 #Invoke the IScheduler as a library directly
 heron.scheduler.is.service:                  False

--- a/heron/config/src/yaml/conf/standalone/scheduler.yaml
+++ b/heron/config/src/yaml/conf/standalone/scheduler.yaml
@@ -11,7 +11,7 @@ heron.scheduler.local.working.directory:     ${HOME}/.herondata/topologies/${CLU
 heron.directory.sandbox.java.home:           ${JAVA_HOME}
 
 # The URI of Nomad API
-::             http://127.0.0.1:4646
+heron.nomad.scheduler.uri:             http://127.0.0.1:4646
 
 #Invoke the IScheduler as a library directly
 heron.scheduler.is.service:                  False

--- a/heron/config/src/yaml/conf/standalone/templates/apiserver.template.hcl
+++ b/heron/config/src/yaml/conf/standalone/templates/apiserver.template.hcl
@@ -13,7 +13,13 @@ job "apiserver" {
       driver = "raw_exec"
       config {
         command = <heron_apiserver_executable>
-        args = ["--cluster", "standalone"],
+        args = [
+        "--cluster", "standalone",
+        "--base-template", "standalone",
+        "-D", "heron.statemgr.connection.string=<zookeeper_host:zookeeper_port>",
+        "-D", "heron.nomad.scheduler.uri=<scheduler_uri>",
+        "-D", "heron.class.uploader=com.twitter.heron.uploader.http.HttpUploader",
+        "--verbose"]
       }
       resources {
         cpu    = 500 # 500 MHz

--- a/heron/config/src/yaml/conf/standalone/templates/heron_tools.template.hcl
+++ b/heron/config/src/yaml/conf/standalone/templates/heron_tools.template.hcl
@@ -1,0 +1,40 @@
+job "heron-tools" {
+  datacenters = ["dc1"]
+  type = "service"
+
+  constraint {
+    attribute = "${attr.unique.hostname}"
+    value     = <heron_tools_hostname>
+  }
+
+  group "heron-tools" {
+    count = 1
+    task "heron-tracker" {
+      driver = "raw_exec"
+      config {
+        command = <heron_tracker_executable>
+        args = [
+        "--type=zookeeper",
+        "--hostport=<zookeeper_host:zookeeper_port>",
+        "--name=standalone",
+        "--rootpath=heron"
+       ]
+      }
+      resources {
+        cpu    = 500 # 500 MHz
+        memory = 256 # 256MB
+      }
+    }
+
+    task "heron-ui" {
+          driver = "raw_exec"
+          config {
+            command = <heron_ui_executable>
+          }
+          resources {
+            cpu    = 500 # 500 MHz
+            memory = 256 # 256MB
+          }
+        }
+  }
+}

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/nomad/NomadSchedulerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/nomad/NomadSchedulerTest.java
@@ -358,7 +358,7 @@ public class NomadSchedulerTest {
         task.getEnv().get(NomadConstants.HERON_CORE_PACKAGE_URI));
     Assert.assertEquals(TOPOLOGY_DOWNLOAD_CMD,
         task.getEnv().get(NomadConstants.HERON_TOPOLOGY_DOWNLOAD_CMD));
-    Assert.assertEquals("executor-binary args1 args2",
+    Assert.assertEquals("./heron-core/bin/heron-executor args1 args2",
         task.getEnv().get(NomadConstants.HERON_EXECUTOR_CMD));
   }
 }

--- a/heron/tools/admin/src/python/BUILD
+++ b/heron/tools/admin/src/python/BUILD
@@ -1,7 +1,5 @@
 package(default_visibility = ["//visibility:public"])
 
-load("/tools/rules/pex/pex_rules", "pex_library", "pex_binary")
-
 pex_library(
     name = "admin-py",
     srcs = glob(

--- a/heron/tools/admin/src/python/BUILD
+++ b/heron/tools/admin/src/python/BUILD
@@ -1,0 +1,30 @@
+package(default_visibility = ["//visibility:public"])
+
+load("/tools/rules/pex/pex_rules", "pex_library", "pex_binary")
+
+pex_library(
+    name = "admin-py",
+    srcs = glob(
+        ["**/*.py"],
+    ),
+    deps = [
+        "//heron/common/src/python:common-py",
+        "//heron/tools/common/src/python:common-py",
+        "//heron/tools/cli/src/python:cli-py",
+        "//heron/proto:proto-py",
+    ],
+    reqs = [
+      "PyYAML==3.10",
+      "enum34==1.1.6",
+      "requests==2.12.3",
+      "netifaces==0.10.6"
+    ],
+)
+
+pex_binary(
+    name = "heron-admin",
+    srcs = [
+        "main.py",
+    ],
+    deps = [":admin-py"],
+)

--- a/heron/tools/admin/src/python/main.py
+++ b/heron/tools/admin/src/python/main.py
@@ -18,7 +18,6 @@ import argparse
 import os
 import shutil
 import sys
-import time
 import traceback
 
 import heron.common.src.python.utils.log as log
@@ -33,153 +32,147 @@ HELP_EPILOG = '''Getting more help:
 
 For detailed documentation, go to http://heronstreaming.io'''
 
-
 # pylint: disable=protected-access,superfluous-parens
 class _HelpAction(argparse._HelpAction):
-    def __call__(self, parser, namespace, values, option_string=None):
-        parser.print_help()
+  def __call__(self, parser, namespace, values, option_string=None):
+    parser.print_help()
 
-        # retrieve subparsers from parser
-        subparsers_actions = [
-            action for action in parser._actions
-            if isinstance(action, argparse._SubParsersAction)
-        ]
+    # retrieve subparsers from parser
+    subparsers_actions = [
+        action for action in parser._actions
+        if isinstance(action, argparse._SubParsersAction)
+    ]
 
-        # there will probably only be one subparser_action,
-        # but better save than sorry
-        for subparsers_action in subparsers_actions:
-            # get all subparsers and print help
-            for choice, subparser in subparsers_action.choices.items():
-                print("Subparser '{}'".format(choice))
-                print(subparser.format_help())
-                return
+    # there will probably only be one subparser_action,
+    # but better save than sorry
+    for subparsers_action in subparsers_actions:
+      # get all subparsers and print help
+      for choice, subparser in subparsers_action.choices.items():
+        print("Subparser '{}'".format(choice))
+        print(subparser.format_help())
+        return
 
 ################################################################################
 def get_command_handlers():
-    '''
-    Create a map of command names and handlers
-    '''
-    return {
-        'standalone': standalone,
-    }
+  '''
+  Create a map of command names and handlers
+  '''
+  return {
+      'standalone': standalone,
+  }
 
 ################################################################################
 def create_parser(command_handlers):
-    '''
-    Main parser
-    :return:
-    '''
-    parser = argparse.ArgumentParser(
-        prog='heron',
-        epilog=HELP_EPILOG,
-        formatter_class=config.SubcommandHelpFormatter,
-        add_help=True)
+  '''
+  Main parser
+  :return:
+  '''
+  parser = argparse.ArgumentParser(
+      prog='heron',
+      epilog=HELP_EPILOG,
+      formatter_class=config.SubcommandHelpFormatter,
+      add_help=True)
 
-    subparsers = parser.add_subparsers(
-        title="Available commands",
-        metavar='<command> <options>')
+  subparsers = parser.add_subparsers(
+      title="Available commands",
+      metavar='<command> <options>')
 
-    command_list = sorted(command_handlers.items())
-    for command in command_list:
-        command[1].create_parser(subparsers)
+  command_list = sorted(command_handlers.items())
+  for command in command_list:
+    command[1].create_parser(subparsers)
 
-    return parser
-
+  return parser
 
 ################################################################################
 def run(handlers, command, parser, command_args, unknown_args):
-    '''
-    Run the command
-    :param command:
-    :param parser:
-    :param command_args:
-    :param unknown_args:
-    :return:
-    '''
+  '''
+  Run the command
+  :param command:
+  :param parser:
+  :param command_args:
+  :param unknown_args:
+  :return:
+  '''
 
-    if command in handlers:
-        return handlers[command].run(command, parser, command_args, unknown_args)
-    else:
-        err_context = 'Unknown subcommand: %s' % command
-        return result.SimpleResult(result.Status.InvocationError, err_context)
+  if command in handlers:
+    return handlers[command].run(command, parser, command_args, unknown_args)
+  else:
+    err_context = 'Unknown subcommand: %s' % command
+    return result.SimpleResult(result.Status.InvocationError, err_context)
 
 def cleanup(files):
-    '''
-    :param files:
-    :return:
-    '''
-    for cur_file in files:
-        if os.path.isdir(cur_file):
-            shutil.rmtree(cur_file)
-        else:
-            shutil.rmtree(os.path.dirname(cur_file))
-
+  '''
+  :param files:
+  :return:
+  '''
+  for cur_file in files:
+    if os.path.isdir(cur_file):
+      shutil.rmtree(cur_file)
+    else:
+      shutil.rmtree(os.path.dirname(cur_file))
 
 ################################################################################
 def check_environment():
-    '''
-    Check whether the environment variables are set
-    :return:
-    '''
-    if not config.check_java_home_set():
-        sys.exit(1)
+  '''
+  Check whether the environment variables are set
+  :return:
+  '''
+  if not config.check_java_home_set():
+    sys.exit(1)
 
-    if not config.check_release_file_exists():
-        sys.exit(1)
+  if not config.check_release_file_exists():
+    sys.exit(1)
 
 ################################################################################
 def execute(handlers):
-    '''
-    Run the command
-    :return:
-    '''
-    # verify if the environment variables are correctly set
-    check_environment()
+  '''
+  Run the command
+  :return:
+  '''
+  # verify if the environment variables are correctly set
+  check_environment()
 
-    # create the argument parser
-    parser = create_parser(handlers)
+  # create the argument parser
+  parser = create_parser(handlers)
 
-    # if no argument is provided, print help and exit
-    if len(sys.argv[1:]) == 0:
-        parser.print_help()
-        return 0
+  # if no argument is provided, print help and exit
+  if len(sys.argv[1:]) == 0:
+    parser.print_help()
+    return 0
 
-    # insert the boolean values for some of the options
-    sys.argv = config.insert_bool_values(sys.argv)
+  # insert the boolean values for some of the options
+  sys.argv = config.insert_bool_values(sys.argv)
 
-    try:
-        # parse the args
-        args, unknown_args = parser.parse_known_args()
-    except ValueError as ex:
-        Log.error("Error while parsing arguments: %s", str(ex))
-        Log.debug(traceback.format_exc())
-        sys.exit(1)
+  try:
+    # parse the args
+    args, unknown_args = parser.parse_known_args()
+  except ValueError as ex:
+    Log.error("Error while parsing arguments: %s", str(ex))
+    Log.debug(traceback.format_exc())
+    sys.exit(1)
 
-    command_line_args = vars(args)
+  command_line_args = vars(args)
 
-    # set log level
-    log.set_logging_level(command_line_args)
-    Log.debug("Input Command Line Args: %s", command_line_args)
+  # set log level
+  log.set_logging_level(command_line_args)
+  Log.debug("Input Command Line Args: %s", command_line_args)
 
-    # command to be execute
-    command = command_line_args['subcommand']
+  # command to be execute
+  command = command_line_args['subcommand']
 
-    # print the input parameters, if verbose is enabled
-    Log.debug("Processed Command Line Args: %s", command_line_args)
+  # print the input parameters, if verbose is enabled
+  Log.debug("Processed Command Line Args: %s", command_line_args)
 
-    start = time.time()
-    results = run(handlers, command, parser, command_line_args, unknown_args)
+  results = run(handlers, command, parser, command_line_args, unknown_args)
 
-    end = time.time()
-
-    return 0 if result.is_successful(results) else 1
+  return 0 if result.is_successful(results) else 1
 
 def main():
-    # Create a map of supported commands and handlers
-    command_handlers = get_command_handlers()
-    # Execute
-    return execute(command_handlers)
+  # Create a map of supported commands and handlers
+  command_handlers = get_command_handlers()
+  # Execute
+  return execute(command_handlers)
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+  sys.exit(main())

--- a/heron/tools/admin/src/python/main.py
+++ b/heron/tools/admin/src/python/main.py
@@ -1,0 +1,185 @@
+# Copyright 2016 Twitter. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# !/usr/bin/env python2.7
+''' main.py '''
+import argparse
+import os
+import shutil
+import sys
+import time
+import traceback
+
+import heron.common.src.python.utils.log as log
+import heron.tools.common.src.python.utils.config as config
+import heron.tools.cli.src.python.result as result
+import heron.tools.admin.src.python.standalone as standalone
+
+Log = log.Log
+
+HELP_EPILOG = '''Getting more help:
+  heron help <command> Prints help and options for <command>
+
+For detailed documentation, go to http://heronstreaming.io'''
+
+
+# pylint: disable=protected-access,superfluous-parens
+class _HelpAction(argparse._HelpAction):
+    def __call__(self, parser, namespace, values, option_string=None):
+        parser.print_help()
+
+        # retrieve subparsers from parser
+        subparsers_actions = [
+            action for action in parser._actions
+            if isinstance(action, argparse._SubParsersAction)
+        ]
+
+        # there will probably only be one subparser_action,
+        # but better save than sorry
+        for subparsers_action in subparsers_actions:
+            # get all subparsers and print help
+            for choice, subparser in subparsers_action.choices.items():
+                print("Subparser '{}'".format(choice))
+                print(subparser.format_help())
+                return
+
+################################################################################
+def get_command_handlers():
+    '''
+    Create a map of command names and handlers
+    '''
+    return {
+        'standalone': standalone,
+    }
+
+################################################################################
+def create_parser(command_handlers):
+    '''
+    Main parser
+    :return:
+    '''
+    parser = argparse.ArgumentParser(
+        prog='heron',
+        epilog=HELP_EPILOG,
+        formatter_class=config.SubcommandHelpFormatter,
+        add_help=True)
+
+    subparsers = parser.add_subparsers(
+        title="Available commands",
+        metavar='<command> <options>')
+
+    command_list = sorted(command_handlers.items())
+    for command in command_list:
+        command[1].create_parser(subparsers)
+
+    return parser
+
+
+################################################################################
+def run(handlers, command, parser, command_args, unknown_args):
+    '''
+    Run the command
+    :param command:
+    :param parser:
+    :param command_args:
+    :param unknown_args:
+    :return:
+    '''
+
+    if command in handlers:
+        return handlers[command].run(command, parser, command_args, unknown_args)
+    else:
+        err_context = 'Unknown subcommand: %s' % command
+        return result.SimpleResult(result.Status.InvocationError, err_context)
+
+def cleanup(files):
+    '''
+    :param files:
+    :return:
+    '''
+    for cur_file in files:
+        if os.path.isdir(cur_file):
+            shutil.rmtree(cur_file)
+        else:
+            shutil.rmtree(os.path.dirname(cur_file))
+
+
+################################################################################
+def check_environment():
+    '''
+    Check whether the environment variables are set
+    :return:
+    '''
+    if not config.check_java_home_set():
+        sys.exit(1)
+
+    if not config.check_release_file_exists():
+        sys.exit(1)
+
+################################################################################
+def execute(handlers):
+    '''
+    Run the command
+    :return:
+    '''
+    # verify if the environment variables are correctly set
+    check_environment()
+
+    # create the argument parser
+    parser = create_parser(handlers)
+
+    # if no argument is provided, print help and exit
+    if len(sys.argv[1:]) == 0:
+        parser.print_help()
+        return 0
+
+    # insert the boolean values for some of the options
+    sys.argv = config.insert_bool_values(sys.argv)
+
+    try:
+        # parse the args
+        args, unknown_args = parser.parse_known_args()
+    except ValueError as ex:
+        Log.error("Error while parsing arguments: %s", str(ex))
+        Log.debug(traceback.format_exc())
+        sys.exit(1)
+
+    command_line_args = vars(args)
+
+    # set log level
+    log.set_logging_level(command_line_args)
+    Log.debug("Input Command Line Args: %s", command_line_args)
+
+    # command to be execute
+    command = command_line_args['subcommand']
+
+    # print the input parameters, if verbose is enabled
+    Log.debug("Processed Command Line Args: %s", command_line_args)
+
+    start = time.time()
+    results = run(handlers, command, parser, command_line_args, unknown_args)
+
+    end = time.time()
+
+    return 0 if result.is_successful(results) else 1
+
+def main():
+    # Create a map of supported commands and handlers
+    command_handlers = get_command_handlers()
+    # Execute
+    return execute(command_handlers)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/heron/tools/admin/src/python/standalone.py
+++ b/heron/tools/admin/src/python/standalone.py
@@ -23,29 +23,35 @@ import socket
 import requests
 import time
 import netifaces
+import yaml
 
 from heron.common.src.python.utils.log import Log
-from heron.tools.cli.src.python.result import SimpleResult, Status
+from heron.tools.cli.src.python.result   import SimpleResult, Status
 import heron.tools.cli.src.python.args as cli_args
 import heron.tools.common.src.python.utils.config as config
 
 # pylint: disable=anomalous-backslash-in-string
 
-class ACTION(object):
+class Action(object):
   SET = "set"
   CLUSTER = "cluster"
   TEMPLATE = "template"
+  GET = "get"
 
 TYPE = "type"
 
-class SET(object):
+class Role(object):
   ZOOKEEPERS = "zookeepers"
   MASTERS = "masters"
   SLAVES = "slaves"
+  CLUSTER = "cluster"
 
-class CLUSTER(object):
+class Cluster(object):
   START = "start"
   STOP = "stop"
+
+class Get(object):
+  SERVICE_URL = "service-url"
 ################################################################################
 def create_parser(subparsers):
   '''
@@ -64,51 +70,38 @@ def create_parser(subparsers):
   parser_action = parser.add_subparsers()
 
   parser_cluster = parser_action.add_parser(
-      ACTION.CLUSTER,
+      Action.CLUSTER,
       help='Start or stop cluster',
       add_help=True,
       formatter_class=argparse.RawTextHelpFormatter,
   )
-  parser_cluster.set_defaults(action=ACTION.CLUSTER)
+  parser_cluster.set_defaults(action=Action.CLUSTER)
 
   parser_set = parser_action.add_parser(
-      ACTION.SET,
+      Action.SET,
       help='Set configurations for standalone cluster e.g. master or slave nodes',
       add_help=True,
       formatter_class=argparse.RawTextHelpFormatter
   )
-  parser_set.set_defaults(action=ACTION.SET)
+  parser_set.set_defaults(action=Action.SET)
 
   parser_template = parser_action.add_parser(
-      ACTION.TEMPLATE,
+      Action.TEMPLATE,
       help='Template Heron configurations based on cluster roles',
       add_help=True,
       formatter_class=argparse.RawTextHelpFormatter
   )
-  parser_template.set_defaults(action=ACTION.TEMPLATE)
+  parser_template.set_defaults(action=Action.TEMPLATE)
 
   parser_cluster.add_argument(
       TYPE,
       type=str,
-      choices={CLUSTER.START, CLUSTER.STOP},
+      choices={Cluster.START, Cluster.STOP},
       help= \
 """
 Choices supports the following:
   start     - Start standalone Heron cluster
   stop      - Stop standalone Heron cluster
-"""
-  )
-
-  parser_set.add_argument(
-      TYPE,
-      type=str,
-      choices={SET.MASTERS, SET.SLAVES, SET.ZOOKEEPERS},
-      help=\
-"""
-Choices supports the following:
-  masters     - Set the hostname/IP for master nodes
-  slaves      - Set the hostname/IP for slave nodes
-  zookeepers  - Set the hostname/IP for Zookeeper servers
 """
   )
 
@@ -118,7 +111,26 @@ Choices supports the following:
       choices={"configs"},
   )
 
-  add_additional_args([parser_set, parser_cluster, parser_template])
+  parser_get = parser_action.add_parser(
+    Action.GET,
+    help='Get attributes about the standalone cluster',
+    add_help=True,
+    formatter_class=argparse.RawTextHelpFormatter
+  )
+  parser_get.set_defaults(action=Action.GET)
+
+  parser_get.add_argument(
+    TYPE,
+    type=str,
+    choices={Get.SERVICE_URL},
+    help= \
+      """
+      Choices supports the following:
+        service-url     - Get service url for standalone cluster
+      """
+  )
+
+  add_additional_args([parser_set, parser_cluster, parser_template, parser_get])
   parser.set_defaults(subcommand='standalone')
   return parser
 
@@ -131,23 +143,14 @@ def run(command, parser, cl_args, unknown_args):
   '''
 
   action = cl_args["action"]
-  action_type = cl_args["type"]
-  if action == ACTION.SET:
-    if action_type == SET.ZOOKEEPERS:
-      call_editor(get_role_definition_file(SET.ZOOKEEPERS, cl_args))
-      update_zookeeper_config_files(cl_args)
-    elif action_type == SET.SLAVES:
-      call_editor(get_role_definition_file(SET.SLAVES, cl_args))
-      update_slave_config_files(cl_args)
-    elif action_type == SET.MASTERS:
-      call_editor(get_role_definition_file(SET.MASTERS, cl_args))
-      update_master_config_files(cl_args)
-    else:
-      raise ValueError("Invalid set type %s" % action_type)
-  elif action == ACTION.CLUSTER:
-    if action_type == CLUSTER.START:
+  if action == Action.SET:
+    call_editor(get_inventory_file(cl_args))
+    update_config_files(cl_args)
+  elif action == Action.CLUSTER:
+    action_type = cl_args["type"]
+    if action_type == Cluster.START:
       start_cluster(cl_args)
-    elif action_type == CLUSTER.STOP:
+    elif action_type == Cluster.STOP:
       if check_sure(cl_args, "Are you sure you want to stop the cluster?"
                              " This will terminate everything running in "
                              "the cluster and remove any scheduler state."):
@@ -155,120 +158,129 @@ def run(command, parser, cl_args, unknown_args):
         stop_cluster(cl_args)
     else:
       raise ValueError("Invalid cluster action %s" % action_type)
-  elif action == ACTION.TEMPLATE:
-    update_zookeeper_config_files(cl_args)
-    update_master_config_files(cl_args)
-    update_slave_config_files(cl_args)
+  elif action == Action.TEMPLATE:
+    update_config_files(cl_args)
+  elif action == Action.GET:
+    get_service_url(cl_args)
   else:
     raise ValueError("Invalid action %s" % action)
 
   return SimpleResult(Status.Ok)
 
 ################################################################################
-def update_slave_config_files(cl_args):
-  '''
-  update/template config files related to slave servers
-  '''
 
+def update_config_files(cl_args):
+  Log.info("Updating config files...")
   roles = read_and_parse_roles(cl_args)
-  slaves = list(roles[SET.SLAVES])
-  if not slaves:
-    return
-  Log.debug("Templating files for slaves...")
+  Log.debug("roles: %s" % roles)
+  masters = list(roles[Role.MASTERS])
+  slaves = list(roles[Role.SLAVES])
+  zookeepers = list(roles[Role.ZOOKEEPERS])
 
-  # update apiserver location
+  template_slave_hcl(cl_args, masters)
+  template_scheduler_yaml(cl_args, masters)
+  template_uploader_yaml(cl_args, masters)
+  template_apiserver_hcl(cl_args, masters, zookeepers)
+  template_statemgr_yaml(cl_args, zookeepers)
 
-  single_slave = slaves[0]
+
+##################### Templating functions ######################################
+
+def template_slave_hcl(cl_args, masters):
+  '''
+  Template slave config file
+  '''
+
+  slave_config_template = "%s/standalone/templates/slave.template.hcl" % cl_args["config_path"]
+  slave_config_actual = "%s/standalone/resources/slave.hcl" % cl_args["config_path"]
+  masters_in_quotes = ['"%s"' % master for master in masters]
+  template_file(slave_config_template, slave_config_actual,
+                {"<nomad_masters:master_port>": ", ".join(masters_in_quotes)})
+
+def template_scheduler_yaml(cl_args, masters):
+  '''
+  Template scheduler.yaml
+  '''
+
+  single_master = masters[0]
+  scheduler_config_actual = "%s/standalone/scheduler.yaml" % cl_args["config_path"]
+
+  scheduler_config_template = "%s/standalone/templates/scheduler.template.yaml" \
+                              % cl_args["config_path"]
+  template_file(scheduler_config_template, scheduler_config_actual,
+                {"<scheduler_uri>": "http://%s:4646" % single_master})
+
+def template_uploader_yaml(cl_args, masters):
+  '''
+  Tempate uploader.yaml
+  '''
+
+  single_master = masters[0]
   uploader_config_template = "%s/standalone/templates/uploader.template.yaml" \
                              % cl_args["config_path"]
-  with open(uploader_config_template, 'r') as tf:
-    file_contents = tf.read()
-    new_file_contents = file_contents.replace("<http_uploader_uri>",
-                                              "http://%s:9000/api/v1/file/upload" % single_slave)
-
   uploader_config_actual = "%s/standalone/uploader.yaml" % cl_args["config_path"]
-  with open(uploader_config_actual, 'w') as tf:
-    tf.write(new_file_contents)
-    tf.truncate()
 
-  # Api server nomad job def
+  template_file(uploader_config_template, uploader_config_actual,
+                {"<http_uploader_uri>": "http://%s:9000/api/v1/file/upload" % single_master})
+
+def template_apiserver_hcl(cl_args, masters, zookeepers):
+  """
+  template apiserver.hcl
+  """
+  single_master = masters[0]
   apiserver_config_template = "%s/standalone/templates/apiserver.template.hcl" \
                               % cl_args["config_path"]
-  with open(apiserver_config_template, 'r') as tf:
-    file_contents = tf.read()
-    new_file_contents = file_contents.replace(
-        "<heron_apiserver_hostname>", '"%s"' % get_hostname(single_slave, cl_args))
-    if is_self(single_slave):
-      new_file_contents = new_file_contents.replace(
-          "<heron_apiserver_executable>",
-          '"%s/heron-apiserver"' % config.get_heron_bin_dir())
-    else:
-      new_file_contents = new_file_contents.replace(
-          "<heron_apiserver_executable>",
-          '"%s/.heron/bin/heron-apiserver"' % get_remote_home(single_slave, cl_args))
-
   apiserver_config_actual = "%s/standalone/resources/apiserver.hcl" % cl_args["config_path"]
-  with open(apiserver_config_actual, 'w') as tf:
-    tf.write(new_file_contents)
-    tf.truncate()
 
-def update_master_config_files(cl_args):
+  replacements = {
+    "<heron_apiserver_hostname>": '"%s"' % get_hostname(single_master, cl_args),
+    "<heron_apiserver_executable>": '"%s/heron-apiserver"' % config.get_heron_bin_dir() if is_self(
+      single_master) else '"%s/.heron/bin/heron-apiserver"' % get_remote_home(single_master,
+                                                                              cl_args),
+    "<zookeeper_host:zookeeper_port>": ",".join(
+      ['%s' % zk if ":" in zk else '%s:2181' % zk for zk in zookeepers]),
+    "<scheduler_uri>": "http://%s:4646" % single_master
+  }
+
+  template_file(apiserver_config_template, apiserver_config_actual, replacements)
+
+
+def template_statemgr_yaml(cl_args, zookeepers):
   '''
-  update/template config files related to master servers
+  Template statemgr.yaml
   '''
-  roles = read_and_parse_roles(cl_args)
-  masters = list(roles[SET.MASTERS])
-  if not masters:
-    return
-  Log.debug("Templating files for masters...")
-  slave_config_template = "%s/standalone/templates/slave.template.hcl" % cl_args["config_path"]
-  new_file_contents = ""
-  with open(slave_config_template, 'r') as tf:
-    file_contents = tf.read()
-    masters_in_quotes = ['"%s"' % master for master in masters]
-    new_file_contents = file_contents.replace("<nomad_masters:master_port>",
-                                              ", ".join(masters_in_quotes))
 
-  slave_config_actual = "%s/standalone/resources/slave.hcl" % cl_args["config_path"]
-  with open(slave_config_actual, 'w') as tf:
-    tf.write(new_file_contents)
-    tf.truncate()
-
-  # template scheduler.yaml
-  single_master = masters[0]
-  scheduler_config_template = "%s/standalone/templates/scheduler.template.yaml" \
-                               % cl_args["config_path"]
-  with open(scheduler_config_template, 'r') as tf:
-    file_contents = tf.read()
-    new_file_contents = file_contents.replace("<scheduler_uri>",
-                                              "http://%s:4646" % single_master)
-
-  scheduler_config_actual = "%s/standalone/scheduler.yaml" % cl_args["config_path"]
-  with open(scheduler_config_actual, 'w') as tf:
-    tf.write(new_file_contents)
-    tf.truncate()
-
-def update_zookeeper_config_files(cl_args):
-  '''
-  update/template config files related to zookeeper servers
-  '''
-  roles = read_and_parse_roles(cl_args)
-  zookeepers = ['"%s"' % zk if ":" in zk else '"%s:2181"' % zk for zk in roles[SET.ZOOKEEPERS]]
-  if not zookeepers:
-    return
-  Log.debug("Templating files for zookeepers...")
   statemgr_config_file_template = "%s/standalone/templates/statemgr.template.yaml" \
                                   % cl_args["config_path"]
-  new_file_contents = ""
-  with open(statemgr_config_file_template, 'r') as tf:
-    file_contents = tf.read()
-    new_file_contents = file_contents.replace("<zookeeper_host:zookeeper_port>",
-                                              ",".join(zookeepers))
-
   statemgr_config_file_actual = "%s/standalone/statemgr.yaml" % cl_args["config_path"]
-  with open(statemgr_config_file_actual, 'w') as tf:
-    tf.write(new_file_contents)
+
+  template_file(statemgr_config_file_template, statemgr_config_file_actual,
+                {"<zookeeper_host:zookeeper_port>": ",".join(
+                  ['"%s"' % zk if ":" in zk else '"%s:2181"' % zk for zk in zookeepers])})
+
+def template_file(src, dest, replacements_dict):
+  Log.debug("Templating %s - > %s with %s" % (src, dest, replacements_dict))
+
+  file_contents = ""
+  with open(src, 'r') as tf:
+    file_contents = tf.read()
+    for key, value in replacements_dict.iteritems():
+      file_contents = file_contents.replace(key, value)
+
+  if not file_contents:
+    Log.error("File contents after templating is empty")
+    sys.exit(-1)
+
+  with open(dest, 'w') as tf:
+    tf.write(file_contents)
     tf.truncate()
+
+################################################################################
+
+def get_service_url(cl_args):
+  roles = read_and_parse_roles(cl_args)
+  service_url = "http://%s:9000" % list(roles[Role.MASTERS])[0]
+  print service_url
 
 def add_additional_args(parsers):
   '''
@@ -289,8 +301,8 @@ def stop_cluster(cl_args):
   Log.info("Terminating cluster...")
 
   roles = read_and_parse_roles(cl_args)
-  masters = roles[SET.MASTERS]
-  slaves = roles[SET.SLAVES]
+  masters = roles[Role.MASTERS]
+  slaves = roles[Role.SLAVES]
   dist_nodes = masters.union(slaves)
 
   # stop all jobs
@@ -344,9 +356,9 @@ def start_cluster(cl_args):
   Start a Heron standalone cluster
   '''
   roles = read_and_parse_roles(cl_args)
-  masters = roles[SET.MASTERS]
-  slaves = roles[SET.SLAVES]
-  zookeepers = roles[SET.ZOOKEEPERS]
+  masters = roles[Role.MASTERS]
+  slaves = roles[Role.SLAVES]
+  zookeepers = roles[Role.ZOOKEEPERS]
   Log.info("Roles:")
   Log.info(" - Master Servers: %s" % list(masters))
   Log.info(" - Slave Servers: %s" % list(slaves))
@@ -361,9 +373,7 @@ def start_cluster(cl_args):
     Log.error("No zookeeper servers specified!")
     sys.exit(-1)
   # make sure configs are templated
-  update_zookeeper_config_files(cl_args)
-  update_master_config_files(cl_args)
-  update_slave_config_files(cl_args)
+  update_config_files(cl_args)
 
   dist_nodes = list(masters.union(slaves))
   # if just local deployment
@@ -381,7 +391,8 @@ def start_api_server(masters, cl_args):
   # make sure nomad cluster is up
   single_master = list(masters)[0]
 
-  for i in range(10):
+  i=0
+  while(True):
     try:
       r = requests.get("http://%s:4646/v1/status/leader" % single_master)
       if r.status_code == 200:
@@ -390,6 +401,10 @@ def start_api_server(masters, cl_args):
       Log.debug(sys.exc_info()[0])
       Log.info("Waiting for cluster to come up... %s" % i)
       time.sleep(1)
+      if i > 10:
+        Log.error("Failed to start Nomad Cluster!")
+        sys.exit(-1)
+    i = i + 1
 
 
   cmd = "%s run %s >> /tmp/apiserver_start.log 2>&1 &" \
@@ -419,8 +434,8 @@ def distribute_package(roles, cl_args):
   '''
 
   Log.info("Distributing heron package to nodes (this might take a while)...")
-  masters = roles[SET.MASTERS]
-  slaves = roles[SET.SLAVES]
+  masters = roles[Role.MASTERS]
+  slaves = roles[Role.SLAVES]
 
   tar_file = tempfile.NamedTemporaryFile(suffix=".tmp").name
   Log.debug("TAR file %s to %s" % (cl_args["heron_dir"], tar_file))
@@ -551,9 +566,28 @@ def read_and_parse_roles(cl_args):
   read config files to get roles
   '''
   roles = dict()
-  roles[SET.ZOOKEEPERS] = set(read_file(get_role_definition_file(SET.ZOOKEEPERS, cl_args)))
-  roles[SET.MASTERS] = set(read_file(get_role_definition_file(SET.MASTERS, cl_args)))
-  roles[SET.SLAVES] = set(read_file(get_role_definition_file(SET.SLAVES, cl_args)))
+
+  with open(get_inventory_file(cl_args), 'r') as stream:
+    try:
+      roles = yaml.load(stream)
+    except yaml.YAMLError as exc:
+      Log.error("Error parsing inventory file: %s" % exc)
+      sys.exit(-1)
+
+  if Role.ZOOKEEPERS not in roles or not roles[Role.ZOOKEEPERS]:
+    Log.error("Zookeeper servers node defined!")
+    sys.exit(-1)
+
+  if Role.CLUSTER not in roles or not roles[Role.CLUSTER]:
+    Log.error("Heron cluster nodes defined!")
+    sys.exit(-1)
+
+  # Set roles
+  roles[Role.MASTERS] = set([roles[Role.CLUSTER][0]])
+  roles[Role.SLAVES] = set(roles[Role.CLUSTER])
+  roles[Role.ZOOKEEPERS] = set(roles[Role.ZOOKEEPERS])
+  roles[Role.CLUSTER] = set(roles[Role.CLUSTER])
+
   return roles
 
 def read_file(file_path):
@@ -575,16 +609,11 @@ def call_editor(file_path):
   with open(file_path, 'r+') as tf:
     call([EDITOR, tf.name])
 
-def get_role_definition_file(role, cl_args):
+def get_inventory_file(cl_args):
   '''
-  get the location of role files
+  get the location of inventory file
   '''
-  if role == SET.ZOOKEEPERS:
-    return "%s/standalone/roles/zookeeper_servers.txt" % cl_args["config_path"]
-  if role == SET.MASTERS:
-    return "%s/standalone/roles/master_servers.txt" % cl_args["config_path"]
-  if role == SET.SLAVES:
-    return "%s/standalone/roles/slave_servers.txt" % cl_args["config_path"]
+  return "%s/standalone/inventory.yaml" % cl_args["config_path"]
 
 def ssh_remote_execute(cmd, host, cl_args):
   '''

--- a/heron/tools/apiserver/src/java/BUILD
+++ b/heron/tools/apiserver/src/java/BUILD
@@ -15,6 +15,7 @@ scheduler_deps_files = [
   "//heron/schedulers/src/java:mesos-scheduler-java",
   "//heron/schedulers/src/java:yarn-scheduler-java",
   "//heron/schedulers/src/java:slurm-scheduler-java",
+  "//heron/schedulers/src/java:nomad-scheduler-java"
 ]
 
 packing_deps_files = [

--- a/heron/tools/apiserver/src/java/com/twitter/heron/apiserver/Runtime.java
+++ b/heron/tools/apiserver/src/java/com/twitter/heron/apiserver/Runtime.java
@@ -241,12 +241,11 @@ public final class Runtime {
     final String configurationOverrides = loadOverrides(cmd);
     final int port = getPort(cmd);
 
-    LOG.info("load baseConfiguration");
     final Config baseConfiguration =
         ConfigUtils.getBaseConfiguration(heronDirectory,
-        heronConfigurationDirectory,
-        releaseFile,
-        configurationOverrides);
+            heronConfigurationDirectory,
+            releaseFile,
+            configurationOverrides);
 
     final ResourceConfig config = new ResourceConfig(Resources.get());
     final Server server = new Server(port);
@@ -256,7 +255,6 @@ public final class Runtime {
     contextHandler.setContextPath("/");
 
     LOG.info("using configuration path: {}", heronConfigurationDirectory);
-    LOG.info("baseConfiguration: {}", baseConfiguration);
 
     contextHandler.setAttribute(HeronResource.ATTRIBUTE_CLUSTER, cluster);
     contextHandler.setAttribute(HeronResource.ATTRIBUTE_CONFIGURATION, baseConfiguration);

--- a/heron/tools/apiserver/src/java/com/twitter/heron/apiserver/Runtime.java
+++ b/heron/tools/apiserver/src/java/com/twitter/heron/apiserver/Runtime.java
@@ -165,8 +165,10 @@ public final class Runtime {
   // working-dir/heron-core
   private static String getHeronDirectory(CommandLine cmd) {
     final String cluster = cmd.getOptionValue(Flag.Cluster.name);
-    return "local".equalsIgnoreCase(cluster)
-        ? Constants.DEFAULT_HERON_LOCAL : Key.HERON_CLUSTER_HOME.getDefaultString();
+    if ("local".equalsIgnoreCase(cluster) || "standalone".equalsIgnoreCase(cluster)) {
+      return Constants.DEFAULT_HERON_LOCAL;
+    }
+    return Key.HERON_CLUSTER_HOME.getDefaultString();
   }
 
   private static String getReleaseFile(String toolsHome, CommandLine cmd) {
@@ -239,11 +241,12 @@ public final class Runtime {
     final String configurationOverrides = loadOverrides(cmd);
     final int port = getPort(cmd);
 
+    LOG.info("load baseConfiguration");
     final Config baseConfiguration =
         ConfigUtils.getBaseConfiguration(heronDirectory,
-            heronConfigurationDirectory,
-            releaseFile,
-            configurationOverrides);
+        heronConfigurationDirectory,
+        releaseFile,
+        configurationOverrides);
 
     final ResourceConfig config = new ResourceConfig(Resources.get());
     final Server server = new Server(port);
@@ -253,6 +256,7 @@ public final class Runtime {
     contextHandler.setContextPath("/");
 
     LOG.info("using configuration path: {}", heronConfigurationDirectory);
+    LOG.info("baseConfiguration: {}", baseConfiguration);
 
     contextHandler.setAttribute(HeronResource.ATTRIBUTE_CLUSTER, cluster);
     contextHandler.setAttribute(HeronResource.ATTRIBUTE_CONFIGURATION, baseConfiguration);

--- a/heron/tools/apiserver/src/java/com/twitter/heron/apiserver/actions/ActionFactoryImpl.java
+++ b/heron/tools/apiserver/src/java/com/twitter/heron/apiserver/actions/ActionFactoryImpl.java
@@ -16,7 +16,6 @@ package com.twitter.heron.apiserver.actions;
 import com.twitter.heron.api.exception.InvalidTopologyException;
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.api.utils.TopologyUtils;
-import com.twitter.heron.apiserver.utils.ConfigUtils;
 import com.twitter.heron.spi.common.Config;
 
 public class ActionFactoryImpl implements ActionFactory {
@@ -30,16 +29,8 @@ public class ActionFactoryImpl implements ActionFactory {
     } catch (InvalidTopologyException e) {
       throw new RuntimeException(e);
     }
-    final Config topologyConfig =
-        ConfigUtils.getTopologyConfig(topologyPackagePath, topologyBinaryFileName,
-            topologyDefinitionPath, topology);
-    final Config configWithTopology =
-        Config.newBuilder()
-            .putAll(config)
-            .putAll(topologyConfig)
-            .build();
 
-    return new SubmitTopologyAction(configWithTopology, topology);
+    return new SubmitTopologyAction(config, topology);
   }
 
   @Override

--- a/heron/tools/apiserver/src/java/com/twitter/heron/apiserver/resources/TopologyResource.java
+++ b/heron/tools/apiserver/src/java/com/twitter/heron/apiserver/resources/TopologyResource.java
@@ -66,7 +66,6 @@ import com.twitter.heron.scheduler.dryrun.UpdateDryRunResponse;
 import com.twitter.heron.scheduler.utils.DryRunRenders;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Key;
-import com.twitter.heron.spi.packing.PackingPlan;
 
 @Path("/topologies")
 public class TopologyResource extends HeronResource {

--- a/heron/tools/apiserver/src/java/com/twitter/heron/apiserver/utils/ConfigUtils.java
+++ b/heron/tools/apiserver/src/java/com/twitter/heron/apiserver/utils/ConfigUtils.java
@@ -25,7 +25,9 @@ import java.util.Properties;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
+import com.twitter.heron.api.exception.InvalidTopologyException;
 import com.twitter.heron.api.generated.TopologyAPI;
+import com.twitter.heron.api.utils.TopologyUtils;
 import com.twitter.heron.common.basics.SysUtils;
 import com.twitter.heron.scheduler.utils.SubmitterUtils;
 import com.twitter.heron.spi.common.Config;
@@ -67,7 +69,14 @@ public final class ConfigUtils {
   }
 
   public static Config getTopologyConfig(String topologyPackage, String topologyBinaryFile,
-        String topologyDefinitionFile, TopologyAPI.Topology topology) {
+        String topologyDefinitionFile) {
+
+    final TopologyAPI.Topology topology;
+    try {
+      topology = TopologyUtils.getTopology(topologyDefinitionFile);
+    } catch (InvalidTopologyException e) {
+      throw new RuntimeException(e);
+    }
     return SubmitterUtils.topologyConfigs(
         topologyPackage,
         topologyBinaryFile,

--- a/heron/tools/cli/src/python/main.py
+++ b/heron/tools/cli/src/python/main.py
@@ -37,7 +37,6 @@ import heron.tools.cli.src.python.submit as submit
 import heron.tools.cli.src.python.update as update
 import heron.tools.cli.src.python.version as version
 import heron.tools.cli.src.python.config as hconfig
-import heron.tools.cli.src.python.standalone as standalone
 
 from heron.tools.cli.src.python.opts import cleaned_up_files
 
@@ -81,7 +80,6 @@ def get_command_handlers():
       'help': cli_help,
       'kill': kill,
       'restart': restart,
-      'standalone': standalone,
       'submit': submit,
       'update': update,
       'version': version
@@ -379,7 +377,7 @@ def main():
   # Create a map of supported commands and handlers
   command_handlers = get_command_handlers()
   # Execute
-  local_commands = ('help', 'version', 'config', 'standalone')
+  local_commands = ('help', 'version', 'config')
   return execute(command_handlers, local_commands)
 
 

--- a/scripts/packages/template_bin.sh
+++ b/scripts/packages/template_bin.sh
@@ -72,6 +72,10 @@ if [ -L "${bin}/heron" ]; then
   rm -f "${bin}/heron"
 fi
 
+if [ -L "${bin}/heron-admin" ]; then
+  rm -f "${bin}/heron-admin"
+fi
+
 if [ -L "${bin}/heron-explorer" ]; then
   rm -f "${bin}/heron-explorer"
 fi
@@ -99,6 +103,7 @@ unzip -q -o "${BASH_SOURCE[0]}" -d "${base}"
 untar ${base}/heron.tar.gz ${base}
 echo -n .
 chmod 0755 ${base}/bin/heron
+chmod 0755 ${base}/bin/heron-admin
 chmod 0755 ${base}/bin/heron-explorer
 chmod 0755 ${base}/bin/heron-tracker
 chmod 0755 ${base}/bin/heron-ui
@@ -110,6 +115,7 @@ chmod -R u+rwX "${base}"
 echo -n .
 
 ln -s "${base}/bin/heron" "${bin}/heron"
+ln -s "${base}/bin/heron-admin" "${bin}/heron-admin"
 ln -s "${base}/bin/heron-explorer" "${bin}/heron-explorer"
 ln -s "${base}/bin/heron-tracker" "${bin}/heron-tracker"
 ln -s "${base}/bin/heron-ui" "${bin}/heron-ui"

--- a/tools/rules/heron_client.bzl
+++ b/tools/rules/heron_client.bzl
@@ -5,6 +5,7 @@ def heron_client_bin_files():
     return [
         "//heron/tools/cli/src/python:heron",
         "//heron/tools/explorer/src/python:heron-explorer",
+        "//heron/tools/admin/src/python:heron-admin",
         "//third_party/nomad:heron-nomad",
     ]
 


### PR DESCRIPTION
- Put the standalone mode cli into a separate heron-admin cli
- allow users to submit topologies to standalone cluster via apiserver
- Users can submit a topology via a service-url or without.  If you do not provide a service url the configs in ~/.heron/conf/standalone needs to correspond to the cluster.  These configs will be set for you if you start a standalone cluster.
- Being able to user a service-url allows users to easy share access with other users since all you need to submit a topology to the cluster is the service-url

To set cluster roles:

`heron-admin standalone set`

To start cluster:

`heron-admin standalone cluster start`

To get service-url:

`heron-admin standalone get service-url`

To submit topology with service-url:

`heron submit --service-url=http://10.128.0.5:9000 standalone  ~/heron/bazel-bin/examples/src/java/api-examples-unshaded_deploy.jar com.twitter.heron.examples.api.AckingTopology --verbose test3`

To submit topology without service-url:

`heron submit standalone  ~/heron/bazel-bin/examples/src/java/api-examples-unshaded_deploy.jar com.twitter.heron.examples.api.AckingTopology --verbose test5`

To kill:

`heron kill --service-url=http://10.128.0.5:9000 standalone test2`

or 

`heron kill standalone test2`

Stop Cluster:

`heron-admin standalone cluster stop`
