### PR TITLE
[API] Improve HeronSubmitter

### DIFF
--- a/heron/api/src/java/com/twitter/heron/api/HeronSubmitter.java
+++ b/heron/api/src/java/com/twitter/heron/api/HeronSubmitter.java
@@ -30,7 +30,6 @@
  * limitations under the License.
  */
 
-
 package com.twitter.heron.api;
 
 import java.io.BufferedOutputStream;
@@ -43,6 +42,7 @@ import java.util.logging.Logger;
 
 import com.twitter.heron.api.exception.AlreadyAliveException;
 import com.twitter.heron.api.exception.InvalidTopologyException;
+import com.twitter.heron.api.exception.TopologySubmissionException;
 import com.twitter.heron.api.generated.TopologyAPI;
 import com.twitter.heron.api.utils.TopologyUtils;
 import com.twitter.heron.api.utils.Utils;
@@ -53,8 +53,10 @@ import com.twitter.heron.api.utils.Utils;
  * submit your topologies.
  */
 public final class HeronSubmitter {
+
   private static final Logger LOG = Logger.getLogger(HeronSubmitter.class.getName());
 
+  private static final String TOPOLOGY_DEFINITION_SUFFIX = ".defn";
   private static final String CMD_TOPOLOGY_INITIAL_STATE = "cmdline.topology.initial.state";
   private static final String CMD_TOPOLOGY_DEFN_TEMPDIR = "cmdline.topologydefn.tmpdirectory";
   private static final String CMD_TOPOLOGY_ROLE = "cmdline.topology.role";
@@ -75,7 +77,8 @@ public final class HeronSubmitter {
    */
   public static void submitTopology(String name, Config heronConfig, HeronTopology topology)
       throws AlreadyAliveException, InvalidTopologyException {
-    Map<String, String> heronCmdOptions = Utils.readCommandLineOpts();
+
+    Map<String, String> heronCmdOptions = getHeronCmdOptions();
 
     // We would read the topology initial state from arguments from heron-cli
     TopologyAPI.TopologyState initialState;
@@ -107,33 +110,33 @@ public final class HeronSubmitter {
     TopologyUtils.validateTopology(fTopology);
     assert fTopology.isInitialized();
 
-    if (heronCmdOptions.get(CMD_TOPOLOGY_DEFN_TEMPDIR) != null) {
-      submitTopologyToFile(fTopology, heronCmdOptions);
-    } else {
-      throw new RuntimeException("topology definition temp directory not specified");
-    }
+    submitTopologyToFile(fTopology, heronCmdOptions);
   }
 
-  // Submits to the file
+  /**
+   * Submits a topology to definition file
+   *
+   * @param fTopology the processing to execute.
+   * @param heronCmdOptions the commandline options.
+   * @throws TopologySubmissionException if the topology submission is failed
+   */
   private static void submitTopologyToFile(TopologyAPI.Topology fTopology,
                                            Map<String, String> heronCmdOptions) {
-    String dirName = heronCmdOptions.get("cmdline.topologydefn.tmpdirectory");
+    String dirName = heronCmdOptions.get(CMD_TOPOLOGY_DEFN_TEMPDIR);
     if (dirName == null || dirName.isEmpty()) {
-      throw new RuntimeException("Improper specification of directory");
+      throw new TopologySubmissionException("Topology definition temp directory not specified. "
+          + "Please set cmdline option: " + CMD_TOPOLOGY_DEFN_TEMPDIR);
     }
-    String fileName = dirName + "/" + fTopology.getName() + ".defn";
-    BufferedOutputStream bos = null;
-    try {
-      //create an object of FileOutputStream
-      FileOutputStream fos = new FileOutputStream(new File(fileName));
-      //create an object of BufferedOutputStream
-      bos = new BufferedOutputStream(fos);
+
+    String fileName = dirName + "/" + fTopology.getName() + TOPOLOGY_DEFINITION_SUFFIX;
+
+    try (FileOutputStream fos = new FileOutputStream(new File(fileName));
+        BufferedOutputStream bos = new BufferedOutputStream(fos)) {
       byte[] topEncoding = fTopology.toByteArray();
       bos.write(topEncoding);
-      bos.flush();
-      bos.close();
     } catch (IOException e) {
-      throw new RuntimeException("Error writing topology defn to temp directory " + dirName);
+      throw new TopologySubmissionException("Error writing topology definition to temp directory: "
+          + dirName, e);
     }
   }
 
@@ -143,6 +146,10 @@ public final class HeronSubmitter {
    */
   // TODO add submit options
   public static String submitJar(Config config, String localJar) {
-    throw new UnsupportedOperationException("submitJar unsupported");
+    throw new UnsupportedOperationException("submitJar functionality is unsupported");
+  }
+
+  static Map<String, String> getHeronCmdOptions() {
+    return Utils.readCommandLineOpts();
   }
 }

--- a/heron/api/src/java/com/twitter/heron/api/HeronSubmitter.java
+++ b/heron/api/src/java/com/twitter/heron/api/HeronSubmitter.java
@@ -36,6 +36,7 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -128,7 +129,8 @@ public final class HeronSubmitter {
           + "Please set cmdline option: " + CMD_TOPOLOGY_DEFN_TEMPDIR);
     }
 
-    String fileName = dirName + "/" + fTopology.getName() + TOPOLOGY_DEFINITION_SUFFIX;
+    String fileName =
+        Paths.get(dirName, fTopology.getName() + TOPOLOGY_DEFINITION_SUFFIX).toString();
 
     try (FileOutputStream fos = new FileOutputStream(new File(fileName));
         BufferedOutputStream bos = new BufferedOutputStream(fos)) {

--- a/heron/api/src/java/com/twitter/heron/api/exception/TopologySubmissionException.java
+++ b/heron/api/src/java/com/twitter/heron/api/exception/TopologySubmissionException.java
@@ -1,0 +1,31 @@
+//  Copyright 2018 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package com.twitter.heron.api.exception;
+
+/**
+ * Thrown to indicate that the application has attempted to submit an invalid topology.
+ */
+public class TopologySubmissionException extends RuntimeException {
+
+  private static final long serialVersionUID = -5045350685867299824L;
+
+  public TopologySubmissionException(String message) {
+    super(message);
+  }
+
+  public TopologySubmissionException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/heron/api/tests/java/com/twitter/heron/api/HeronSubmitterTest.java
+++ b/heron/api/tests/java/com/twitter/heron/api/HeronSubmitterTest.java
@@ -183,7 +183,7 @@ public class HeronSubmitterTest {
 
   public static class TestSpout2 extends TestSpout {
 
-    private static final long serialVersionUID = -630307949908406294L;
+    private static final long serialVersionUID = 4070649954154119533L;
 
     @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {

--- a/heron/api/tests/java/com/twitter/heron/api/HeronSubmitterTest.java
+++ b/heron/api/tests/java/com/twitter/heron/api/HeronSubmitterTest.java
@@ -13,64 +13,43 @@
 //  limitations under the License.
 package com.twitter.heron.api;
 
+import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.twitter.heron.api.bolt.BaseBasicBolt;
 import com.twitter.heron.api.bolt.BasicOutputCollector;
 import com.twitter.heron.api.exception.AlreadyAliveException;
 import com.twitter.heron.api.exception.InvalidTopologyException;
+import com.twitter.heron.api.exception.TopologySubmissionException;
 import com.twitter.heron.api.spout.BaseRichSpout;
 import com.twitter.heron.api.spout.SpoutOutputCollector;
 import com.twitter.heron.api.topology.OutputFieldsDeclarer;
 import com.twitter.heron.api.topology.TopologyBuilder;
 import com.twitter.heron.api.topology.TopologyContext;
+import com.twitter.heron.api.tuple.Fields;
 import com.twitter.heron.api.tuple.Tuple;
 import com.twitter.heron.common.basics.ByteAmount;
 
+/**
+ * This class covers HeronSubmitter Unit Tests for both positive and negative cases
+ */
+@RunWith(PowerMockRunner.class)
 public class HeronSubmitterTest {
 
-  public static class TestSpout extends BaseRichSpout {
-
-    private static final long serialVersionUID = -630307949908406294L;
-
-    @SuppressWarnings("rawtypes")
-    public void open(
-        Map conf,
-        TopologyContext context,
-        SpoutOutputCollector acollector) {
-    }
-
-    public void close() {
-    }
-
-    public void nextTuple() {
-    }
-
-    @Override
-    public void declareOutputFields(OutputFieldsDeclarer declarer) {
-
-    }
-  }
-
-  public static class TestBolt extends BaseBasicBolt {
-
-    private static final long serialVersionUID = -5888421647633083078L;
-
-    @Override
-    public void execute(Tuple input, BasicOutputCollector collector) {
-
-    }
-
-    @Override
-    public void declareOutputFields(OutputFieldsDeclarer declarer) {
-
-    }
-  }
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
 
   @Test(expected = InvalidTopologyException.class)
-  public void testInvalidTopologySubmittion()
+  public void testInvalidTopologySubmission()
       throws AlreadyAliveException, InvalidTopologyException {
     TopologyBuilder builder = new TopologyBuilder();
 
@@ -105,4 +84,126 @@ public class HeronSubmitterTest {
     conf.setNumStmgrs(2);
     HeronSubmitter.submitTopology("test", conf, builder.createTopology());
   }
+
+  @Test
+  @PrepareForTest(HeronSubmitter.class)
+  public void testValidTopologySubmission() throws AlreadyAliveException, InvalidTopologyException {
+    TopologyBuilder builder = createTopologyBuilderWithMinimumSetup();
+
+    Config conf = new Config();
+
+    Map<String, String> map = new HashMap();
+    map.put("cmdline.topologydefn.tmpdirectory", folder.getRoot().getPath());
+
+    PowerMockito.spy(HeronSubmitter.class);
+    Mockito.when(HeronSubmitter.getHeronCmdOptions()).thenReturn(map);
+
+    HeronSubmitter.submitTopology("test", conf, builder.createTopology());
+  }
+
+  @Test(expected = TopologySubmissionException.class)
+  @PrepareForTest(HeronSubmitter.class)
+  public void testTopologySubmissionWhenTmpDirectoryIsEmptyPath()
+      throws AlreadyAliveException, InvalidTopologyException {
+    TopologyBuilder builder = createTopologyBuilderWithMinimumSetup();
+
+    Config conf = new Config();
+
+    Map<String, String> map = new HashMap();
+    map.put("cmdline.topologydefn.tmpdirectory", "");
+
+    PowerMockito.spy(HeronSubmitter.class);
+    Mockito.when(HeronSubmitter.getHeronCmdOptions()).thenReturn(map);
+
+    HeronSubmitter.submitTopology("test", conf, builder.createTopology());
+  }
+
+  @Test(expected = TopologySubmissionException.class)
+  @PrepareForTest(HeronSubmitter.class)
+  public void testTopologySubmissionWhenTmpDirectoryIsSetAsInvalidPath()
+      throws AlreadyAliveException, InvalidTopologyException {
+    TopologyBuilder builder = createTopologyBuilderWithMinimumSetup();
+
+    Config conf = new Config();
+
+    Map<String, String> map = new HashMap();
+    map.put("cmdline.topologydefn.tmpdirectory", "invalid_path");
+
+    PowerMockito.spy(HeronSubmitter.class);
+    Mockito.when(HeronSubmitter.getHeronCmdOptions()).thenReturn(map);
+
+    HeronSubmitter.submitTopology("test", conf, builder.createTopology());
+  }
+
+  @Test(expected = TopologySubmissionException.class)
+  public void testTopologySubmissionWhenTmpDirectoryIsNotSet()
+      throws AlreadyAliveException, InvalidTopologyException {
+    TopologyBuilder builder = createTopologyBuilderWithMinimumSetup();
+    Config conf = new Config();
+    HeronSubmitter.submitTopology("test", conf, builder.createTopology());
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testSubmitJar() {
+    Config conf = new Config();
+    HeronSubmitter.submitJar(conf, "test_jar");
+  }
+
+  private TopologyBuilder createTopologyBuilderWithMinimumSetup() {
+    TopologyBuilder builder = new TopologyBuilder();
+
+    int spouts = 2;
+    int bolts = 2;
+    builder.setSpout("word", new TestSpout2(), spouts);
+    builder.setBolt("exclaim1", new TestBolt(), bolts).shuffleGrouping("word");
+    return builder;
+  }
+
+  public static class TestSpout extends BaseRichSpout {
+
+    private static final long serialVersionUID = -630307949908406294L;
+
+    @SuppressWarnings("rawtypes")
+    public void open(
+        Map conf,
+        TopologyContext context,
+        SpoutOutputCollector acollector) {
+    }
+
+    public void close() {
+    }
+
+    public void nextTuple() {
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+    }
+  }
+
+  public static class TestSpout2 extends TestSpout {
+
+    private static final long serialVersionUID = -630307949908406294L;
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+      declarer.declare(new Fields("word"));
+    }
+  }
+
+  public static class TestBolt extends BaseBasicBolt {
+
+    private static final long serialVersionUID = -5888421647633083078L;
+
+    @Override
+    public void execute(Tuple input, BasicOutputCollector collector) {
+
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+
+    }
+  }
+
 }


### PR DESCRIPTION
This PR aims the following changes:

- Current writing topology definition to `OutputStream` has been refactored with `try-with-resources` statement so explicit `flush` and `close` method calls have been removed.
- Redundant `directory check` has been removed.
- Added `UT` coverages for the following cases:
  - Success case (by submitting valid topology)
  - 4 negative cases 
    - If Tmp Directory is not set,
    - If Tmp Directory is set as empty path,
    - If Tmp Directory is set as invalid path,
    - `submitJar` is not supported yet
- `Javadocs` have been added.

Also: new added UT cases execution time is as follows:
//heron/api/tests/java:HeronSubmitterTest      PASSED in **3.8s**