### PR TITLE
add a switch for metricscache

### DIFF
--- a/heron/config/src/yaml/conf/local/healthmgr.yaml
+++ b/heron/config/src/yaml/conf/local/healthmgr.yaml
@@ -7,6 +7,9 @@ heron.topology.healthmgr.mode: disabled
 heron.healthmgr.metricsource.type: com.twitter.heron.healthmgr.sensors.TrackerMetricsProvider
 heron.healthmgr.metricsource.url: http://localhost:8888
 
+# Enable MetricsCache if MetricsCache is chosen as metrics provider
+#heron.topology.metricscachemgr.mode: cluster
+
 ## list of policies to be executed for self regulation
 #heron.class.health.policies:
 #  - dynamic-resource-allocation

--- a/heron/config/src/yaml/conf/sandbox/healthmgr.yaml
+++ b/heron/config/src/yaml/conf/sandbox/healthmgr.yaml
@@ -7,6 +7,9 @@ heron.topology.healthmgr.mode: disabled
 heron.healthmgr.metricsource.type: com.twitter.heron.healthmgr.sensors.TrackerMetricsProvider
 heron.healthmgr.metricsource.url: http://localhost:8888
 
+# Enable MetricsCache if MetricsCache is chosen as metrics provider
+#heron.topology.metricscachemgr.mode: cluster
+
 ## list of policies to be executed for self regulation
 #heron.class.health.policies:
 #  - dynamic-resource-allocation

--- a/heron/config/src/yaml/conf/yarn/healthmgr.yaml
+++ b/heron/config/src/yaml/conf/yarn/healthmgr.yaml
@@ -7,6 +7,9 @@ heron.topology.healthmgr.mode: disabled
 heron.healthmgr.metricsource.type: com.twitter.heron.healthmgr.sensors.TrackerMetricsProvider
 heron.healthmgr.metricsource.url: http://localhost:8888
 
+# Enable MetricsCache if MetricsCache is chosen as metrics provider
+#heron.topology.metricscachemgr.mode: cluster
+
 ## list of policies to be executed for self regulation
 #heron.class.health.policies:
 #  - dynamic-resource-allocation

--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -239,7 +239,7 @@ class HeronExecutor(object):
     self.checkpoint_manager_port = parsed_args.checkpoint_manager_port
     self.stateful_config_file = parsed_args.stateful_config_file
     self.metricscache_manager_mode = parsed_args.metricscache_manager_mode \
-        if parsed_args.jvm_remote_debugger_ports else "disabled"
+        if parsed_args.metricscache_manager_mode else "disabled"
     self.health_manager_mode = parsed_args.health_manager_mode
     self.health_manager_classpath = '%s:%s'\
         % (self.scheduler_classpath, parsed_args.health_manager_classpath)

--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -238,6 +238,8 @@ class HeronExecutor(object):
     self.checkpoint_manager_classpath = parsed_args.checkpoint_manager_classpath
     self.checkpoint_manager_port = parsed_args.checkpoint_manager_port
     self.stateful_config_file = parsed_args.stateful_config_file
+    self.metricscache_manager_mode = parsed_args.metricscache_manager_mode \
+        if parsed_args.jvm_remote_debugger_ports else "disabled"
     self.health_manager_mode = parsed_args.health_manager_mode
     self.health_manager_classpath = '%s:%s'\
         % (self.scheduler_classpath, parsed_args.health_manager_classpath)
@@ -312,6 +314,7 @@ class HeronExecutor(object):
     parser.add_argument("--metricscache-manager-classpath", required=True)
     parser.add_argument("--metricscache-manager-master-port", required=True)
     parser.add_argument("--metricscache-manager-stats-port", required=True)
+    parser.add_argument("--metricscache-manager-mode", required=False)
     parser.add_argument("--is-stateful", required=True)
     parser.add_argument("--checkpoint-manager-classpath", required=True)
     parser.add_argument("--checkpoint-manager-port", required=True)
@@ -510,9 +513,10 @@ class HeronExecutor(object):
     retval["heron-tmaster"] = tmaster_cmd
 
 
-    if self.health_manager_mode.lower() != "disabled":
-      # align metricscache and healthmgr toggle switch
+    if self.metricscache_manager_mode.lower() != "disabled":
       retval["heron-metricscache"] = self._get_metrics_cache_cmd()
