### PR TITLE
JavaCheckstyle fix for IntelliJ setup script #2737

### DIFF
--- a/tools/java/src/com/twitter/bazel/checkstyle/JavaCheckstyle.java
+++ b/tools/java/src/com/twitter/bazel/checkstyle/JavaCheckstyle.java
@@ -113,7 +113,7 @@ public final class JavaCheckstyle {
         Predicates.containsPattern("storm-compatibility.src.java"),
         Predicates.containsPattern("tools/test/LcovMerger"),
         Predicates.containsPattern("contrib"),
-        Predicates.containsPattern("external") // from external/ directory for bazel  
+        Predicates.containsPattern("external") // from external/ directory for bazel
     )));
   }
 


### PR DESCRIPTION
Fix for https://github.com/twitter/heron/issues/2737

Trimmed trailing whitespaces at the end of the comment to help IntelliJ setup script run successfully.