### PR TITLE
add warning when `aurora job add` command fails during `heron update`

### DIFF
--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
@@ -14,7 +14,6 @@
 
 package com.twitter.heron.scheduler;
 
-import java.io.Console;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
@@ -163,7 +163,7 @@ public class RuntimeManagerRunner {
   }
 
   boolean confirmWithUser(int oldContainerCount, int newContainerCount) {
-    System.out.print(String.format("The present aurora job has %d containers. "
+    LOG.info(String.format("The present aurora job has %d containers. "
         + "After update there will be %d containers. "
         + "Please make sure there are sufficient resources to update this job. "
         + "Continue update? [y/N]: ", oldContainerCount, newContainerCount));
@@ -206,7 +206,7 @@ public class RuntimeManagerRunner {
 
     int newContainerCount = proposedPlan.getContainerPlansCount();
     int oldContainerCount = currentPlan.getContainerPlansCount();
-    if (newContainerCount > oldContainerCount && Context.updatePrompt(config)) {
+    if (newContainerCount > oldContainerCount && "prompt".equals(Context.updatePrompt(config))) {
       if (!confirmWithUser(oldContainerCount, newContainerCount)) {
         LOG.warning("Scheduler updated topology canceled.");
         return;

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
@@ -162,23 +162,23 @@ public class RuntimeManagerRunner {
     LOG.fine("Scheduler killed topology successfully.");
   }
 
-  boolean consolePrompt(int oldContainerCount, int newContainerCount) {
+  boolean confirmWithUser(int oldContainerCount, int newContainerCount) {
     String fmt =
-        "The present aurora job has %d containers. After update there will be %d containers. ";
+        "The present aurora job has %d containers. After update there will be %d containers.";
     Console c = System.console();
     if (c == null) {
-      LOG.warning("No console to prompt user");
+      LOG.warning("No console to prompt user. Proceeding.");
       System.err.println(String.format(fmt, oldContainerCount, newContainerCount));
       return true;
     }
 
     String userInput = c.readLine(
         String.format(fmt + " Please make sure there are sufficient resources to update this job."
-            + " Continue update? [Y/n]: ", oldContainerCount, newContainerCount));
-    if ("n".equalsIgnoreCase(userInput)) {
-      return false;
+            + " Continue update? [y/N]: ", oldContainerCount, newContainerCount));
+    if ("y".equalsIgnoreCase(userInput)) {
+      return true;
     }
-    return true;
+    return false;
   }
 
   /**
@@ -213,8 +213,8 @@ public class RuntimeManagerRunner {
     int newContainerCount = proposedPlan.getContainerPlansCount();
     int oldContainerCount = currentPlan.getContainerPlansCount();
     if (newContainerCount > oldContainerCount) {
-      if (!consolePrompt(oldContainerCount, newContainerCount)) {
-        LOG.fine("Scheduler updated topology canceled.");
+      if (!confirmWithUser(oldContainerCount, newContainerCount)) {
+        LOG.warning("Scheduler updated topology canceled.");
         return;
       }
     }

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
@@ -175,7 +175,7 @@ public class RuntimeManagerRunner {
     String userInput = c.readLine(
         String.format(fmt + " Please make sure there are sufficient resources to update this job."
             + " Continue update? [Y/n]: ", oldContainerCount, newContainerCount));
-    if (userInput.equalsIgnoreCase("n")) {
+    if ("n".equalsIgnoreCase(userInput)) {
       return false;
     }
     return true;
@@ -209,7 +209,7 @@ public class RuntimeManagerRunner {
       PackingPlan newPlan = deserializer.fromProto(proposedPlan);
       throw new UpdateDryRunResponse(topology, config, newPlan, oldPlan, changeRequests);
     }
-    
+
     int newContainerCount = proposedPlan.getContainerPlansCount();
     int oldContainerCount = currentPlan.getContainerPlansCount();
     if (newContainerCount > oldContainerCount) {

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
@@ -206,7 +206,8 @@ public class RuntimeManagerRunner {
 
     int newContainerCount = proposedPlan.getContainerPlansCount();
     int oldContainerCount = currentPlan.getContainerPlansCount();
-    if (newContainerCount > oldContainerCount && "prompt".equals(Context.updatePrompt(config))) {
+    if (newContainerCount > oldContainerCount
+        && "prompt".equalsIgnoreCase(Context.updatePrompt(config))) {
       if (!confirmWithUser(oldContainerCount, newContainerCount)) {
         LOG.warning("Scheduler updated topology canceled.");
         return;

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
@@ -227,9 +227,10 @@ public class RuntimeManagerRunner {
 
     LOG.fine("Sending Updating topology request: " + updateTopologyRequest);
     if (!schedulerClient.updateTopology(updateTopologyRequest)) {
-      throw new TopologyRuntimeManagementException(String.format(
+      throw new TopologyRuntimeManagementException(
           "Failed to update topology with Scheduler, updateTopologyRequest="
-              + updateTopologyRequest));
+              + updateTopologyRequest + "The topology can be in a strange stage. "
+                  + "Please check carefully or redeploy the topology !!");
     }
 
     // Clean the connection when we are done.

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
@@ -18,6 +18,7 @@ import java.io.Console;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Scanner;
 import java.util.logging.Logger;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -163,18 +164,12 @@ public class RuntimeManagerRunner {
   }
 
   boolean confirmWithUser(int oldContainerCount, int newContainerCount) {
-    String fmt =
-        "The present aurora job has %d containers. After update there will be %d containers.";
-    Console c = System.console();
-    if (c == null) {
-      LOG.warning("No console to prompt user. Proceeding.");
-      System.err.println(String.format(fmt, oldContainerCount, newContainerCount));
-      return true;
-    }
-
-    String userInput = c.readLine(
-        String.format(fmt + " Please make sure there are sufficient resources to update this job."
-            + " Continue update? [y/N]: ", oldContainerCount, newContainerCount));
+    System.out.print(String.format("The present aurora job has %d containers. "
+        + "After update there will be %d containers. "
+        + "Please make sure there are sufficient resources to update this job. "
+        + "Continue update? [y/N]: ", oldContainerCount, newContainerCount));
+    Scanner scanner = new Scanner(System.in);
+    String userInput = scanner.nextLine();
     if ("y".equalsIgnoreCase(userInput)) {
       return true;
     }

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/RuntimeManagerRunner.java
@@ -206,7 +206,7 @@ public class RuntimeManagerRunner {
 
     int newContainerCount = proposedPlan.getContainerPlansCount();
     int oldContainerCount = currentPlan.getContainerPlansCount();
-    if (newContainerCount > oldContainerCount) {
+    if (newContainerCount > oldContainerCount && Context.updatePrompt(config)) {
       if (!confirmWithUser(oldContainerCount, newContainerCount)) {
         LOG.warning("Scheduler updated topology canceled.");
         return;

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
@@ -161,6 +161,11 @@ public class UpdateTopologyManager implements Closeable {
       Set<PackingPlan.ContainerPlan> containersToAdd = containerDelta.getContainersToAdd();
       Set<PackingPlan.ContainerPlan> containersAdded =
           scalableScheduler.get().addContainers(containersToAdd);
+      if (containersAdded.size() != containersToAdd.size()) {
+        updatedContainers.addAll(containersAdded);
+        throw new RuntimeException("Scheduler failed to add expected countainer count: added "
+            + containersAdded.size() + ", requested " + containersToAdd.size());
+      }
       // Update the PackingPlan with new container-ids
       if (containersAdded != null) {
         updatedContainers.removeAll(containersToAdd);

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
@@ -163,8 +163,8 @@ public class UpdateTopologyManager implements Closeable {
           scalableScheduler.get().addContainers(containersToAdd);
       if (containersAdded.size() != containersToAdd.size()) {
         updatedContainers.addAll(containersAdded);
-        throw new RuntimeException("Scheduler failed to add expected countainer count: added "
-            + containersAdded.size() + ", requested " + containersToAdd.size() + ". "
+        throw new RuntimeException("Scheduler failed to add requested containers. Requested "
+            + containersToAdd.size() + ", added " + containersAdded.size() + ". "
                 + "The topology can be in a strange stage. "
                 + "Please check carefully or redeploy the topology !!");
       }

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
@@ -162,7 +162,6 @@ public class UpdateTopologyManager implements Closeable {
       Set<PackingPlan.ContainerPlan> containersAdded =
           scalableScheduler.get().addContainers(containersToAdd);
       if (containersAdded.size() != containersToAdd.size()) {
-        updatedContainers.addAll(containersAdded);
         throw new RuntimeException("Scheduler failed to add requested containers. Requested "
             + containersToAdd.size() + ", added " + containersAdded.size() + ". "
                 + "The topology can be in a strange stage. "

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/UpdateTopologyManager.java
@@ -164,7 +164,9 @@ public class UpdateTopologyManager implements Closeable {
       if (containersAdded.size() != containersToAdd.size()) {
         updatedContainers.addAll(containersAdded);
         throw new RuntimeException("Scheduler failed to add expected countainer count: added "
-            + containersAdded.size() + ", requested " + containersToAdd.size());
+            + containersAdded.size() + ", requested " + containersToAdd.size() + ". "
+                + "The topology can be in a strange stage. "
+                + "Please check carefully or redeploy the topology !!");
       }
       // Update the PackingPlan with new container-ids
       if (containersAdded != null) {

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/UpdateTopologyManagerTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/UpdateTopologyManagerTest.java
@@ -46,7 +46,6 @@ import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.common.utils.topology.TopologyTests;
 import com.twitter.heron.proto.system.PackingPlans;
 import com.twitter.heron.proto.system.PhysicalPlans;
-import com.twitter.heron.proto.system.PackingPlans.ContainerPlan;
 import com.twitter.heron.scheduler.UpdateTopologyManager.ContainerDelta;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Key;

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/UpdateTopologyManagerTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/UpdateTopologyManagerTest.java
@@ -42,14 +42,17 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.twitter.heron.api.generated.TopologyAPI;
+import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.common.utils.topology.TopologyTests;
 import com.twitter.heron.proto.system.PackingPlans;
 import com.twitter.heron.proto.system.PhysicalPlans;
+import com.twitter.heron.proto.system.PackingPlans.ContainerPlan;
 import com.twitter.heron.scheduler.UpdateTopologyManager.ContainerDelta;
 import com.twitter.heron.spi.common.Config;
 import com.twitter.heron.spi.common.Key;
 import com.twitter.heron.spi.packing.PackingPlan;
 import com.twitter.heron.spi.packing.PackingPlanProtoSerializer;
+import com.twitter.heron.spi.packing.Resource;
 import com.twitter.heron.spi.scheduler.IScalable;
 import com.twitter.heron.spi.statemgr.IStateManager;
 import com.twitter.heron.spi.statemgr.Lock;
@@ -150,6 +153,12 @@ public class UpdateTopologyManagerTest {
     SchedulerStateManagerAdaptor mockStateMgr = mockStateManager(
         testTopology, this.currentProtoPlan, lock);
     IScalable mockScheduler = mock(IScalable.class);
+    HashSet<PackingPlan.ContainerPlan> mockRetrunSet = new HashSet<>();
+    mockRetrunSet.add(new PackingPlan.ContainerPlan(0, new HashSet<>(),
+        new Resource(1, ByteAmount.ZERO, ByteAmount.ZERO)));
+    mockRetrunSet.add(new PackingPlan.ContainerPlan(1, new HashSet<>(),
+        new Resource(1, ByteAmount.ZERO, ByteAmount.ZERO)));
+    when(mockScheduler.addContainers(any())).thenReturn(mockRetrunSet);
     UpdateTopologyManager spyUpdateManager =
         spyUpdateManager(mockStateMgr, mockScheduler, testTopology);
 

--- a/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/UpdateTopologyManagerTest.java
+++ b/heron/scheduler-core/tests/java/com/twitter/heron/scheduler/UpdateTopologyManagerTest.java
@@ -155,9 +155,9 @@ public class UpdateTopologyManagerTest {
     IScalable mockScheduler = mock(IScalable.class);
     HashSet<PackingPlan.ContainerPlan> mockRetrunSet = new HashSet<>();
     mockRetrunSet.add(new PackingPlan.ContainerPlan(0, new HashSet<>(),
-        new Resource(1, ByteAmount.ZERO, ByteAmount.ZERO)));
+        new Resource(5, ByteAmount.ZERO, ByteAmount.ZERO)));
     mockRetrunSet.add(new PackingPlan.ContainerPlan(1, new HashSet<>(),
-        new Resource(1, ByteAmount.ZERO, ByteAmount.ZERO)));
+        new Resource(6, ByteAmount.ZERO, ByteAmount.ZERO)));
     when(mockScheduler.addContainers(any())).thenReturn(mockRetrunSet);
     UpdateTopologyManager spyUpdateManager =
         spyUpdateManager(mockStateMgr, mockScheduler, testTopology);

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraCLIController.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraCLIController.java
@@ -112,6 +112,9 @@ class AuroraCLIController implements AuroraController {
     }
   }
 
+  private static final String errPrompt =
+      "The topology can be in a strange stage. Please check carefully or redeploy the topology !!";
+
   @Override
   public Set<Integer> addContainers(Integer count) {
     //aurora job add <cluster>/<role>/<env>/<name>/<instance_id> <count>
@@ -123,11 +126,11 @@ class AuroraCLIController implements AuroraController {
     LOG.info(String.format("Requesting %s new aurora containers %s", count, auroraCmd));
     StringBuilder stderr = new StringBuilder();
     if (!runProcess(auroraCmd, null, stderr)) {
-      throw new RuntimeException("Failed to create " + count + " new aurora instances");
+      throw new RuntimeException("Failed to create " + count + " new aurora instances. "+errPrompt);
     }
 
     if (stderr.length() <= 0) { // no container was added
-      throw new RuntimeException("empty output by Aurora");
+      throw new RuntimeException("Empty output by Aurora. " + errPrompt);
     }
     return extractContainerIds(stderr.toString());
   }

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraCLIController.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraCLIController.java
@@ -112,7 +112,7 @@ class AuroraCLIController implements AuroraController {
     }
   }
 
-  private static final String errPrompt =
+  private static final String ERR_PROMPT =
       "The topology can be in a strange stage. Please check carefully or redeploy the topology !!";
 
   @Override
@@ -126,11 +126,12 @@ class AuroraCLIController implements AuroraController {
     LOG.info(String.format("Requesting %s new aurora containers %s", count, auroraCmd));
     StringBuilder stderr = new StringBuilder();
     if (!runProcess(auroraCmd, null, stderr)) {
-      throw new RuntimeException("Failed to create " + count + " new aurora instances. "+errPrompt);
+      throw new RuntimeException(
+          "Failed to create " + count + " new aurora instances. " + ERR_PROMPT);
     }
 
     if (stderr.length() <= 0) { // no container was added
-      throw new RuntimeException("Empty output by Aurora. " + errPrompt);
+      throw new RuntimeException("Empty output by Aurora. " + ERR_PROMPT);
     }
     return extractContainerIds(stderr.toString());
   }

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Context.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Context.java
@@ -325,8 +325,8 @@ public class Context {
     return cfg.getStringValue(Key.DOWNLOADER_BINARY);
   }
 
-  public static boolean updatePrompt(Config cfg) {
-    return cfg.getBooleanValue(Key.UPDATE_PROMPT);
+  public static String updatePrompt(Config cfg) {
+    return cfg.getStringValue(Key.UPDATE_PROMPT);
   }
 
   @SuppressWarnings("unchecked")

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Context.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Context.java
@@ -325,6 +325,10 @@ public class Context {
     return cfg.getStringValue(Key.DOWNLOADER_BINARY);
   }
 
+  public static boolean updatePrompt(Config cfg) {
+    return cfg.getBooleanValue(Key.UPDATE_PROMPT);
+  }
+
   @SuppressWarnings("unchecked")
   public static final String statefulStorageCustomClassPath(Config cfg) {
     Map<String, Object> statefulStorageConfig =

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Key.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Key.java
@@ -171,7 +171,8 @@ public enum Key {
   PYTHON_INSTANCE_BINARY("heron.binaries.python.instance", "${HERON_BIN}/heron-python-instance"),
   CPP_INSTANCE_BINARY   ("heron.binaries.cpp.instance",    "${HERON_BIN}/heron-cpp-instance"),
   DOWNLOADER_BINARY     ("heron.binaries.downloader",      "${HERON_BIN}/heron-downloader"),
-  
+
+  // keys for `heron` command line
   UPDATE_PROMPT         ("heron.command.update.prompt", Boolean.FALSE);
 
 

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Key.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Key.java
@@ -173,8 +173,9 @@ public enum Key {
   DOWNLOADER_BINARY     ("heron.binaries.downloader",      "${HERON_BIN}/heron-downloader"),
 
   // keys for `heron` command line.
-  // `heron update` prompt default config: disabled => no prompt
-  // to enable `heron update` prompt: prompt => enable prompt
+  // Prompt user when more containers are required so that
+  // user has another chance to double check quota is available.
+  // To enable it, change the config from "disabled" to "prompt".
   UPDATE_PROMPT         ("heron.command.update.prompt", "disabled");
 
 

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Key.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Key.java
@@ -172,7 +172,9 @@ public enum Key {
   CPP_INSTANCE_BINARY   ("heron.binaries.cpp.instance",    "${HERON_BIN}/heron-cpp-instance"),
   DOWNLOADER_BINARY     ("heron.binaries.downloader",      "${HERON_BIN}/heron-downloader"),
 
-  // keys for `heron` command line
+  // keys for `heron` command line.
+  // `heron update` prompt default config: disabled => no prompt
+  // to enable `heron update` prompt: prompt => enable prompt
   UPDATE_PROMPT         ("heron.command.update.prompt", "disabled");
 
 

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Key.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Key.java
@@ -173,7 +173,7 @@ public enum Key {
   DOWNLOADER_BINARY     ("heron.binaries.downloader",      "${HERON_BIN}/heron-downloader"),
 
   // keys for `heron` command line
-  UPDATE_PROMPT         ("heron.command.update.prompt", Boolean.FALSE);
+  UPDATE_PROMPT         ("heron.command.update.prompt", "disable");
 
 
   private final String value;

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Key.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Key.java
@@ -170,7 +170,9 @@ public enum Key {
   SHELL_BINARY          ("heron.binaries.shell",           "${HERON_BIN}/heron-shell"),
   PYTHON_INSTANCE_BINARY("heron.binaries.python.instance", "${HERON_BIN}/heron-python-instance"),
   CPP_INSTANCE_BINARY   ("heron.binaries.cpp.instance",    "${HERON_BIN}/heron-cpp-instance"),
-  DOWNLOADER_BINARY     ("heron.binaries.downloader",      "${HERON_BIN}/heron-downloader");
+  DOWNLOADER_BINARY     ("heron.binaries.downloader",      "${HERON_BIN}/heron-downloader"),
+  
+  UPDATE_PROMPT         ("heron.command.update.prompt", Boolean.FALSE);
 
 
   private final String value;

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Key.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Key.java
@@ -173,7 +173,7 @@ public enum Key {
   DOWNLOADER_BINARY     ("heron.binaries.downloader",      "${HERON_BIN}/heron-downloader"),
 
   // keys for `heron` command line
-  UPDATE_PROMPT         ("heron.command.update.prompt", "disable");
+  UPDATE_PROMPT         ("heron.command.update.prompt", "disabled");
 
 
   private final String value;


### PR DESCRIPTION
replace #2733

After discussion with maosong and ning, we agree:
1 Warn users clearly before the actual update process. So they can know the risks. (done by prompt)
2 Warn users clearly after failure. And let users know the topology can enter a wired state, and a re-deployment is recommended. 

Since the warning tells the users to assure the topology's running state, heron does not try to activate it.

Example:
```
$ ~/bin/heron update --config-property heron.command.update.prompt=prompt \
--verbose local ExclamationTopology --component-parallelism word:4
```
Default config value `disabled`