### PR TITLE
[Streamlet Scala API] Add initial Build Files

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -881,11 +881,11 @@ new_http_archive(
 rules_scala_version="5cdae2f034581a05e23c3473613b409de5978833" # update this as needed
 
 http_archive(
-             name = "io_bazel_rules_scala",
-             url = "https://github.com/bazelbuild/rules_scala/archive/%s.zip"%rules_scala_version,
-             type = "zip",
-             strip_prefix= "rules_scala-%s" % rules_scala_version
-             )
+    name = "io_bazel_rules_scala",
+    url = "https://github.com/bazelbuild/rules_scala/archive/%s.zip"%rules_scala_version,
+    type = "zip",
+    strip_prefix= "rules_scala-%s" % rules_scala_version
+)
 
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
 scala_repositories()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -876,3 +876,18 @@ new_http_archive(
     urls = ["https://releases.hashicorp.com/nomad/0.7.0/nomad_0.7.0_linux_amd64.zip"],
     build_file = "third_party/nomad/nomad.BUILD",
 )
+
+# scala integration
+rules_scala_version="5cdae2f034581a05e23c3473613b409de5978833" # update this as needed
+
+http_archive(
+             name = "io_bazel_rules_scala",
+             url = "https://github.com/bazelbuild/rules_scala/archive/%s.zip"%rules_scala_version,
+             type = "zip",
+             strip_prefix= "rules_scala-%s" % rules_scala_version
+             )
+
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
+scala_repositories()
+load("@io_bazel_rules_scala//specs2:specs2_junit.bzl","specs2_junit_repositories")
+specs2_junit_repositories()

--- a/heron/api/src/scala/BUILD
+++ b/heron/api/src/scala/BUILD
@@ -1,0 +1,12 @@
+licenses(["notice"])
+
+package(default_visibility = ["//visibility:public"])
+
+scala_library(
+    name = "api-scala",
+    srcs = glob(["com/twitter/heron/streamlet/scala/**/*.scala"]),
+    deps = [
+            "//heron/api/src/java:api-java-low-level",
+            "//heron/api/src/java:api-java"
+        ]
+)

--- a/heron/api/src/scala/com/twitter/heron/streamlet/scala/Source.scala
+++ b/heron/api/src/scala/com/twitter/heron/streamlet/scala/Source.scala
@@ -1,0 +1,34 @@
+//  Copyright 2018 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.streamlet.scala
+
+import java.io.Serializable
+import com.twitter.heron.streamlet.Context
+
+/**
+  * Source is how Streamlet's originate. The get method
+  * invocation returns new element that form the tuples of the streamlet.
+  * setup/cleanup is where the generator can do any one time setup work, like
+  * establishing/closing connection to sources, etc.
+  */
+trait Source[T] extends Serializable {
+
+  def setup(context: Context): Unit
+
+  def get: scala.Iterable[T]
+
+  def cleanup(): Unit
+
+}
+

--- a/heron/api/tests/scala/BUILD
+++ b/heron/api/tests/scala/BUILD
@@ -1,0 +1,10 @@
+scala_test(
+    name = "api-scala-test",
+    srcs = glob(["com/twitter/heron/streamlet/scala/**/*.scala"]),
+    deps = [
+        "//third_party/java:junit4",
+        "//heron/api/src/scala:api-scala",
+        "//heron/api/src/java:api-java",
+        "//heron/api/src/java:api-java-low-level"
+    ],
+)

--- a/heron/api/tests/scala/com/twitter/heron/streamlet/scala/SourceTest.scala
+++ b/heron/api/tests/scala/com/twitter/heron/streamlet/scala/SourceTest.scala
@@ -1,0 +1,75 @@
+//  Copyright 2018 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.streamlet.scala
+
+import java.{io, util}
+import java.util.function.Supplier
+
+import com.twitter.heron.api.state.State
+import com.twitter.heron.streamlet.Context
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.WordSpec
+
+import scala.collection.mutable.ListBuffer
+
+@RunWith(classOf[JUnitRunner])
+class SourceTest extends WordSpec {
+
+  "SourceTest" should {
+
+    val expectedList = List(1, 2, 3, 4, 5)
+
+    "provide data" in {
+      val source = new MySource()
+      source.setup(new MyContext())
+      assert(source.get == expectedList)
+    }
+
+    "support cleanup" in {
+      val source = new MySource()
+      source.setup(new MyContext())
+      assert(source.get == expectedList)
+      source.cleanup()
+      assert(source.get == List[Int]())
+    }
+
+  }
+
+  private class MySource() extends Source[Int] {
+    private val numbers = ListBuffer[Int]()
+
+    override def setup(context: Context): Unit = {
+      numbers += (1, 2, 3, 4, 5)
+    }
+
+    override def get: Iterable[Int] = numbers
+
+    override def cleanup(): Unit = numbers.clear()
+  }
+
+  private class MyContext extends Context {
+    override def getTaskId: Int = ???
+
+    override def getConfig: util.Map[String, AnyRef] = ???
+
+    override def getStreamName: String = ???
+
+    override def getStreamPartition: Int = ???
+
+    override def registerMetric[T](metricName: String, collectionInterval: Int, metricFn: Supplier[T]): Unit = ???
+
+    override def getState: State[io.Serializable, io.Serializable] = ???
+  }
+}

--- a/tools/build_rules/prelude_bazel
+++ b/tools/build_rules/prelude_bazel
@@ -37,3 +37,8 @@ load(
     "container_image",
     "container_push",
 )
+
+load("@io_bazel_rules_scala//scala:scala.bzl",
+    "scala_binary",
+    "scala_library",
+    "scala_test")


### PR DESCRIPTION
This PR aims the following changes:

- Base PR for Scala `Streamlet` API
- Scala API Bazel Build Support
- Source Trait as pure Scala version of Java interface
- UT Coverage by approving initial Scala Tests passed