### PR TITLE
enable write_env_exec_file method

### DIFF
--- a/bazel_configure.py
+++ b/bazel_configure.py
@@ -398,7 +398,7 @@ def main():
   env_map['STRIP'] = discover_tool_default('strip', "strip", 'STRIP', '/usr/bin/strip')
 
   # write the environment executable file
-  # write_env_exec_file(platform, env_map)
+  write_env_exec_file(platform, env_map)
 
 if __name__ == '__main__':
   main()


### PR DESCRIPTION
As is noted in https://twitter.github.io/heron/docs/contributors/community/, in order to bootstrap an intellij idea project, `$ ./scripts/setup-intellij.sh` should run first. It uses `./scripts/compile_env/env_exec.sh` file which should be created by `./bazel_configure.py`.