### PR TITLE
no need to check the existence of env_exec.sh in scripts/setup-intell…

### DIFF
--- a/scripts/setup-intellij.sh
+++ b/scripts/setup-intellij.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-# Make sure ./bazel_configure.py is run before runing this scripts
-if [[ ! -f ./scripts/compile/env_exec.sh ]] ; then
-  echo "ERROR: File ./scripts/compile_env/env_exec.sh is not found."
-  echo "Run ./bazel_configure.py first."
-  exit
-fi
-
 # Generates an IntelliJ project in heron
 
 set -o errexit


### PR DESCRIPTION
This PR comes from #2681

After removing the heading`if` block, `./scripts/setup-intellij.sh` can run smoothly. I think for history reason, as was noted in PR #1429 , that heading`if` block was added to check the existence of `env_exec.sh`. But for now, the `env_exec.sh` file is not needed anymore.