### PR TITLE
Add cluster role and environment info to sink context.

### DIFF
--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -399,13 +399,16 @@ class HeronExecutor(object):
                       '-cp',
                       self.metrics_manager_classpath,
                       metricsmgr_main_class,
-                      metricsManagerId,
-                      port,
-                      self.topology_name,
-                      self.topology_id,
-                      self.heron_internals_config_file,
-                      self.override_config_file,
-                      sink_config_file]
+                      '--id=' + metricsManagerId,
+                      '--port=' + str(port),
+                      '--topology=' + self.topology_name,
+                      '--cluster=' + self.cluster,
+                      '--role=' + self.role,
+                      '--environment=' + self.environment,
+                      '--topology-id=' + self.topology_id,
+                      '--system-config-file=' + self.heron_internals_config_file,
+                      '--override-config-file=' + self.override_config_file,
+                      '--sink-config-file=' + sink_config_file]
 
     return metricsmgr_cmd
 

--- a/heron/executor/tests/python/heron_executor_unittest.py
+++ b/heron/executor/tests/python/heron_executor_unittest.py
@@ -98,9 +98,11 @@ class HeronExecutorTest(unittest.TestCase):
            "-XX:+PrintPromotionFailure -XX:+PrintTenuringDistribution -XX:+PrintHeapAtGC " \
            "-XX:+HeapDumpOnOutOfMemoryError -XX:+UseConcMarkSweepGC -XX:+PrintCommandLineFlags " \
            "-Xloggc:log-files/gc.metricsmgr.log -Djava.net.preferIPv4Stack=true " \
-           "-cp metricsmgr_classpath com.twitter.heron.metricsmgr.MetricsManager metricsmgr-%d " \
-           "metricsmgr_port topname topid %s %s " \
-           "metrics_sinks_config_file" % (container_id, INTERNAL_CONF_PATH, OVERRIDE_PATH)
+           "-cp metricsmgr_classpath com.twitter.heron.metricsmgr.MetricsManager " \
+           "--id=metricsmgr-%d --port=metricsmgr_port " \
+           "--topology=topname --cluster=cluster --role=role --environment=environ --topology-id=topid " \
+           "--system-config-file=%s --override-config-file=%s --sink-config-file=metrics_sinks_config_file" %\
+           (container_id, INTERNAL_CONF_PATH, OVERRIDE_PATH)
 
   def get_expected_metricscachemgr_command():
       return "heron_java_home/bin/java -Xmx1024M -XX:+PrintCommandLineFlags -verbosegc " \

--- a/heron/metricsmgr/src/java/BUILD
+++ b/heron/metricsmgr/src/java/BUILD
@@ -21,6 +21,7 @@ java_library(
         "//heron/metricsmgr/src/thrift:thrift_scribe_java",
         "//third_party/java:guava", # only used in WebSink
         "//third_party/java:jackson",
+        "//third_party/java:cli",
         "//third_party/java:logging", # slf4j is only used for thrift in scribe-sink
         "@com_google_protobuf_protobuf_java//jar",
         "@org_apache_thrift_libthrift//jar",
@@ -40,6 +41,7 @@ java_binary(
         "//heron/common/src/java:utils-java",
         "//heron/spi/src/java:metricsmgr-spi-java",
         "//heron/proto:proto_metrics_java",
+        "//third_party/java:cli",
     ],
 )
 

--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/AbstractWebSink.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/AbstractWebSink.java
@@ -160,6 +160,8 @@ abstract class AbstractWebSink implements IMetricsSink {
 
   @Override
   public void close() {
-    httpServer.stop(0);
+    if (httpServer != null) {
+      httpServer.stop(0);
+    }
   }
 }

