### PR TITLE
Decouple increment and log to avoid potential error

### DIFF
--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/metricscache/MetricsCacheSink.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/metricscache/MetricsCacheSink.java
@@ -368,8 +368,8 @@ public class MetricsCacheSink implements IMetricsSink {
               metricsCacheClientConfig.get(KEY_TMASTER_RECONNECT_INTERVAL_SEC),
               ChronoUnit.SECONDS));
 
-      LOG.severe(String.format("Starting metricsCacheClient for the %d time.",
-          startedAttempts.incrementAndGet()));
+      int attempts = startedAttempts.incrementAndGet();
+      LOG.severe(String.format("Starting metricsCacheClient for the %d time.", attempts));
       metricsCacheClientExecutor.execute(metricsCacheClient);
     }
 

--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/tmaster/TMasterSink.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/tmaster/TMasterSink.java
@@ -361,8 +361,8 @@ public class TMasterSink implements IMetricsSink {
               TypeUtils.getDuration(
                   tmasterClientConfig.get(KEY_TMASTER_RECONNECT_INTERVAL_SEC), ChronoUnit.SECONDS));
 
-      LOG.severe(String.format("Starting TMasterClient for the %d time.",
-          startedAttempts.incrementAndGet()));
+      int attempts = startedAttempts.incrementAndGet();
+      LOG.severe(String.format("Starting TMasterClient for the %d time.", attempts));
       tmasterClientExecutor.execute(tMasterClient);
     }
 


### PR DESCRIPTION
Separate counting and logging. It could be risky to increase a counter in a logging call.