### PR TITLE
[metricscache] reduce exception stack trace to first 2 lines

### DIFF
--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/metricscache/MetricsCacheSink.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/metricscache/MetricsCacheSink.java
@@ -210,8 +210,8 @@ public class MetricsCacheSink implements IMetricsSink {
     for (ExceptionInfo exceptionInfo : record.getExceptions()) {
       String exceptionStackTrace = exceptionInfo.getStackTrace();
       String[] exceptionStackTraceLines = exceptionStackTrace.split("\r\n|[\r\n]", 3);
-      String exceptionStackTraceFirstTwoLines =
-          String.join(System.lineSeparator(), exceptionStackTraceLines[0], exceptionStackTraceLines[1]);
+      String exceptionStackTraceFirstTwoLines = String.join(System.lineSeparator(),
+          exceptionStackTraceLines[0], exceptionStackTraceLines[1]);
       TopologyMaster.TmasterExceptionLog exceptionLog =
           TopologyMaster.TmasterExceptionLog.newBuilder()
               .setComponentName(componentName)

--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/metricscache/MetricsCacheSink.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/metricscache/MetricsCacheSink.java
@@ -208,12 +208,16 @@ public class MetricsCacheSink implements IMetricsSink {
     }
 
     for (ExceptionInfo exceptionInfo : record.getExceptions()) {
+      String exceptionStackTrace = exceptionInfo.getStackTrace();
+      String[] exceptionStackTraceLines = exceptionStackTrace.split("\r\n|[\r\n]", 3);
+      String exceptionStackTraceFirstTwoLines =
+          String.join(System.lineSeparator(), exceptionStackTraceLines[0], exceptionStackTraceLines[1]);
       TopologyMaster.TmasterExceptionLog exceptionLog =
           TopologyMaster.TmasterExceptionLog.newBuilder()
               .setComponentName(componentName)
               .setHostname(hostPort)
               .setInstanceId(instanceId)
-              .setStacktrace(exceptionInfo.getStackTrace())
+              .setStacktrace(exceptionStackTraceFirstTwoLines)
               .setLasttime(exceptionInfo.getLastTime())
               .setFirsttime(exceptionInfo.getFirstTime())
               .setCount(exceptionInfo.getCount())


### PR DESCRIPTION
Our customers requires to reduce the exception stack trace size.
I found the spi comment (https://github.com/twitter/heron/blob/master/heron/spi/src/java/com/twitter/heron/spi/metricsmgr/metrics/ExceptionInfo.java#L37) showing 'first 2 lines', but the present tmaster-metricscollector and metricscache, they include all lines. This PR reduces the metricscachesink to first 2 lines while keeping tmaster-metricscolletor untouched.