### PR TITLE
[Uploaders] Improve HttpUploader

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,6 +7,7 @@ powermock_version = "1.6.2"
 reef_version = "0.14.0"
 slf4j_version = "1.7.7"
 distributedlog_version = "0.5.0"
+http_client_version = "4.5.2"
 
 # heron api server
 jetty_version = "9.4.6.v20170531"
@@ -150,7 +151,13 @@ maven_jar(
 
 maven_jar(
   name = "org_apache_httpcomponents_http_client",
-  artifact = "org.apache.httpcomponents:httpclient:4.5.2",
+  artifact = "org.apache.httpcomponents:httpclient:" + http_client_version,
+)
+
+http_jar(
+  name = "org_apache_httpcomponents_http_client_test",
+  url = "http://central.maven.org/maven2/org/apache/httpcomponents/httpclient/" +
+  http_client_version + "/httpclient-" + http_client_version + "-tests.jar"
 )
 
 maven_jar(

--- a/heron/uploaders/tests/java/BUILD
+++ b/heron/uploaders/tests/java/BUILD
@@ -95,3 +95,18 @@ java_test(
         "//third_party/java:google-api-services-storage"
     ],
 )
+
+java_test(
+    name = "HttpUploaderTest",
+    srcs = glob(["**/http/HttpUploaderTest.java"]),
+    deps = common_deps_files + spi_deps_files + [
+         "//heron/uploaders/src/java:http-uploader-java",
+         "@commons_logging_commons_logging//jar",
+         "@org_apache_httpcomponents_http_core//jar",
+         "@org_apache_httpcomponents_http_client//jar",
+         "@org_apache_httpcomponents_http_client_test//jar",
+         "//heron/common/src/java:basics-java",
+    ],
+    size = "small",
+)
+

--- a/heron/uploaders/tests/java/com/twitter/heron/uploader/http/HttpUploaderTest.java
+++ b/heron/uploaders/tests/java/com/twitter/heron/uploader/http/HttpUploaderTest.java
@@ -1,0 +1,137 @@
+//  Copyright 2018 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.uploader.http;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.localserver.LocalServerTestBase;
+import org.apache.http.protocol.HttpRequestHandler;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.twitter.heron.common.basics.PackageType;
+import com.twitter.heron.spi.common.Config;
+import com.twitter.heron.spi.common.Key;
+import com.twitter.heron.spi.uploader.UploaderException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class HttpUploaderTest extends LocalServerTestBase {
+
+  private static final String EXPECTED_URI = "/test";
+
+  private HttpHost httpHost;
+  private Config config;
+  private static File tempFile;
+
+  @BeforeClass
+  public static void setUpClass() throws IOException {
+    tempFile = File.createTempFile("test_topology", ".tar.gz");
+  }
+
+  @AfterClass
+  public static void tearDownClass() {
+    tempFile.delete();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    this.serverBootstrap.registerHandler(
+        "/*", (HttpRequestHandler) (request, response, context) -> {
+          response.setStatusCode(HttpStatus.SC_OK);
+          response.setEntity(new StringEntity(EXPECTED_URI));
+        });
+
+    httpHost = start();
+
+    final URI uri = new URIBuilder()
+        .setScheme("http")
+        .setHost(httpHost.getHostName())
+        .setPort(httpHost.getPort())
+        .setPath(EXPECTED_URI)
+        .build();
+
+    // Create the minimum config for tests
+    config = Config.newBuilder()
+        .put(Key.CLUSTER, "cluster")
+        .put(Key.ROLE, "role")
+        .put(Key.TOPOLOGY_NAME, "topology")
+        .put(Key.TOPOLOGY_PACKAGE_TYPE, PackageType.TAR)
+        .put(Key.TOPOLOGY_PACKAGE_FILE, tempFile.getCanonicalPath())
+        .put(HttpUploaderContext.HERON_UPLOADER_HTTP_URI, uri.getPath())
+        .build();
+  }
+
+  @After
+  public void shutdown() throws Exception {
+    if (this.httpclient != null) {
+      this.httpclient.close();
+    }
+    if (this.server != null) {
+      this.server.shutdown(0L, TimeUnit.SECONDS);
+    }
+  }
+
+  @Test
+  public void testUndo() {
+    HttpUploader httpUploader = new TestHttpUploader();
+    assertFalse(httpUploader.undo());
+  }
+
+  @Test
+  public void testUploadPackage() {
+    HttpUploader httpUploader = new TestHttpUploader();
+    httpUploader.initialize(config);
+    URI uri = httpUploader.uploadPackage();
+    assertTrue(uri.getPath().equals(EXPECTED_URI));
+  }
+
+  @Test(expected = UploaderException.class)
+  public void testUploadPackageWhenUploaderExceptionIsThrown() {
+    HttpUploader httpUploader = new TestHttpUploaderWithException();
+    httpUploader.initialize(config);
+    httpUploader.uploadPackage();
+  }
+
+  private class TestHttpUploader extends HttpUploader {
+    @Override
+    protected HttpResponse execute(HttpClient client) throws IOException {
+      HttpResponse httpResponse = client.execute(httpHost, getPost());
+      assertEquals(HttpStatus.SC_OK, httpResponse.getStatusLine().getStatusCode());
+      return httpResponse;
+    }
+  }
+
+  private class TestHttpUploaderWithException extends HttpUploader {
+    @Override
+    protected HttpResponse execute(HttpClient client) throws IOException {
+      throw new IOException("Topology package can not be uploaded");
+    }
+  }
+}


### PR DESCRIPTION
This PR aims the following changes:
- Some refactorings has been applied at `HttpUploader` level.
- Adding UT coverage by using `org.apache.http.localserver.LocalServerTestBase`.
Also new added `HttpUploaderTest` execution time is as follows:
`//heron/uploaders/tests/java:HttpUploaderTest   PASSED in 1.8s`