+
+    if self.health_manager_mode.lower() != "disabled":
       retval["heron-healthmgr"] = self._get_healthmgr_cmd()
 
     retval[self.metricsmgr_ids[0]] = self._get_metricsmgr_cmd(

--- a/heron/executor/tests/python/heron_executor_unittest.py
+++ b/heron/executor/tests/python/heron_executor_unittest.py
@@ -269,7 +269,8 @@ class HeronExecutorTest(unittest.TestCase):
       ("--checkpoint-manager-port", "ckptmgr-port"),
       ("--stateful-config-file", "stateful_config_file"),
       ("--health-manager-mode", "healthmgr_mode"),
-      ("--health-manager-classpath", "healthmgr_classpath")
+      ("--health-manager-classpath", "healthmgr_classpath"),
+      ("--metricscache-manager-mode", "metricscache_mode")
     ]
 
     args = ("%s=%s" % (arg[0], (str(arg[1]))) for arg in executor_args)

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/ExecutorFlag.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/ExecutorFlag.java
@@ -52,6 +52,7 @@ public enum ExecutorFlag {
   MetricsCacheManagerClasspath("metricscache-manager-classpath"),
   MetricsCacheManagerMasterPort("metricscache-manager-master-port"),
   MetricsCacheManagerStatsPort("metricscache-manager-stats-port"),
+  MetricsCacheManagerMode("metricscache-manager-mode"),
   IsStateful("is-stateful"),
   CheckpointManagerClasspath("checkpoint-manager-classpath"),
   CheckpointManagerPort("checkpoint-manager-port"),

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/SchedulerUtils.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/SchedulerUtils.java
@@ -293,6 +293,9 @@ public final class SchedulerUtils {
 
     args.add(createCommandArg(ExecutorFlag.MetricsCacheManagerClasspath,
         Context.metricsCacheManagerClassPath(config)));
+    String metricscacheMgrMode = Context.metricscacheMgrMode(config)
+        == null ? "disabled" : Context.metricscacheMgrMode(config);
+    args.add(createCommandArg(ExecutorFlag.MetricsCacheManagerMode, metricscacheMgrMode));
 
     Boolean ckptMgrEnabled = TopologyUtils.shouldStartCkptMgr(topology);
     args.add(createCommandArg(ExecutorFlag.IsStateful, Boolean.toString(ckptMgrEnabled)));

--- a/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraSchedulerTest.java
+++ b/heron/schedulers/tests/java/com/twitter/heron/scheduler/aurora/AuroraSchedulerTest.java
@@ -324,6 +324,7 @@ public class AuroraSchedulerTest {
             + " --python-instance-binary=" + expectedBin + "/heron-python-instance"
             + " --cpp-instance-binary=" + expectedBin + "/heron-cpp-instance"
             + " --metricscache-manager-classpath=" + expectedLib + "/metricscachemgr/*"
+            + " --metricscache-manager-mode=disabled"
             + " --is-stateful=false"
             + " --checkpoint-manager-classpath=" + expectedLib + "/ckptmgr/*:"
             + expectedLib + "/statefulstorage/*:"

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Context.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Context.java
@@ -339,4 +339,9 @@ public class Context {
     Object o = statefulStorageConfig.get(Key.STATEFUL_STORAGE_CUSTOM_CLASSPATH.value());
     return o == null ? "" : (String) o;
   }
+
+  public static String metricscacheMgrMode(Config cfg) {
+    return cfg.getStringValue(Key.METRICSCACHEMGR_MODE);
+  }
+
 }

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Key.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Key.java
@@ -121,6 +121,8 @@ public enum Key {
   STATEFUL_STORAGE_CONF                    ("heron.statefulstorage.config", Type.MAP),
   STATEFUL_STORAGE_CUSTOM_CLASSPATH        ("heron.statefulstorage.custom.classpath", Type.STRING),
 
+  // keys for metricscache manager
+  METRICSCACHEMGR_MODE       ("heron.topology.metricscachemgr.mode", "disabled"),
   // keys for health manager
   HEALTHMGR_MODE             ("heron.topology.healthmgr.mode", Type.STRING),
 


### PR DESCRIPTION
Added a switch to turn on/off metricscache. Config options:
```
heron.topology.metricscachemgr.mode: cluster
heron.topology.metricscachemgr.mode: disabled (default)
```

In some scenarios, the customers do not turn on healthmgr/dhalion, so the metricscache does not have consumer. This PR add a switch so that user can turn it off.