### PR TITLE
[hold]restore the initial state when `aurora job add` command fails during `heron update`

### DIFF
--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerMain.java
@@ -325,6 +325,14 @@ public class RuntimeManagerMain {
       // Exit with status code 200 to indicate dry-run response is sent out
       System.exit(200);
       // SUPPRESS CHECKSTYLE IllegalCatch
+    } catch (TopologyUpdateRecoverableException recoverableException) {
+      LOG.log(Level.FINE, "encountered recoverable error and the topology keep unchanged.");
+     // Output may contain UTF-8 characters, so we should print using UTF-8 encoding
+      PrintStream out = new PrintStream(System.out, true, StandardCharsets.UTF_8.name());
+      recoverableException.printStackTrace(out);
+      // Exit with status code 201 to indicate `heron update` was not performed
+      System.exit(201);
+      // SUPPRESS CHECKSTYLE IllegalCatch
     } catch (Exception e) {
       LOG.log(Level.FINE, "Exception when submitting topology", e);
       System.out.println(e.getMessage());

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
@@ -199,7 +199,10 @@ public class RuntimeManagerRunner {
     LOG.fine("Sending Updating topology request: " + updateTopologyRequest);
     if (!schedulerClient.updateTopology(updateTopologyRequest)) {
       throw new TopologyRuntimeManagementException(String.format(
-          "Failed to update topology with Scheduler, updateTopologyRequest="
+          "Failed to update topology with Scheduler. "
+          + "The topology can be in a strange stage. "
+          + "Please check carefully or redeploy the topology. "
+          + "UpdateTopologyRequest="
               + updateTopologyRequest));
     }
 

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/TopologyUpdateRecoverableException.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/TopologyUpdateRecoverableException.java
@@ -1,0 +1,30 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.twitter.heron.scheduler;
+
+/**
+ * Thrown to indicate that a recoverable error occurred while updating topology
+ */
+public class TopologyUpdateRecoverableException extends RuntimeException {
+  private static final long serialVersionUID = 2876075901239747697L;
+
+  public TopologyUpdateRecoverableException(String message) {
+    super(message);
+  }
+
+  public TopologyUpdateRecoverableException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
@@ -153,39 +153,41 @@ public class UpdateTopologyManager implements Closeable {
       deactivateTopology(stateManager, topology, proposedPackingPlan);
     }
 
-    Set<PackingPlan.ContainerPlan> updatedContainers =
-        new HashSet<>(proposedPackingPlan.getContainers());
-    // request new resources if necessary. Once containers are allocated we should make the changes
-    // to state manager quickly, otherwise the scheduler might penalize for thrashing on start-up
-    if (newContainerCount > 0 && scalableScheduler.isPresent()) {
-      Set<PackingPlan.ContainerPlan> containersToAdd = containerDelta.getContainersToAdd();
-      Set<PackingPlan.ContainerPlan> containersAdded =
-          scalableScheduler.get().addContainers(containersToAdd);
-      // Update the PackingPlan with new container-ids
-      if (containersAdded != null) {
-        updatedContainers.removeAll(containersToAdd);
-        updatedContainers.addAll(containersAdded);
+    try {
+      Set<PackingPlan.ContainerPlan> updatedContainers =
+          new HashSet<>(proposedPackingPlan.getContainers());
+      // request new resources if necessary. Once containers are allocated we should make the changes
+      // to state manager quickly, otherwise the scheduler might penalize for thrashing on start-up
+      if (newContainerCount > 0 && scalableScheduler.isPresent()) {
+        Set<PackingPlan.ContainerPlan> containersToAdd = containerDelta.getContainersToAdd();
+        Set<PackingPlan.ContainerPlan> containersAdded =
+            scalableScheduler.get().addContainers(containersToAdd);
+        // Update the PackingPlan with new container-ids
+        if (containersAdded != null) {
+          updatedContainers.removeAll(containersToAdd);
+          updatedContainers.addAll(containersAdded);
+        }
       }
-    }
-
-    PackingPlan updatedPackingPlan =
-        new PackingPlan(proposedPackingPlan.getId(), updatedContainers);
-    PackingPlanProtoSerializer serializer = new PackingPlanProtoSerializer();
-    PackingPlans.PackingPlan updatedProtoPackingPlan = serializer.toProto(updatedPackingPlan);
-    LOG.fine("The updated Packing Plan: " + updatedProtoPackingPlan);
-
-    // update packing plan to trigger the scaling event
-    logInfo("Update new PackingPlan: %s",
-        stateManager.updatePackingPlan(updatedProtoPackingPlan, topologyName));
-
-    // reactivate topology
-    if (initiallyRunning) {
-      // wait before reactivating to give the tmaster a chance to receive the packing update and
-      // delete the packing plan. Instead we could message tmaster to invalidate the physical plan
-      // and/or possibly even update the packing plan directly
-      SysUtils.sleep(Duration.ofSeconds(10));
-      // Will throw exceptions internally if tmaster fails to deactivate
-      reactivateTopology(stateManager, topology, removableContainerCount);
+  
+      PackingPlan updatedPackingPlan =
+          new PackingPlan(proposedPackingPlan.getId(), updatedContainers);
+      PackingPlanProtoSerializer serializer = new PackingPlanProtoSerializer();
+      PackingPlans.PackingPlan updatedProtoPackingPlan = serializer.toProto(updatedPackingPlan);
+      LOG.fine("The updated Packing Plan: " + updatedProtoPackingPlan);
+  
+      // update packing plan to trigger the scaling event
+      logInfo("Update new PackingPlan: %s",
+          stateManager.updatePackingPlan(updatedProtoPackingPlan, topologyName));
+    } finally {
+      // reactivate topology
+      if (initiallyRunning) {
+        // wait before reactivating to give the tmaster a chance to receive the packing update and
+        // delete the packing plan. Instead we could message tmaster to invalidate the physical plan
+        // and/or possibly even update the packing plan directly
+        SysUtils.sleep(Duration.ofSeconds(10));
+        // Will throw exceptions internally if tmaster fails to deactivate
+        reactivateTopology(stateManager, topology, removableContainerCount);
+      }
     }
 
     if (removableContainerCount > 0 && scalableScheduler.isPresent()) {

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
@@ -156,8 +156,9 @@ public class UpdateTopologyManager implements Closeable {
     try {
       Set<PackingPlan.ContainerPlan> updatedContainers =
           new HashSet<>(proposedPackingPlan.getContainers());
-      // request new resources if necessary. Once containers are allocated we should make the changes
-      // to state manager quickly, otherwise the scheduler might penalize for thrashing on start-up
+      // request new resources if necessary. Once containers are allocated we should make the
+      // changes to state manager quickly, otherwise the scheduler might penalize for thrashing
+      // on start-up
       if (newContainerCount > 0 && scalableScheduler.isPresent()) {
         Set<PackingPlan.ContainerPlan> containersToAdd = containerDelta.getContainersToAdd();
         Set<PackingPlan.ContainerPlan> containersAdded =
@@ -168,13 +169,13 @@ public class UpdateTopologyManager implements Closeable {
           updatedContainers.addAll(containersAdded);
         }
       }
-  
+
       PackingPlan updatedPackingPlan =
           new PackingPlan(proposedPackingPlan.getId(), updatedContainers);
       PackingPlanProtoSerializer serializer = new PackingPlanProtoSerializer();
       PackingPlans.PackingPlan updatedProtoPackingPlan = serializer.toProto(updatedPackingPlan);
       LOG.fine("The updated Packing Plan: " + updatedProtoPackingPlan);
-  
+
       // update packing plan to trigger the scaling event
       logInfo("Update new PackingPlan: %s",
           stateManager.updatePackingPlan(updatedProtoPackingPlan, topologyName));

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
@@ -163,6 +163,10 @@ public class UpdateTopologyManager implements Closeable {
         Set<PackingPlan.ContainerPlan> containersToAdd = containerDelta.getContainersToAdd();
         Set<PackingPlan.ContainerPlan> containersAdded =
             scalableScheduler.get().addContainers(containersToAdd);
+        if (containersAdded.size() != containersToAdd.size()) {
+          throw new RuntimeException("Scheduler failed to add expected countainer count: added "
+              + containersAdded.size() + ", requested " + containersToAdd.size());
+        }
         // Update the PackingPlan with new container-ids
         if (containersAdded != null) {
           updatedContainers.removeAll(containersToAdd);

--- a/heron/schedulers/src/java/BUILD
+++ b/heron/schedulers/src/java/BUILD
@@ -93,14 +93,18 @@ genrule(
 java_library(
     name='aurora-scheduler-java',
     srcs = glob(["**/aurora/*.java"]),
-    deps = scheduler_deps_files,
+    deps = scheduler_deps_files + [
+       "//third_party/java:jackson",
+	],
     resources = glob(["**/aurora/*.aurora"]),
 )
 
 java_binary(
     name='aurora-scheduler-unshaded',
     srcs = glob(["**/aurora/*.java"]),
-    deps = scheduler_deps_files,
+    deps = scheduler_deps_files + [
+       "//third_party/java:jackson",
+	],
     resources = glob(["**/aurora/*.aurora"]),
 )
 

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraCLIController.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraCLIController.java
@@ -14,6 +14,7 @@
 
 package com.twitter.heron.scheduler.aurora;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -23,8 +24,12 @@ import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 
+import com.twitter.heron.scheduler.TopologyUpdateRecoverableException;
 import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.utils.ShellUtils;
 
@@ -41,7 +46,6 @@ class AuroraCLIController implements AuroraController {
   private final String env;
   private final String cluster;
   private final String role;
-  
 
   AuroraCLIController(
       String jobName,
@@ -119,11 +123,11 @@ class AuroraCLIController implements AuroraController {
     }
   }
 
-  private boolean hasEnoughQuota(Integer count) {
-    String roleSpec = cluster+"/"+role;
-    List<String> auroraCmd = new ArrayList<>(Arrays.asList(
-        "aurora", "quota", "get", "--write-json", roleSpec));
-    
+  private JsonNode askAuroraQuota() throws JsonProcessingException, IOException {
+    String roleSpec = cluster + "/" + role;
+    List<String> auroraCmd =
+        new ArrayList<>(Arrays.asList("aurora", "quota", "get", "--write-json", roleSpec));
+
     LOG.info(String.format("Query quota: %s", auroraCmd));
     StringBuilder stderr = new StringBuilder();
     if (!runProcess(auroraCmd, null, stderr)) {
@@ -133,26 +137,108 @@ class AuroraCLIController implements AuroraController {
     if (stderr.length() <= 0) { // no container was added
       throw new RuntimeException("empty quota query output by Aurora");
     }
-    
+
     String jsonStr = stderr.toString();
     LOG.info(String.format("Quota: %s", jsonStr));
-    JsonObject jsonQuota = new JsonObject(jsonStr);
-    jsonQuota.
-    
-    
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode actualObj = mapper.readTree(jsonStr);
+    return actualObj;
+  }
+
+  private JsonNode askAuroraStatus() throws JsonProcessingException, IOException {
+    List<String> auroraCmd = new ArrayList<>(Arrays.asList("aurora", "job", "status", jobSpec));
+
+    LOG.info(String.format("Query resource per container: %s", auroraCmd));
+    StringBuilder stderr = new StringBuilder();
+    if (!runProcess(auroraCmd, null, stderr)) {
+      throw new TopologyUpdateRecoverableException(
+          "Failed to query resource per container " + jobSpec);
+    }
+
+    if (stderr.length() <= 0) { // no container was added
+      throw new TopologyUpdateRecoverableException(
+          "empty resource per container query output by Aurora");
+    }
+
+    String jsonStr = stderr.toString();
+    LOG.info(String.format("Resource per container: %s", jsonStr));
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode actualObj = mapper.readTree(jsonStr);
+    return actualObj;
+  }
+
+  private boolean hasEnoughQuota(JsonNode resource, Integer count)
+      throws JsonProcessingException, IOException {
+    // calc available quota
+    JsonNode quota = askAuroraQuota();
+
+    JsonNode quotaNode = quota.get("quota");
+    long quotaDiskMb = quotaNode.get("diskMb").longValue();
+    double quotaNumCpus = quotaNode.get("numCpus").doubleValue();
+    long quotaRamMb = quotaNode.get("ramMb").longValue();
+
+    JsonNode prodNode = quota.get("prodSharedConsumption");
+    long prodDiskMb = prodNode.get("diskMb").longValue();
+    double prodNumCpus = prodNode.get("numCpus").doubleValue();
+    long prodRamMb = prodNode.get("ramMb").longValue();
+
+    long availableDiskMb = quotaDiskMb - prodDiskMb;
+    double availableNumCpus = quotaNumCpus - prodNumCpus;
+    long availableRamMb = quotaRamMb - prodRamMb;
+
+    // calc res for one container
+    JsonNode containerNode =
+        resource.get(0).get("active").get(0).get("assignedTask").get("task").get("resources");
+    double containerNumCpus = containerNode.get("numCpus").doubleValue();
+    long containerRamMb = containerNode.get("ramMb").longValue();
+    long containerDiskMb = containerNode.get("diskMb").longValue();
+
+    // check if res is enough
+    if (containerNumCpus * count > availableNumCpus) {
+      String msg =
+          String.format("not enough cpu quota: %f cpu per container x %d container > %f available",
+              containerNumCpus, count, availableNumCpus);
+      throw new TopologyUpdateRecoverableException(msg);
+    } else if (containerRamMb * count > availableRamMb) {
+      String msg =
+          String.format("not enough ram quota: %d ram per container x %d container > %d available",
+              containerRamMb, count, availableRamMb);
+      throw new TopologyUpdateRecoverableException(msg);
+    } else if (containerDiskMb * count > availableDiskMb) {
+      String msg = String.format(
+          "not enough disk quota: %d disk per container x %d container > %d available",
+          containerDiskMb, count, availableDiskMb);
+      throw new TopologyUpdateRecoverableException(msg);
+    }
     return true;
   }
-  
+
+  private boolean isProd(JsonNode jsonStatus) {
+    String tier = jsonStatus.get(0).get("active").get(0).get("assignedTask").get("task").get("tier")
+        .textValue();
+    if ("preferred".equals(tier)) {
+      return true;
+    }
+    return false;
+  }
+
   @Override
   public Set<Integer> addContainers(Integer count) {
-    if (env.equalsIgnoreCase("prod")) {
-      if (!hasEnoughQuota(count)) {
-        throw new RuntimeException("[Aurora quota exception] Aurora quota request is not satified");
+    try {
+      JsonNode jsonStatus = askAuroraStatus();
+      if (isProd(jsonStatus)) {
+        if (!hasEnoughQuota(jsonStatus, count)) {
+          throw new TopologyUpdateRecoverableException(
+              "[Aurora quota exception] Aurora quota request is not satified");
+        }
       }
+    } catch (IOException e) {
+      throw new TopologyUpdateRecoverableException("recoverable error before `aurora add` command",
+          e);
     }
-    
-    //aurora job add <cluster>/<role>/<env>/<name>/<instance_id> <count>
-    //clone instance 0
+
+    // aurora job add <cluster>/<role>/<env>/<name>/<instance_id> <count>
+    // clone instance 0
     List<String> auroraCmd = new ArrayList<>(Arrays.asList(
         "aurora", "job", "add", "--wait-until", "RUNNING",
         jobSpec + "/0", count.toString(), "--verbose"));


### PR DESCRIPTION
When the `aurora job add xxx` fails due to some reason, the activated topology stays `deactivated`. The PR fixes the issue by putting it in a try/finally. 