### PR TITLE
Add support for custom evictor and trigger policies

### DIFF
--- a/heron/api/src/java/com/twitter/heron/api/bolt/BaseWindowedBolt.java
+++ b/heron/api/src/java/com/twitter/heron/api/bolt/BaseWindowedBolt.java
@@ -38,9 +38,8 @@ import java.util.Map;
 
 import com.twitter.heron.api.topology.OutputFieldsDeclarer;
 import com.twitter.heron.api.topology.TopologyContext;
-import com.twitter.heron.api.windowing.TimestampExtractor;
-import com.twitter.heron.api.windowing.TupleFieldTimestampExtractor;
-import com.twitter.heron.api.windowing.WindowingConfigs;
+import com.twitter.heron.api.tuple.Tuple;
+import com.twitter.heron.api.windowing.*;
 
 public abstract class BaseWindowedBolt implements IWindowedBolt {
   private static final long serialVersionUID = 5688213068448231559L;
@@ -309,6 +308,28 @@ public abstract class BaseWindowedBolt implements IWindowedBolt {
     }
     windowConfiguration.put(WindowingConfigs.TOPOLOGY_BOLTS_WATERMARK_EVENT_INTERVAL_MS,
         interval.toMillis());
+    return this;
+  }
+
+  /**
+   * Sets a custom eviction policy to use for this bolt
+   *
+   * @param evictionPolicy the eviction policy to use
+   * @return this
+   */
+  public BaseWindowedBolt withCustomEvictor(EvictionPolicy<Tuple, ?> evictionPolicy){
+    windowConfiguration.setTopologyBoltsWindowCustomEvictor(evictionPolicy);
+    return this;
+  }
+
+  /**
+   * Sets a custom trigger policy to use for this bolt
+   *
+   * @param triggerPolicy the trigger policy to use
+   * @return this
+   */
+  public BaseWindowedBolt withCustomTrigger(TriggerPolicy<Tuple, ?> triggerPolicy){
+    windowConfiguration.setTopologyBoltsWindowCustomTrigger(triggerPolicy);
     return this;
   }
 

--- a/heron/api/src/java/com/twitter/heron/api/bolt/BaseWindowedBolt.java
+++ b/heron/api/src/java/com/twitter/heron/api/bolt/BaseWindowedBolt.java
@@ -39,7 +39,11 @@ import java.util.Map;
 import com.twitter.heron.api.topology.OutputFieldsDeclarer;
 import com.twitter.heron.api.topology.TopologyContext;
 import com.twitter.heron.api.tuple.Tuple;
