### PR TITLE
Add wait for exit function in WakeableLooper and fix exiting code in SocketChannelHelper

### DIFF
--- a/heron/common/src/java/com/twitter/heron/common/network/SocketChannelHelper.java
+++ b/heron/common/src/java/com/twitter/heron/common/network/SocketChannelHelper.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 import com.twitter.heron.common.basics.ByteAmount;
@@ -213,6 +214,10 @@ public class SocketChannelHelper {
   // Force to flush all data in underneath buffer queue to socket with best effort
   // It is most likely happen when we are handling some unexpected cases, such as exiting
   public void forceFlushWithBestEffort() {
+    looper.exitLoop();
+    // Wait for NIO loop to confirm stopping process.
+    looper.waitForExit(10, TimeUnit.SECONDS);
+
     LOG.info("Forcing to flush data to socket with best effort.");
     while (!outgoingPacketsToWrite.isEmpty()) {
       int writeState = outgoingPacketsToWrite.poll().writeToChannel(socketChannel);

--- a/heron/common/tests/java/com/twitter/heron/common/basics/WakeableLooperTest.java
+++ b/heron/common/tests/java/com/twitter/heron/common/basics/WakeableLooperTest.java
@@ -14,9 +14,9 @@
 
 package com.twitter.heron.common.basics;
 
+import java.lang.Thread;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.Thread;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 

--- a/heron/common/tests/java/com/twitter/heron/common/basics/WakeableLooperTest.java
+++ b/heron/common/tests/java/com/twitter/heron/common/basics/WakeableLooperTest.java
@@ -162,7 +162,7 @@ public class WakeableLooperTest {
    * Method: waitForExit()
    */
   @Test
-  public void testwaitForExit() {
+  public void testWaitForExit() {
     int sleepTimeMS = 200;
     Runnable r = new Runnable() {
       @Override
@@ -187,6 +187,33 @@ public class WakeableLooperTest {
     Assert.assertTrue(ret);
     Assert.assertTrue(endTime - startTime >= sleepTimeMS * 1000);
     Assert.assertEquals(10, globalValue);
+  }
+
+  @Test
+  public void testWaitForExitTimeout() {
+    int sleepTimeMS = 200;
+    Runnable r = new Runnable() {
+      @Override
+      public void run() {
+        try {
+          slaveLooper.exitLoop(); // Exit after the first wake up
+          Thread.sleep(sleepTimeMS);
+          globalValue = 10;
+        } catch (InterruptedException e) {
+          return;
+        }
+      }
+    };
+    LooperThread looperThread = new LooperThread(slaveLooper);
+    looperThread.start();
+    long startTime = System.nanoTime();
+    slaveLooper.addTasksOnWakeup(r);
+    // Wait for it to finish.
+    boolean ret = slaveLooper.waitForExit(sleepTimeMS / 10, TimeUnit.MILLISECONDS);
+    long endTime = System.nanoTime();
+
+    Assert.assertFalse(ret);
+    Assert.assertEquals(6, globalValue);
   }
 
   /**


### PR DESCRIPTION
Add waitForExit() function in WakeableLooper and use it to avoid racing condition in SocketChannelHelper's forceFlushWithBestEffort() function.