### PR TITLE
Fix Java checkstyle

### DIFF
--- a/tools/java/src/com/twitter/bazel/checkstyle/JavaCheckstyle.java
+++ b/tools/java/src/com/twitter/bazel/checkstyle/JavaCheckstyle.java
@@ -113,7 +113,7 @@ public final class JavaCheckstyle {
         Predicates.containsPattern("storm-compatibility.src.java"),
         Predicates.containsPattern("tools/test/LcovMerger"),
         Predicates.containsPattern("contrib"),
-        Predicates.containsPattern("external") // from external/ directory for bazel  
+        Predicates.containsPattern("external") // from external/ directory for bazel
     )));
   }
 


### PR DESCRIPTION
Currently `tools/java/src/com/twitter/bazel/checkstyle/JavaCheckstyle.java` will fail the java style checking.
Remove trailing spaces to fix the java checkstyle.