### PR TITLE
Simplify website setup

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -15,19 +15,11 @@ installed:
 * [Node.js](https://nodejs.org/en/)
 * [npm](https://www.npmjs.com/)
 * [pip](https://pypi.python.org/pypi/pip)
+* [Go](https://golang.org) (make sure that your `GOPATH` and `GOROOT` are set)
 
-### OS X Setup
+### macOS setup
 
-To install Node.js and npm on Mac OS X, make sure that you have
-[Homebrew](http://brew.sh/) installed and run:
-
-```bash
-$ brew update && brew install nvm && source $(brew --prefix nvm)/nvm.sh
-$ nvm install node
-$ curl -L https://www.npmjs.com/install.sh | sh
-```
-
-Once this has completed:
+To get set up on macOS:
 
 ```bash
 $ cd website
@@ -35,8 +27,8 @@ $ make setup
 $ make build-static-assets
 ```
 
-This will install Hugo, Gulp, and all of the necessary Gulp plugins and build
-the static assets for the site.
+This will install Gulp and all of the necessary Gulp plugins and build the
+static assets for the site, as well as some necessary Python libraries.
 
 ### Other Operating Systems Setup
 

--- a/website/scripts/setup.sh
+++ b/website/scripts/setup.sh
@@ -5,9 +5,6 @@ source ${DIR}/../../scripts/detect_os_type.sh
 
 PLATFORM=`platform`
 if [ $PLATFORM = darwin ]; then
-  brew update && brew install nvm && source $(brew --prefix nvm)/nvm.sh
-  nvm install node
-  curl -L https://www.npmjs.com/install.sh | sh
   go get -v github.com/gohugoio/hugo
   which wget || brew install wget
 elif [ $PLATFORM = ubuntu ]; then


### PR DESCRIPTION
At the moment, there's a script that automatically performs a complete setup for people that want to build the site locally, including installing Node.js. The Node.js step, however, has proven to be quite error prone and a source of frustration for external contributors. I'd like to provide a better setup script down the road but for now, best to tell people to install these tools on their own.