--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/PrometheusSink.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/PrometheusSink.java
@@ -52,13 +52,24 @@ public class PrometheusSink extends AbstractWebSink {
   // This is the cache that is used to serve the metrics
   private Cache<String, Map<String, Double>> metricsCache;
 
+  private String cluster;
+  private String role;
+  private String environment;
+
   public PrometheusSink() {
     super();
   }
 
   @Override
   void initialize(Map<String, Object> configuration, SinkContext context) {
+
+    LOG.info("prometheus sink configuration:\n" + configuration);
+
     metricsCache = createCache();
+
+    cluster = context.getCluster();
+    role = context.getRole();
+    environment = context.getEnvironment();
   }
 
   @Override
@@ -75,6 +86,12 @@ public class PrometheusSink extends AbstractWebSink {
 
       final boolean componentIsStreamManger = component.contains("stmgr");
       final String componentType = getComponentType(sourceMetrics);
+
+      String c = this.cluster;
+      String r = this.role;
+      String e = this.environment;
+      final String clusterRoleEnv = hasClusterRoleEnvironment(c, r, e)
+          ? String.format("%s/%s/%s", c, r, e) : null;
 
       sourceMetrics.forEach((String metric, Double value) -> {
 
@@ -111,6 +128,10 @@ public class PrometheusSink extends AbstractWebSink {
             .append("topology=\"").append(topology).append("\",")
             .append("component=\"").append(component).append("\",")
             .append("instance_id=\"").append(instance).append("\"");
+
+        if (clusterRoleEnv != null) {
+          sb.append(",cluster_role_env=\"").append(clusterRoleEnv).append("\"");
+        }
 
         if (componentType != null) {
           sb.append(",component_type=\"").append(componentType).append("\"");
@@ -156,6 +177,14 @@ public class PrometheusSink extends AbstractWebSink {
 
   long currentTimeMillis() {
     return System.currentTimeMillis();
+  }
+
+  static boolean hasClusterRoleEnvironment(String c, String r, String e) {
+    return isNotEmpty(c) && isNotEmpty(r) && isNotEmpty(e);
+  }
+
+  static boolean isNotEmpty(String string) {
+    return string != null && !string.isEmpty();
   }
 
   static String getComponentType(Map<String, Double> sourceMetrics) {

--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/PrometheusSink.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/PrometheusSink.java
@@ -62,9 +62,6 @@ public class PrometheusSink extends AbstractWebSink {
 
   @Override
   void initialize(Map<String, Object> configuration, SinkContext context) {
-
-    LOG.info("prometheus sink configuration:\n" + configuration);
-
     metricsCache = createCache();
 
     cluster = context.getCluster();

--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/SinkContextImpl.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/SinkContextImpl.java
@@ -35,11 +35,18 @@ public class SinkContextImpl implements SinkContext {
 
   private final String topologyName;
 
-  public SinkContextImpl(String topologyName,
-                         String metricsmgrId,
-                         String sinkId,
-                         MultiCountMetric internalMultiCountMetrics) {
+  private final String cluster;
+
+  private final String role;
+
+  private final String environment;
+
+  public SinkContextImpl(String topologyName, String cluster, String role, String environment,
+      String metricsmgrId, String sinkId, MultiCountMetric internalMultiCountMetrics) {
     this.topologyName = topologyName;
+    this.cluster = cluster;
+    this.role = role;
+    this.environment = environment;
     this.metricsmgrId = metricsmgrId;
     this.sinkId = sinkId;
     this.internalMultiCountMetrics = internalMultiCountMetrics;
@@ -48,6 +55,21 @@ public class SinkContextImpl implements SinkContext {
   @Override
   public String getTopologyName() {
     return topologyName;
+  }
+
+  @Override
+  public String getCluster() {
+    return cluster;
+  }
+
+  @Override
+  public String getRole() {
+    return role;
+  }
+
+  @Override
+  public String getEnvironment() {
+    return environment;
   }
 
   @Override

--- a/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/executor/SinkExecutorTest.java
+++ b/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/executor/SinkExecutorTest.java
@@ -73,7 +73,8 @@ public class SinkExecutorTest {
     communicator = new Communicator<>(null, slaveLooper);
 
     SinkContext sinkContext =
-        new SinkContextImpl("topology-name", "metricsmgr-id", "sink-id", new MultiCountMetric());
+        new SinkContextImpl("topology-name", "cluster", "role", "environment",
+            "metricsmgr-id", "sink-id", new MultiCountMetric());
 
     sinkExecutor =
         new SinkExecutor("testSinkId", metricsSink, slaveLooper, communicator, sinkContext);

--- a/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/metricscache/MetricsCacheSinkTest.java
+++ b/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/metricscache/MetricsCacheSinkTest.java
@@ -144,7 +144,8 @@ public class MetricsCacheSinkTest {
 
     MultiCountMetric multiCountMetric = new MultiCountMetric();
     SinkContext sinkContext =
-        new SinkContextImpl("topology-name", "metricsmgr-id", "sink-id", multiCountMetric);
+        new SinkContextImpl("topology-name", "cluster", "role", "environment",
+            "metricsmgr-id", "sink-id", multiCountMetric);
 
     // Start the MetricsCacheSink
     metricsCacheSink.init(sinkConfig, sinkContext);

--- a/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/tmaster/TMasterSinkTest.java
+++ b/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/tmaster/TMasterSinkTest.java
@@ -143,7 +143,8 @@ public class TMasterSinkTest {
 
     MultiCountMetric multiCountMetric = new MultiCountMetric();
     SinkContext sinkContext =
-        new SinkContextImpl("topology-name", "metricsmgr-id", "sink-id", multiCountMetric);
+        new SinkContextImpl("topology-name", "cluster", "role", "environment",
+            "metricsmgr-id", "sink-id", multiCountMetric);
 
     // Start the TMasterSink
     tMasterSink.init(sinkConfig, sinkContext);

--- a/heron/spi/src/java/com/twitter/heron/spi/metricsmgr/sink/SinkContext.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/metricsmgr/sink/SinkContext.java
@@ -25,6 +25,12 @@ package com.twitter.heron.spi.metricsmgr.sink;
 public interface SinkContext {
   String getTopologyName();
 
+  String getCluster();
+
+  String getRole();
+
+  String getEnvironment();
+
   String getMetricsMgrId();
 
   String getSinkId();


### PR DESCRIPTION
This patch exposes cluster, role and environment to
the SinkContext so metric sinks can export this information.