### PR TITLE
Call cleanState() before submitting topology in case previous kill co…

### DIFF
--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
@@ -28,6 +28,7 @@ import com.twitter.heron.proto.system.PackingPlans;
 import com.twitter.heron.scheduler.client.ISchedulerClient;
 import com.twitter.heron.scheduler.dryrun.UpdateDryRunResponse;
 import com.twitter.heron.scheduler.utils.Runtime;
+import com.twitter.heron.scheduler.utils.SchedulerUtils;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Context;
 import com.twitter.heron.spi.packing.IRepacking;
@@ -209,69 +210,12 @@ public class RuntimeManagerRunner {
 
   /**
    * Clean all states of a heron topology
-   * 1. Topology def and ExecutionState are required to exist to delete
-   * 2. TMasterLocation, SchedulerLocation and PhysicalPlan may not exist to delete
    */
   protected void cleanState(
       String topologyName,
       SchedulerStateManagerAdaptor statemgr) throws TopologyRuntimeManagementException {
     LOG.fine("Cleaning up topology state");
-
-    Boolean result;
-
-    // It is possible that TMasterLocation, MetricsCacheLocation, PackingPlan, PhysicalPlan and
-    // SchedulerLocation are not set. Just log but don't consider it a failure and don't return
-    // false
-    result = statemgr.deleteTMasterLocation(topologyName);
-    if (result == null || !result) {
-      throw new TopologyRuntimeManagementException(
-          "Failed to clear TMaster location. Check whether TMaster set it correctly.");
-    }
-
-    result = statemgr.deleteMetricsCacheLocation(topologyName);
-    if (result == null || !result) {
-      throw new TopologyRuntimeManagementException(
-          "Failed to clear MetricsCache location. Check whether MetricsCache set it correctly.");
-    }
-
-    result = statemgr.deletePackingPlan(topologyName);
-    if (result == null || !result) {
-      throw new TopologyRuntimeManagementException(
-          "Failed to clear packing plan. Check whether Launcher set it correctly.");
-    }
-
-    result = statemgr.deletePhysicalPlan(topologyName);
-    if (result == null || !result) {
-      throw new TopologyRuntimeManagementException(
-          "Failed to clear physical plan. Check whether TMaster set it correctly.");
-    }
-
-    result = statemgr.deleteSchedulerLocation(topologyName);
-    if (result == null || !result) {
-      throw new TopologyRuntimeManagementException(
-          "Failed to clear scheduler location. Check whether Scheduler set it correctly.");
-    }
-
-    result = statemgr.deleteLocks(topologyName);
-    if (result == null || !result) {
-      throw new TopologyRuntimeManagementException(
-          "Failed to delete locks. It's possible that the topology never created any.");
-    }
-
-    result = statemgr.deleteExecutionState(topologyName);
-    if (result == null || !result) {
-      throw new TopologyRuntimeManagementException(
-          "Failed to clear execution state");
-    }
-
-    // Set topology def at last since we determine whether a topology is running
-    // by checking the existence of topology def
-    result = statemgr.deleteTopology(topologyName);
-    if (result == null || !result) {
-      throw new TopologyRuntimeManagementException(
-          "Failed to clear topology definition");
-    }
-
+    SchedulerUtils.cleanState(topologyName, statemgr);
     LOG.fine("Cleaned up topology state");
   }
 

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
@@ -35,6 +35,7 @@ import com.twitter.heron.api.utils.TopologyUtils;
 import com.twitter.heron.common.basics.DryRunFormatType;
 import com.twitter.heron.common.basics.SysUtils;
 import com.twitter.heron.common.utils.logging.LoggingHelper;
+import com.twitter.heron.proto.system.ExecutionEnvironment;
 import com.twitter.heron.scheduler.dryrun.SubmitDryRunResponse;
 import com.twitter.heron.scheduler.utils.DryRunRenders;
 import com.twitter.heron.scheduler.utils.LauncherUtils;
@@ -429,8 +430,7 @@ public class SubmitterMain {
 
       // Try to clear left over data in case the previous kill operation
       // wasn't fully successful
-      LOG.fine("Cleaning up previous topology state before submission");
-      SchedulerUtils.cleanState(topology.getName(), adaptor);
+      cleanState(adaptor, topology.getName());
 
       LOG.log(Level.FINE, "Topology {0} to be submitted", topology.getName());
 
@@ -547,6 +547,16 @@ public class SubmitterMain {
       throw new TopologySubmissionException(
           String.format("Topology '%s' already exists", topologyName));
     }
+  }
+
+  /**
+   * Clean all states of a heron topology
+   */
+  protected void cleanState(SchedulerStateManagerAdaptor statemgr, String topologyName)
+      throws TopologyRuntimeManagementException {
+    LOG.fine("Cleaning up topology state");
+    SchedulerUtils.cleanState(topologyName, statemgr);
+    LOG.fine("Cleaned up topology state");
   }
 
   protected URI uploadPackage(IUploader uploader) throws UploaderException {

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/SubmitterMain.java
@@ -38,6 +38,7 @@ import com.twitter.heron.common.utils.logging.LoggingHelper;
 import com.twitter.heron.scheduler.dryrun.SubmitDryRunResponse;
 import com.twitter.heron.scheduler.utils.DryRunRenders;
 import com.twitter.heron.scheduler.utils.LauncherUtils;
+import com.twitter.heron.scheduler.utils.SchedulerUtils;
 import com.twitter.heron.scheduler.utils.SubmitterUtils;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.ConfigLoader;
@@ -324,6 +325,7 @@ public class SubmitterMain {
        - status code >= 200
          program sends out dry-run response */
     try {
+      // Submit topology
       submitterMain.submitTopology();
     } catch (SubmitDryRunResponse response) {
       LOG.log(Level.FINE, "Sending out dry-run response");
@@ -424,6 +426,11 @@ public class SubmitterMain {
 
       // Check if topology is already running
       validateSubmit(adaptor, topology.getName());
+
+      // Try to clear left over data in case the previous kill operation
+      // wasn't fully successful
+      LOG.fine("Cleaning up previous topology state before submission");
+      SchedulerUtils.cleanState(topology.getName(), adaptor);
 
       LOG.log(Level.FINE, "Topology {0} to be submitted", topology.getName());
 
@@ -530,8 +537,13 @@ public class SubmitterMain {
     // Check whether the topology has already been running
     // TODO(rli): anti-pattern is too nested on this path to be refactored
     Boolean isTopologyRunning = adaptor.isTopologyRunning(topologyName);
+    ExecutionEnvironment.ExecutionState executionState = adaptor.getExecutionState(topologyName);
 
-    if (isTopologyRunning != null && isTopologyRunning.equals(Boolean.TRUE)) {
+    // RuntimeManager considers topology to be running when isTopologyRunning is true and
+    // executionState exists in validateRuntimeManage() function. The same condition is used here
+    if (isTopologyRunning != null
+        && isTopologyRunning.equals(Boolean.TRUE)
+        && executionState != null) {
       throw new TopologySubmissionException(
           String.format("Topology '%s' already exists", topologyName));
     }


### PR DESCRIPTION
…mmand wasn't fully successful and there is left-over data

Internal users reported an issue that a kill command is not fully successful. As the result there are some left over data in zk and users won't be able to submit the topology again. And because the key data has been deleted, "heron kill" command throws a "Topology 'test' does not exist" error when users tried to run it again.

It seems clearState() function deletes 8 nodes one by one and the delete calls don't guarantee to be successful. Now we call clearState() again in case there is any left over (unexpected) data. The validation code in submitMain is also updated to be consistent to the validation in RuntimeManager.

