### PR TITLE
Use the minimal ram size for components instead of the last one

### DIFF
--- a/heron/spi/src/java/com/twitter/heron/spi/packing/PackingPlan.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/packing/PackingPlan.java
@@ -123,11 +123,15 @@ public class PackingPlan {
    * @return String describing component ram distribution
    */
   public String getComponentRamDistribution() {
+    // Generate a map with the minimal ram size for each component
     Map<String, ByteAmount> ramMap = new HashMap<>();
-    // The implementation assumes instances for the same component require same ram
     for (ContainerPlan containerPlan : this.getContainers()) {
       for (InstancePlan instancePlan : containerPlan.getInstances()) {
-        ramMap.put(instancePlan.getComponentName(), instancePlan.getResource().getRam());
+        ByteAmount newRam = instancePlan.getResource().getRam();
+        ByteAmount currentRam = ramMap.get(instancePlan.getComponentName());
+        if (currentRam == null || currentRam.asBytes() > newRam.asBytes()) {
+          ramMap.put(instancePlan.getComponentName(), newRam);
+        }
       }
     }
 

--- a/heron/spi/tests/java/com/twitter/heron/spi/packing/PackingPlanTest.java
+++ b/heron/spi/tests/java/com/twitter/heron/spi/packing/PackingPlanTest.java
@@ -29,28 +29,32 @@ import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.spi.utils.PackingTestUtils;
 
 public class PackingPlanTest {
-  private static PackingPlan generatePacking(Map<Integer, List<InstanceId>> basePacking) {
+  class TestInstance {
+    public InstanceId id;
+    public int ramInG;
+
+    TestInstance(InstanceId id, int ramInG) {
+      this.id = id;
+      this.ramInG = ramInG;
+    }
+  }
+
+  private static PackingPlan generatePacking(Map<Integer, List<TestInstance>> basePacking) {
     Resource resource
         = new Resource(1.0, ByteAmount.fromGigabytes(1), ByteAmount.fromGigabytes(10));
 
     Set<PackingPlan.ContainerPlan> containerPlans = new HashSet<>();
 
     for (int containerId : basePacking.keySet()) {
-      List<InstanceId> instanceList = basePacking.get(containerId);
+      List<TestInstance> instanceList = basePacking.get(containerId);
 
       Set<PackingPlan.InstancePlan> instancePlans = new HashSet<>();
 
-      for (InstanceId instanceId : instanceList) {
-        String componentName = instanceId.getComponentName();
-        Resource instanceResource;
-        if ("bolt".equals(componentName)) {
-          instanceResource
-              = new Resource(1.0, ByteAmount.fromGigabytes(2), ByteAmount.fromGigabytes(10));
-        } else {
-          instanceResource
-              = new Resource(1.0, ByteAmount.fromGigabytes(3), ByteAmount.fromGigabytes(10));
-        }
-        instancePlans.add(new PackingPlan.InstancePlan(instanceId, instanceResource));
+      for (TestInstance instance : instanceList) {
+        String componentName = instance.id.getComponentName();
+        Resource instanceResource = new Resource(1.0,
+            ByteAmount.fromGigabytes(instance.ramInG), ByteAmount.fromGigabytes(10));
+        instancePlans.add(new PackingPlan.InstancePlan(instance.id, instanceResource));
       }
 
       PackingPlan.ContainerPlan containerPlan =
@@ -64,10 +68,10 @@ public class PackingPlanTest {
 
   @Test
   public void testComponentRamDistribution() {
-    Map<Integer, List<InstanceId>> packing = new HashMap<>();
+    Map<Integer, List<TestInstance>> packing = new HashMap<>();
     packing.put(1, Arrays.asList(
-        new InstanceId("spout", 1, 0),
-        new InstanceId("bolt", 3, 0)));
+        new TestInstance(new InstanceId("spout", 1, 0), 3),
+        new TestInstance(new InstanceId("bolt", 3, 0), 2)));
     PackingPlan packingPlan = generatePacking(packing);
 
     String ramDistStr = packingPlan.getComponentRamDistribution();
@@ -75,13 +79,29 @@ public class PackingPlanTest {
   }
 
   @Test
-  public void testPackingPlanSerde() {
-    Map<Integer, List<InstanceId>> packing = new HashMap<>();
+  public void testComponentRamDistributionUnbalanced() {
+    Map<Integer, List<TestInstance>> packing = new HashMap<>();
     packing.put(1, Arrays.asList(
-        new InstanceId("spout", 1, 0),
-        new InstanceId("bolt", 3, 0)));
+        new TestInstance(new InstanceId("spout", 1, 0), 3),
+        new TestInstance(new InstanceId("bolt", 6, 0), 3)));
+    packing.put(2, Arrays.asList(new TestInstance(new InstanceId("spout", 2, 1), 2)));
+    packing.put(3, Arrays.asList(new TestInstance(new InstanceId("bolt", 3, 2), 1)));
+    packing.put(4, Arrays.asList(new TestInstance(new InstanceId("bolt", 4, 3), 2)));
+    packing.put(5, Arrays.asList(new TestInstance(new InstanceId("bolt", 5, 4), 3)));
+    PackingPlan packingPlan = generatePacking(packing);
+
+    String ramDistStr = packingPlan.getComponentRamDistribution();
+    Assert.assertEquals("spout:2147483648,bolt:1073741824", ramDistStr);
+  }
+
+  @Test
+  public void testPackingPlanSerde() {
+    Map<Integer, List<TestInstance>> packing = new HashMap<>();
+    packing.put(1, Arrays.asList(
+        new TestInstance(new InstanceId("spout", 1, 0), 3),
+        new TestInstance(new InstanceId("bolt", 3, 0), 2)));
     packing.put(2, Arrays.asList(
-        new InstanceId("spout", 2, 1)));
+        new TestInstance(new InstanceId("spout", 2, 1), 3)));
 
     PackingPlan packingPlan = generatePacking(packing);
 


### PR DESCRIPTION
Currently the component ram size calculation assumes all instances for a component use the same amount of memory, when generating component ram map. However this is not true for some packingplan algorithms, like RoundRobin. As the result, the bigger ram size can be used and the total memory used by instances in more crowded container can be more than the container ram size.

Example:
each container has 2G for instances.

container 1 has 1 "spout" and 1 "bolt", the ram size is 1G per instance
container 2 has 1 "bolt", the ram size is 2G per instance
The component ram map might be "spout:1g,bolt:1g" or "spout:1g,bolt:2g". In the second case, the instances in container 1 would use 3G memory, because the instances in the container would have the following jvm arguments:
spout 1: "-xmx 1g"
bolt 1: "-xmx 2g"
