### PR TITLE
Allow user to run kill command when some topology data is missing

### DIFF
--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
@@ -377,7 +377,7 @@ public class RuntimeManagerMain {
       // TODO(mfu): timeout should read from config
       SchedulerStateManagerAdaptor adaptor = new SchedulerStateManagerAdaptor(statemgr, 5000);
 
-      boolean foundData = validateRuntimeManage(adaptor, topologyName);
+      boolean hasRunningData = validateRuntimeManage(adaptor, topologyName);
 
       // 2. Try to manage topology if valid
       // invoke the appropriate command to manage the topology
@@ -392,7 +392,7 @@ public class RuntimeManagerMain {
       // Create a ISchedulerClient basing on the config
       ISchedulerClient schedulerClient = getSchedulerClient(runtime);
 
-      callRuntimeManagerRunner(runtime, schedulerClient, foundData);
+      callRuntimeManagerRunner(runtime, schedulerClient, hasRunningData);
     } finally {
       // 3. Do post work basing on the result
       // Currently nothing to do here
@@ -417,8 +417,8 @@ public class RuntimeManagerMain {
       String topologyName) throws TopologyRuntimeManagementException {
     // Check whether the topology has already been running
     Boolean isTopologyRunning = adaptor.isTopologyRunning(topologyName);
-    boolean found = isTopologyRunning != null && isTopologyRunning.equals(Boolean.TRUE);
-    if (!found) {
+    boolean hasRunningData = isTopologyRunning != null && isTopologyRunning.equals(Boolean.TRUE);
+    if (!hasRunningData) {
       if (command == Command.KILL) {
         LOG.warning(String.format("Topology '%s' is not found or not running", topologyName));
       } else {
@@ -454,17 +454,17 @@ public class RuntimeManagerMain {
             topologyName, currentState, configState));
       }
     }
-    return found;
+    return hasRunningData;
   }
 
   protected void callRuntimeManagerRunner(
       Config runtime,
       ISchedulerClient schedulerClient,
-      boolean foundData)
+      boolean hasRunningData)
     throws TopologyRuntimeManagementException, TMasterException, PackingException {
     // create an instance of the runner class
     RuntimeManagerRunner runtimeManagerRunner =
-        new RuntimeManagerRunner(config, runtime, command, schedulerClient, foundData);
+        new RuntimeManagerRunner(config, runtime, command, schedulerClient, hasRunningData);
 
     // invoke the appropriate handlers based on command
     runtimeManagerRunner.call();

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
@@ -438,23 +438,34 @@ public class RuntimeManagerMain {
       }
     } else {
       // Execution state is available, validate configurations.
-      String stateCluster = executionState.getCluster();
-      String stateRole = executionState.getRole();
-      String stateEnv = executionState.getEnviron();
-      String configCluster = Context.cluster(config);
-      String configRole = Context.role(config);
-      String configEnv = Context.environ(config);
-      if (!stateCluster.equals(configCluster)
-          || !stateRole.equals(configRole)
-          || !stateEnv.equals(configEnv)) {
-        String currentState = String.format("%s/%s/%s", stateCluster, stateRole, stateEnv);
-        String configState = String.format("%s/%s/%s", configCluster, configRole, configEnv);
-        throw new TopologyRuntimeManagementException(String.format(
-            "cluster/role/environ does not match. Topology '%s' is running at %s, not %s",
-            topologyName, currentState, configState));
-      }
+      validateExecutionState(topologyName, executionState);
     }
     return hasExecutionData;
+  }
+
+  /**
+   * Verify that the environment information in execution state matches the request
+   */
+  protected void validateExecutionState(
+      String topologyName,
+      ExecutionEnvironment.ExecutionState executionState)
+      throws TopologyRuntimeManagementException {
+    String stateCluster = executionState.getCluster();
+    String stateRole = executionState.getRole();
+    String stateEnv = executionState.getEnviron();
+    String configCluster = Context.cluster(config);
+    String configRole = Context.role(config);
+    String configEnv = Context.environ(config);
+
+    if (!stateCluster.equals(configCluster)
+        || !stateRole.equals(configRole)
+        || !stateEnv.equals(configEnv)) {
+      String currentState = String.format("%s/%s/%s", stateCluster, stateRole, stateEnv);
+      String configState = String.format("%s/%s/%s", configCluster, configRole, configEnv);
+      throw new TopologyRuntimeManagementException(String.format(
+          "cluster/role/environ does not match. Topology '%s' is running at %s, not %s",
+          topologyName, currentState, configState));
+    }
   }
 
   protected void callRuntimeManagerRunner(

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
@@ -471,11 +471,12 @@ public class RuntimeManagerMain {
   protected void callRuntimeManagerRunner(
       Config runtime,
       ISchedulerClient schedulerClient,
-      boolean hasStaleExecutionData)
+      boolean potentialStaleExecutionData)
     throws TopologyRuntimeManagementException, TMasterException, PackingException {
     // create an instance of the runner class
     RuntimeManagerRunner runtimeManagerRunner =
-        new RuntimeManagerRunner(config, runtime, command, schedulerClient, hasStaleExecutionData);
+        new RuntimeManagerRunner(config, runtime, command, schedulerClient,
+            potentialStaleExecutionData);
 
     // invoke the appropriate handlers based on command
     runtimeManagerRunner.call();

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
@@ -341,7 +341,7 @@ public class RuntimeManagerMain {
   private final Command command;
 
   // topology is running or not
-  private boolean running;
+  private boolean isRunning;
 
   public RuntimeManagerMain(
       Config config,
@@ -349,7 +349,7 @@ public class RuntimeManagerMain {
     // initialize the options
     this.config = config;
     this.command = command;
-    this.running = false;
+    this.isRunning = false;
   }
 
   /**
@@ -382,7 +382,7 @@ public class RuntimeManagerMain {
       // TODO(mfu): timeout should read from config
       SchedulerStateManagerAdaptor adaptor = new SchedulerStateManagerAdaptor(statemgr, 5000);
 
-      running = validateRuntimeManage(adaptor, topologyName);
+      isRunning = validateRuntimeManage(adaptor, topologyName);
 
       // 2. Try to manage topology if valid
       // invoke the appropriate command to manage the topology
@@ -419,8 +419,8 @@ public class RuntimeManagerMain {
       String topologyName) throws TopologyRuntimeManagementException {
     // Check whether the topology has already been running
     Boolean isTopologyRunning = adaptor.isTopologyRunning(topologyName);
-    boolean topologyRunning = isTopologyRunning != null && isTopologyRunning.equals(Boolean.TRUE);
-    if (!topologyRunning) {
+    boolean runningFlag = isTopologyRunning != null && isTopologyRunning.equals(Boolean.TRUE);
+    if (!runningFlag) {
       if (command == Command.KILL) {
         LOG.warning(String.format("Topology '%s' is not found or not running", topologyName));
       } else {
@@ -456,14 +456,14 @@ public class RuntimeManagerMain {
             topologyName, currentState, configState));
       }
     }
-    return topologyRunning;
+    return runningFlag;
   }
 
   protected void callRuntimeManagerRunner(Config runtime, ISchedulerClient schedulerClient)
     throws TopologyRuntimeManagementException, TMasterException, PackingException {
     // create an instance of the runner class
     RuntimeManagerRunner runtimeManagerRunner =
-        new RuntimeManagerRunner(config, runtime, command, schedulerClient, running);
+        new RuntimeManagerRunner(config, runtime, command, schedulerClient, isRunning);
 
     // invoke the appropriate handlers based on command
     runtimeManagerRunner.call();

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
@@ -219,9 +219,6 @@ public class RuntimeManagerRunner {
 
     Boolean result;
 
-    // It is possible that TMasterLocation, MetricsCacheLocation, PackingPlan, PhysicalPlan and
-    // SchedulerLocation are not set. Just log but don't consider it a failure and don't return
-    // false
     result = statemgr.deleteTMasterLocation(topologyName);
     if (result == null || !result) {
       throw new TopologyRuntimeManagementException(

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
@@ -48,18 +48,18 @@ public class RuntimeManagerRunner {
   private final Config runtime;
   private final Command command;
   private final ISchedulerClient schedulerClient;
-  private final boolean isRunning;
+  private final boolean foundData;
 
   public RuntimeManagerRunner(Config config,
                               Config runtime,
                               Command command,
                               ISchedulerClient schedulerClient,
-                              boolean isRunning) {
+                              boolean foundData) {
 
     this.config = config;
     this.runtime = runtime;
     this.command = command;
-    this.isRunning = isRunning;
+    this.foundData = foundData;
 
     this.schedulerClient = schedulerClient;
   }
@@ -95,7 +95,7 @@ public class RuntimeManagerRunner {
    * Handler to activate a topology
    */
   private void activateTopologyHandler(String topologyName) throws TMasterException {
-    assert isRunning;
+    assert foundData;
     NetworkUtils.TunnelConfig tunnelConfig =
         NetworkUtils.TunnelConfig.build(config, NetworkUtils.HeronSystem.SCHEDULER);
     TMasterUtils.transitionTopologyState(topologyName,
@@ -107,7 +107,7 @@ public class RuntimeManagerRunner {
    * Handler to deactivate a topology
    */
   private void deactivateTopologyHandler(String topologyName) throws TMasterException {
-    assert isRunning;
+    assert foundData;
     NetworkUtils.TunnelConfig tunnelConfig =
         NetworkUtils.TunnelConfig.build(config, NetworkUtils.HeronSystem.SCHEDULER);
     TMasterUtils.transitionTopologyState(topologyName,
@@ -120,7 +120,7 @@ public class RuntimeManagerRunner {
    */
   @VisibleForTesting
   void restartTopologyHandler(String topologyName) throws TopologyRuntimeManagementException {
-    assert isRunning;
+    assert foundData;
     Integer containerId = Context.topologyContainerId(config);
     Scheduler.RestartTopologyRequest restartTopologyRequest =
         Scheduler.RestartTopologyRequest.newBuilder()
@@ -165,10 +165,10 @@ public class RuntimeManagerRunner {
     // clean up the state of the topology in state manager
     cleanState(topologyName, Runtime.schedulerStateManagerAdaptor(runtime));
 
-    if (isRunning) {
+    if (foundData) {
       LOG.fine(String.format("Scheduler killed topology %s successfully.", topologyName));
     } else {
-      LOG.warning(String.format("Topology %s is not running, but scheduler has tried to"
+      LOG.warning(String.format("Topology %s data is not found, but scheduler has tried to"
           + " clean up data for it anyway.", topologyName));
     }
   }
@@ -179,7 +179,7 @@ public class RuntimeManagerRunner {
   @VisibleForTesting
   void updateTopologyHandler(String topologyName, String newParallelism)
       throws TopologyRuntimeManagementException, PackingException, UpdateDryRunResponse {
-    assert isRunning;
+    assert foundData;
     LOG.fine(String.format("updateTopologyHandler called for %s with %s",
         topologyName, newParallelism));
     SchedulerStateManagerAdaptor manager = Runtime.schedulerStateManagerAdaptor(runtime);

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
@@ -48,18 +48,18 @@ public class RuntimeManagerRunner {
   private final Config runtime;
   private final Command command;
   private final ISchedulerClient schedulerClient;
-  private final boolean running;
+  private final boolean isRunning;
 
   public RuntimeManagerRunner(Config config,
                               Config runtime,
                               Command command,
                               ISchedulerClient schedulerClient,
-                              boolean running) {
+                              boolean isRunning) {
 
     this.config = config;
     this.runtime = runtime;
     this.command = command;
-    this.running = running;
+    this.isRunning = isRunning;
 
     this.schedulerClient = schedulerClient;
   }
@@ -95,7 +95,7 @@ public class RuntimeManagerRunner {
    * Handler to activate a topology
    */
   private void activateTopologyHandler(String topologyName) throws TMasterException {
-    assert running;
+    assert isRunning;
     NetworkUtils.TunnelConfig tunnelConfig =
         NetworkUtils.TunnelConfig.build(config, NetworkUtils.HeronSystem.SCHEDULER);
     TMasterUtils.transitionTopologyState(topologyName,
@@ -107,7 +107,7 @@ public class RuntimeManagerRunner {
    * Handler to deactivate a topology
    */
   private void deactivateTopologyHandler(String topologyName) throws TMasterException {
-    assert running;
+    assert isRunning;
     NetworkUtils.TunnelConfig tunnelConfig =
         NetworkUtils.TunnelConfig.build(config, NetworkUtils.HeronSystem.SCHEDULER);
     TMasterUtils.transitionTopologyState(topologyName,
@@ -120,7 +120,7 @@ public class RuntimeManagerRunner {
    */
   @VisibleForTesting
   void restartTopologyHandler(String topologyName) throws TopologyRuntimeManagementException {
-    assert running;
+    assert isRunning;
     Integer containerId = Context.topologyContainerId(config);
     Scheduler.RestartTopologyRequest restartTopologyRequest =
         Scheduler.RestartTopologyRequest.newBuilder()
@@ -165,7 +165,7 @@ public class RuntimeManagerRunner {
     // clean up the state of the topology in state manager
     cleanState(topologyName, Runtime.schedulerStateManagerAdaptor(runtime));
 
-    if (running) {
+    if (isRunning) {
       LOG.fine(String.format("Scheduler killed topology %s successfully.", topologyName));
     } else {
       LOG.warning(String.format("Topology %s is not running, but scheduler has tried to"
@@ -179,7 +179,7 @@ public class RuntimeManagerRunner {
   @VisibleForTesting
   void updateTopologyHandler(String topologyName, String newParallelism)
       throws TopologyRuntimeManagementException, PackingException, UpdateDryRunResponse {
-    assert running;
+    assert isRunning;
     LOG.fine(String.format("updateTopologyHandler called for %s with %s",
         topologyName, newParallelism));
     SchedulerStateManagerAdaptor manager = Runtime.schedulerStateManagerAdaptor(runtime);

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
@@ -48,18 +48,18 @@ public class RuntimeManagerRunner {
   private final Config runtime;
   private final Command command;
   private final ISchedulerClient schedulerClient;
-  private final boolean hasStaleExecutionData;
+  private final boolean potentialStaleExecutionData;
 
   public RuntimeManagerRunner(Config config,
                               Config runtime,
                               Command command,
                               ISchedulerClient schedulerClient,
-                              boolean hasStaleExecutionData) {
+                              boolean potentialStaleExecutionData) {
 
     this.config = config;
     this.runtime = runtime;
     this.command = command;
-    this.hasStaleExecutionData = hasStaleExecutionData;
+    this.potentialStaleExecutionData = potentialStaleExecutionData;
 
     this.schedulerClient = schedulerClient;
   }
@@ -95,7 +95,7 @@ public class RuntimeManagerRunner {
    * Handler to activate a topology
    */
   private void activateTopologyHandler(String topologyName) throws TMasterException {
-    assert !hasStaleExecutionData;
+    assert !potentialStaleExecutionData;
     NetworkUtils.TunnelConfig tunnelConfig =
         NetworkUtils.TunnelConfig.build(config, NetworkUtils.HeronSystem.SCHEDULER);
     TMasterUtils.transitionTopologyState(topologyName,
@@ -107,7 +107,7 @@ public class RuntimeManagerRunner {
    * Handler to deactivate a topology
    */
   private void deactivateTopologyHandler(String topologyName) throws TMasterException {
-    assert !hasStaleExecutionData;
+    assert !potentialStaleExecutionData;
     NetworkUtils.TunnelConfig tunnelConfig =
         NetworkUtils.TunnelConfig.build(config, NetworkUtils.HeronSystem.SCHEDULER);
     TMasterUtils.transitionTopologyState(topologyName,
@@ -120,7 +120,7 @@ public class RuntimeManagerRunner {
    */
   @VisibleForTesting
   void restartTopologyHandler(String topologyName) throws TopologyRuntimeManagementException {
-    assert !hasStaleExecutionData;
+    assert !potentialStaleExecutionData;
     Integer containerId = Context.topologyContainerId(config);
     Scheduler.RestartTopologyRequest restartTopologyRequest =
         Scheduler.RestartTopologyRequest.newBuilder()
@@ -165,9 +165,9 @@ public class RuntimeManagerRunner {
     // clean up the state of the topology in state manager
     cleanState(topologyName, Runtime.schedulerStateManagerAdaptor(runtime));
 
-    if (hasStaleExecutionData) {
-      LOG.warning(String.format("Topology %s data is not found, but scheduler has tried to"
-          + " clean up data for it anyway.", topologyName));
+    if (potentialStaleExecutionData) {
+      LOG.warning(String.format("Topology %s does not exist. Cleaned up potential stale state.",
+          topologyName));
     } else {
       LOG.fine(String.format("Scheduler killed topology %s successfully.", topologyName));
     }
@@ -179,7 +179,7 @@ public class RuntimeManagerRunner {
   @VisibleForTesting
   void updateTopologyHandler(String topologyName, String newParallelism)
       throws TopologyRuntimeManagementException, PackingException, UpdateDryRunResponse {
-    assert !hasStaleExecutionData;
+    assert !potentialStaleExecutionData;
     LOG.fine(String.format("updateTopologyHandler called for %s with %s",
         topologyName, newParallelism));
     SchedulerStateManagerAdaptor manager = Runtime.schedulerStateManagerAdaptor(runtime);

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
@@ -48,18 +48,18 @@ public class RuntimeManagerRunner {
   private final Config runtime;
   private final Command command;
   private final ISchedulerClient schedulerClient;
-  private final boolean foundData;
+  private final boolean hasRunningData;
 
   public RuntimeManagerRunner(Config config,
                               Config runtime,
                               Command command,
                               ISchedulerClient schedulerClient,
-                              boolean foundData) {
+                              boolean hasRunningData) {
 
     this.config = config;
     this.runtime = runtime;
     this.command = command;
-    this.foundData = foundData;
+    this.hasRunningData = hasRunningData;
 
     this.schedulerClient = schedulerClient;
   }
@@ -95,7 +95,7 @@ public class RuntimeManagerRunner {
    * Handler to activate a topology
    */
   private void activateTopologyHandler(String topologyName) throws TMasterException {
-    assert foundData;
+    assert hasRunningData;
     NetworkUtils.TunnelConfig tunnelConfig =
         NetworkUtils.TunnelConfig.build(config, NetworkUtils.HeronSystem.SCHEDULER);
     TMasterUtils.transitionTopologyState(topologyName,
@@ -107,7 +107,7 @@ public class RuntimeManagerRunner {
    * Handler to deactivate a topology
    */
   private void deactivateTopologyHandler(String topologyName) throws TMasterException {
-    assert foundData;
+    assert hasRunningData;
     NetworkUtils.TunnelConfig tunnelConfig =
         NetworkUtils.TunnelConfig.build(config, NetworkUtils.HeronSystem.SCHEDULER);
     TMasterUtils.transitionTopologyState(topologyName,
@@ -120,7 +120,7 @@ public class RuntimeManagerRunner {
    */
   @VisibleForTesting
   void restartTopologyHandler(String topologyName) throws TopologyRuntimeManagementException {
-    assert foundData;
+    assert hasRunningData;
     Integer containerId = Context.topologyContainerId(config);
     Scheduler.RestartTopologyRequest restartTopologyRequest =
         Scheduler.RestartTopologyRequest.newBuilder()
@@ -165,7 +165,7 @@ public class RuntimeManagerRunner {
     // clean up the state of the topology in state manager
     cleanState(topologyName, Runtime.schedulerStateManagerAdaptor(runtime));
 
-    if (foundData) {
+    if (hasRunningData) {
       LOG.fine(String.format("Scheduler killed topology %s successfully.", topologyName));
     } else {
       LOG.warning(String.format("Topology %s data is not found, but scheduler has tried to"
@@ -179,7 +179,7 @@ public class RuntimeManagerRunner {
   @VisibleForTesting
   void updateTopologyHandler(String topologyName, String newParallelism)
       throws TopologyRuntimeManagementException, PackingException, UpdateDryRunResponse {
-    assert foundData;
+    assert hasRunningData;
     LOG.fine(String.format("updateTopologyHandler called for %s with %s",
         topologyName, newParallelism));
     SchedulerStateManagerAdaptor manager = Runtime.schedulerStateManagerAdaptor(runtime);

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/RuntimeManagerMainTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/RuntimeManagerMainTest.java
@@ -255,7 +255,7 @@ public class RuntimeManagerMainTest {
 
     // Failed to callRuntimeManagerRunner
     doThrow(new TopologyRuntimeManagementException("")).when(runtimeManagerMain)
-        .callRuntimeManagerRunner(any(Config.class), eq(client), true);
+        .callRuntimeManagerRunner(any(Config.class), eq(client), eq(true));
     runtimeManagerMain.manageTopology();
   }
 
@@ -342,7 +342,7 @@ public class RuntimeManagerMainTest {
     doReturn(client).when(runtimeManagerMain).getSchedulerClient(any(Config.class));
     // Happy path
     doNothing().when(runtimeManagerMain)
-        .callRuntimeManagerRunner(any(Config.class), eq(client), true);
+        .callRuntimeManagerRunner(any(Config.class), eq(client), eq(true));
     runtimeManagerMain.manageTopology();
   }
 }

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/RuntimeManagerMainTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/RuntimeManagerMainTest.java
@@ -255,7 +255,7 @@ public class RuntimeManagerMainTest {
 
     // Failed to callRuntimeManagerRunner
     doThrow(new TopologyRuntimeManagementException("")).when(runtimeManagerMain)
-        .callRuntimeManagerRunner(any(Config.class), eq(client));
+        .callRuntimeManagerRunner(any(Config.class), eq(client), true);
     runtimeManagerMain.manageTopology();
   }
 
@@ -341,7 +341,8 @@ public class RuntimeManagerMainTest {
     ISchedulerClient client = mock(ISchedulerClient.class);
     doReturn(client).when(runtimeManagerMain).getSchedulerClient(any(Config.class));
     // Happy path
-    doNothing().when(runtimeManagerMain).callRuntimeManagerRunner(any(Config.class), eq(client));
+    doNothing().when(runtimeManagerMain)
+        .callRuntimeManagerRunner(any(Config.class), eq(client), true);
     runtimeManagerMain.manageTopology();
   }
 }

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/RuntimeManagerMainTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/RuntimeManagerMainTest.java
@@ -255,7 +255,7 @@ public class RuntimeManagerMainTest {
 
     // Failed to callRuntimeManagerRunner
     doThrow(new TopologyRuntimeManagementException("")).when(runtimeManagerMain)
-        .callRuntimeManagerRunner(any(Config.class), eq(client), eq(true));
+        .callRuntimeManagerRunner(any(Config.class), eq(client), eq(false));
     runtimeManagerMain.manageTopology();
   }
 
@@ -342,7 +342,7 @@ public class RuntimeManagerMainTest {
     doReturn(client).when(runtimeManagerMain).getSchedulerClient(any(Config.class));
     // Happy path
     doNothing().when(runtimeManagerMain)
-        .callRuntimeManagerRunner(any(Config.class), eq(client), eq(true));
+        .callRuntimeManagerRunner(any(Config.class), eq(client), eq(false));
     runtimeManagerMain.manageTopology();
   }
 }

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/RuntimeManagerMainTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/RuntimeManagerMainTest.java
@@ -55,7 +55,7 @@ import static org.mockito.Mockito.when;
 public class RuntimeManagerMainTest {
   private static final String TOPOLOGY_NAME = "topologyName";
   private static final String TOPOLOGY_ID = "topologyId";
-  private static final Command MOCK_COMMAND = Command.KILL;
+  private static final Command MOCK_COMMAND = Command.ACTIVATE;
   private static final String CLUSTER = "cluster";
   private static final String ROLE = "role";
   private static final String ENVIRON = "env";
@@ -121,6 +121,15 @@ public class RuntimeManagerMainTest {
     // Matched
     ExecutionEnvironment.ExecutionState correctState = stateBuilder.setRole(ROLE).build();
     when(adaptor.getExecutionState(eq(TOPOLOGY_NAME))).thenReturn(correctState);
+    runtimeManagerMain.validateRuntimeManage(adaptor, TOPOLOGY_NAME);
+  }
+
+  @Test
+  public void testValidateRuntimeManageExecStateNotRequiredForKillCommand() {
+    SchedulerStateManagerAdaptor adaptor = mock(SchedulerStateManagerAdaptor.class);
+    RuntimeManagerMain runtimeManagerMain = new RuntimeManagerMain(config, Command.KILL);
+    when(adaptor.isTopologyRunning(eq(TOPOLOGY_NAME))).thenReturn(true);
+    when(adaptor.getExecutionState(eq(TOPOLOGY_NAME))).thenReturn(null);
     runtimeManagerMain.validateRuntimeManage(adaptor, TOPOLOGY_NAME);
   }
 

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/RuntimeManagerRunnerTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/RuntimeManagerRunnerTest.java
@@ -63,7 +63,7 @@ public class RuntimeManagerRunnerTest {
   }
 
   private RuntimeManagerRunner newRuntimeManagerRunner(Command command, ISchedulerClient client) {
-    return spy(new RuntimeManagerRunner(config, runtime, command, client));
+    return spy(new RuntimeManagerRunner(config, runtime, command, client, true));
   }
 
   @Test

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/RuntimeManagerRunnerTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/RuntimeManagerRunnerTest.java
@@ -63,7 +63,7 @@ public class RuntimeManagerRunnerTest {
   }
 
   private RuntimeManagerRunner newRuntimeManagerRunner(Command command, ISchedulerClient client) {
-    return spy(new RuntimeManagerRunner(config, runtime, command, client, true));
+    return spy(new RuntimeManagerRunner(config, runtime, command, client, false));
   }
 
   @Test


### PR DESCRIPTION
When kill or submit command is not fully successful, it is possible that there are some incomplete data for the topology. We need to allow users to run kill command in this case instead of rejecting it because of missing data.


Previous tries:
https://github.com/twitter/heron/pull/2685
https://github.com/twitter/heron/pull/2689