### PR TITLE
JSON output for heron-admin standalone cluster info command

### DIFF
--- a/heron/tools/admin/src/python/standalone.py
+++ b/heron/tools/admin/src/python/standalone.py
@@ -180,7 +180,7 @@ def run(command, parser, cl_args, unknown_args):
     update_config_files(cl_args)
   elif action == Action.GET:
     action_type = cl_args["type"]
-    if action_type == Get.HERON_TRACKER_URL:
+    if action_type == Get.SERVICE_URL:
       print get_service_url(cl_args)
     elif action_type == Get.HERON_UI_URL:
       print get_heron_ui_url(cl_args)

--- a/heron/tools/admin/src/python/standalone.py
+++ b/heron/tools/admin/src/python/standalone.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ''' standalone.py '''
+from collections import OrderedDict
 from subprocess import call
 import subprocess
 import sys
@@ -24,6 +25,7 @@ import requests
 import time
 import netifaces
 import yaml
+import json
 
 from heron.common.src.python.utils.log import Log
 from heron.tools.cli.src.python.result   import SimpleResult, Status
@@ -341,24 +343,30 @@ def get_heron_ui_url(cl_args):
   return "http://%s:8889" % list(roles[Role.MASTERS])[0]
 
 def print_cluster_info(cl_args):
-  roles = read_and_parse_roles(cl_args)
-  masters = roles[Role.MASTERS]
-  slaves = roles[Role.SLAVES]
-  zookeepers = roles[Role.ZOOKEEPERS]
-  cluster = roles[Role.CLUSTER]
-  print "Cluster:"
-  print " - Total # of nodes: %s" % len(cluster)
-  print " - Nodes: %s" % cluster
-  print "\n"
-  print "Roles:"
-  print " - Master Servers: %s" % list(masters)
-  print " - Slave Servers: %s" % list(slaves)
-  print " - Zookeeper Servers: %s" % list(zookeepers)
-  print "\n"
-  print "URLs:"
-  print " - Service URL: %s" % get_service_url(cl_args)
-  print " - Heron UI URL: %s" % get_heron_ui_url(cl_args)
-  print " - Heron Tracker URL: %s" % get_heron_tracker_url(cl_args)
+  '''
+  get cluster info for standalone cluster
+  '''
+  parsed_roles = read_and_parse_roles(cl_args)
+  masters = list(parsed_roles[Role.MASTERS])
+  slaves = list(parsed_roles[Role.SLAVES])
+  zookeepers = list(parsed_roles[Role.ZOOKEEPERS])
+  cluster = list(parsed_roles[Role.CLUSTER])
+
+  info = OrderedDict()
+  info['numNodes'] = len(cluster)
+  info['nodes'] = cluster
+  roles = OrderedDict()
+  roles['masters'] = masters
+  roles['slaves'] = slaves
+  roles['zookeepers'] = zookeepers
+  urls = OrderedDict()
+  urls['serviceUrl'] = get_service_url(cl_args)
+  urls['heronUi'] = get_heron_ui_url(cl_args)
+  urls['heronTracker'] = get_heron_tracker_url(cl_args)
+  info['roles'] = roles
+  info['urls'] = urls
+
+  print json.dumps(info, indent=2)
 
 def add_additional_args(parsers):
   '''

--- a/heron/tools/admin/src/python/standalone.py
+++ b/heron/tools/admin/src/python/standalone.py
@@ -352,6 +352,8 @@ def print_cluster_info(cl_args):
   zookeepers = list(parsed_roles[Role.ZOOKEEPERS])
   cluster = list(parsed_roles[Role.CLUSTER])
 
+  # OrderedDicts are used here so that the key order can be
+  # specified directly
   info = OrderedDict()
   info['numNodes'] = len(cluster)
   info['nodes'] = cluster
@@ -578,7 +580,7 @@ def wait_for_job_to_start(single_master, job):
         raise RuntimeError()
     except:
       Log.debug(sys.exc_info()[0])
-      Log.info("Waiting for apiserver to come up... %s" % i)
+      Log.info("Waiting for %s to come up... %s" % (job, i))
       time.sleep(1)
       if i > 20:
         Log.error("Failed to start Nomad Cluster!")


### PR DESCRIPTION
At the moment, running `heron-admin standalone info` command outputs a formatted string. This PR changes the output to pretty-printed JSON so that the output can be easily stored in JSON files and used with tools like `jq`.