### PR TITLE
Increase wait time  in MetricsCacheSinkTest and TMasterSinkTest

### DIFF
--- a/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/metricscache/MetricsCacheSinkTest.java
+++ b/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/metricscache/MetricsCacheSinkTest.java
@@ -48,8 +48,9 @@ public class MetricsCacheSinkTest {
       TopologyMaster.MetricsCacheLocation.newBuilder().getDescriptorForType().getFullName();
 
   private static final Duration RECONNECT_INTERVAL = Duration.ofSeconds(1);
-  // Restart wait time is set at 3 times of reconnect time. One reconnect time at beginning
-  // and another delay of reconnect time caused by exception handler.
+  // Restart wait time is set at 2 times of reconnect time plus another second. The 2 times factor
+  // is because of localtion checking event interval and the sleep of reconnect interval in
+  // exception handling.
   private static final Duration RESTART_WAIT_INTERVAL = Duration.ofSeconds(3);
   private static final Duration METRICSCACHE_LOCATION_CHECK_INTERVAL = Duration.ofSeconds(1);
 
@@ -120,9 +121,9 @@ public class MetricsCacheSinkTest {
 
     // Then we check whether the MetricsCacheService has restarted the MetricsCacheClient for
     // several times Take other factors into account, we would check whether the MetricsCacheClient
-    // at least RESTART_WAIT_INTERVAL - RECONNECT_INTERVAL * 2
+    // has restarted at least half the RESTART_WAIT_INTERVAL_SECONDS/RECONNECT_INTERVAL
     assertTrue(metricsCacheSink.getMetricsCacheStartedAttempts()
-        >= (RESTART_WAIT_INTERVAL.getSeconds() - 2 * RECONNECT_INTERVAL.getSeconds()));
+        >= (RESTART_WAIT_INTERVAL.getSeconds() / RECONNECT_INTERVAL.getSeconds() / 2));
     metricsCacheSink.close();
   }
 

--- a/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/metricscache/MetricsCacheSinkTest.java
+++ b/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/metricscache/MetricsCacheSinkTest.java
@@ -120,9 +120,9 @@ public class MetricsCacheSinkTest {
 
     // Then we check whether the MetricsCacheService has restarted the MetricsCacheClient for
     // several times Take other factors into account, we would check whether the MetricsCacheClient
-    // has restarted at least half the RESTART_WAIT_INTERVAL_SECONDS/RECONNECT_INTERVAL
+    // at least RESTART_WAIT_INTERVAL - RECONNECT_INTERVAL * 2
     assertTrue(metricsCacheSink.getMetricsCacheStartedAttempts()
-        >= (RESTART_WAIT_INTERVAL.getSeconds() / RECONNECT_INTERVAL.getSeconds() / 2));
+        >= (RESTART_WAIT_INTERVAL.getSeconds() - 2 * RECONNECT_INTERVAL.getSeconds()));
     metricsCacheSink.close();
   }
 

