### PR TITLE
mitigate prompt during installation

### DIFF
--- a/scripts/packages/template_bin.sh
+++ b/scripts/packages/template_bin.sh
@@ -126,7 +126,7 @@ untar ${base}/dist/heron-core.tar.gz ${base}/dist
 
 rm "${base}/heron.tar.gz"
 rm "${base}/dist/heron-core.tar.gz"
-rm "${base}/dist/release.yaml"
+rm -f "${base}/dist/release.yaml"
 
 cat <<EOF
 


### PR DESCRIPTION
The install.sh always prompts user to type `y` on my mac. See below
```
Uncompressing...done
tar xfz /Users/xxx/.heron/heron.tar.gz -C /Users/xxx/.heron
...Uncompressing.
tar xfz /Users/xxx/.heron/dist/heron-core.tar.gz -C /Users/xxx/.heron/dist
override r-xr-xr-x  xxx/yyy for /Users/xxx/.heron/dist/release.yaml? y

Heron is now installed!
```

This pr bypass user typing `y`
```
override r-xr-xr-x  xxx/yyy for /Users/xxx/.heron/dist/release.yaml? y
```