### PR TITLE
Fixing  the slurm scheduler

### DIFF
--- a/heron/config/src/yaml/conf/slurm/slurm.sh
+++ b/heron/config/src/yaml/conf/slurm/slurm.sh
@@ -13,9 +13,10 @@ ONE=1
 for i in $(seq 1 $SLURM_NNODES); do
     index=`expr $i - $ONE`
     echo "Exec" $1 $index ${@:3}
-    srun -lN1 -n1 --nodes=1 --relative=$index $1 $index ${@:2} &
+    srun -lN1 -n1 --nodes=1 --relative=$index $1 --shard=$index ${@:2} &
 done
 
 echo $SLURM_JOB_ID > slurm-job.pid
 
 wait
+

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/SchedulerUtils.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/SchedulerUtils.java
@@ -339,7 +339,9 @@ public final class SchedulerUtils {
     String remoteDebuggerPorts = ExecutorPort.getPort(
         ExecutorPort.JVM_REMOTE_DEBUGGER_PORTS, ports);
 
-    args.add(createCommandArg(ExecutorFlag.Shard, containerIndex));
+    if (containerIndex != null) {
+      args.add(createCommandArg(ExecutorFlag.Shard, containerIndex));
+    }
     args.add(createCommandArg(ExecutorFlag.MasterPort, masterPort));
     args.add(createCommandArg(ExecutorFlag.TMasterControllerPort, tmasterControllerPort));
     args.add(createCommandArg(ExecutorFlag.TMasterStatsPort, tmasterStatsPort));

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/slurm/SlurmScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/slurm/SlurmScheduler.java
@@ -54,7 +54,7 @@ public class SlurmScheduler implements IScheduler {
 
   @Override
   public void initialize(Config mConfig, Config mRuntime) {
-    this.config = mConfig;
+    this.config = Config.toClusterMode(mConfig);
     this.runtime = mRuntime;
     this.controller = getController();
 
@@ -138,7 +138,7 @@ public class SlurmScheduler implements IScheduler {
     }
 
     String[] executorCmd = SchedulerUtils.executorCommandArgs(this.config, this.runtime,
-        ports, "0");
+        ports, null);
 
     LOG.log(Level.FINE, "Executor command line: ", Arrays.toString(executorCmd));
     return executorCmd;

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/slurm/SlurmSchedulerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/slurm/SlurmSchedulerTest.java
@@ -74,12 +74,11 @@ public class SlurmSchedulerTest {
   }
 
   private static Config createRunnerConfig() {
-    Config config = Mockito.mock(Config.class);
-    Mockito.when(config.getStringValue(Key.TOPOLOGY_NAME)).thenReturn(TOPOLOGY_NAME);
-    Mockito.when(config.getStringValue(Key.CLUSTER)).thenReturn(CLUSTER);
-    Mockito.when(config.getStringValue(Key.ROLE)).thenReturn(ROLE);
-    Mockito.when(config.getStringValue(Key.ENVIRON)).thenReturn(ENVIRON);
-
+    Config config = Config.newBuilder()
+        .put(Key.TOPOLOGY_NAME, TOPOLOGY_NAME)
+        .put(Key.CLUSTER, CLUSTER)
+        .put(Key.ROLE, ROLE)
+        .put(Key.ENVIRON, ENVIRON).build();
     return config;
   }
 


### PR DESCRIPTION
Fixing the slurm scheduler, the shard id is generated by the slurm.sh script, so we are not including that in the command generated from the java code.