-import com.twitter.heron.api.windowing.*;
+import com.twitter.heron.api.windowing.EvictionPolicy;
+import com.twitter.heron.api.windowing.TimestampExtractor;
+import com.twitter.heron.api.windowing.TriggerPolicy;
+import com.twitter.heron.api.windowing.TupleFieldTimestampExtractor;
+import com.twitter.heron.api.windowing.WindowingConfigs;
 
 public abstract class BaseWindowedBolt implements IWindowedBolt {
   private static final long serialVersionUID = 5688213068448231559L;
@@ -317,7 +321,7 @@ public abstract class BaseWindowedBolt implements IWindowedBolt {
    * @param evictionPolicy the eviction policy to use
    * @return this
    */
-  public BaseWindowedBolt withCustomEvictor(EvictionPolicy<Tuple, ?> evictionPolicy){
+  public BaseWindowedBolt withCustomEvictor(EvictionPolicy<Tuple, ?> evictionPolicy) {
     windowConfiguration.setTopologyBoltsWindowCustomEvictor(evictionPolicy);
     return this;
   }
@@ -328,7 +332,7 @@ public abstract class BaseWindowedBolt implements IWindowedBolt {
    * @param triggerPolicy the trigger policy to use
    * @return this
    */
-  public BaseWindowedBolt withCustomTrigger(TriggerPolicy<Tuple, ?> triggerPolicy){
+  public BaseWindowedBolt withCustomTrigger(TriggerPolicy<Tuple, ?> triggerPolicy) {
     windowConfiguration.setTopologyBoltsWindowCustomTrigger(triggerPolicy);
     return this;
   }

--- a/heron/api/src/java/com/twitter/heron/api/bolt/WindowedBoltExecutor.java
+++ b/heron/api/src/java/com/twitter/heron/api/bolt/WindowedBoltExecutor.java
@@ -238,15 +238,17 @@ public class WindowedBoltExecutor implements IRichBolt,
     validate(topoConf, windowLengthCount, windowLengthDurationMs, slidingIntervalCount,
         slidingIntervalDurationMs);
 
-    if(topoConf.containsKey(WindowingConfigs.TOPOLOGY_BOLTS_WINDOW_CUSTOM_EVICTOR)){
-      evictionPolicy = (EvictionPolicy<Tuple, ?>) topoConf.get(WindowingConfigs.TOPOLOGY_BOLTS_WINDOW_CUSTOM_EVICTOR);
-    }else{
+    if (topoConf.containsKey(WindowingConfigs.TOPOLOGY_BOLTS_WINDOW_CUSTOM_EVICTOR)) {
+      evictionPolicy = (EvictionPolicy<Tuple, ?>)
+              topoConf.get(WindowingConfigs.TOPOLOGY_BOLTS_WINDOW_CUSTOM_EVICTOR);
+    } else {
       evictionPolicy = getEvictionPolicy(windowLengthCount, windowLengthDurationMs);
     }
 
-    if(topoConf.containsKey(WindowingConfigs.TOPOLOGY_BOLTS_WINDOW_CUSTOM_TRIGGER)){
-      triggerPolicy = (TriggerPolicy<Tuple, ?>) topoConf.get(WindowingConfigs.TOPOLOGY_BOLTS_WINDOW_CUSTOM_TRIGGER);
-    }else{
+    if (topoConf.containsKey(WindowingConfigs.TOPOLOGY_BOLTS_WINDOW_CUSTOM_TRIGGER)) {
+      triggerPolicy = (TriggerPolicy<Tuple, ?>)
+              topoConf.get(WindowingConfigs.TOPOLOGY_BOLTS_WINDOW_CUSTOM_TRIGGER);
+    } else {
       triggerPolicy = getTriggerPolicy(slidingIntervalCount, slidingIntervalDurationMs, manager,
               evictionPolicy, topoConf);
     }

--- a/heron/api/src/java/com/twitter/heron/api/bolt/WindowedBoltExecutor.java
+++ b/heron/api/src/java/com/twitter/heron/api/bolt/WindowedBoltExecutor.java
@@ -250,9 +250,9 @@ public class WindowedBoltExecutor implements IRichBolt,
       validate(topoConf, windowLengthCount, windowLengthDurationMs, slidingIntervalCount,
               slidingIntervalDurationMs);
 
+      evictionPolicy = getEvictionPolicy(windowLengthCount, windowLengthDurationMs);
       triggerPolicy = getTriggerPolicy(slidingIntervalCount, slidingIntervalDurationMs, manager,
               evictionPolicy, topoConf);
-      evictionPolicy = getEvictionPolicy(windowLengthCount, windowLengthDurationMs);
     } else {
       throw new IllegalArgumentException(
               "If either a custom TriggerPolicy or EvictionPolicy is defined, both must be."

--- a/heron/api/src/java/com/twitter/heron/api/bolt/WindowedBoltExecutor.java
+++ b/heron/api/src/java/com/twitter/heron/api/bolt/WindowedBoltExecutor.java
@@ -237,9 +237,21 @@ public class WindowedBoltExecutor implements IRichBolt,
     // validate
     validate(topoConf, windowLengthCount, windowLengthDurationMs, slidingIntervalCount,
         slidingIntervalDurationMs);
-    evictionPolicy = getEvictionPolicy(windowLengthCount, windowLengthDurationMs);
-    triggerPolicy = getTriggerPolicy(slidingIntervalCount, slidingIntervalDurationMs, manager,
-        evictionPolicy, topoConf);
+
+    if(topoConf.containsKey(WindowingConfigs.TOPOLOGY_BOLTS_WINDOW_CUSTOM_EVICTOR)){
+      evictionPolicy = (EvictionPolicy<Tuple, ?>) topoConf.get(WindowingConfigs.TOPOLOGY_BOLTS_WINDOW_CUSTOM_EVICTOR);
+    }else{
+      evictionPolicy = getEvictionPolicy(windowLengthCount, windowLengthDurationMs);
+    }
+
+    if(topoConf.containsKey(WindowingConfigs.TOPOLOGY_BOLTS_WINDOW_CUSTOM_TRIGGER)){
+      triggerPolicy = (TriggerPolicy<Tuple, ?>) topoConf.get(WindowingConfigs.TOPOLOGY_BOLTS_WINDOW_CUSTOM_TRIGGER);
+    }else{
+      triggerPolicy = getTriggerPolicy(slidingIntervalCount, slidingIntervalDurationMs, manager,
+              evictionPolicy, topoConf);
+    }
+
+
     manager.setEvictionPolicy(evictionPolicy);
     manager.setTriggerPolicy(triggerPolicy);
     // restore state if there is existing state

--- a/heron/api/src/java/com/twitter/heron/api/bolt/WindowedBoltExecutor.java
+++ b/heron/api/src/java/com/twitter/heron/api/bolt/WindowedBoltExecutor.java
@@ -251,13 +251,17 @@ public class WindowedBoltExecutor implements IRichBolt,
               slidingIntervalDurationMs);
 
       evictionPolicy = getEvictionPolicy(windowLengthCount, windowLengthDurationMs);
-      triggerPolicy = getTriggerPolicy(slidingIntervalCount, slidingIntervalDurationMs, manager,
-              evictionPolicy, topoConf);
+      triggerPolicy = getTriggerPolicy(slidingIntervalCount, slidingIntervalDurationMs);
     } else {
       throw new IllegalArgumentException(
               "If either a custom TriggerPolicy or EvictionPolicy is defined, both must be."
       );
     }
+
+    triggerPolicy.setEvictionPolicy(evictionPolicy);
+    triggerPolicy.setTopologyConfig(topoConf);
+    triggerPolicy.setTriggerHandler(manager);
+    triggerPolicy.setWindowManager(manager);
 
     manager.setEvictionPolicy(evictionPolicy);
     manager.setTriggerPolicy(triggerPolicy);
@@ -305,22 +309,18 @@ public class WindowedBoltExecutor implements IRichBolt,
 
   @SuppressWarnings("HiddenField")
   private TriggerPolicy<Tuple, ?> getTriggerPolicy(Count slidingIntervalCount, Long
-      slidingIntervalDurationMs, WindowManager<Tuple> manager, EvictionPolicy<Tuple, ?>
-      evictionPolicy, Map<String, Object> topoConf) {
+      slidingIntervalDurationMs) {
     if (slidingIntervalCount != null) {
       if (isTupleTs()) {
-        return new WatermarkCountTriggerPolicy<>(slidingIntervalCount.value, manager,
-            evictionPolicy, manager);
+        return new WatermarkCountTriggerPolicy<>(slidingIntervalCount.value);
       } else {
-        return new CountTriggerPolicy<>(slidingIntervalCount.value, manager, evictionPolicy);
+        return new CountTriggerPolicy<>(slidingIntervalCount.value);
       }
     } else {
       if (isTupleTs()) {
-        return new WatermarkTimeTriggerPolicy<>(slidingIntervalDurationMs, manager,
-            evictionPolicy, manager);
+        return new WatermarkTimeTriggerPolicy<>(slidingIntervalDurationMs);
       } else {
-        return new TimeTriggerPolicy<>(slidingIntervalDurationMs, manager,
-            evictionPolicy, topoConf);
+        return new TimeTriggerPolicy<>(slidingIntervalDurationMs);
       }
     }
   }

--- a/heron/api/src/java/com/twitter/heron/api/windowing/TriggerPolicy.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/TriggerPolicy.java
@@ -30,10 +30,10 @@
  * limitations under the License.
  */
 
-
 package com.twitter.heron.api.windowing;
 
 import java.io.Serializable;
+import java.util.Map;
 
 /**
  * Triggers the window calculations based on the policy.
@@ -80,4 +80,32 @@ public interface TriggerPolicy<T extends Serializable, S> {
    * @param state the state
    */
   void restoreState(S state);
+
+  /**
+   * Set the eviction policy to whatever eviction policy to use this with
+   *
+   * @param evictionPolicy the eviction policy
+   */
+  void setEvictionPolicy(EvictionPolicy<T, ?> evictionPolicy);
+
+  /**
+   * Set the trigger handler for this trigger policy to trigger
+   *
+   * @param triggerHandler the trigger handler
+   */
+  void setTriggerHandler(TriggerHandler triggerHandler);
+
+  /**
+   * Sets the window manager that uses this trigger policy
+   *
+   * @param windowManager the window manager
+   */
+  void setWindowManager(WindowManager<T> windowManager);
+
+  /**
+   * Sets the Config used for this topology
+   *
+   * @param config the configuration policy
+   */
+  void setTopologyConfig(Map<String, Object> config);
 }

--- a/heron/api/src/java/com/twitter/heron/api/windowing/WindowingConfigs.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/WindowingConfigs.java
@@ -32,10 +32,11 @@
 
 package com.twitter.heron.api.windowing;
 
-import com.twitter.heron.api.tuple.Tuple;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import com.twitter.heron.api.tuple.Tuple;
+
 
 public class WindowingConfigs extends HashMap<String, Object> {
 
@@ -92,9 +93,11 @@ public class WindowingConfigs extends HashMap<String, Object> {
   public static final String TOPOLOGY_BOLTS_WATERMARK_EVENT_INTERVAL_MS = "topology.bolts"
       + ".watermark.event.interval.ms";
 
-  public static final String TOPOLOGY_BOLTS_WINDOW_CUSTOM_EVICTOR = "topology.bolts.window.custom.evictor";
+  public static final String TOPOLOGY_BOLTS_WINDOW_CUSTOM_EVICTOR =
+          "topology.bolts.window.custom.evictor";
 
-  public static final String TOPOLOGY_BOLTS_WINDOW_CUSTOM_TRIGGER = "topology.bolts.window.custom.trigger";
+  public static final String TOPOLOGY_BOLTS_WINDOW_CUSTOM_TRIGGER =
+          "topology.bolts.window.custom.trigger";
 
   public void setTopologyBoltsWindowLengthCount(long value) {
     setTopologyBoltsWindowLengthCount(this, value);
@@ -154,19 +157,21 @@ public class WindowingConfigs extends HashMap<String, Object> {
     conf.put(TOPOLOGY_BOLTS_WATERMARK_EVENT_INTERVAL_MS, value);
   }
 
-  public void setTopologyBoltsWindowCustomEvictor(EvictionPolicy<Tuple, ?> value){
+  public void setTopologyBoltsWindowCustomEvictor(EvictionPolicy<Tuple, ?> value) {
     setTopologyBoltsWindowCustomEvictor(this, value);
   }
 
-  public static void setTopologyBoltsWindowCustomEvictor(Map<String, Object> conf, EvictionPolicy<Tuple, ?> value){
+  public static void setTopologyBoltsWindowCustomEvictor(Map<String, Object> conf,
+                                                         EvictionPolicy<Tuple, ?> value) {
     conf.put(TOPOLOGY_BOLTS_WINDOW_CUSTOM_EVICTOR, value);
   }
 
-  public void setTopologyBoltsWindowCustomTrigger(TriggerPolicy<Tuple, ?> value){
+  public void setTopologyBoltsWindowCustomTrigger(TriggerPolicy<Tuple, ?> value) {
     setTopologyBoltsWindowCustomTrigger(this, value);
   }
 
-  public static void setTopologyBoltsWindowCustomTrigger(Map<String, Object> conf, TriggerPolicy<Tuple, ?> value){
+  public static void setTopologyBoltsWindowCustomTrigger(Map<String, Object> conf,
+                                                         TriggerPolicy<Tuple, ?> value) {
     conf.put(TOPOLOGY_BOLTS_WINDOW_CUSTOM_TRIGGER, value);
   }
 }

--- a/heron/api/src/java/com/twitter/heron/api/windowing/WindowingConfigs.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/WindowingConfigs.java
@@ -37,7 +37,6 @@ import java.util.Map;
 
 import com.twitter.heron.api.tuple.Tuple;
 
-
 public class WindowingConfigs extends HashMap<String, Object> {
 
   private static final long serialVersionUID = 1395902349429869055L;

--- a/heron/api/src/java/com/twitter/heron/api/windowing/WindowingConfigs.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/WindowingConfigs.java
@@ -32,6 +32,8 @@
 
 package com.twitter.heron.api.windowing;
 
+import com.twitter.heron.api.tuple.Tuple;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -90,6 +92,10 @@ public class WindowingConfigs extends HashMap<String, Object> {
   public static final String TOPOLOGY_BOLTS_WATERMARK_EVENT_INTERVAL_MS = "topology.bolts"
       + ".watermark.event.interval.ms";
 
+  public static final String TOPOLOGY_BOLTS_WINDOW_CUSTOM_EVICTOR = "topology.bolts.window.custom.evictor";
+
+  public static final String TOPOLOGY_BOLTS_WINDOW_CUSTOM_TRIGGER = "topology.bolts.window.custom.trigger";
+
   public void setTopologyBoltsWindowLengthCount(long value) {
     setTopologyBoltsWindowLengthCount(this, value);
   }
@@ -146,5 +152,21 @@ public class WindowingConfigs extends HashMap<String, Object> {
   public static void setTopologyBoltsWatermarkEventIntervalMs(
       Map<String, Object> conf, long value) {
     conf.put(TOPOLOGY_BOLTS_WATERMARK_EVENT_INTERVAL_MS, value);
+  }
+
+  public void setTopologyBoltsWindowCustomEvictor(EvictionPolicy<Tuple, ?> value){
+    setTopologyBoltsWindowCustomEvictor(this, value);
+  }
+
+  public static void setTopologyBoltsWindowCustomEvictor(Map<String, Object> conf, EvictionPolicy<Tuple, ?> value){
+    conf.put(TOPOLOGY_BOLTS_WINDOW_CUSTOM_EVICTOR, value);
+  }
+
+  public void setTopologyBoltsWindowCustomTrigger(TriggerPolicy<Tuple, ?> value){
+    setTopologyBoltsWindowCustomTrigger(this, value);
+  }
+
+  public static void setTopologyBoltsWindowCustomTrigger(Map<String, Object> conf, TriggerPolicy<Tuple, ?> value){
+    conf.put(TOPOLOGY_BOLTS_WINDOW_CUSTOM_TRIGGER, value);
   }
 }

--- a/heron/api/src/java/com/twitter/heron/api/windowing/triggers/AbstractBaseTriggerPolicy.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/triggers/AbstractBaseTriggerPolicy.java
@@ -1,3 +1,35 @@
+// Copyright 2017 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.twitter.heron.api.windowing.triggers;
 
 import java.io.Serializable;
@@ -8,68 +40,88 @@ import com.twitter.heron.api.windowing.TriggerHandler;
 import com.twitter.heron.api.windowing.TriggerPolicy;
 import com.twitter.heron.api.windowing.WindowManager;
 
+
 public abstract class AbstractBaseTriggerPolicy<T extends Serializable, S>
-        implements TriggerPolicy<T , S> {
-    protected TriggerHandler handler;
-    protected EvictionPolicy<T, ?> evictionPolicy;
-    protected WindowManager<T> windowManager;
-    protected Boolean started;
-    protected Map<String, Object> topoConf;
+    implements TriggerPolicy<T, S> {
+  protected TriggerHandler handler;
+  protected EvictionPolicy<T, ?> evictionPolicy;
+  protected WindowManager<T> windowManager;
+  protected Boolean started;
+  protected Map<String, Object> topoConf;
 
-    /**
-     * Set the eviction policy to whatever eviction policy to use this with
-     *
-     * @param evictionPolicy the eviction policy
-     */
-    public void setEvictionPolicy(EvictionPolicy<T, ?> evictionPolicy){
-        this.evictionPolicy = evictionPolicy;
+  private boolean requiresEvictionPolicy = false;
+  private boolean requiresWindowManager = false;
+  private boolean requiresTopologyConfig = false;
+
+  /**
+  * Set the requirements in the constructor
+  */
+  public AbstractBaseTriggerPolicy(boolean requiresEvictionPolicy,
+                                   boolean requiresWindowManager,
+                                   boolean requiresTopologyConfig) {
+    this.requiresEvictionPolicy = requiresEvictionPolicy;
+    this.requiresWindowManager = requiresWindowManager;
+    this.requiresTopologyConfig = requiresTopologyConfig;
+  }
+
+  /**
+  * Set the eviction policy to whatever eviction policy to use this with
+  *
+  * @param evictionPolicy the eviction policy
+  */
+  public void setEvictionPolicy(EvictionPolicy<T, ?> evictionPolicy) {
+    this.evictionPolicy = evictionPolicy;
+  }
+
+  /**
+  * Set the trigger handler for this trigger policy to trigger
+  *
+  * @param triggerHandler the trigger handler
+  */
+  public void setTriggerHandler(TriggerHandler triggerHandler) {
+    this.handler = triggerHandler;
+  }
+
+  /**
+  * Sets the window manager that uses this trigger policy
+  *
+  * @param windowManager the window manager
+  */
+  public void setWindowManager(WindowManager<T> windowManager) {
+    this.windowManager = windowManager;
+  }
+
+  /**
+  * Sets the Config used for this topology
+  *
+  * @param config the configuration object
+  */
+  public void setTopologyConfig(Map<String, Object> config) {
+    this.topoConf = config;
+  }
+
+  /**
+  * Starts the trigger policy. This can be used
+  * during recovery to start the triggers after
+  * recovery is complete.
+  */
+  public void start() {
+    if (this.evictionPolicy == null && this.requiresEvictionPolicy) {
+      throw new RuntimeException("EvictionPolicy of TriggerPolicy was not set.");
     }
 
-    /**
-     * Set the trigger handler for this trigger policy to trigger
-     *
-     * @param triggerHandler the trigger handler
-     */
-    public void setTriggerHandler(TriggerHandler triggerHandler){
-        this.handler = triggerHandler;
+    if (this.handler == null) {
+      throw new RuntimeException("TriggerHandler of TriggerPolicy was not set.");
     }
 
-    /**
-     * Sets the window manager that uses this trigger policy
-     *
-     * @param windowManager the window manager
-     */
-    public void setWindowManager(WindowManager<T> windowManager){
-        this.windowManager = windowManager;
+    if (this.windowManager == null && this.requiresWindowManager) {
+      throw new RuntimeException("WindowManager of TriggerPolicy was not set.");
     }
 
-    /**
-     * Sets the Config used for this topology
-     *
-     * @param config the configuration object
-     */
-    public void setTopologyConfig(Map<String, Object> config){
-        this.topoConf = config;
+    if (this.topoConf == null && this.requiresTopologyConfig) {
+      throw new RuntimeException("WindowManager of TriggerPolicy was not set.");
     }
 
-    /**
-     * Starts the trigger policy. This can be used
-     * during recovery to start the triggers after
-     * recovery is complete.
-     */
-    public void start(){
-        if(this.evictionPolicy == null){
-            throw new RuntimeException("EvictionPolicy of TriggerPolicy was not set.");
-        }
-
-        if(this.handler == null){
-            throw new RuntimeException("TriggerHandler of TriggerPolicy was not set.");
-        }
-
-        if(this.windowManager == null){
-            throw new RuntimeException("WindowManager of TriggerPolicy was not set.");
-        }
-
-        started = true;
-    }
+    started = true;
+  }
 }

--- a/heron/api/src/java/com/twitter/heron/api/windowing/triggers/AbstractBaseTriggerPolicy.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/triggers/AbstractBaseTriggerPolicy.java
@@ -56,12 +56,7 @@ public abstract class AbstractBaseTriggerPolicy<T extends Serializable, S>
   /**
   * Set the requirements in the constructor
   */
-  public AbstractBaseTriggerPolicy(boolean requiresEvictionPolicy,
-                                   boolean requiresWindowManager,
-                                   boolean requiresTopologyConfig) {
-    this.requiresEvictionPolicy = requiresEvictionPolicy;
-    this.requiresWindowManager = requiresWindowManager;
-    this.requiresTopologyConfig = requiresTopologyConfig;
+  public AbstractBaseTriggerPolicy() {
   }
 
   /**
@@ -107,22 +102,6 @@ public abstract class AbstractBaseTriggerPolicy<T extends Serializable, S>
   */
   @Override
   public void start() {
-    if (this.evictionPolicy == null && this.requiresEvictionPolicy) {
-      throw new RuntimeException("EvictionPolicy of TriggerPolicy was not set.");
-    }
-
-    if (this.handler == null) {
-      throw new RuntimeException("TriggerHandler of TriggerPolicy was not set.");
-    }
-
-    if (this.windowManager == null && this.requiresWindowManager) {
-      throw new RuntimeException("WindowManager of TriggerPolicy was not set.");
-    }
-
-    if (this.topoConf == null && this.requiresTopologyConfig) {
-      throw new RuntimeException("WindowManager of TriggerPolicy was not set.");
-    }
-
     started = true;
   }
 }

--- a/heron/api/src/java/com/twitter/heron/api/windowing/triggers/AbstractBaseTriggerPolicy.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/triggers/AbstractBaseTriggerPolicy.java
@@ -1,0 +1,75 @@
+package com.twitter.heron.api.windowing.triggers;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import com.twitter.heron.api.windowing.EvictionPolicy;
+import com.twitter.heron.api.windowing.TriggerHandler;
+import com.twitter.heron.api.windowing.TriggerPolicy;
+import com.twitter.heron.api.windowing.WindowManager;
+
+public abstract class AbstractBaseTriggerPolicy<T extends Serializable, S>
+        implements TriggerPolicy<T , S> {
+    protected TriggerHandler handler;
+    protected EvictionPolicy<T, ?> evictionPolicy;
+    protected WindowManager<T> windowManager;
+    protected Boolean started;
+    protected Map<String, Object> topoConf;
+
+    /**
+     * Set the eviction policy to whatever eviction policy to use this with
+     *
+     * @param evictionPolicy the eviction policy
+     */
+    public void setEvictionPolicy(EvictionPolicy<T, ?> evictionPolicy){
+        this.evictionPolicy = evictionPolicy;
+    }
+
+    /**
+     * Set the trigger handler for this trigger policy to trigger
+     *
+     * @param triggerHandler the trigger handler
+     */
+    public void setTriggerHandler(TriggerHandler triggerHandler){
+        this.handler = triggerHandler;
+    }
+
+    /**
+     * Sets the window manager that uses this trigger policy
+     *
+     * @param windowManager the window manager
+     */
+    public void setWindowManager(WindowManager<T> windowManager){
+        this.windowManager = windowManager;
+    }
+
+    /**
+     * Sets the Config used for this topology
+     *
+     * @param config the configuration object
+     */
+    public void setTopologyConfig(Map<String, Object> config){
+        this.topoConf = config;
+    }
+
+    /**
+     * Starts the trigger policy. This can be used
+     * during recovery to start the triggers after
+     * recovery is complete.
+     */
+    public void start(){
+        if(this.evictionPolicy == null){
+            throw new RuntimeException("EvictionPolicy of TriggerPolicy was not set.");
+        }
+
+        if(this.handler == null){
+            throw new RuntimeException("TriggerHandler of TriggerPolicy was not set.");
+        }
+
+        if(this.windowManager == null){
+            throw new RuntimeException("WindowManager of TriggerPolicy was not set.");
+        }
+
+        started = true;
+    }
+}

--- a/heron/api/src/java/com/twitter/heron/api/windowing/triggers/AbstractBaseTriggerPolicy.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/triggers/AbstractBaseTriggerPolicy.java
@@ -105,6 +105,7 @@ public abstract class AbstractBaseTriggerPolicy<T extends Serializable, S>
   * during recovery to start the triggers after
   * recovery is complete.
   */
+  @Override
   public void start() {
     if (this.evictionPolicy == null && this.requiresEvictionPolicy) {
       throw new RuntimeException("EvictionPolicy of TriggerPolicy was not set.");

--- a/heron/api/src/java/com/twitter/heron/api/windowing/triggers/CountTriggerPolicy.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/triggers/CountTriggerPolicy.java
@@ -52,6 +52,8 @@ public class CountTriggerPolicy<T extends Serializable> extends
   private boolean started;
 
   public CountTriggerPolicy(int count) {
+    super(true, false, false);
+
     this.count = count;
     this.currentCount = new AtomicInteger();
     this.started = false;

--- a/heron/api/src/java/com/twitter/heron/api/windowing/triggers/CountTriggerPolicy.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/triggers/CountTriggerPolicy.java
@@ -37,9 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import com.twitter.heron.api.windowing.DefaultEvictionContext;
 import com.twitter.heron.api.windowing.Event;
-import com.twitter.heron.api.windowing.EvictionPolicy;
 import com.twitter.heron.api.windowing.TriggerHandler;
-import com.twitter.heron.api.windowing.TriggerPolicy;
 
 /**
  * A trigger that tracks event counts and calls back {@link TriggerHandler#onTrigger()}
@@ -47,19 +45,15 @@ import com.twitter.heron.api.windowing.TriggerPolicy;
  *
  * @param <T> the type of event tracked by this policy.
  */
-public class CountTriggerPolicy<T extends Serializable> implements TriggerPolicy<T, Integer> {
+public class CountTriggerPolicy<T extends Serializable> extends
+        AbstractBaseTriggerPolicy<T, Integer> {
   private final int count;
   private final AtomicInteger currentCount;
-  private final TriggerHandler handler;
-  private final EvictionPolicy<T, ?> evictionPolicy;
   private boolean started;
 
-  public CountTriggerPolicy(int count, TriggerHandler handler, EvictionPolicy<T, ?>
-      evictionPolicy) {
+  public CountTriggerPolicy(int count) {
     this.count = count;
     this.currentCount = new AtomicInteger();
-    this.handler = handler;
-    this.evictionPolicy = evictionPolicy;
     this.started = false;
   }
 
@@ -76,11 +70,6 @@ public class CountTriggerPolicy<T extends Serializable> implements TriggerPolicy
   @Override
   public void reset() {
     currentCount.set(0);
-  }
-
-  @Override
-  public void start() {
-    started = true;
   }
 
   @Override

--- a/heron/api/src/java/com/twitter/heron/api/windowing/triggers/CountTriggerPolicy.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/triggers/CountTriggerPolicy.java
@@ -49,14 +49,12 @@ public class CountTriggerPolicy<T extends Serializable> extends
         AbstractBaseTriggerPolicy<T, Integer> {
   private final int count;
   private final AtomicInteger currentCount;
-  private boolean started;
 
   public CountTriggerPolicy(int count) {
     super(true, false, false);
 
     this.count = count;
     this.currentCount = new AtomicInteger();
-    this.started = false;
   }
 
   @Override

--- a/heron/api/src/java/com/twitter/heron/api/windowing/triggers/CountTriggerPolicy.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/triggers/CountTriggerPolicy.java
@@ -51,7 +51,7 @@ public class CountTriggerPolicy<T extends Serializable> extends
   private final AtomicInteger currentCount;
 
   public CountTriggerPolicy(int count) {
-    super(true, false, false);
+    super();
 
     this.count = count;
     this.currentCount = new AtomicInteger();

--- a/heron/api/src/java/com/twitter/heron/api/windowing/triggers/TimeTriggerPolicy.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/triggers/TimeTriggerPolicy.java
@@ -34,7 +34,6 @@ package com.twitter.heron.api.windowing.triggers;
 
 import java.io.Serializable;
 import java.time.Duration;
-import java.util.Map;
 
 import com.twitter.heron.api.Config;
 import com.twitter.heron.api.windowing.DefaultEvictionContext;
@@ -49,6 +48,8 @@ public class TimeTriggerPolicy<T extends Serializable> extends AbstractBaseTrigg
   private long duration;
 
   public TimeTriggerPolicy(long millis) {
+    super(true, false, true);
+
     this.duration = millis;
   }
 

--- a/heron/api/src/java/com/twitter/heron/api/windowing/triggers/TimeTriggerPolicy.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/triggers/TimeTriggerPolicy.java
@@ -39,32 +39,17 @@ import java.util.Map;
 import com.twitter.heron.api.Config;
 import com.twitter.heron.api.windowing.DefaultEvictionContext;
 import com.twitter.heron.api.windowing.Event;
-import com.twitter.heron.api.windowing.EvictionPolicy;
 import com.twitter.heron.api.windowing.TriggerHandler;
-import com.twitter.heron.api.windowing.TriggerPolicy;
 
 /**
  * Invokes {@link TriggerHandler#onTrigger()} after the duration.
  */
 
-public class TimeTriggerPolicy<T extends Serializable> implements TriggerPolicy<T, Void> {
-
+public class TimeTriggerPolicy<T extends Serializable> extends AbstractBaseTriggerPolicy<T, Void> {
   private long duration;
-  private final TriggerHandler handler;
-  private final EvictionPolicy<T, ?> evictionPolicy;
-  private Map<String, Object> topoConf;
 
-
-  public TimeTriggerPolicy(long millis, TriggerHandler handler) {
-    this(millis, handler, null, new Config());
-  }
-
-  public TimeTriggerPolicy(long millis, TriggerHandler handler, EvictionPolicy<T, ?>
-      evictionPolicy, Map<String, Object> topoConf) {
+  public TimeTriggerPolicy(long millis) {
     this.duration = millis;
-    this.handler = handler;
-    this.evictionPolicy = evictionPolicy;
-    this.topoConf = topoConf;
   }
 
   @Override
@@ -79,6 +64,7 @@ public class TimeTriggerPolicy<T extends Serializable> implements TriggerPolicy<
 
   @Override
   public void start() {
+    super.start();
     Config.registerTopologyTimerEvents(this.topoConf, "TimeTriggerPolicyTimer",
         Duration.ofMillis(this.duration), () -> triggerTask());
   }

--- a/heron/api/src/java/com/twitter/heron/api/windowing/triggers/TimeTriggerPolicy.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/triggers/TimeTriggerPolicy.java
@@ -48,7 +48,7 @@ public class TimeTriggerPolicy<T extends Serializable> extends AbstractBaseTrigg
   private long duration;
 
   public TimeTriggerPolicy(long millis) {
-    super(true, false, true);
+    super();
 
     this.duration = millis;
   }

--- a/heron/api/src/java/com/twitter/heron/api/windowing/triggers/WatermarkCountTriggerPolicy.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/triggers/WatermarkCountTriggerPolicy.java
@@ -50,6 +50,7 @@ public class WatermarkCountTriggerPolicy<T extends Serializable> extends
   private volatile long lastProcessedTs;
 
   public WatermarkCountTriggerPolicy(int count) {
+    super(true, true, false);
     this.count = count;
   }
 

--- a/heron/api/src/java/com/twitter/heron/api/windowing/triggers/WatermarkCountTriggerPolicy.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/triggers/WatermarkCountTriggerPolicy.java
@@ -50,7 +50,7 @@ public class WatermarkCountTriggerPolicy<T extends Serializable> extends
   private volatile long lastProcessedTs;
 
   public WatermarkCountTriggerPolicy(int count) {
-    super(true, true, false);
+    super();
     this.count = count;
   }
 

--- a/heron/api/src/java/com/twitter/heron/api/windowing/triggers/WatermarkCountTriggerPolicy.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/triggers/WatermarkCountTriggerPolicy.java
@@ -37,10 +37,6 @@ import java.util.List;
 
 import com.twitter.heron.api.windowing.DefaultEvictionContext;
 import com.twitter.heron.api.windowing.Event;
-import com.twitter.heron.api.windowing.EvictionPolicy;
-import com.twitter.heron.api.windowing.TriggerHandler;
-import com.twitter.heron.api.windowing.TriggerPolicy;
-import com.twitter.heron.api.windowing.WindowManager;
 
 /**
  * A trigger policy that tracks event counts and sets the context for
@@ -48,21 +44,13 @@ import com.twitter.heron.api.windowing.WindowManager;
  *
  * @param <T> the type of event tracked by this policy.
  */
-public class WatermarkCountTriggerPolicy<T extends Serializable> implements TriggerPolicy<T, Long> {
+public class WatermarkCountTriggerPolicy<T extends Serializable> extends
+        AbstractBaseTriggerPolicy<T, Long> {
   private final int count;
-  private final TriggerHandler handler;
-  private final EvictionPolicy<T, ?> evictionPolicy;
-  private final WindowManager<T> windowManager;
   private volatile long lastProcessedTs;
-  private boolean started;
 
-  public WatermarkCountTriggerPolicy(int count, TriggerHandler handler, EvictionPolicy<T, ?>
-      evictionPolicy, WindowManager<T> windowManager) {
+  public WatermarkCountTriggerPolicy(int count) {
     this.count = count;
-    this.handler = handler;
-    this.evictionPolicy = evictionPolicy;
-    this.windowManager = windowManager;
-    this.started = false;
   }
 
   @Override
@@ -75,11 +63,6 @@ public class WatermarkCountTriggerPolicy<T extends Serializable> implements Trig
   @Override
   public void reset() {
     // NOOP
-  }
-
-  @Override
-  public void start() {
-    started = true;
   }
 
   @Override

--- a/heron/api/src/java/com/twitter/heron/api/windowing/triggers/WatermarkTimeTriggerPolicy.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/triggers/WatermarkTimeTriggerPolicy.java
@@ -50,7 +50,7 @@ public class WatermarkTimeTriggerPolicy<T extends Serializable> extends
   private volatile long nextWindowEndTs;
 
   public WatermarkTimeTriggerPolicy(long slidingIntervalMs) {
-    super(true, true, false);
+    super();
     this.slidingIntervalMs = slidingIntervalMs;
   }
 

--- a/heron/api/src/java/com/twitter/heron/api/windowing/triggers/WatermarkTimeTriggerPolicy.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/triggers/WatermarkTimeTriggerPolicy.java
@@ -37,32 +37,20 @@ import java.util.logging.Logger;
 
 import com.twitter.heron.api.windowing.DefaultEvictionContext;
 import com.twitter.heron.api.windowing.Event;
-import com.twitter.heron.api.windowing.EvictionPolicy;
 import com.twitter.heron.api.windowing.TriggerHandler;
-import com.twitter.heron.api.windowing.TriggerPolicy;
-import com.twitter.heron.api.windowing.WindowManager;
 
 /**
  * Handles watermark events and triggers {@link TriggerHandler#onTrigger()} for each window
  * interval that has events to be processed up to the watermark ts.
  */
-public class WatermarkTimeTriggerPolicy<T extends Serializable> implements TriggerPolicy<T, Long> {
+public class WatermarkTimeTriggerPolicy<T extends Serializable> extends
+        AbstractBaseTriggerPolicy<T, Long> {
   private static final Logger LOG = Logger.getLogger(WatermarkTimeTriggerPolicy.class.getName());
   private final long slidingIntervalMs;
-  private final TriggerHandler handler;
-  private final EvictionPolicy<T, ?> evictionPolicy;
-  private final WindowManager<T> windowManager;
   private volatile long nextWindowEndTs;
-  private boolean started;
 
-  public WatermarkTimeTriggerPolicy(long slidingIntervalMs, TriggerHandler handler,
-                                    EvictionPolicy<T, ?> evictionPolicy, WindowManager<T>
-                                        windowManager) {
+  public WatermarkTimeTriggerPolicy(long slidingIntervalMs) {
     this.slidingIntervalMs = slidingIntervalMs;
-    this.handler = handler;
-    this.evictionPolicy = evictionPolicy;
-    this.windowManager = windowManager;
-    this.started = false;
   }
 
   @Override
@@ -75,11 +63,6 @@ public class WatermarkTimeTriggerPolicy<T extends Serializable> implements Trigg
   @Override
   public void reset() {
     // NOOP
-  }
-
-  @Override
-  public void start() {
-    started = true;
   }
 
   @Override

--- a/heron/api/src/java/com/twitter/heron/api/windowing/triggers/WatermarkTimeTriggerPolicy.java
+++ b/heron/api/src/java/com/twitter/heron/api/windowing/triggers/WatermarkTimeTriggerPolicy.java
@@ -50,6 +50,7 @@ public class WatermarkTimeTriggerPolicy<T extends Serializable> extends
   private volatile long nextWindowEndTs;
 
   public WatermarkTimeTriggerPolicy(long slidingIntervalMs) {
+    super(true, true, false);
     this.slidingIntervalMs = slidingIntervalMs;
   }
 

--- a/heron/api/src/java/com/twitter/heron/streamlet/WindowConfig.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/WindowConfig.java
@@ -74,7 +74,8 @@ public interface WindowConfig {
    * @param evictionPolicy The eviction policy to use
    * @return WindowConfig that can be passed to the transformation
    */
-  static WindowConfig CustomWindow(TriggerPolicy<Tuple, ?> triggerPolicy, EvictionPolicy<Tuple, ?> evictionPolicy){
+  static WindowConfig CustomWindow(TriggerPolicy<Tuple, ?> triggerPolicy,
+                                   EvictionPolicy<Tuple, ?> evictionPolicy) {
     return new WindowConfigImpl(triggerPolicy, evictionPolicy);
   }
 }

--- a/heron/api/src/java/com/twitter/heron/streamlet/WindowConfig.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/WindowConfig.java
@@ -17,6 +17,9 @@ package com.twitter.heron.streamlet;
 
 import java.time.Duration;
 
+import com.twitter.heron.api.tuple.Tuple;
+import com.twitter.heron.api.windowing.EvictionPolicy;
+import com.twitter.heron.api.windowing.TriggerPolicy;
 import com.twitter.heron.streamlet.impl.WindowConfigImpl;
 
 /**
@@ -63,5 +66,15 @@ public interface WindowConfig {
    */
   static WindowConfig SlidingCountWindow(int windowSize, int slideSize) {
     return new WindowConfigImpl(windowSize, slideSize);
+  }
+
+  /**
+   * Creates a window based on the provided custom trigger and eviction policies
+   * @param triggerPolicy The trigger policy to use
+   * @param evictionPolicy The eviction policy to use
+   * @return WindowConfig that can be passed to the transformation
+   */
+  static WindowConfig CustomWindow(TriggerPolicy<Tuple, ?> triggerPolicy, EvictionPolicy<Tuple, ?> evictionPolicy){
+    return new WindowConfigImpl(triggerPolicy, evictionPolicy);
   }
 }

--- a/heron/api/src/java/com/twitter/heron/streamlet/impl/WindowConfigImpl.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/impl/WindowConfigImpl.java
@@ -46,7 +46,8 @@ public final class WindowConfigImpl implements WindowConfig {
     this.windowSize = windowSize;
     this.slideInterval = slideInterval;
   }
-  public WindowConfigImpl(TriggerPolicy<Tuple, ?> triggerPolicy, EvictionPolicy<Tuple, ?> evictionPolicy){
+  public WindowConfigImpl(TriggerPolicy<Tuple, ?> triggerPolicy,
+                          EvictionPolicy<Tuple, ?> evictionPolicy) {
     this.windowType = WindowType.CUSTOM;
     this.triggerPolicy = triggerPolicy;
     this.evictionPolicy = evictionPolicy;

--- a/heron/api/tests/java/com/twitter/heron/api/windowing/WindowManagerTest.java
+++ b/heron/api/tests/java/com/twitter/heron/api/windowing/WindowManagerTest.java
@@ -145,10 +145,13 @@ public class WindowManagerTest {
   public void testExpireThreshold() throws Exception {
     int threshold = WindowManager.EXPIRE_EVENTS_THRESHOLD;
     int windowLength = 5;
-    windowManager.setEvictionPolicy(new CountEvictionPolicy<Integer>(5));
+    CountEvictionPolicy<Integer> countEvictionPolicy = new CountEvictionPolicy<Integer>(5);
+    windowManager.setEvictionPolicy(countEvictionPolicy);
     TriggerPolicy<Integer, ?> triggerPolicy = new TimeTriggerPolicy<Integer>(Duration.ofHours(1)
         .toMillis());
+    triggerPolicy.setEvictionPolicy(countEvictionPolicy);
     triggerPolicy.setTriggerHandler(windowManager);
+    triggerPolicy.setTopologyConfig(new Config());
     triggerPolicy.start();
     windowManager.setTriggerPolicy(triggerPolicy);
     for (int i : seq(1, 5)) {
@@ -303,6 +306,8 @@ public class WindowManagerTest {
     TriggerPolicy<Integer, ?> triggerPolicy = new TimeTriggerPolicy<Integer>(Duration.ofDays(1)
         .toMillis());
     triggerPolicy.setTriggerHandler(windowManager);
+    triggerPolicy.setEvictionPolicy(evictionPolicy);
+    triggerPolicy.setTopologyConfig(new Config());
     triggerPolicy.start();
     windowManager.setTriggerPolicy(triggerPolicy);
     long now = System.currentTimeMillis();

--- a/heron/api/tests/java/com/twitter/heron/api/windowing/WindowManagerTest.java
+++ b/heron/api/tests/java/com/twitter/heron/api/windowing/WindowManagerTest.java
@@ -102,8 +102,9 @@ public class WindowManagerTest {
   @Test
   public void testCountBasedWindow() throws Exception {
     EvictionPolicy<Integer, ?> evictionPolicy = new CountEvictionPolicy<Integer>(5);
-    TriggerPolicy<Integer, ?> triggerPolicy = new CountTriggerPolicy<Integer>(2, windowManager,
-        evictionPolicy);
+    TriggerPolicy<Integer, ?> triggerPolicy = new CountTriggerPolicy<Integer>(2);
+    triggerPolicy.setTriggerHandler(windowManager);
+    triggerPolicy.setEvictionPolicy(evictionPolicy);
     triggerPolicy.start();
     windowManager.setEvictionPolicy(evictionPolicy);
     windowManager.setTriggerPolicy(triggerPolicy);
@@ -146,7 +147,8 @@ public class WindowManagerTest {
     int windowLength = 5;
     windowManager.setEvictionPolicy(new CountEvictionPolicy<Integer>(5));
     TriggerPolicy<Integer, ?> triggerPolicy = new TimeTriggerPolicy<Integer>(Duration.ofHours(1)
-        .toMillis(), windowManager);
+        .toMillis());
+    triggerPolicy.setTriggerHandler(windowManager);
     triggerPolicy.start();
     windowManager.setTriggerPolicy(triggerPolicy);
     for (int i : seq(1, 5)) {
@@ -178,8 +180,10 @@ public class WindowManagerTest {
      */
     int threshold = WindowManager.EXPIRE_EVENTS_THRESHOLD;
     windowManager.setEvictionPolicy(watermarkEvictionPolicy);
-    WatermarkCountTriggerPolicy triggerPolicy = new WatermarkCountTriggerPolicy(windowLength,
-        windowManager, watermarkEvictionPolicy, windowManager);
+    WatermarkCountTriggerPolicy triggerPolicy = new WatermarkCountTriggerPolicy(windowLength);
+    triggerPolicy.setTriggerHandler(windowManager);
+    triggerPolicy.setEvictionPolicy(watermarkEvictionPolicy);
+    triggerPolicy.setWindowManager(windowManager);
     triggerPolicy.start();
     windowManager.setTriggerPolicy(triggerPolicy);
     for (int i : seq(1, threshold)) {
@@ -226,7 +230,10 @@ public class WindowManagerTest {
          * Set it to a large value and trigger manually.
           */
     TriggerPolicy<Integer, ?> triggerPolicy = new TimeTriggerPolicy<Integer>(Duration.ofDays(1)
-        .toMillis(), windowManager, evictionPolicy, new Config());
+        .toMillis());
+    triggerPolicy.setTriggerHandler(windowManager);
+    triggerPolicy.setEvictionPolicy(evictionPolicy);
+    triggerPolicy.setTopologyConfig(new Config());
     triggerPolicy.start();
     windowManager.setTriggerPolicy(triggerPolicy);
     long now = System.currentTimeMillis();
@@ -294,7 +301,8 @@ public class WindowManagerTest {
          * Set it to a large value and trigger manually.
           */
     TriggerPolicy<Integer, ?> triggerPolicy = new TimeTriggerPolicy<Integer>(Duration.ofDays(1)
-        .toMillis(), windowManager);
+        .toMillis());
+    triggerPolicy.setTriggerHandler(windowManager);
     triggerPolicy.start();
     windowManager.setTriggerPolicy(triggerPolicy);
     long now = System.currentTimeMillis();
@@ -327,8 +335,9 @@ public class WindowManagerTest {
   public void testTumblingWindow() throws Exception {
     EvictionPolicy<Integer, ?> evictionPolicy = new CountEvictionPolicy<Integer>(3);
     windowManager.setEvictionPolicy(evictionPolicy);
-    TriggerPolicy<Integer, ?> triggerPolicy = new CountTriggerPolicy<Integer>(3, windowManager,
-        evictionPolicy);
+    TriggerPolicy<Integer, ?> triggerPolicy = new CountTriggerPolicy<Integer>(3);
+    triggerPolicy.setTriggerHandler(windowManager);
+    triggerPolicy.setEvictionPolicy(evictionPolicy);
     triggerPolicy.start();
     windowManager.setTriggerPolicy(triggerPolicy);
     windowManager.add(1);
@@ -358,8 +367,10 @@ public class WindowManagerTest {
   public void testEventTimeBasedWindow() throws Exception {
     EvictionPolicy<Integer, ?> evictionPolicy = new WatermarkTimeEvictionPolicy<>(20);
     windowManager.setEvictionPolicy(evictionPolicy);
-    TriggerPolicy<Integer, ?> triggerPolicy = new WatermarkTimeTriggerPolicy<Integer>(10,
-        windowManager, evictionPolicy, windowManager);
+    TriggerPolicy<Integer, ?> triggerPolicy = new WatermarkTimeTriggerPolicy<Integer>(10);
+    triggerPolicy.setTriggerHandler(windowManager);
+    triggerPolicy.setEvictionPolicy(evictionPolicy);
+    triggerPolicy.setWindowManager(windowManager);
     triggerPolicy.start();
     windowManager.setTriggerPolicy(triggerPolicy);
 
@@ -425,8 +436,10 @@ public class WindowManagerTest {
   public void testCountBasedWindowWithEventTs() throws Exception {
     EvictionPolicy<Integer, ?> evictionPolicy = new WatermarkCountEvictionPolicy<>(3);
     windowManager.setEvictionPolicy(evictionPolicy);
-    TriggerPolicy<Integer, ?> triggerPolicy = new WatermarkTimeTriggerPolicy<Integer>(10,
-        windowManager, evictionPolicy, windowManager);
+    TriggerPolicy<Integer, ?> triggerPolicy = new WatermarkTimeTriggerPolicy<Integer>(10);
+    triggerPolicy.setTriggerHandler(windowManager);
+    triggerPolicy.setEvictionPolicy(evictionPolicy);
+    triggerPolicy.setWindowManager(windowManager);
     triggerPolicy.start();
     windowManager.setTriggerPolicy(triggerPolicy);
 
@@ -465,8 +478,10 @@ public class WindowManagerTest {
   public void testCountBasedTriggerWithEventTs() throws Exception {
     EvictionPolicy<Integer, ?> evictionPolicy = new WatermarkTimeEvictionPolicy<Integer>(20);
     windowManager.setEvictionPolicy(evictionPolicy);
-    TriggerPolicy<Integer, ?> triggerPolicy = new WatermarkCountTriggerPolicy<Integer>(3,
-        windowManager, evictionPolicy, windowManager);
+    TriggerPolicy<Integer, ?> triggerPolicy = new WatermarkCountTriggerPolicy<Integer>(3);
+    triggerPolicy.setTriggerHandler(windowManager);
+    triggerPolicy.setEvictionPolicy(evictionPolicy);
+    triggerPolicy.setWindowManager(windowManager);
     triggerPolicy.start();
     windowManager.setTriggerPolicy(triggerPolicy);
 
@@ -506,8 +521,10 @@ public class WindowManagerTest {
   public void testCountBasedTumblingWithSameEventTs() throws Exception {
     EvictionPolicy<Integer, ?> evictionPolicy = new WatermarkCountEvictionPolicy<>(2);
     windowManager.setEvictionPolicy(evictionPolicy);
-    TriggerPolicy<Integer, ?> triggerPolicy = new WatermarkCountTriggerPolicy<Integer>(2,
-        windowManager, evictionPolicy, windowManager);
+    TriggerPolicy<Integer, ?> triggerPolicy = new WatermarkCountTriggerPolicy<Integer>(2);
+    triggerPolicy.setTriggerHandler(windowManager);
+    triggerPolicy.setEvictionPolicy(evictionPolicy);
+    triggerPolicy.setWindowManager(windowManager);
     triggerPolicy.start();
     windowManager.setTriggerPolicy(triggerPolicy);
 
@@ -535,8 +552,10 @@ public class WindowManagerTest {
   public void testCountBasedSlidingWithSameEventTs() throws Exception {
     EvictionPolicy<Integer, ?> evictionPolicy = new WatermarkCountEvictionPolicy<>(5);
     windowManager.setEvictionPolicy(evictionPolicy);
-    TriggerPolicy<Integer, ?> triggerPolicy = new WatermarkCountTriggerPolicy<Integer>(2,
-        windowManager, evictionPolicy, windowManager);
+    TriggerPolicy<Integer, ?> triggerPolicy = new WatermarkCountTriggerPolicy<Integer>(2);
+    triggerPolicy.setTriggerHandler(windowManager);
+    triggerPolicy.setEvictionPolicy(evictionPolicy);
+    triggerPolicy.setWindowManager(windowManager);
     triggerPolicy.start();
     windowManager.setTriggerPolicy(triggerPolicy);
 
@@ -565,8 +584,10 @@ public class WindowManagerTest {
   public void testEventTimeLag() throws Exception {
     EvictionPolicy<Integer, ?> evictionPolicy = new WatermarkTimeEvictionPolicy<>(20, 5);
     windowManager.setEvictionPolicy(evictionPolicy);
-    TriggerPolicy<Integer, ?> triggerPolicy = new WatermarkTimeTriggerPolicy<Integer>(10,
-        windowManager, evictionPolicy, windowManager);
+    TriggerPolicy<Integer, ?> triggerPolicy = new WatermarkTimeTriggerPolicy<Integer>(10);
+    triggerPolicy.setTriggerHandler(windowManager);
+    triggerPolicy.setEvictionPolicy(evictionPolicy);
+    triggerPolicy.setWindowManager(windowManager);
     triggerPolicy.start();
     windowManager.setTriggerPolicy(triggerPolicy);
 
@@ -601,8 +622,10 @@ public class WindowManagerTest {
 
     };
     windowManager.setEvictionPolicy(evictionPolicy);
-    TriggerPolicy<Integer, ?> triggerPolicy = new WatermarkTimeTriggerPolicy<Integer>(10,
-        windowManager, evictionPolicy, windowManager);
+    TriggerPolicy<Integer, ?> triggerPolicy = new WatermarkTimeTriggerPolicy<Integer>(10);
+    triggerPolicy.setTriggerHandler(windowManager);
+    triggerPolicy.setEvictionPolicy(evictionPolicy);
+    triggerPolicy.setWindowManager(windowManager);
     triggerPolicy.start();
     windowManager.setTriggerPolicy(triggerPolicy);
 


### PR DESCRIPTION
Hello,

Pursuant to my question in #2647 , I've added support for custom eviction and trigger policies.  The modifications that I have made is to:

-Add the ability to add a custom EvictionPolicy and TriggerPolicy to a WindowingConfigs
-Add an if statement to check for the existence of custom policies in the WindowingConfigs passed to a WindowedBoltExecutor
-Add the ability to add a custom trigger or evictor policy to a BaseWindowedBolt
-Add support for a custom trigger and evictor policy WindowConfig and WindowConfigImpl in the streamlet api

Thoughts? This is my first time interacting with the underlying api, but I tried to keep the methods/implementation as similar as possible to what already existed.

Daniel

-------------

Add support in both the streamlet and topology apis for the usage of custom eviction policies extending com.twitter.heron.api.windowing.EvictionPolicy and trigger policies extending com.twitter.heron.api.windowing.TriggerPolicy to enable user-defined windowing schemes.