### PR TITLE
Make scala dependencies from rules_scala explicit

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -875,10 +875,12 @@ new_http_archive(
 
 # scala integration
 rules_scala_version="5cdae2f034581a05e23c3473613b409de5978833" # update this as needed
+scala_version = "2.11"
+scala_point_version = scala_version +".11"
 
 http_archive(
     name = "io_bazel_rules_scala",
-    url = "https://github.com/bazelbuild/rules_scala/archive/%s.zip"%rules_scala_version,
+    url = "https://github.com/bazelbuild/rules_scala/archive/%s.zip" % rules_scala_version,
     type = "zip",
     strip_prefix= "rules_scala-%s" % rules_scala_version
 )
@@ -887,13 +889,13 @@ SCALA_BUILD_FILE = """
 # scala.BUILD
 java_import(
     name = "scala-xml",
-    jars = ["lib/scala-xml_2.11-1.0.5.jar"],
+    jars = ["lib/scala-xml_%s-1.0.5.jar"],
     visibility = ["//visibility:public"],
 )
 
 java_import(
     name = "scala-parser-combinators",
-    jars = ["lib/scala-parser-combinators_2.11-1.0.4.jar"],
+    jars = ["lib/scala-parser-combinators_%s-1.0.4.jar"],
     visibility = ["//visibility:public"],
 )
 
@@ -914,20 +916,20 @@ java_import(
     jars = ["lib/scala-reflect.jar"],
     visibility = ["//visibility:public"],
 )
-"""
+""" % (scala_version, scala_version)
 
 new_http_archive(
   name = "scala",
-  strip_prefix = "scala-2.11.11",
-  # sha256 = "12037ca64c68468e717e950f47fc77d5ceae5e74e3bdca56f6d02fd5bfd6900b",
-  url = "https://downloads.lightbend.com/scala/2.11.11/scala-2.11.11.tgz",
+  strip_prefix = "scala-" + scala_point_version,
+  sha256 = "12037ca64c68468e717e950f47fc77d5ceae5e74e3bdca56f6d02fd5bfd6900b",
+  url = "https://downloads.lightbend.com/scala/%s/scala-%s.tgz" % (scala_point_version, scala_point_version),
   build_file_content = SCALA_BUILD_FILE,
 )
 
 # scalatest has macros, note http_jar is invoking ijar
 http_jar(
     name = "scalatest",
-    url = "https://mirror.bazel.build/oss.sonatype.org/content/groups/public/org/scalatest/scalatest_2.11/2.2.6/scalatest_2.11-2.2.6.jar",
+    url = "https://mirror.bazel.build/oss.sonatype.org/content/groups/public/org/scalatest/scalatest_%s/2.2.6/scalatest_%s-2.2.6.jar" % (scala_version, scala_version),
     sha256 = "f198967436a5e7a69cfd182902adcfbcb9f2e41b349e1a5c8881a2407f615962",
 )
 
@@ -944,7 +946,7 @@ http_file(
           BAZEL_JAVA_LAUNCHER_VERSION +
           "/src/main/java/com/google/devtools/build/lib/bazel/rules/java/" +
           "java_stub_template.txt"),
-  # sha256 = "f09d06d55cd25168427a323eb29d32beca0ded43bec80d76fc6acd8199a24489",
+  sha256 = "f09d06d55cd25168427a323eb29d32beca0ded43bec80d76fc6acd8199a24489",
 )
 
 bind(name = "io_bazel_rules_scala/dependency/com_google_protobuf/protobuf_java", actual = "@scalac_rules_protobuf_java//jar")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -883,7 +883,74 @@ http_archive(
     strip_prefix= "rules_scala-%s" % rules_scala_version
 )
 
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
-scala_repositories()
-load("@io_bazel_rules_scala//specs2:specs2_junit.bzl","specs2_junit_repositories")
-specs2_junit_repositories()
+SCALA_BUILD_FILE = """
+# scala.BUILD
+java_import(
+    name = "scala-xml",
+    jars = ["lib/scala-xml_2.11-1.0.5.jar"],
+    visibility = ["//visibility:public"],
+)
+
+java_import(
+    name = "scala-parser-combinators",
+    jars = ["lib/scala-parser-combinators_2.11-1.0.4.jar"],
+    visibility = ["//visibility:public"],
+)
+
+java_import(
+    name = "scala-library",
+    jars = ["lib/scala-library.jar"],
+    visibility = ["//visibility:public"],
+)
+
+java_import(
+    name = "scala-compiler",
+    jars = ["lib/scala-compiler.jar"],
+    visibility = ["//visibility:public"],
+)
+
+java_import(
+    name = "scala-reflect",
+    jars = ["lib/scala-reflect.jar"],
+    visibility = ["//visibility:public"],
+)
+"""
+
+new_http_archive(
+  name = "scala",
+  strip_prefix = "scala-2.11.11",
+  # sha256 = "12037ca64c68468e717e950f47fc77d5ceae5e74e3bdca56f6d02fd5bfd6900b",
+  url = "https://downloads.lightbend.com/scala/2.11.11/scala-2.11.11.tgz",
+  build_file_content = SCALA_BUILD_FILE,
+)
+
+# scalatest has macros, note http_jar is invoking ijar
+http_jar(
+    name = "scalatest",
+    url = "https://mirror.bazel.build/oss.sonatype.org/content/groups/public/org/scalatest/scalatest_2.11/2.2.6/scalatest_2.11-2.2.6.jar",
+    sha256 = "f198967436a5e7a69cfd182902adcfbcb9f2e41b349e1a5c8881a2407f615962",
+)
+
+maven_jar(
+  name = "scalac_rules_protobuf_java",
+  artifact = "com.google.protobuf:protobuf-java:3.1.0",
+)
+
+# Template for binary launcher
+BAZEL_JAVA_LAUNCHER_VERSION = "0.4.5"
+http_file(
+  name = "java_stub_template",
+  url = ("https://raw.githubusercontent.com/bazelbuild/bazel/" +
+          BAZEL_JAVA_LAUNCHER_VERSION +
+          "/src/main/java/com/google/devtools/build/lib/bazel/rules/java/" +
+          "java_stub_template.txt"),
+  # sha256 = "f09d06d55cd25168427a323eb29d32beca0ded43bec80d76fc6acd8199a24489",
+)
+
+bind(name = "io_bazel_rules_scala/dependency/com_google_protobuf/protobuf_java", actual = "@scalac_rules_protobuf_java//jar")
+bind(name = "io_bazel_rules_scala/dependency/scala/parser_combinators", actual = "@scala//:scala-parser-combinators")
+bind(name = "io_bazel_rules_scala/dependency/scala/scala_compiler", actual = "@scala//:scala-compiler")
+bind(name = "io_bazel_rules_scala/dependency/scala/scala_library", actual = "@scala//:scala-library")
+bind(name = "io_bazel_rules_scala/dependency/scala/scala_reflect", actual = "@scala//:scala-reflect")
+bind(name = "io_bazel_rules_scala/dependency/scala/scala_xml", actual = "@scala//:scala-xml")
+bind(name = "io_bazel_rules_scala/dependency/scalatest/scalatest", actual = "@scalatest//jar")


### PR DESCRIPTION
Currently some internal dependencies are used directly and can not be preprocessed.