### PR TITLE
[Streamlet Scala API] Add FunSuite Support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -892,5 +892,3 @@ http_archive(
 
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
 scala_repositories()
-load("@io_bazel_rules_scala//specs2:specs2_junit.bzl","specs2_junit_repositories")
-specs2_junit_repositories()

--- a/heron/api/tests/scala/com/twitter/heron/streamlet/scala/SourceTest.scala
+++ b/heron/api/tests/scala/com/twitter/heron/streamlet/scala/SourceTest.scala
@@ -13,38 +13,34 @@
 //  limitations under the License.
 package com.twitter.heron.streamlet.scala
 
-import java.{io, util}
-import java.util.function.Supplier
-
-import com.twitter.heron.api.state.State
-import com.twitter.heron.streamlet.Context
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
-import org.scalatest.WordSpec
-
 import scala.collection.mutable.ListBuffer
 
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import com.twitter.heron.streamlet.Context
+import com.twitter.heron.streamlet.scala.common.{BaseFunSuite, TestContext}
+
+/**
+  * Tests for Source Trait functionality
+  */
 @RunWith(classOf[JUnitRunner])
-class SourceTest extends WordSpec {
+class SourceTest extends BaseFunSuite {
 
-  "SourceTest" should {
+  val expectedList = List(1, 2, 3, 4, 5)
 
-    val expectedList = List(1, 2, 3, 4, 5)
+  test("Source should provide data") {
+    val source = new MySource()
+    source.setup(new TestContext())
+    assert(source.get == expectedList)
+  }
 
-    "provide data" in {
-      val source = new MySource()
-      source.setup(new MyContext())
-      assert(source.get == expectedList)
-    }
-
-    "support cleanup" in {
-      val source = new MySource()
-      source.setup(new MyContext())
-      assert(source.get == expectedList)
-      source.cleanup()
-      assert(source.get == List[Int]())
-    }
-
+  test("Source should support cleanup") {
+    val source = new MySource()
+    source.setup(new TestContext())
+    assert(source.get == expectedList)
+    source.cleanup()
+    assert(source.get == List[Int]())
   }
 
   private class MySource() extends Source[Int] {
@@ -59,17 +55,4 @@ class SourceTest extends WordSpec {
     override def cleanup(): Unit = numbers.clear()
   }
 
-  private class MyContext extends Context {
-    override def getTaskId: Int = ???
-
-    override def getConfig: util.Map[String, AnyRef] = ???
-
-    override def getStreamName: String = ???
-
-    override def getStreamPartition: Int = ???
-
-    override def registerMetric[T](metricName: String, collectionInterval: Int, metricFn: Supplier[T]): Unit = ???
-
-    override def getState: State[io.Serializable, io.Serializable] = ???
-  }
 }

--- a/heron/api/tests/scala/com/twitter/heron/streamlet/scala/SourceTest.scala
+++ b/heron/api/tests/scala/com/twitter/heron/streamlet/scala/SourceTest.scala
@@ -15,16 +15,12 @@ package com.twitter.heron.streamlet.scala
 
 import scala.collection.mutable.ListBuffer
 
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
-
 import com.twitter.heron.streamlet.Context
 import com.twitter.heron.streamlet.scala.common.{BaseFunSuite, TestContext}
 
 /**
   * Tests for Source Trait functionality
   */
-@RunWith(classOf[JUnitRunner])
 class SourceTest extends BaseFunSuite {
 
   val expectedList = List(1, 2, 3, 4, 5)

--- a/heron/api/tests/scala/com/twitter/heron/streamlet/scala/common/BaseFunSuite.scala
+++ b/heron/api/tests/scala/com/twitter/heron/streamlet/scala/common/BaseFunSuite.scala
@@ -1,0 +1,24 @@
+//  Copyright 2018 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.streamlet.scala.common
+
+import org.scalatest.FunSuite
+
+/**
+  * Base abstract class for all unit tests in Heron Streamlet Scala API
+  * in order to keep common test functionality.
+  */
+private[scala] abstract class BaseFunSuite extends FunSuite {
+
+}

--- a/heron/api/tests/scala/com/twitter/heron/streamlet/scala/common/TestContext.scala
+++ b/heron/api/tests/scala/com/twitter/heron/streamlet/scala/common/TestContext.scala
@@ -19,23 +19,32 @@ import java.util.function.Supplier
 import com.twitter.heron.api.state.State
 import com.twitter.heron.streamlet.Context
 
+/**
+  * State represents the state interface as seen by stateful bolts and spouts.
+  * In Heron, state gives a notional Key/Value interface along with the
+  * ability to iterate over the key/values. This class aims its test implementation.
+  */
 private[scala] class TestState[K <: io.Serializable, V <: io.Serializable]
   extends util.HashMap[K, V] with State[K, V] {}
 
+/**
+  * Context is the information available at runtime for operators like transform.
+  * This class aims its test implementation with initial values.
+  */
 private[scala] class TestContext extends Context {
-  override def getTaskId: Int = 0
+  override def getTaskId = 0
 
-  override def getConfig: util.Map[String, AnyRef] = new util.HashMap[String, AnyRef]()
+  override def getConfig = new util.HashMap[String, AnyRef]()
 
-  override def getStreamName: String = ""
+  override def getStreamName = ""
 
-  override def getStreamPartition: Int = 0
+  override def getStreamPartition = 0
 
   override def registerMetric[T](metricName: String,
                                  collectionInterval: Int,
                                  metricFn: Supplier[T]): Unit = {}
 
-  override def getState: State[io.Serializable, io.Serializable] =
+  override def getState =
     new TestState[io.Serializable, io.Serializable]()
 
 }

--- a/heron/api/tests/scala/com/twitter/heron/streamlet/scala/common/TestContext.scala
+++ b/heron/api/tests/scala/com/twitter/heron/streamlet/scala/common/TestContext.scala
@@ -1,0 +1,43 @@
+//  Copyright 2018 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.streamlet.scala.common
+
+import java.{io, util}
+import java.util.function.Supplier
+
+import com.twitter.heron.api.state.State
+import com.twitter.heron.streamlet.Context
+
+private[scala] class TestState[K <: io.Serializable, V <: io.Serializable]
+  extends util.HashMap[K, V] with State[K, V] {}
+
+private[scala] class TestContext extends Context {
+  override def getTaskId: Int = 0
+
+  override def getConfig: util.Map[String, AnyRef] = new util.HashMap[String, AnyRef]()
+
+  override def getStreamName: String = ""
+
+  override def getStreamPartition: Int = 0
+
+  override def registerMetric[T](metricName: String,
+                                 collectionInterval: Int,
+                                 metricFn: Supplier[T]): Unit = {}
+
+  override def getState: State[io.Serializable, io.Serializable] =
+    new TestState[io.Serializable, io.Serializable]()
+
+}
+
+


### PR DESCRIPTION
This PR aims the following changes:
- Adding ScalaTest `FunSuite` Support to Streamlet Scala API Tests
- UT specific common logic moves under `common` package