--- a/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/metricscache/MetricsCacheSinkTest.java
+++ b/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/metricscache/MetricsCacheSinkTest.java
@@ -48,7 +48,9 @@ public class MetricsCacheSinkTest {
       TopologyMaster.MetricsCacheLocation.newBuilder().getDescriptorForType().getFullName();
 
   private static final Duration RECONNECT_INTERVAL = Duration.ofSeconds(1);
-  private static final Duration RESTART_WAIT_INTERVAL = Duration.ofSeconds(2);
+  // Restart wait time is set at 3 times of reconnect time. One reconnect time at beginning
+  // and another delay of reconnect time caused by exception handler.
+  private static final Duration RESTART_WAIT_INTERVAL = Duration.ofSeconds(3);
   private static final Duration METRICSCACHE_LOCATION_CHECK_INTERVAL = Duration.ofSeconds(1);
 
   private static Map<String, Object> buildServiceConfig() {

--- a/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/tmaster/TMasterSinkTest.java
+++ b/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/tmaster/TMasterSinkTest.java
@@ -48,7 +48,9 @@ public class TMasterSinkTest {
       TopologyMaster.TMasterLocation.newBuilder().getDescriptorForType().getFullName();
 
   private static final Duration RECONNECT_INTERVAL = Duration.ofSeconds(1);
-  private static final Duration RESTART_WAIT_INTERVAL = Duration.ofSeconds(2);
+  // Restart wait time is set at 3 times of reconnect time. One reconnect time at beginning
+  // and another delay of reconnect time caused by exception handler.
+  private static final Duration RESTART_WAIT_INTERVAL = Duration.ofSeconds(3);
   private static final Duration TMASTER_LOCATION_CHECK_INTERVAL = Duration.ofSeconds(1);
 
   // These are config for TMasterClient

--- a/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/tmaster/TMasterSinkTest.java
+++ b/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/tmaster/TMasterSinkTest.java
@@ -49,7 +49,7 @@ public class TMasterSinkTest {
 
   private static final Duration RECONNECT_INTERVAL = Duration.ofSeconds(1);
   // Restart wait time is set at 2 times of reconnect time plus another second. The 2 times factor
-  // is because of localtion checking event interval and the sleep of reconnect interval in
+  // is because of location checking event interval and the sleep of reconnect interval in
   // exception handling.
   private static final Duration RESTART_WAIT_INTERVAL = Duration.ofSeconds(3);
   private static final Duration TMASTER_LOCATION_CHECK_INTERVAL = Duration.ofSeconds(1);
@@ -120,7 +120,7 @@ public class TMasterSinkTest {
 
     // Then we check whether the TMasterService has restarted the TMasterClient for several times
     // Take other factors into account, we would check whether the TMasterClient has restarted
-    // at least half the RESTART_WAIT_INTERVAL_SECONDS/RECONNECT_INTERVAL
+    // at least half the RESTART_WAIT_INTERVAL/RECONNECT_INTERVAL
     assertTrue(tMasterSink.getTMasterStartedAttempts()
         >= (RESTART_WAIT_INTERVAL.getSeconds() / RECONNECT_INTERVAL.getSeconds() / 2));
     tMasterSink.close();

--- a/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/tmaster/TMasterSinkTest.java
+++ b/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/tmaster/TMasterSinkTest.java
@@ -48,8 +48,9 @@ public class TMasterSinkTest {
       TopologyMaster.TMasterLocation.newBuilder().getDescriptorForType().getFullName();
 
   private static final Duration RECONNECT_INTERVAL = Duration.ofSeconds(1);
-  // Restart wait time is set at 3 times of reconnect time. One reconnect time at beginning
-  // and another delay of reconnect time caused by exception handler.
+  // Restart wait time is set at 2 times of reconnect time plus another second. The 2 times factor
+  // is because of localtion checking event interval and the sleep of reconnect interval in
+  // exception handling.
   private static final Duration RESTART_WAIT_INTERVAL = Duration.ofSeconds(3);
   private static final Duration TMASTER_LOCATION_CHECK_INTERVAL = Duration.ofSeconds(1);
 
@@ -119,9 +120,9 @@ public class TMasterSinkTest {
 
     // Then we check whether the TMasterService has restarted the TMasterClient for several times
     // Take other factors into account, we would check whether the TMasterClient has restarted
-    // at least RESTART_WAIT_INTERVAL - RECONNECT_INTERVAL * 2
+    // has restarted at least half the RESTART_WAIT_INTERVAL_SECONDS/RECONNECT_INTERVAL
     assertTrue(tMasterSink.getTMasterStartedAttempts()
-        >= (RESTART_WAIT_INTERVAL.getSeconds() - 2 * RECONNECT_INTERVAL.getSeconds()));
+        >= (RESTART_WAIT_INTERVAL.getSeconds() / RECONNECT_INTERVAL.getSeconds() / 2));
     tMasterSink.close();
   }
 

--- a/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/tmaster/TMasterSinkTest.java
+++ b/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/tmaster/TMasterSinkTest.java
@@ -119,9 +119,9 @@ public class TMasterSinkTest {
 
     // Then we check whether the TMasterService has restarted the TMasterClient for several times
     // Take other factors into account, we would check whether the TMasterClient has restarted
-    // at least half the RESTART_WAIT_INTERVAL/RECONNECT_INTERVAL
+    // at least RESTART_WAIT_INTERVAL - RECONNECT_INTERVAL * 2
     assertTrue(tMasterSink.getTMasterStartedAttempts()
-        >= (RESTART_WAIT_INTERVAL.getSeconds() / RECONNECT_INTERVAL.getSeconds() / 2));
+        >= (RESTART_WAIT_INTERVAL.getSeconds() - 2 * RECONNECT_INTERVAL.getSeconds()));
     tMasterSink.close();
   }
 

--- a/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/tmaster/TMasterSinkTest.java
+++ b/heron/metricsmgr/tests/java/com/twitter/heron/metricsmgr/sink/tmaster/TMasterSinkTest.java
@@ -120,7 +120,7 @@ public class TMasterSinkTest {
 
     // Then we check whether the TMasterService has restarted the TMasterClient for several times
     // Take other factors into account, we would check whether the TMasterClient has restarted
-    // has restarted at least half the RESTART_WAIT_INTERVAL_SECONDS/RECONNECT_INTERVAL
+    // at least half the RESTART_WAIT_INTERVAL_SECONDS/RECONNECT_INTERVAL
     assertTrue(tMasterSink.getTMasterStartedAttempts()
         >= (RESTART_WAIT_INTERVAL.getSeconds() / RECONNECT_INTERVAL.getSeconds() / 2));
     tMasterSink.close();


### PR DESCRIPTION
Restart wait time is changed to 3 times of reconnect time from 2. One reconnect
time at beginning and another delay of reconnect time caused by exception handler and extra time.