### PR TITLE
[work in progress][healthmgr] add backpressure-diagnoser

### DIFF
--- a/heron/config/src/yaml/conf/local/healthmgr.yaml
+++ b/heron/config/src/yaml/conf/local/healthmgr.yaml
@@ -10,6 +10,7 @@ heron.healthmgr.metricsource.url: http://localhost:8888
 ## list of policies to be executed for self regulation
 #heron.class.health.policies:
 #  - dynamic-resource-allocation
+#  - auto-restart-slow-container
 #  - auto-restart-backpressure-container
 #
 ## configuration specific to individual policies listed above
@@ -18,7 +19,11 @@ heron.healthmgr.metricsource.url: http://localhost:8888
 #  health.policy.interval.ms: 120000
 #  BackPressureDetector.noiseFilterMillis: 20
 #  GrowingWaitQueueDetector.limit: 5
+#auto-restart-slow-container:
+#  health.policy.class: com.twitter.heron.healthmgr.policy.AutoRestartSlowContainerPolicy
+#  health.policy.interval.ms: 120000
+#  BackPressureDetector.noiseFilterMillis: 20
 #auto-restart-backpressure-container:
 #  health.policy.class: com.twitter.heron.healthmgr.policy.AutoRestartBackpressureContainerPolicy
 #  health.policy.interval.ms: 120000
-#  BackPressureDetector.noiseFilterMillis: 20
+#  BackPressureDetector.noiseFilterMillis: 60000

--- a/heron/healthmgr/src/java/com/twitter/heron/healthmgr/diagnosers/BackpressureInstanceDiagnoser.java
+++ b/heron/healthmgr/src/java/com/twitter/heron/healthmgr/diagnosers/BackpressureInstanceDiagnoser.java
@@ -1,0 +1,44 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.twitter.heron.healthmgr.diagnosers;
+
+import java.util.List;
+import java.util.logging.Logger;
+
+import com.microsoft.dhalion.detector.Symptom;
+import com.microsoft.dhalion.diagnoser.Diagnosis;
+import com.microsoft.dhalion.metrics.ComponentMetrics;
+
+import static com.twitter.heron.healthmgr.diagnosers.BaseDiagnoser.DiagnosisName.DIAGNOSIS_BACKPRESSURE_INSTANCE;
+import static com.twitter.heron.healthmgr.diagnosers.BaseDiagnoser.DiagnosisName.SYMPTOM_BACKPRESSURE_INSTANCE;
+
+public class BackpressureInstanceDiagnoser extends BaseDiagnoser {
+  private static final Logger LOG = Logger.getLogger(BackpressureInstanceDiagnoser.class.getName());
+
+  @Override
+  public Diagnosis diagnose(List<Symptom> symptoms) {
+    List<Symptom> bpSymptoms = getBackPressureSymptoms(symptoms);
+    if (bpSymptoms.isEmpty()) {
+      // Since there is no back pressure, no action is needed
+      return null;
+    } else if (bpSymptoms.size() > 1) {
+      // TODO handle cases where multiple detectors create back pressure symptom
+      throw new IllegalStateException("Multiple back-pressure symptoms case");
+    }
+    ComponentMetrics bpMetrics = bpSymptoms.iterator().next().getComponent();
+    Symptom resultSymptom = new Symptom(SYMPTOM_BACKPRESSURE_INSTANCE.text(), bpMetrics);
+    return new Diagnosis(DIAGNOSIS_BACKPRESSURE_INSTANCE.text(), resultSymptom);
+  }
+}

--- a/heron/healthmgr/src/java/com/twitter/heron/healthmgr/diagnosers/BaseDiagnoser.java
+++ b/heron/healthmgr/src/java/com/twitter/heron/healthmgr/diagnosers/BaseDiagnoser.java
@@ -34,9 +34,11 @@ public abstract class BaseDiagnoser implements IDiagnoser {
     SYMPTOM_UNDER_PROVISIONING("SYMPTOM_UNDER_PROVISIONING"),
     SYMPTOM_DATA_SKEW("SYMPTOM_DATA_SKEW"),
     SYMPTOM_SLOW_INSTANCE("SYMPTOM_SLOW_INSTANCE"),
+    SYMPTOM_BACKPRESSURE_INSTANCE("SYMPTOM_BACKPRESSURE_INSTANCE"),
 
     DIAGNOSIS_UNDER_PROVISIONING(UnderProvisioningDiagnoser.class.getSimpleName()),
     DIAGNOSIS_SLOW_INSTANCE(SlowInstanceDiagnoser.class.getSimpleName()),
+    DIAGNOSIS_BACKPRESSURE_INSTANCE(BackpressureInstanceDiagnoser.class.getSimpleName()),
     DIAGNOSIS_DATA_SKEW(DataSkewDiagnoser.class.getSimpleName());
 
     private String text;


### PR DESCRIPTION
The present `AutoRestartBackpressureContainerPolicy.java` actually means `slow instance`.
This PR renamed `AutoRestartBackpressureContainerPolicy.java` to `AutoRestartSlowContainerPolicy.java`.

Besides, this PR added `BackpressureInstanceDiagnoser.java` and `AutoRestartBackpressureContainerPolicy.java`