### PR TITLE
Fix for localhost metrics manager

### DIFF
--- a/heron/common/src/java/com/twitter/heron/common/utils/misc/PhysicalPlanHelper.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/misc/PhysicalPlanHelper.java
@@ -111,7 +111,11 @@ public class PhysicalPlanHelper {
     }
 
     try {
-      this.hostname = InetAddress.getLocalHost().getHostName();
+      if (System.getenv("HOST") != null) {
+        this.hostname = System.getenv("HOST");
+      } else {
+        this.hostname = InetAddress.getLocalHost().getHostName();
+      }
     } catch (UnknownHostException e) {
       throw new RuntimeException("GetHostName failed");
     }

--- a/heron/instance/src/java/com/twitter/heron/network/MetricsManagerClient.java
+++ b/heron/instance/src/java/com/twitter/heron/network/MetricsManagerClient.java
@@ -72,9 +72,14 @@ public class MetricsManagerClient extends HeronClient {
     addMetricsManagerClientTasksOnWakeUp();
 
     try {
-      this.hostname = InetAddress.getLocalHost().getHostName();
+      if (System.getenv("HOST") != null) {
+        this.hostname = System.getenv("HOST");
+      } else {
+        this.hostname = InetAddress.getLocalHost().getHostName();
+      }
     } catch (UnknownHostException e) {
-      throw new RuntimeException("GetHostName failed");
+      LOG.log(Level.SEVERE, "Unable to get local host name", e);
+      this.hostname = "localhost";
     }
   }
 

--- a/heron/metricscachemgr/src/java/com/twitter/heron/metricscachemgr/MetricsCacheManager.java
+++ b/heron/metricscachemgr/src/java/com/twitter/heron/metricscachemgr/MetricsCacheManager.java
@@ -17,6 +17,7 @@ package com.twitter.heron.metricscachemgr;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -354,12 +355,24 @@ public class MetricsCacheManager {
         .build());
     LOG.info("Cli Config: " + config.toString());
 
+    String hostname;
+    try {
+      if (System.getenv("HOST") != null) {
+        hostname = System.getenv("HOST");
+      } else {
+        hostname = InetAddress.getLocalHost().getHostName();
+      }
+    } catch( UnknownHostException e) {
+      LOG.log(Level.SEVERE, "Unable to get local hostname", e);
+      hostname = "localhost";
+    }
+
     // build metricsCache location
     TopologyMaster.MetricsCacheLocation metricsCacheLocation =
         TopologyMaster.MetricsCacheLocation.newBuilder()
             .setTopologyName(topologyName)
             .setTopologyId(topologyId)
-            .setHost(InetAddress.getLocalHost().getHostName())
+            .setHost(hostname)
             .setControllerPort(-1) // not used for metricscache
             .setMasterPort(masterPort)
             .setStatsPort(statsPort)

--- a/heron/spi/src/java/com/twitter/heron/spi/utils/NetworkUtils.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/utils/NetworkUtils.java
@@ -399,7 +399,11 @@ public final class NetworkUtils {
   public static String getHostName() {
     String hostName;
     try {
-      hostName = InetAddress.getLocalHost().getHostName();
+      if (System.getenv("HOST") != null) {
+        hostName = System.getenv("HOST");
+      } else {
+        hostName = InetAddress.getLocalHost().getHostName();
+      }
     } catch (UnknownHostException e) {
       LOG.log(Level.SEVERE, "Unable to get local host name", e);
       hostName = "localhost";


### PR DESCRIPTION
What?
- Fixes for getting local hostname from within a Docker container

Why?
- Metrics management doesn't work correctly if running Heron using Docker containers deployed in a cluster environment