### PR TITLE
Nwang/count stmgr connection failures in all clients

### DIFF
--- a/heron/stmgr/src/cpp/manager/stmgr-client.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-client.cpp
@@ -170,6 +170,7 @@ void StMgrClient::HandleHelloResponse(void*, proto::stmgr::StrMgrHelloResponse* 
 }
 
 void StMgrClient::OnReConnectTimer() {
+  client_manager_->HandleStMgrClientReconnect(other_stmgr_id_);
   reconnect_attempts_ += 1;
 
   if (reconnect_attempts_ < reconnect_other_streammgrs_max_attempt_) {

--- a/heron/stmgr/src/cpp/manager/stmgr-clientmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-clientmgr.cpp
@@ -35,10 +35,10 @@ namespace stmgr {
 // New connections made with other stream managers.
 const sp_string METRIC_STMGR_NEW_CONNECTIONS = "__stmgr_new_connections";
 
-StMgrClientMgr::StMgrClientMgr(EventLoop *eventLoop, const sp_string &_topology_name,
-                               const sp_string &_topology_id, const sp_string &_stmgr_id,
-                               StMgr *_stream_manager,
-                               heron::common::MetricsMgrSt *_metrics_manager_client,
+StMgrClientMgr::StMgrClientMgr(EventLoop* eventLoop, const sp_string& _topology_name,
+                               const sp_string& _topology_id, const sp_string& _stmgr_id,
+                               StMgr* _stream_manager,
+                               heron::common::MetricsMgrSt* _metrics_manager_client,
                                sp_int64 _high_watermark, sp_int64 _low_watermark,
                                bool _droptuples_upon_backpressure)
     : topology_name_(_topology_name),

--- a/heron/stmgr/src/cpp/manager/stmgr-clientmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr-clientmgr.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "manager/stmgr-clientmgr.h"
+#include <algorithm>
 #include <iostream>
 #include <map>
 #include <unordered_set>
@@ -34,10 +35,10 @@ namespace stmgr {
 // New connections made with other stream managers.
 const sp_string METRIC_STMGR_NEW_CONNECTIONS = "__stmgr_new_connections";
 
-StMgrClientMgr::StMgrClientMgr(EventLoop* eventLoop, const sp_string& _topology_name,
-                               const sp_string& _topology_id, const sp_string& _stmgr_id,
-                               StMgr* _stream_manager,
-                               heron::common::MetricsMgrSt* _metrics_manager_client,
+StMgrClientMgr::StMgrClientMgr(EventLoop *eventLoop, const sp_string &_topology_name,
+                               const sp_string &_topology_id, const sp_string &_stmgr_id,
+                               StMgr *_stream_manager,
+                               heron::common::MetricsMgrSt *_metrics_manager_client,
                                sp_int64 _high_watermark, sp_int64 _low_watermark,
                                bool _droptuples_upon_backpressure)
     : topology_name_(_topology_name),
@@ -48,9 +49,12 @@ StMgrClientMgr::StMgrClientMgr(EventLoop* eventLoop, const sp_string& _topology_
       metrics_manager_client_(_metrics_manager_client),
       high_watermark_(_high_watermark),
       low_watermark_(_low_watermark),
-      droptuples_upon_backpressure_(_droptuples_upon_backpressure) {
+      droptuples_upon_backpressure_(_droptuples_upon_backpressure),
+      total_reconnect_attempts_(0) {
   stmgr_clientmgr_metrics_ = new heron::common::MultiCountMetric();
   metrics_manager_client_->register_metric("__clientmgr", stmgr_clientmgr_metrics_);
+  per_client_reconnect_other_streammgrs_max_attempt_ =
+      config::HeronInternalsConfigReader::Instance()->GetHeronStreammgrClientReconnectMaxAttempts();
 }
 
 StMgrClientMgr::~StMgrClientMgr() {
@@ -183,6 +187,27 @@ void StMgrClientMgr::HandleDeadStMgrConnection(const sp_string& _dead_stmgr) {
 void StMgrClientMgr::HandleStMgrClientRegistered() {
   if (AllStMgrClientsRegistered()) {
     stream_manager_->HandleAllStMgrClientsRegistered();
+  }
+}
+
+void StMgrClientMgr::HandleStMgrClientReconnect(const sp_string &_stmgr_id) {
+  // The default client reconnect time is 1s and the default max attempt is 300.
+  // Therefore if a connection is broken, stmgr would be restartd in 5 minutes by stmgr client.
+  // Although we want to restart stmgr sooner if there are more broken connections,
+  // it could be risky if the threshold is too agressive and causing stmgr to restart too soon.
+  // Here the max attempt across all clients is set to: per client max attempt * client count / 8.
+  // Hence if all connections are broken, the lower bound of restart time is about 40s.
+  // However in reality, broken connections cause extra delays hence less reconnects are made.
+  // In one case, it takes more than 120 minutes for a stmgr client to reach the max attempt and
+  // restart. So the stmgr is expected to be restarted in 10 to 20 minutes with the / 8 factor.
+  // The mininum max attempt is per client max attempt * 2 in case number of clients is too low.
+  sp_int32 max_attempt = per_client_reconnect_other_streammgrs_max_attempt_ * clients_.size() / 8;
+  max_attempt = std::max(max_attempt, per_client_reconnect_other_streammgrs_max_attempt_ * 2);
+
+  total_reconnect_attempts_++;
+  if (total_reconnect_attempts_ >= max_attempt) {
+    LOG(FATAL) << "Total stmgr client reconnect attempt count reaches threshold " << max_attempt
+               << ". Quitting...";
   }
 }
 

--- a/heron/stmgr/src/cpp/manager/stmgr-clientmgr.h
+++ b/heron/stmgr/src/cpp/manager/stmgr-clientmgr.h
@@ -58,10 +58,14 @@ class StMgrClientMgr {
   void SendStartBackPressureToOtherStMgrs();
   void SendStopBackPressureToOtherStMgrs();
   bool DidAnnounceBackPressure();
+
   // Called by StMgrClient when its connection closes
   void HandleDeadStMgrConnection(const sp_string& _stmgr_id);
   // Called by StMgrClient when it successfully registers
   void HandleStMgrClientRegistered();
+  // Called by StMgrClient when it tries to reconnect
+  void HandleStMgrClientReconnect(const sp_string &_stmgr_id);
+
   void SendDownstreamStatefulCheckpoint(const sp_string& _stmgr_id,
                                         proto::ckptmgr::DownstreamStatefulCheckpoint* _message);
 
@@ -92,6 +96,9 @@ class StMgrClientMgr {
   sp_int64 low_watermark_;
 
   bool droptuples_upon_backpressure_;
+
+  sp_int32 total_reconnect_attempts_;
+  sp_int32 per_client_reconnect_other_streammgrs_max_attempt_;
 };
 
 }  // namespace stmgr


### PR DESCRIPTION
We found out that when a bad stmgr is experiencing connection issue to
all other stmgrs, it takes the stmgr a lot longer to reach the per stmgr
client max attempt and quite becaus bad connections cause extra delays.
In our case, instead of quitting after 5 minutes (1s reconnect timeout,
300 max attempts), the bad stmgr quitted after more than 2 hours. At the
same time, all other good stmgrs were quitting every 5 minutes.

A total reconnection attempt checking is added in order to make the bad
stmgr quit sooner.