### PR TITLE
Add skip runtime validation option

### DIFF
--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
@@ -153,13 +153,13 @@ public class RuntimeManagerMain {
         .build();
 
     Option dryRun = Option.builder("u")
-        .desc("run in dry-run mode")
+        .desc("Run in dry-run mode")
         .longOpt("dry_run")
         .required(false)
         .build();
 
     Option dryRunFormat = Option.builder("t")
-        .desc("dry-run format")
+        .desc("Dry-run format")
         .longOpt("dry_run_format")
         .hasArg()
         .required(false)
@@ -168,6 +168,12 @@ public class RuntimeManagerMain {
     Option verbose = Option.builder("v")
         .desc("Enable debug logs")
         .longOpt("verbose")
+        .build();
+
+    Option skipRuntimeValidation = Option.builder("k")
+        .desc("Skip runtime validation")
+        .longOpt("skip_runtime_validation")
+        .required(false)
         .build();
 
     options.addOption(cluster);
@@ -185,6 +191,7 @@ public class RuntimeManagerMain {
     options.addOption(dryRun);
     options.addOption(dryRunFormat);
     options.addOption(verbose);
+    options.addOption(skipRuntimeValidation);
 
     return options;
   }
@@ -253,6 +260,15 @@ public class RuntimeManagerMain {
       containerId = cmd.getOptionValue("container_id");
     }
 
+    // Optional argument in the case of kill
+    // This option can be useful when a topolgoy is not "fully killed",
+    // a.k.a. topology is killed but data clean up is not successful,
+    // to skip the runtime validation in order to run the kill command again.
+    Boolean skipRuntimeValidation = false;
+    if (cmd.hasOption("skip_runtime_validation")) {
+      skipRuntimeValidation = cmd.getOptionValue("skip_runtime_validation");
+    }
+
     Boolean dryRun = false;
     if (cmd.hasOption("u")) {
       dryRun = true;
@@ -277,7 +293,8 @@ public class RuntimeManagerMain {
         .put(Key.DRY_RUN, dryRun)
         .put(Key.DRY_RUN_FORMAT_TYPE, dryRunFormat)
         .put(Key.VERBOSE, verbose)
-        .put(Key.TOPOLOGY_CONTAINER_ID, containerId);
+        .put(Key.TOPOLOGY_CONTAINER_ID, containerId)
+        .put(Key.SKIP_RUNTIME_VALIDATION, skipRuntimeValidation);
 
     // This is a command line option, but not a valid config key. Hence we don't use Keys
     if (componentParallelism != null) {

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
@@ -396,6 +396,7 @@ public class RuntimeManagerMain {
       SchedulerStateManagerAdaptor adaptor = new SchedulerStateManagerAdaptor(statemgr, 5000);
 
       if (!config.getBooleanValue(Key.SKIP_RUNTIME_VALIDATION)) {
+        LOG.fine("Validate topology state");
         validateRuntimeManage(adaptor, topologyName);
       } else {
         LOG.log(Level.FINE, "The skip_runtime_validation flag is set to true. "

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
@@ -398,8 +398,8 @@ public class RuntimeManagerMain {
       if (!config.getBooleanValue(Key.SKIP_RUNTIME_VALIDATION)) {
         validateRuntimeManage(adaptor, topologyName);
       } else {
-        LOG.log(Level.FINE, "The skip_runtime_validation flag is set to true. " +
-          "Bypass validation and run command directly");
+        LOG.log(Level.FINE, "The skip_runtime_validation flag is set to true. "
+            + "Bypass validation and run command {0} directly", command);
       }
 
       // 2. Try to manage topology if valid

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
@@ -262,11 +262,11 @@ public class RuntimeManagerMain {
 
     // Optional argument in the case of kill
     // This option can be useful when a topolgoy is not "fully killed",
-    // a.k.a. topology is killed but data clean up is not successful,
-    // to skip the runtime validation in order to run the kill command again.
+    // for example, topology is killed but data clean up is not successful,
+    // to skip the runtime validation in order to run the kill command again
     Boolean skipRuntimeValidation = false;
     if (cmd.hasOption("skip_runtime_validation")) {
-      skipRuntimeValidation = cmd.getOptionValue("skip_runtime_validation");
+      skipRuntimeValidation = true;
     }
 
     Boolean dryRun = false;
@@ -395,7 +395,11 @@ public class RuntimeManagerMain {
       // TODO(mfu): timeout should read from config
       SchedulerStateManagerAdaptor adaptor = new SchedulerStateManagerAdaptor(statemgr, 5000);
 
-      validateRuntimeManage(adaptor, topologyName);
+      if (!config.getBooleanValue(Key.SKIP_RUNTIME_VALIDATION)) {
+        validateRuntimeManage(adaptor, topologyName);
+      } else {
+        LOG.log(Level.FINE, "Skip runntime validation flag is set to true. Run the command now");
+      }
 
       // 2. Try to manage topology if valid
       // invoke the appropriate command to manage the topology

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
@@ -398,7 +398,8 @@ public class RuntimeManagerMain {
       if (!config.getBooleanValue(Key.SKIP_RUNTIME_VALIDATION)) {
         validateRuntimeManage(adaptor, topologyName);
       } else {
-        LOG.log(Level.FINE, "Skip runntime validation flag is set to true. Run the command now");
+        LOG.log(Level.FINE, "The skip_runtime_validation flag is set to true. " +
+          "Bypass validation and run command directly");
       }
 
       // 2. Try to manage topology if valid

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Key.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Key.java
@@ -48,14 +48,15 @@ public enum Key {
   STATEFUL_YAML            ("heron.config.file.stateful.yaml",  "${HERON_CONF}/stateful.yaml"),
 
   //keys for config provided in the command line
-  CLUSTER                  ("heron.config.cluster",             Type.STRING),
-  ROLE                     ("heron.config.role",                Type.STRING),
-  ENVIRON                  ("heron.config.environ",             Type.STRING),
-  SUBMIT_USER              ("heron.config.submit_user",         Type.STRING),
-  DRY_RUN                  ("heron.config.dry_run",             Boolean.FALSE),
-  DRY_RUN_FORMAT_TYPE      ("heron.config.dry_run_format_type", Type.DRY_RUN_FORMAT_TYPE),
-  VERBOSE                  ("heron.config.verbose",             Boolean.FALSE),
-  CONFIG_PROPERTY          ("heron.config.property",            Type.STRING),
+  CLUSTER                  ("heron.config.cluster",                 Type.STRING),
+  ROLE                     ("heron.config.role",                    Type.STRING),
+  ENVIRON                  ("heron.config.environ",                 Type.STRING),
+  SUBMIT_USER              ("heron.config.submit_user",             Type.STRING),
+  DRY_RUN                  ("heron.config.dry_run",                 Boolean.FALSE),
+  DRY_RUN_FORMAT_TYPE      ("heron.config.dry_run_format_type",     Type.DRY_RUN_FORMAT_TYPE),
+  VERBOSE                  ("heron.config.verbose",                 Boolean.FALSE),
+  CONFIG_PROPERTY          ("heron.config.property",                Type.STRING),
+  SKIP_RUNTIME_VALIDATION  ("heron.config.skip_runtime_validation", Boolean.FALSE),
 
   //keys for release/build information
   BUILD_VERSION            ("heron.build.version",   Type.STRING),

--- a/heron/tools/cli/src/python/kill.py
+++ b/heron/tools/cli/src/python/kill.py
@@ -45,14 +45,17 @@ def run(command, parser, cl_args, unknown_args):
   :return:
   '''
   Log.debug("Kill Args: %s", cl_args)
+  skip_runtime_validation = False
+  if cl_args.get('skip_runtime_validation', 'false').lower() == 'true':
+    skip_runtime_validation = True
 
   if cl_args['deploy_mode'] == config.SERVER_MODE:
     dict_extra_args = {}
-    if cl_args['skip-runtime-validation']:
+    if skip_runtime_validation:
       dict_extra_args['skip_runtime_validation'] = True
     return cli_helper.run_server(command, cl_args, "kill topology", extra_args=dict_extra_args)
   else:
     list_extra_args = []
-    if cl_args['skip-runtime-validation']:
+    if skip_runtime_validation:
       list_extra_args.append('--skip_runtime_validation')
     return cli_helper.run_direct(command, cl_args, "kill topology", extra_args=list_extra_args)

--- a/heron/tools/cli/src/python/kill.py
+++ b/heron/tools/cli/src/python/kill.py
@@ -23,7 +23,15 @@ def create_parser(subparsers):
   :param subparsers:
   :return:
   '''
-  return cli_helper.create_parser(subparsers, 'kill', 'Kill a topology')
+  parser = cli_helper.create_parser(subparsers, 'kill', 'Kill a topology')
+
+  parser.add_argument(
+      'skip-runtime-validation',
+      default=False,
+      help='Skip runtime validation. This option should only be used when the topology is running '
+           'in an unexpected state and can\'t be killed without this option')
+
+  return parser
 
 
 # pylint: disable=unused-argument
@@ -36,4 +44,11 @@ def run(command, parser, cl_args, unknown_args):
   :return:
   '''
   Log.debug("Kill Args: %s", cl_args)
-  return cli_helper.run(command, cl_args, "kill topology")
+  skip_runtime_validation = cl_args['skip-runtime-validation']
+
+  if cl_args['deploy_mode'] == config.SERVER_MODE:
+    dict_extra_args = {"skip_runtime_validation": str(skip_runtime_validation)}
+    return cli_helper.run_server(command, cl_args, "kill topology", extra_args=dict_extra_args)
+  else:
+    list_extra_args = ["--skip_runtime_validation", str(skip_runtime_validation)]
+    return cli_helper.run_direct(command, cl_args, "kill topology", extra_args=list_extra_args)

--- a/heron/tools/cli/src/python/kill.py
+++ b/heron/tools/cli/src/python/kill.py
@@ -17,6 +17,7 @@
 ''' kill.py '''
 from heron.common.src.python.utils.log import Log
 import heron.tools.cli.src.python.cli_helper as cli_helper
+import heron.tools.common.src.python.utils.config as config
 
 def create_parser(subparsers):
   '''
@@ -26,7 +27,7 @@ def create_parser(subparsers):
   parser = cli_helper.create_parser(subparsers, 'kill', 'Kill a topology')
 
   parser.add_argument(
-      'skip-runtime-validation',
+      '--skip-runtime-validation',
       default=False,
       help='Skip runtime validation. This option should only be used when the topology is running '
            'in an unexpected state and can\'t be killed without this option')
@@ -44,11 +45,14 @@ def run(command, parser, cl_args, unknown_args):
   :return:
   '''
   Log.debug("Kill Args: %s", cl_args)
-  skip_runtime_validation = cl_args['skip-runtime-validation']
 
   if cl_args['deploy_mode'] == config.SERVER_MODE:
-    dict_extra_args = {"skip_runtime_validation": str(skip_runtime_validation)}
+    dict_extra_args = {}
+    if cl_args['skip-runtime-validation']:
+      dict_extra_args['skip_runtime_validation'] = True
     return cli_helper.run_server(command, cl_args, "kill topology", extra_args=dict_extra_args)
   else:
-    list_extra_args = ["--skip_runtime_validation", str(skip_runtime_validation)]
+    list_extra_args = []
+    if cl_args['skip-runtime-validation']:
+      list_extra_args.append('--skip_runtime_validation')
     return cli_helper.run_direct(command, cl_args, "kill topology", extra_args=list_extra_args)


### PR DESCRIPTION
Internal users reported an issue that a kill command is not fully successful. As the result there are some left over data in zk. It seems clearState() function deletes 8 nodes one by one and the delete calls don't guarantee to be successful.

Because of these left over data, users can't deploy the topology.
And because some key data has been deleted, "heron kill" command throws a "Topology 'test' does not exist" error when users tried to run it again.

This new "skip-runtime-validation" option can be useful when a topolgoy is not "fully killed",
for example, topology is killed but data clean up is not successful,
to skip the runtime validation in order to run the kill command again