### PR TITLE
[Streamlet Scala API] Add Scala StreamletImpl Support

### DIFF
--- a/heron/api/src/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverter.scala
+++ b/heron/api/src/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverter.scala
@@ -1,0 +1,45 @@
+//  Copyright 2018 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.streamlet.scala.converter
+
+import com.twitter.heron.streamlet.Context
+import com.twitter.heron.streamlet.scala.Sink
+
+/**
+  * This class transforms passed User defined Scala Functions, Sources, Sinks
+  * to related Java versions
+  */
+object ScalaToJavaConverter {
+
+  def toSerializableSupplier[T](f: () => T) =
+    new com.twitter.heron.streamlet.SerializableSupplier[T] {
+      override def get(): T = f()
+    }
+
+  def toSerializableFunction[R, T](f: R => _ <: T) =
+    new com.twitter.heron.streamlet.SerializableFunction[R, T] {
+      override def apply(r: R): T = f(r)
+    }
+
+  def toJavaSink[T](sink: Sink[T]): com.twitter.heron.streamlet.Sink[T] = {
+    new com.twitter.heron.streamlet.Sink[T] {
+      override def setup(context: Context): Unit = sink.setup(context)
+
+      override def put(tuple: T): Unit = sink.put(tuple)
+
+      override def cleanup(): Unit = sink.cleanup()
+    }
+  }
+
+}

--- a/heron/api/tests/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverterTest.scala
+++ b/heron/api/tests/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverterTest.scala
@@ -1,0 +1,60 @@
+//  Copyright 2018 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.streamlet.scala.converter
+
+import org.junit.Assert.assertTrue
+
+import com.twitter.heron.streamlet.Context
+import com.twitter.heron.streamlet.scala.Sink
+import com.twitter.heron.streamlet.scala.common.BaseFunSuite
+
+/**
+  * Tests for Streamlet APIs' Scala to Java Conversion functionality
+  */
+class ScalaToJavaConverterTest extends BaseFunSuite {
+
+  test("ScalaToJavaConverterTest should support SerializableSupplier") {
+    def testFunction() = ""
+    val serializableSupplier =
+      ScalaToJavaConverter.toSerializableSupplier[String](testFunction)
+    assertTrue(
+      serializableSupplier
+        .isInstanceOf[com.twitter.heron.streamlet.SerializableSupplier[_]])
+  }
+
+  test("ScalaToJavaConverterTest should support SerializableFunction") {
+    def stringToIntFunction(number: String) = number.toInt
+    val serializableFunction =
+      ScalaToJavaConverter.toSerializableFunction[String, Int](
+        stringToIntFunction)
+    assertTrue(
+      serializableFunction
+        .isInstanceOf[com.twitter.heron.streamlet.SerializableFunction[_, _]])
+  }
+
+  test("ScalaToJavaConverterTest should support Java Sink") {
+    val javaSink =
+      ScalaToJavaConverter.toJavaSink[Int](new TestSink())
+    assertTrue(
+      javaSink
+        .isInstanceOf[com.twitter.heron.streamlet.Sink[Int]])
+  }
+
+  private class TestSink() extends Sink[Int] {
+    override def setup(context: Context): Unit = {}
+    override def put(tuple: Int): Unit = {}
+    override def cleanup(): Unit = {}
+  }
+
+}

--- a/heron/api/tests/scala/com/twitter/heron/streamlet/scala/impl/StreamletImplTest.scala
+++ b/heron/api/tests/scala/com/twitter/heron/streamlet/scala/impl/StreamletImplTest.scala
@@ -1,0 +1,73 @@
+//  Copyright 2018 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.streamlet.scala.impl
+
+import com.twitter.heron.streamlet.scala.Streamlet
+import com.twitter.heron.streamlet.scala.common.BaseFunSuite
+import org.junit.Assert.{assertEquals, assertTrue}
+
+/**
+  * Tests for Scala Streamlet Implementation functionality
+  */
+class StreamletImplTest extends BaseFunSuite {
+
+  test(
+    "StreamletImpl should support setting name and number of partitions per streamlet") {
+    val supplierStreamlet = StreamletImpl
+      .createSupplierStreamlet(() => Math.random)
+      .setName("Supplier_Streamlet_1")
+      .setNumPartitions(20)
+
+    assertTrue(supplierStreamlet.isInstanceOf[Streamlet[Double]])
+    assertEquals("Supplier_Streamlet_1", supplierStreamlet.getName)
+    assertEquals(20, supplierStreamlet.getNumPartitions)
+
+    val mapStreamlet = supplierStreamlet
+      .map[Double]((num: Double) => num * 10)
+      .setName("Map_Streamlet_1")
+      .setNumPartitions(5)
+
+    assertTrue(mapStreamlet.isInstanceOf[Streamlet[Double]])
+    assertEquals("Map_Streamlet_1", mapStreamlet.getName)
+    assertEquals(5, mapStreamlet.getNumPartitions)
+  }
+
+  test("StreamletImpl should support map transformation") {
+    val supplierStreamlet = StreamletImpl
+      .createSupplierStreamlet(() => Math.random)
+      .setName("Supplier_Streamlet_1")
+      .setNumPartitions(20)
+
+    supplierStreamlet
+      .map[Double]((num: Double) => num * 10)
+      .setName("Map_Streamlet_1")
+      .setNumPartitions(5)
+
+    val supplierStreamletImpl =
+      supplierStreamlet.asInstanceOf[StreamletImpl[Double]]
+    assertEquals(1, supplierStreamletImpl.getChildren.size)
+    assertTrue(
+      supplierStreamletImpl
+        .getChildren(0)
+        .isInstanceOf[
+          com.twitter.heron.streamlet.impl.streamlets.MapStreamlet[_, _]])
+    val mapStreamlet = supplierStreamletImpl
+      .getChildren(0)
+      .asInstanceOf[
+        com.twitter.heron.streamlet.impl.streamlets.MapStreamlet[_, _]]
+    assertEquals("Map_Streamlet_1", mapStreamlet.getName)
+    assertEquals(0, mapStreamlet.getChildren.size())
+  }
+
+}


### PR DESCRIPTION
This PR aims the following changes:

Adding `Scala StreamletImpl` by providing abstraction for Scala API specific logic
Adding Scala Streamlet `map` function support
Adding `ScalaToJavaConverter` in order to transform following logics:
 - Scala `Supplier` to `SerializableSupplier`
 - Scala `Function` to `SerializableFunction`
 - Scala `Sink` to Java `Sink`
Adding UT Coverages for both `Scala StreamletImpl` and `ScalaToJavaConverter`