### PR TITLE
Move stmgr quitting logic from stmgr client to tmaster client

### DIFF
--- a/heron/common/src/cpp/config/heron-internals-config-reader.cpp
+++ b/heron/common/src/cpp/config/heron-internals-config-reader.cpp
@@ -234,8 +234,8 @@ sp_int32 HeronInternalsConfigReader::GetHeronStreammgrXormgrRotatingmapNbuckets(
   return config_[HeronInternalsConfigVars::HERON_STREAMMGR_XORMGR_ROTATINGMAP_NBUCKETS].as<int>();
 }
 
-sp_int32 HeronInternalsConfigReader::GetHeronStreammgrClientReconnectMaxAttempts() {
-  return config_[HeronInternalsConfigVars::HERON_STREAMMGR_CLIENT_RECONNECT_MAX_ATTEMPTS].as<int>();
+sp_int32 HeronInternalsConfigReader::GetHeronStreammgrClientReconnectTmasterMaxAttempts() {
+  return config_[HeronInternalsConfigVars::HERON_STREAMMGR_CLIENT_RECONNECT_TMASTER_MAX_ATTEMPTS].as<int>();
 }
 
 sp_int32 HeronInternalsConfigReader::GetHeronStreammgrClientReconnectIntervalSec() {

--- a/heron/common/src/cpp/config/heron-internals-config-reader.cpp
+++ b/heron/common/src/cpp/config/heron-internals-config-reader.cpp
@@ -235,7 +235,8 @@ sp_int32 HeronInternalsConfigReader::GetHeronStreammgrXormgrRotatingmapNbuckets(
 }
 
 sp_int32 HeronInternalsConfigReader::GetHeronStreammgrClientReconnectTmasterMaxAttempts() {
-  return config_[HeronInternalsConfigVars::HERON_STREAMMGR_CLIENT_RECONNECT_TMASTER_MAX_ATTEMPTS].as<int>();
+  return config_[HeronInternalsConfigVars::HERON_STREAMMGR_CLIENT_RECONNECT_TMASTER_MAX_ATTEMPTS]
+      .as<int>();
 }
 
 sp_int32 HeronInternalsConfigReader::GetHeronStreammgrClientReconnectIntervalSec() {

--- a/heron/common/src/cpp/config/heron-internals-config-reader.h
+++ b/heron/common/src/cpp/config/heron-internals-config-reader.h
@@ -160,14 +160,14 @@ class HeronInternalsConfigReader : public YamlFileReader {
   // Get the Nbucket value, for efficient acknowledgement
   sp_int32 GetHeronStreammgrXormgrRotatingmapNbuckets();
 
-  // The max reconnect attempts to other stream managers for stream manager client
-  sp_int32 GetHeronStreammgrClientReconnectMaxAttempts();
-
   // The reconnect interval to other stream managers in second for stream manager client
   sp_int32 GetHeronStreammgrClientReconnectIntervalSec();
 
   // The reconnect interval to tamster in second for stream manager client
   sp_int32 GetHeronStreammgrClientReconnectTmasterIntervalSec();
+
+  // The max reconnect attempts to tmaster for stream manager client
+  sp_int32 GetHeronStreammgrClientReconnectTmasterMaxAttempts();
 
   // The maximum packet size in MB of stream manager's network options
   sp_int32 GetHeronStreammgrNetworkOptionsMaximumPacketMb();

--- a/heron/common/src/cpp/config/heron-internals-config-vars.cpp
+++ b/heron/common/src/cpp/config/heron-internals-config-vars.cpp
@@ -90,16 +90,17 @@ const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_MEMPOOL_MAX_MESSAGE_NU
     "heron.streammgr.mempool.max.message.number";
 const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_XORMGR_ROTATINGMAP_NBUCKETS =
     "heron.streammgr.xormgr.rotatingmap.nbuckets";
-const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_CLIENT_RECONNECT_MAX_ATTEMPTS =
-    "heron.streammgr.client.reconnect.max.attempts";
 const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_CLIENT_RECONNECT_INTERVAL_SEC =
     "heron.streammgr.client.reconnect.interval.sec";
 const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_CLIENT_RECONNECT_TMASTER_INTERVAL_SEC =
     "heron.streammgr.client.reconnect.tmaster.interval.sec";
+const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_CLIENT_RECONNECT_TMASTER_MAX_ATTEMPTS =
+    "heron.streammgr.client.reconnect.tmaster.max.attempts";
 const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_NETWORK_OPTIONS_MAXIMUM_PACKET_MB =
     "heron.streammgr.network.options.maximum.packet.mb";
 const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_TMASTER_HEARTBEAT_INTERVAL_SEC =
     "heron.streammgr.tmaster.heartbeat.interval.sec";
+
 const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_CONNECTION_READ_BATCH_SIZE_MB =
     "heron.streammgr.connection.read.batch.size.mb";
 const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_CONNECTION_WRITE_BATCH_SIZE_MB =

--- a/heron/common/src/cpp/config/heron-internals-config-vars.cpp
+++ b/heron/common/src/cpp/config/heron-internals-config-vars.cpp
@@ -100,7 +100,6 @@ const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_NETWORK_OPTIONS_MAXIMU
     "heron.streammgr.network.options.maximum.packet.mb";
 const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_TMASTER_HEARTBEAT_INTERVAL_SEC =
     "heron.streammgr.tmaster.heartbeat.interval.sec";
-
 const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_CONNECTION_READ_BATCH_SIZE_MB =
     "heron.streammgr.connection.read.batch.size.mb";
 const sp_string HeronInternalsConfigVars::HERON_STREAMMGR_CONNECTION_WRITE_BATCH_SIZE_MB =

--- a/heron/common/src/cpp/config/heron-internals-config-vars.h
+++ b/heron/common/src/cpp/config/heron-internals-config-vars.h
@@ -146,14 +146,14 @@ class HeronInternalsConfigVars {
   // For efficient acknowledgement
   static const sp_string HERON_STREAMMGR_XORMGR_ROTATINGMAP_NBUCKETS;
 
-  // The max reconnect attempts to other stream managers for stream manager client
-  static const sp_string HERON_STREAMMGR_CLIENT_RECONNECT_MAX_ATTEMPTS;
-
   // The reconnect interval to other stream managers in second for stream manager client
   static const sp_string HERON_STREAMMGR_CLIENT_RECONNECT_INTERVAL_SEC;
 
   // The reconnect interval to tamster in second for stream manager client
   static const sp_string HERON_STREAMMGR_CLIENT_RECONNECT_TMASTER_INTERVAL_SEC;
+
+  // The max reconnect attempts to tmaster for stream manager client
+  static const sp_string HERON_STREAMMGR_CLIENT_RECONNECT_TMASTER_MAX_ATTEMPTS;
 
   // The maximum packet size in MB of stream manager's network options
   static const sp_string HERON_STREAMMGR_NETWORK_OPTIONS_MAXIMUM_PACKET_MB;

--- a/heron/config/src/yaml/conf/aurora/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/aurora/heron_internals.yaml
@@ -65,14 +65,14 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 # The max number of messages in the memory pool for each message type
 heron.streammgr.mempool.max.message.number: 512
 
-# The max reconnect attempts to other stream managers for stream manager client
-heron.streammgr.client.reconnect.max.attempts: 300
-
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 
 # The reconnect interval to tamster in second for stream manager client
 heron.streammgr.client.reconnect.tmaster.interval.sec: 10
+
+# The max reconnect attempts to tmaster for stream manager client
+heron.streammgr.client.reconnect.tmaster.max.attempts: 30
 
 # The maximum packet size in MB of stream manager's network options
 heron.streammgr.network.options.maximum.packet.mb: 10

--- a/heron/config/src/yaml/conf/examples/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/examples/heron_internals.yaml
@@ -65,14 +65,14 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 # The max number of messages in the memory pool for each message type
 heron.streammgr.mempool.max.message.number: 512
 
-# The max reconnect attempts to other stream managers for stream manager client
-heron.streammgr.client.reconnect.max.attempts: 300
-
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 
 # The reconnect interval to tamster in second for stream manager client
 heron.streammgr.client.reconnect.tmaster.interval.sec: 10
+
+# The max reconnect attempts to tmaster for stream manager client
+heron.streammgr.client.reconnect.tmaster.max.attempts: 30
 
 # The maximum packet size in MB of stream manager's network options
 heron.streammgr.network.options.maximum.packet.mb: 10

--- a/heron/config/src/yaml/conf/kubernetes/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/kubernetes/heron_internals.yaml
@@ -68,11 +68,11 @@ heron.streammgr.mempool.max.message.number: 512
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 
-# The max reconnect attempts to other stream managers for stream manager client
-heron.streammgr.client.reconnect.max.attempts: 300
-
 # The reconnect interval to tamster in second for stream manager client
 heron.streammgr.client.reconnect.tmaster.interval.sec: 10
+
+# The max reconnect attempts to tmaster for stream manager client
+heron.streammgr.client.reconnect.tmaster.max.attempts: 30
 
 # The maximum packet size in MB of stream manager's network options
 heron.streammgr.network.options.maximum.packet.mb: 10

--- a/heron/config/src/yaml/conf/local/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/local/heron_internals.yaml
@@ -65,14 +65,14 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 # The max number of messages in the memory pool for each message type
 heron.streammgr.mempool.max.message.number: 512
 
-# The max reconnect attempts to other stream managers for stream manager client
-heron.streammgr.client.reconnect.max.attempts: 300
-
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 
 # The reconnect interval to tamster in second for stream manager client
 heron.streammgr.client.reconnect.tmaster.interval.sec: 10
+
+# The max reconnect attempts to tmaster for stream manager client
+heron.streammgr.client.reconnect.tmaster.max.attempts: 30
 
 # The maximum packet size in MB of stream manager's network options
 heron.streammgr.network.options.maximum.packet.mb: 10

--- a/heron/config/src/yaml/conf/localzk/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/localzk/heron_internals.yaml
@@ -65,14 +65,14 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 # The max number of messages in the memory pool for each message type
 heron.streammgr.mempool.max.message.number: 512
 
-# The max reconnect attempts to other stream managers for stream manager client
-heron.streammgr.client.reconnect.max.attempts: 300
-
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 
 # The reconnect interval to tamster in second for stream manager client
 heron.streammgr.client.reconnect.tmaster.interval.sec: 10
+
+# The max reconnect attempts to tmaster for stream manager client
+heron.streammgr.client.reconnect.tmaster.max.attempts: 30
 
 # The maximum packet size in MB of stream manager's network options
 heron.streammgr.network.options.maximum.packet.mb: 10

--- a/heron/config/src/yaml/conf/marathon/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/marathon/heron_internals.yaml
@@ -65,14 +65,14 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 # The max number of messages in the memory pool for each message type
 heron.streammgr.mempool.max.message.number: 512
 
-# The max reconnect attempts to other stream managers for stream manager client
-heron.streammgr.client.reconnect.max.attempts: 300
-
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 
 # The reconnect interval to tamster in second for stream manager client
 heron.streammgr.client.reconnect.tmaster.interval.sec: 10
+
+# The max reconnect attempts to tmaster for stream manager client
+heron.streammgr.client.reconnect.tmaster.max.attempts: 30
 
 # The maximum packet size in MB of stream manager's network options
 heron.streammgr.network.options.maximum.packet.mb: 10

--- a/heron/config/src/yaml/conf/mesos/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/mesos/heron_internals.yaml
@@ -65,14 +65,14 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 # The max number of messages in the memory pool for each message type
 heron.streammgr.mempool.max.message.number: 512
 
-# The max reconnect attempts to other stream managers for stream manager client
-heron.streammgr.client.reconnect.max.attempts: 300
-
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 
 # The reconnect interval to tamster in second for stream manager client
 heron.streammgr.client.reconnect.tmaster.interval.sec: 10
+
+# The max reconnect attempts to tmaster for stream manager client
+heron.streammgr.client.reconnect.tmaster.max.attempts: 30
 
 # The maximum packet size in MB of stream manager's network options
 heron.streammgr.network.options.maximum.packet.mb: 10

--- a/heron/config/src/yaml/conf/nomad/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/nomad/heron_internals.yaml
@@ -68,11 +68,11 @@ heron.streammgr.mempool.max.message.number: 512
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 
-# The max reconnect attempts to other stream managers for stream manager client
-heron.streammgr.client.reconnect.max.attempts: 300
-
 # The reconnect interval to tamster in second for stream manager client
 heron.streammgr.client.reconnect.tmaster.interval.sec: 10
+
+# The max reconnect attempts to tmaster for stream manager client
+heron.streammgr.client.reconnect.tmaster.max.attempts: 30
 
 # The maximum packet size in MB of stream manager's network options
 heron.streammgr.network.options.maximum.packet.mb: 10

--- a/heron/config/src/yaml/conf/sandbox/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/sandbox/heron_internals.yaml
@@ -65,14 +65,14 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 # The max number of messages in the memory pool for each message type
 heron.streammgr.mempool.max.message.number: 512
 
-# The max reconnect attempts to other stream managers for stream manager client
-heron.streammgr.client.reconnect.max.attempts: 300
-
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 
 # The reconnect interval to tamster in second for stream manager client
 heron.streammgr.client.reconnect.tmaster.interval.sec: 10
+
+# The max reconnect attempts to tmaster for stream manager client
+heron.streammgr.client.reconnect.tmaster.max.attempts: 30
 
 # The maximum packet size in MB of stream manager's network options
 heron.streammgr.network.options.maximum.packet.mb: 10

--- a/heron/config/src/yaml/conf/slurm/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/slurm/heron_internals.yaml
@@ -65,14 +65,14 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 # The max number of messages in the memory pool for each message type
 heron.streammgr.mempool.max.message.number: 512
 
-# The max reconnect attempts to other stream managers for stream manager client
-heron.streammgr.client.reconnect.max.attempts: 300
-
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1 
 
 # The reconnect interval to tamster in second for stream manager client
 heron.streammgr.client.reconnect.tmaster.interval.sec: 10 
+
+# The max reconnect attempts to tmaster for stream manager client
+heron.streammgr.client.reconnect.tmaster.max.attempts: 30
 
 # The maximum packet size in MB of stream manager's network options
 heron.streammgr.network.options.maximum.packet.mb: 10

--- a/heron/config/src/yaml/conf/standalone/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/standalone/heron_internals.yaml
@@ -68,11 +68,11 @@ heron.streammgr.mempool.max.message.number: 512
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 
-# The max reconnect attempts to other stream managers for stream manager client
-heron.streammgr.client.reconnect.max.attempts: 300
-
 # The reconnect interval to tamster in second for stream manager client
 heron.streammgr.client.reconnect.tmaster.interval.sec: 10
+
+# The max reconnect attempts to tmaster for stream manager client
+heron.streammgr.client.reconnect.tmaster.max.attempts: 30
 
 # The maximum packet size in MB of stream manager's network options
 heron.streammgr.network.options.maximum.packet.mb: 10

--- a/heron/config/src/yaml/conf/test/test_heron_internals.yaml
+++ b/heron/config/src/yaml/conf/test/test_heron_internals.yaml
@@ -53,14 +53,14 @@ heron.streammgr.mempool.max.message.number: 512
 # For efficient acknowledgement
 heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 
-# The max reconnect attempts to other stream managers for stream manager client
-heron.streammgr.client.reconnect.max.attempts: 300
-
 # The reconnect interval to other stream managers in second for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 
 # The reconnect interval to tamster in second for stream manager client
 heron.streammgr.client.reconnect.tmaster.interval.sec: 1
+
+# The max reconnect attempts to tmaster for stream manager client
+heron.streammgr.client.reconnect.tmaster.max.attempts: 30
 
 # The maximum packet size in MB of stream manager's network options
 heron.streammgr.network.options.maximum.packet.mb: 10

--- a/heron/config/src/yaml/conf/yarn/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/yarn/heron_internals.yaml
@@ -65,14 +65,14 @@ heron.streammgr.xormgr.rotatingmap.nbuckets: 3
 # The max number of messages in the memory pool for each message type
 heron.streammgr.mempool.max.message.number: 512
 
-# The max reconnect attempts to other stream managers for stream manager client
-heron.streammgr.client.reconnect.max.attempts: 300
-
 # The reconnect interval to other stream managers in secs for stream manager client
 heron.streammgr.client.reconnect.interval.sec: 1
 
 # The reconnect interval to tamster in second for stream manager client
 heron.streammgr.client.reconnect.tmaster.interval.sec: 10
+
+# The max reconnect attempts to tmaster for stream manager client
+heron.streammgr.client.reconnect.tmaster.max.attempts: 30
 
 # The maximum packet size in MB of stream manager's network options
 heron.streammgr.network.options.maximum.packet.mb: 10

--- a/heron/stmgr/src/cpp/manager/tmaster-client.cpp
+++ b/heron/stmgr/src/cpp/manager/tmaster-client.cpp
@@ -210,8 +210,8 @@ void TMasterClient::OnReConnectTimer() {
   if (++reconnect_attempts_ < reconnect_max_attempt_) {
     Start();
   } else {
-    LOG(FATAL) << "Could not connect to tmaster " << other_stmgr_id_
-               << " after reaching the max reconnect attempts" << reconnect_max_attempt_
+    LOG(FATAL) << "Could not connect to tmaster after reaching"
+               << " the max reconnect attempts" << reconnect_max_attempt_
                << ". Quitting...";
   }
 }

--- a/heron/stmgr/src/cpp/manager/tmaster-client.cpp
+++ b/heron/stmgr/src/cpp/manager/tmaster-client.cpp
@@ -58,7 +58,7 @@ TMasterClient::TMasterClient(EventLoop* eventLoop, const NetworkOptions& _option
   stream_to_tmaster_heartbeat_interval_sec_ = config::HeronInternalsConfigReader::Instance()
       ->GetHeronStreammgrTmasterHeartbeatIntervalSec();
   reconnect_max_attempt_ = config::HeronInternalsConfigReader::Instance()
-      ->GetHeronStreammgrClientReconnectTmasterMaxAttempts();  
+      ->GetHeronStreammgrClientReconnectTmasterMaxAttempts();
 
   reconnect_timer_cb = [this]() { this->OnReConnectTimer(); };
   heartbeat_timer_cb = [this]() { this->OnHeartbeatTimer(); };

--- a/heron/stmgr/src/cpp/manager/tmaster-client.cpp
+++ b/heron/stmgr/src/cpp/manager/tmaster-client.cpp
@@ -59,7 +59,6 @@ TMasterClient::TMasterClient(EventLoop* eventLoop, const NetworkOptions& _option
       ->GetHeronStreammgrTmasterHeartbeatIntervalSec();
   reconnect_max_attempt_ = config::HeronInternalsConfigReader::Instance()
       ->GetHeronStreammgrClientReconnectTmasterMaxAttempts();  
-  reconnect_max_attempt_ = 
 
   reconnect_timer_cb = [this]() { this->OnReConnectTimer(); };
   heartbeat_timer_cb = [this]() { this->OnHeartbeatTimer(); };

--- a/heron/stmgr/src/cpp/manager/tmaster-client.h
+++ b/heron/stmgr/src/cpp/manager/tmaster-client.h
@@ -113,6 +113,10 @@ class TMasterClient : public Client {
   sp_int64 reconnect_timer_id;
   sp_int64 heartbeat_timer_id;
 
+  // Counter for reconnect attempts
+  sp_int32 reconnect_attempts_;
+  sp_int32 reconnect_max_attempt_;
+
   // Permanent timer callbacks
   VCallback<> reconnect_timer_cb;
   VCallback<> heartbeat_timer_cb;

--- a/website/data/configs/kubernetes.yaml
+++ b/website/data/configs/kubernetes.yaml
@@ -57,12 +57,12 @@ configfiles:
   - name: heron.streammgr.client.reconnect.interval.sec
     description: The reconnect interval to other stream managers (in seconds) for the stream manager client
     default: 1
-  - name: heron.streammgr.client.reconnect.max.attempts
-    description: The max reconnect attempts to other stream managers for the stream manager client
-    default: 300
   - name: heron.streammgr.client.reconnect.tmaster.interval.sec
     description: The reconnect interval to the topology master (in seconds) for the stream manager client
     default: 10
+  - name: heron.streammgr.client.reconnect.tmaster.max.attempts
+    description: The max reconnect attempts to tmaster for stream manager client
+    default: 30
   - name: heron.streammgr.network.options.maximum.packet.mb
     description: The maximum packet size (in MB) of the stream manager's network options
     default: 10


### PR DESCRIPTION
We found out that when a bad stmgr is experiencing connection issue to
all other stmgrs, it takes the stmgr a lot longer to reach the per stmgr
client max attempt and quite becaus bad connections cause extra delays.
In our case, instead of quitting after 5 minutes (1s reconnect timeout,
300 max attempts), the bad stmgr quitted after more than 2 hours. At the
same time, all other good stmgrs were quitting every 5 minutes.

Here is a more detailed document about the issue:
https://docs.google.com/document/d/1WHNc2NEp2gVL9ge2QVKp9t4Hpd4U9sAbzBqCu4-iDUM/edit#