### PR TITLE
[tracker] add topology_version in tracker /runtimestate

### DIFF
--- a/heron/tools/tracker/src/python/constants.py
+++ b/heron/tools/tracker/src/python/constants.py
@@ -57,7 +57,7 @@ RESPONSE_KEY_EXECUTION_TIME = "executiontime"
 RESPONSE_KEY_MESSAGE = "message"
 RESPONSE_KEY_RESULT = "result"
 RESPONSE_KEY_STATUS = "status"
-RESPONSE_KEY_VERSION = "version"
+RESPONSE_KEY_VERSION = "tracker_version"
 
 # These are the values of the status
 # in the JSON repsonse.

--- a/heron/tools/tracker/src/python/handlers/runtimestatehandler.py
+++ b/heron/tools/tracker/src/python/handlers/runtimestatehandler.py
@@ -108,6 +108,7 @@ class RuntimeStateHandler(BaseHandler):
       topology_name = self.get_argument_topology()
       topology_info = self.tracker.getTopologyInfo(topology_name, cluster, role, environ)
       runtime_state = topology_info["runtime_state"]
+      runtime_state["topology_version"] = topology_info["metadata"]["release_version"]
       topology = self.tracker.getTopologyByClusterRoleEnvironAndName(
           cluster, role, environ, topology_name)
       reg_summary = yield tornado.gen.Task(self.getStmgrsRegSummary, topology.tmaster)


### PR DESCRIPTION
The present tracker returns the tracker_server_version rather than the topology_version. This PR add a field for /runtimestate handler.
