### PR TITLE
use actual path in integration script

### DIFF
--- a/scripts/run_integration_test.sh
+++ b/scripts/run_integration_test.sh
@@ -30,14 +30,14 @@ trap "kill -9 $http_server_id" SIGINT SIGTERM EXIT
 
 # run the java integration tests
 ${TEST_RUNNER} \
-  -hc heron -tb ${JAVA_INTEGRATION_TESTS_BIN} \
+  -hc ~/.heron/bin/heron -tb ${JAVA_INTEGRATION_TESTS_BIN} \
   -rh localhost -rp 8080 \
   -tp ${JAVA_TESTS_DIR} \
   -cl local -rl heron-staging -ev devel -pi ${CORE_PKG}
 
 # run the python integration tests
 ${TEST_RUNNER} \
-  -hc heron -tb ${PYTHON_INTEGRATION_TESTS_BIN} \
+  -hc ~/.heron/bin/heron -tb ${PYTHON_INTEGRATION_TESTS_BIN} \
   -rh localhost -rp 8080 \
   -tp ${PYTHON_TESTS_DIR} \
   -cl local -rl heron-staging -ev devel -pi ${CORE_PKG}


### PR DESCRIPTION
In some environment, there are multiple heron installations. The default heron command may not be the expected executable. This PR uses the actual path rather than symbolic link, since the script installs `heron-install.sh --user`