### PR TITLE
[Streamlet Scala API] Add Scala StreamletImpl Support - Part II

### DIFF
--- a/heron/api/src/scala/com/twitter/heron/streamlet/scala/Streamlet.scala
+++ b/heron/api/src/scala/com/twitter/heron/streamlet/scala/Streamlet.scala
@@ -16,7 +16,11 @@ package com.twitter.heron.streamlet.scala
 import com.twitter.heron.streamlet.{KeyValue, KeyedWindow}
 
 // TODO: This Java Streamlet API references will be changed with Scala versions when they are ready
-import com.twitter.heron.streamlet.{JoinType, SerializableTransformer, WindowConfig}
+import com.twitter.heron.streamlet.{
+  JoinType,
+  SerializableTransformer,
+  WindowConfig
+}
 
 /**
   * A Streamlet is a (potentially unbounded) ordered collection of tuples.
@@ -74,7 +78,7 @@ trait Streamlet[R] {
     *
     * @param mapFn The Map Function that should be applied to each element
     */
-  def map[T](mapFn: R => _ <: T): Streamlet[T]
+  def map[T](mapFn: R => T): Streamlet[T]
 
   /**
     * Return a new Streamlet by applying flatMapFn to each element of this Streamlet and
@@ -105,7 +109,8 @@ trait Streamlet[R] {
     * return 0 or more unique numbers between 0 and npartitions to indicate which partitions
     * this element should be routed to.
     */
-  def repartition(numPartitions: Int, partitionFn: (R, Int) => Seq[Int]): Streamlet[R]
+  def repartition(numPartitions: Int,
+                  partitionFn: (R, Int) => Seq[Int]): Streamlet[R]
 
   /**
     * Clones the current Streamlet. It returns an array of numClones Streamlets where each
@@ -128,11 +133,12 @@ trait Streamlet[R] {
     * have. Typical windowing strategies are sliding windows and tumbling windows
     * @param joinFunction      The join function that needs to be applied
     */
-  def join[K, S, T](other: Streamlet[S],
-                    thisKeyExtractor: R => K,
-                    otherKeyExtractor: S => K,
-                    windowCfg: WindowConfig,
-                    joinFunction: (R, S) => _ <: T): Streamlet[KeyValue[KeyedWindow[K], T]]
+  def join[K, S, T](
+      other: Streamlet[S],
+      thisKeyExtractor: R => K,
+      otherKeyExtractor: S => K,
+      windowCfg: WindowConfig,
+      joinFunction: (R, S) => _ <: T): Streamlet[KeyValue[KeyedWindow[K], T]]
 
   /**
     * Return a new KVStreamlet by joining 'this streamlet with ‘other’ streamlet. The type of joining
@@ -150,12 +156,13 @@ trait Streamlet[R] {
     * @param joinType          Type of Join. Options { @link JoinType}
     * @param joinFunction The join function that needs to be applied
     */
-  def join[K, S, T](other: Streamlet[S],
-                    thisKeyExtractor: R => K,
-                    otherKeyExtractor: S => K,
-                    windowCfg: WindowConfig,
-                    joinType: JoinType,
-                    joinFunction: (R, S) => _ <: T): Streamlet[KeyValue[KeyedWindow[K], T]]
+  def join[K, S, T](
+      other: Streamlet[S],
+      thisKeyExtractor: R => K,
+      otherKeyExtractor: S => K,
+      windowCfg: WindowConfig,
+      joinType: JoinType,
+      joinFunction: (R, S) => _ <: T): Streamlet[KeyValue[KeyedWindow[K], T]]
 
   /**
     * Return a new Streamlet accumulating tuples of this streamlet over a Window defined by
@@ -168,10 +175,11 @@ trait Streamlet[R] {
     *                       Typical windowing strategies are sliding windows and tumbling windows
     * @param reduceFn       The reduce function that you want to apply to all the values of a key.
     */
-  def reduceByKeyAndWindow[K, V](keyExtractor: R => K,
-                                 valueExtractor: R => V,
-                                 windowCfg: WindowConfig,
-                                 reduceFn: (V, V) => V): Streamlet[KeyValue[KeyedWindow[K], V]]
+  def reduceByKeyAndWindow[K, V](
+      keyExtractor: R => K,
+      valueExtractor: R => V,
+      windowCfg: WindowConfig,
+      reduceFn: (V, V) => V): Streamlet[KeyValue[KeyedWindow[K], V]]
 
   /**
     * Return a new Streamlet accumulating tuples of this streamlet over a Window defined by
@@ -187,10 +195,11 @@ trait Streamlet[R] {
     * @param reduceFn     The reduce function takes two parameters: a partial result of the reduction
     *                     and the next element of the stream. It returns a new partial result.
     */
-  def reduceByKeyAndWindow[K, T](keyExtractor: R => K,
-                                 windowCfg: WindowConfig,
-                                 identity: T,
-                                 reduceFn: (T, R) => _ <: T): Streamlet[KeyValue[KeyedWindow[K], T]]
+  def reduceByKeyAndWindow[K, T](
+      keyExtractor: R => K,
+      windowCfg: WindowConfig,
+      identity: T,
+      reduceFn: (T, R) => _ <: T): Streamlet[KeyValue[KeyedWindow[K], T]]
 
   /**
     * Returns a new Streamlet that is the union of this and the ‘other’ streamlet. Essentially
@@ -207,7 +216,8 @@ trait Streamlet[R] {
     * @param <                       T> The return type of the transform
     * @return Streamlet containing the output of the transformFunction
     */
-  def transform[T](serializableTransformer: SerializableTransformer[R, _ <: T]): Streamlet[T]
+  def transform[T](
+      serializableTransformer: SerializableTransformer[R, _ <: T]): Streamlet[T]
 
   /**
     * Logs every element of the streamlet using String.valueOf function

--- a/heron/api/src/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverter.scala
+++ b/heron/api/src/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverter.scala
@@ -13,6 +13,13 @@
 //  limitations under the License.
 package com.twitter.heron.streamlet.scala.converter
 
+import com.twitter.heron.streamlet.{
+  Context,
+  SerializableConsumer,
+  SerializableFunction,
+  SerializablePredicate,
+  SerializableSupplier
+}
 import com.twitter.heron.streamlet.scala.Sink
 
 /**
@@ -22,29 +29,28 @@ import com.twitter.heron.streamlet.scala.Sink
 object ScalaToJavaConverter {
 
   def toSerializableSupplier[T](f: () => T) =
-    new com.twitter.heron.streamlet.SerializableSupplier[T] {
+    new SerializableSupplier[T] {
       override def get(): T = f()
     }
 
-  def toSerializableFunction[R, T](f: R => _ <: T) =
-    new com.twitter.heron.streamlet.SerializableFunction[R, T] {
+  def toSerializableFunction[R, T](f: R => T) =
+    new SerializableFunction[R, T] {
       override def apply(r: R): T = f(r)
     }
 
   def toSerializablePredicate[R](f: R => Boolean) =
-    new com.twitter.heron.streamlet.SerializablePredicate[R] {
+    new SerializablePredicate[R] {
       override def test(r: R): Boolean = f(r)
     }
 
   def toSerializableConsumer[R](f: R => Unit) =
-    new com.twitter.heron.streamlet.SerializableConsumer[R] {
+    new SerializableConsumer[R] {
       override def accept(r: R): Unit = f(r)
     }
 
   def toJavaSink[T](sink: Sink[T]): com.twitter.heron.streamlet.Sink[T] = {
     new com.twitter.heron.streamlet.Sink[T] {
-      override def setup(context: com.twitter.heron.streamlet.Context): Unit =
-        sink.setup(context)
+      override def setup(context: Context): Unit = sink.setup(context)
 
       override def put(tuple: T): Unit = sink.put(tuple)
 

--- a/heron/api/src/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverter.scala
+++ b/heron/api/src/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverter.scala
@@ -13,7 +13,6 @@
 //  limitations under the License.
 package com.twitter.heron.streamlet.scala.converter
 
-import com.twitter.heron.streamlet.Context
 import com.twitter.heron.streamlet.scala.Sink
 
 /**
@@ -32,9 +31,20 @@ object ScalaToJavaConverter {
       override def apply(r: R): T = f(r)
     }
 
+  def toSerializablePredicate[R](f: R => Boolean) =
+    new com.twitter.heron.streamlet.SerializablePredicate[R] {
+      override def test(r: R): Boolean = f(r)
+    }
+
+  def toSerializableConsumer[R](f: R => Unit) =
+    new com.twitter.heron.streamlet.SerializableConsumer[R] {
+      override def accept(r: R): Unit = f(r)
+    }
+
   def toJavaSink[T](sink: Sink[T]): com.twitter.heron.streamlet.Sink[T] = {
     new com.twitter.heron.streamlet.Sink[T] {
-      override def setup(context: Context): Unit = sink.setup(context)
+      override def setup(context: com.twitter.heron.streamlet.Context): Unit =
+        sink.setup(context)
 
       override def put(tuple: T): Unit = sink.put(tuple)
 

--- a/heron/api/src/scala/com/twitter/heron/streamlet/scala/impl/StreamletImpl.scala
+++ b/heron/api/src/scala/com/twitter/heron/streamlet/scala/impl/StreamletImpl.scala
@@ -13,12 +13,14 @@
 //  limitations under the License.
 package com.twitter.heron.streamlet.scala.impl
 
-import com.twitter.heron.streamlet.{KeyValue, KeyedWindow}
 import com.twitter.heron.streamlet.{
   JoinType,
+  KeyValue,
+  KeyedWindow,
   SerializableTransformer,
   WindowConfig
 }
+import com.twitter.heron.streamlet.impl.streamlets.SupplierStreamlet
 import com.twitter.heron.streamlet.scala.{Sink, Streamlet}
 import com.twitter.heron.streamlet.scala.converter.ScalaToJavaConverter._
 
@@ -40,8 +42,7 @@ object StreamletImpl {
   private[impl] def createSupplierStreamlet[R](supplier: () => R) = {
     val serializableSupplier = toSerializableSupplier[R](supplier)
     val newJavaStreamlet =
-      new com.twitter.heron.streamlet.impl.streamlets.SupplierStreamlet[R](
-        serializableSupplier)
+      new SupplierStreamlet[R](serializableSupplier)
     toScalaStreamlet[R](newJavaStreamlet)
   }
 

--- a/heron/api/src/scala/com/twitter/heron/streamlet/scala/impl/StreamletImpl.scala
+++ b/heron/api/src/scala/com/twitter/heron/streamlet/scala/impl/StreamletImpl.scala
@@ -95,7 +95,7 @@ class StreamletImpl[R](
     *
     * @param mapFn The Map Function that should be applied to each element
     */
-  override def map[T](mapFn: R => _ <: T): Streamlet[T] = {
+  override def map[T](mapFn: R => T): Streamlet[T] = {
     val serializableFunction = toSerializableFunction[R, T](mapFn)
     val newJavaStreamlet = javaStreamlet.map[T](serializableFunction)
     toScalaStreamlet[T](newJavaStreamlet)

--- a/heron/api/tests/scala/com/twitter/heron/streamlet/scala/SinkTest.scala
+++ b/heron/api/tests/scala/com/twitter/heron/streamlet/scala/SinkTest.scala
@@ -15,8 +15,11 @@ package com.twitter.heron.streamlet.scala
 
 import scala.collection.mutable.ListBuffer
 
-import com.twitter.heron.streamlet.Context
-import com.twitter.heron.streamlet.scala.common.{BaseFunSuite, TestContext}
+import com.twitter.heron.streamlet.scala.common.{
+  BaseFunSuite,
+  TestContext,
+  TestListBufferSink
+}
 
 /**
   * Sink is how Streamlet's end. This class covers unit tests of Sink functionality
@@ -26,14 +29,14 @@ class SinkTest extends BaseFunSuite {
 
   test("Sink should support setup") {
     val list = ListBuffer[Int]()
-    val sink = new TestSink(list)
+    val sink = new TestListBufferSink(list)
     sink.setup(new TestContext())
     assert(list == List(1, 2))
   }
 
   test("Sink should put data") {
     val list = ListBuffer[Int]()
-    val sink = new TestSink(list)
+    val sink = new TestListBufferSink(list)
     sink.setup(new TestContext())
     sink.put(3)
     assert(list == List(1, 2, 3))
@@ -41,25 +44,11 @@ class SinkTest extends BaseFunSuite {
 
   test("Sink should support cleanup") {
     val list = ListBuffer[Int]()
-    val sink = new TestSink(list)
+    val sink = new TestListBufferSink(list)
     sink.setup(new TestContext())
     sink.put(3)
     sink.cleanup()
     assert(list.isEmpty)
-  }
-
-  private class TestSink(numbers: ListBuffer[Int]) extends Sink[Int] {
-
-    override def setup(context: Context): Unit = {
-      numbers += (1, 2)
-    }
-
-    override def put(tuple: Int): Unit = {
-      numbers += tuple
-    }
-
-    override def cleanup(): Unit = numbers.clear()
-
   }
 
 }

--- a/heron/api/tests/scala/com/twitter/heron/streamlet/scala/common/TestListBufferSink.scala
+++ b/heron/api/tests/scala/com/twitter/heron/streamlet/scala/common/TestListBufferSink.scala
@@ -15,6 +15,7 @@ package com.twitter.heron.streamlet.scala.common
 
 import scala.collection.mutable.ListBuffer
 
+import com.twitter.heron.streamlet.Context
 import com.twitter.heron.streamlet.scala.Sink
 
 /**
@@ -23,8 +24,7 @@ import com.twitter.heron.streamlet.scala.Sink
 private[scala] class TestListBufferSink(
     numbers: ListBuffer[Int] = ListBuffer[Int]())
     extends Sink[Int] {
-  override def setup(context: com.twitter.heron.streamlet.Context): Unit =
-    numbers += (1, 2)
+  override def setup(context: Context): Unit = numbers += (1, 2)
   override def put(tuple: Int): Unit = numbers += tuple
   override def cleanup(): Unit = numbers.clear()
 }

--- a/heron/api/tests/scala/com/twitter/heron/streamlet/scala/common/TestListBufferSink.scala
+++ b/heron/api/tests/scala/com/twitter/heron/streamlet/scala/common/TestListBufferSink.scala
@@ -13,10 +13,18 @@
 //  limitations under the License.
 package com.twitter.heron.streamlet.scala.common
 
-import org.scalatest.FunSuite
+import scala.collection.mutable.ListBuffer
+
+import com.twitter.heron.streamlet.scala.Sink
 
 /**
-  * Base abstract class for all unit tests in Heron Streamlet Scala API
-  * in order to keep common test functionality.
+  * Test ListBuffer Sink for Scala Streamlet API Unit Tests' general usage.
   */
-private[scala] abstract class BaseFunSuite extends FunSuite
+private[scala] class TestListBufferSink(
+    numbers: ListBuffer[Int] = ListBuffer[Int]())
+    extends Sink[Int] {
+  override def setup(context: com.twitter.heron.streamlet.Context): Unit =
+    numbers += (1, 2)
+  override def put(tuple: Int): Unit = numbers += tuple
+  override def cleanup(): Unit = numbers.clear()
+}

--- a/heron/api/tests/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverterTest.scala
+++ b/heron/api/tests/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverterTest.scala
@@ -15,7 +15,6 @@ package com.twitter.heron.streamlet.scala.converter
 
 import org.junit.Assert.assertTrue
 
-import com.twitter.heron.streamlet.Context
 import com.twitter.heron.streamlet.scala.Sink
 import com.twitter.heron.streamlet.scala.common.BaseFunSuite
 
@@ -45,15 +44,33 @@ class ScalaToJavaConverterTest extends BaseFunSuite {
 
   test("ScalaToJavaConverterTest should support Java Sink") {
     val javaSink =
-      ScalaToJavaConverter.toJavaSink[Int](new TestSink())
+      ScalaToJavaConverter.toJavaSink[Int](new TestSink[Int]())
     assertTrue(
       javaSink
         .isInstanceOf[com.twitter.heron.streamlet.Sink[Int]])
   }
 
-  private class TestSink() extends Sink[Int] {
-    override def setup(context: Context): Unit = {}
-    override def put(tuple: Int): Unit = {}
+  test("ScalaToJavaConverterTest should support SerializablePredicate") {
+    def intToBooleanFunction(number: Int) = number.<(5)
+    val serializablePredicate =
+      ScalaToJavaConverter.toSerializablePredicate[Int](intToBooleanFunction)
+    assertTrue(
+      serializablePredicate
+        .isInstanceOf[com.twitter.heron.streamlet.SerializablePredicate[Int]])
+  }
+
+  test("ScalaToJavaConverterTest should support SerializableConsumer") {
+    def consumerFunction(number: Int): Unit = number.toString
+    val serializableConsumer =
+      ScalaToJavaConverter.toSerializableConsumer[Int](consumerFunction)
+    assertTrue(
+      serializableConsumer
+        .isInstanceOf[com.twitter.heron.streamlet.SerializableConsumer[Int]])
+  }
+
+  private class TestSink[T] extends Sink[T] {
+    override def setup(context: com.twitter.heron.streamlet.Context): Unit = {}
+    override def put(tuple: T): Unit = {}
     override def cleanup(): Unit = {}
   }
 

--- a/heron/api/tests/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverterTest.scala
+++ b/heron/api/tests/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverterTest.scala
@@ -29,7 +29,7 @@ class ScalaToJavaConverterTest extends BaseFunSuite {
       ScalaToJavaConverter.toSerializableSupplier[String](testFunction)
     assertTrue(
       serializableSupplier
-        .isInstanceOf[com.twitter.heron.streamlet.SerializableSupplier[_]])
+        .isInstanceOf[com.twitter.heron.streamlet.SerializableSupplier[String]])
   }
 
   test("ScalaToJavaConverterTest should support SerializableFunction") {
@@ -39,7 +39,8 @@ class ScalaToJavaConverterTest extends BaseFunSuite {
         stringToIntFunction)
     assertTrue(
       serializableFunction
-        .isInstanceOf[com.twitter.heron.streamlet.SerializableFunction[_, _]])
+        .isInstanceOf[
+          com.twitter.heron.streamlet.SerializableFunction[String, Int]])
   }
 
   test("ScalaToJavaConverterTest should support Java Sink") {

--- a/heron/api/tests/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverterTest.scala
+++ b/heron/api/tests/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverterTest.scala
@@ -15,6 +15,14 @@ package com.twitter.heron.streamlet.scala.converter
 
 import org.junit.Assert.assertTrue
 
+import com.twitter.heron.streamlet.{
+  Context,
+  SerializableConsumer,
+  SerializableFunction,
+  SerializablePredicate,
+  SerializableSupplier
+}
+
 import com.twitter.heron.streamlet.scala.Sink
 import com.twitter.heron.streamlet.scala.common.BaseFunSuite
 
@@ -29,7 +37,7 @@ class ScalaToJavaConverterTest extends BaseFunSuite {
       ScalaToJavaConverter.toSerializableSupplier[String](testFunction)
     assertTrue(
       serializableSupplier
-        .isInstanceOf[com.twitter.heron.streamlet.SerializableSupplier[String]])
+        .isInstanceOf[SerializableSupplier[String]])
   }
 
   test("ScalaToJavaConverterTest should support SerializableFunction") {
@@ -39,8 +47,7 @@ class ScalaToJavaConverterTest extends BaseFunSuite {
         stringToIntFunction)
     assertTrue(
       serializableFunction
-        .isInstanceOf[
-          com.twitter.heron.streamlet.SerializableFunction[String, Int]])
+        .isInstanceOf[SerializableFunction[String, Int]])
   }
 
   test("ScalaToJavaConverterTest should support Java Sink") {
@@ -57,20 +64,20 @@ class ScalaToJavaConverterTest extends BaseFunSuite {
       ScalaToJavaConverter.toSerializablePredicate[Int](intToBooleanFunction)
     assertTrue(
       serializablePredicate
-        .isInstanceOf[com.twitter.heron.streamlet.SerializablePredicate[Int]])
+        .isInstanceOf[SerializablePredicate[Int]])
   }
 
   test("ScalaToJavaConverterTest should support SerializableConsumer") {
-    def consumerFunction(number: Int): Unit = number.toString
+    def consumerFunction(number: Int): Unit = number * 10
     val serializableConsumer =
       ScalaToJavaConverter.toSerializableConsumer[Int](consumerFunction)
     assertTrue(
       serializableConsumer
-        .isInstanceOf[com.twitter.heron.streamlet.SerializableConsumer[Int]])
+        .isInstanceOf[SerializableConsumer[Int]])
   }
 
   private class TestSink[T] extends Sink[T] {
-    override def setup(context: com.twitter.heron.streamlet.Context): Unit = {}
+    override def setup(context: Context): Unit = {}
     override def put(tuple: T): Unit = {}
     override def cleanup(): Unit = {}
   }

--- a/heron/api/tests/scala/com/twitter/heron/streamlet/scala/impl/StreamletImplTest.scala
+++ b/heron/api/tests/scala/com/twitter/heron/streamlet/scala/impl/StreamletImplTest.scala
@@ -13,9 +13,15 @@
 //  limitations under the License.
 package com.twitter.heron.streamlet.scala.impl
 
-import com.twitter.heron.streamlet.scala.Streamlet
-import com.twitter.heron.streamlet.scala.common.BaseFunSuite
+import scala.util.Random
+
 import org.junit.Assert.{assertEquals, assertTrue}
+
+import com.twitter.heron.streamlet.scala.Streamlet
+import com.twitter.heron.streamlet.scala.common.{
+  BaseFunSuite,
+  TestListBufferSink
+}
 
 /**
   * Tests for Scala Streamlet Implementation functionality
@@ -50,7 +56,7 @@ class StreamletImplTest extends BaseFunSuite {
       .setNumPartitions(20)
 
     supplierStreamlet
-      .map[Double]((num: Double) => num * 10)
+      .map[String]((num: Double) => (num * 10).toString)
       .setName("Map_Streamlet_1")
       .setNumPartitions(5)
 
@@ -64,10 +70,185 @@ class StreamletImplTest extends BaseFunSuite {
           com.twitter.heron.streamlet.impl.streamlets.MapStreamlet[_, _]])
     val mapStreamlet = supplierStreamletImpl
       .getChildren(0)
-      .asInstanceOf[
-        com.twitter.heron.streamlet.impl.streamlets.MapStreamlet[_, _]]
+      .asInstanceOf[com.twitter.heron.streamlet.impl.streamlets.MapStreamlet[
+        Double,
+        String]]
     assertEquals("Map_Streamlet_1", mapStreamlet.getName)
     assertEquals(0, mapStreamlet.getChildren.size())
+  }
+
+  test("StreamletImpl should support filter transformation") {
+    val supplierStreamlet = StreamletImpl
+      .createSupplierStreamlet(() => Math.random)
+      .setName("Supplier_Streamlet_1")
+      .setNumPartitions(20)
+
+    supplierStreamlet
+      .filter((num: Double) => num > 10)
+      .setName("Filter_Streamlet_1")
+      .setNumPartitions(5)
+
+    val supplierStreamletImpl =
+      supplierStreamlet.asInstanceOf[StreamletImpl[Double]]
+    assertEquals(1, supplierStreamletImpl.getChildren.size)
+    assertTrue(
+      supplierStreamletImpl
+        .getChildren(0)
+        .isInstanceOf[
+          com.twitter.heron.streamlet.impl.streamlets.FilterStreamlet[_]])
+    val filterStreamlet = supplierStreamletImpl
+      .getChildren(0)
+      .asInstanceOf[
+        com.twitter.heron.streamlet.impl.streamlets.FilterStreamlet[Double]]
+    assertEquals("Filter_Streamlet_1", filterStreamlet.getName)
+    assertEquals(0, filterStreamlet.getChildren.size())
+  }
+
+  test("StreamletImpl should support repartition transformation") {
+    val supplierStreamlet = StreamletImpl
+      .createSupplierStreamlet(() => "aa bb cc dd ee")
+      .setName("Supplier_Streamlet_1")
+      .setNumPartitions(5)
+
+    supplierStreamlet
+      .repartition(10)
+      .setName("Repartitioned_Streamlet_1")
+
+    assertEquals(5, supplierStreamlet.getNumPartitions)
+
+    val supplierStreamletImpl =
+      supplierStreamlet.asInstanceOf[StreamletImpl[String]]
+    assertEquals(1, supplierStreamletImpl.getChildren.size)
+    assertTrue(
+      supplierStreamletImpl
+        .getChildren(0)
+        .isInstanceOf[
+          com.twitter.heron.streamlet.impl.streamlets.MapStreamlet[_, _]])
+    val repartitionedStreamlet = supplierStreamletImpl
+      .getChildren(0)
+      .asInstanceOf[com.twitter.heron.streamlet.impl.streamlets.MapStreamlet[
+        String,
+        String]]
+    assertEquals("Repartitioned_Streamlet_1", repartitionedStreamlet.getName)
+    assertEquals(0, repartitionedStreamlet.getChildren.size())
+    assertEquals(10, repartitionedStreamlet.getNumPartitions)
+  }
+
+  test("StreamletImpl should support union transformation") {
+    val supplierStreamlet = StreamletImpl
+      .createSupplierStreamlet(() => "aa bb cc dd ee")
+      .setName("Supplier_Streamlet_1")
+      .setNumPartitions(2)
+
+    val supplierStreamlet2 = StreamletImpl
+      .createSupplierStreamlet(() => "fff ggg hhh")
+      .setName("Supplier_Streamlet_2")
+      .setNumPartitions(3)
+
+    supplierStreamlet
+      .union(supplierStreamlet2)
+      .setName("Union_Streamlet_1")
+      .setNumPartitions(4)
+
+    verifySupplierStreamlet(supplierStreamlet)
+    verifySupplierStreamlet(supplierStreamlet2)
+  }
+
+  test("StreamletImpl should support consume function") {
+    val supplierStreamlet = StreamletImpl
+      .createSupplierStreamlet(() => Math.random)
+      .setName("Supplier_Streamlet_1")
+      .setNumPartitions(20)
+
+    supplierStreamlet
+      .consume((num: Double) => num > 10)
+
+    val supplierStreamletImpl =
+      supplierStreamlet.asInstanceOf[StreamletImpl[Double]]
+    assertEquals(1, supplierStreamletImpl.getChildren.size)
+    assertTrue(
+      supplierStreamletImpl
+        .getChildren(0)
+        .isInstanceOf[
+          com.twitter.heron.streamlet.impl.streamlets.ConsumerStreamlet[_]])
+    val consumerStreamlet = supplierStreamletImpl
+      .getChildren(0)
+      .asInstanceOf[
+        com.twitter.heron.streamlet.impl.streamlets.ConsumerStreamlet[Double]]
+    assertEquals(null, consumerStreamlet.getName)
+    assertEquals(0, consumerStreamlet.getChildren.size())
+    assertEquals(20, consumerStreamlet.getNumPartitions)
+  }
+
+  test("StreamletImpl should support log sink") {
+    val supplierStreamlet = StreamletImpl
+      .createSupplierStreamlet(() => Math.random)
+      .setName("Supplier_Streamlet_1")
+      .setNumPartitions(10)
+
+    supplierStreamlet
+      .log()
+
+    val supplierStreamletImpl =
+      supplierStreamlet.asInstanceOf[StreamletImpl[Double]]
+    assertEquals(1, supplierStreamletImpl.getChildren.size)
+    assertTrue(
+      supplierStreamletImpl
+        .getChildren(0)
+        .isInstanceOf[
+          com.twitter.heron.streamlet.impl.streamlets.LogStreamlet[_]])
+    val consumerStreamlet = supplierStreamletImpl
+      .getChildren(0)
+      .asInstanceOf[
+        com.twitter.heron.streamlet.impl.streamlets.LogStreamlet[Double]]
+    assertEquals(null, consumerStreamlet.getName)
+    assertEquals(0, consumerStreamlet.getChildren.size())
+    assertEquals(10, consumerStreamlet.getNumPartitions)
+  }
+
+  test("StreamletImpl should support custom sink") {
+    val supplierStreamlet = StreamletImpl
+      .createSupplierStreamlet(() => Random.nextInt(10))
+      .setName("Supplier_Streamlet_1")
+      .setNumPartitions(10)
+
+    supplierStreamlet
+      .toSink(new TestListBufferSink())
+
+    val supplierStreamletImpl =
+      supplierStreamlet.asInstanceOf[StreamletImpl[Int]]
+    assertEquals(1, supplierStreamletImpl.getChildren.size)
+    assertTrue(
+      supplierStreamletImpl
+        .getChildren(0)
+        .isInstanceOf[
+          com.twitter.heron.streamlet.impl.streamlets.SinkStreamlet[_]])
+    val consumerStreamlet = supplierStreamletImpl
+      .getChildren(0)
+      .asInstanceOf[
+        com.twitter.heron.streamlet.impl.streamlets.SinkStreamlet[Int]]
+    assertEquals(null, consumerStreamlet.getName)
+    assertEquals(0, consumerStreamlet.getChildren.size())
+    assertEquals(10, consumerStreamlet.getNumPartitions)
+  }
+
+  private def verifySupplierStreamlet(
+      supplierStreamlet: Streamlet[String]): Unit = {
+    val supplierStreamletImpl =
+      supplierStreamlet.asInstanceOf[StreamletImpl[String]]
+    assertEquals(1, supplierStreamletImpl.getChildren.size)
+    assertTrue(
+      supplierStreamletImpl
+        .getChildren(0)
+        .isInstanceOf[
+          com.twitter.heron.streamlet.impl.streamlets.UnionStreamlet[_]])
+    val unionStreamlet = supplierStreamletImpl
+      .getChildren(0)
+      .asInstanceOf[
+        com.twitter.heron.streamlet.impl.streamlets.UnionStreamlet[String]]
+    assertEquals("Union_Streamlet_1", unionStreamlet.getName)
+    assertEquals(0, unionStreamlet.getChildren.size())
+    assertEquals(4, unionStreamlet.getNumPartitions)
   }
 
 }

--- a/heron/api/tests/scala/com/twitter/heron/streamlet/scala/impl/StreamletImplTest.scala
+++ b/heron/api/tests/scala/com/twitter/heron/streamlet/scala/impl/StreamletImplTest.scala
@@ -17,6 +17,15 @@ import scala.util.Random
 
 import org.junit.Assert.{assertEquals, assertTrue}
 
+import com.twitter.heron.streamlet.impl.streamlets.{
+  ConsumerStreamlet,
+  FilterStreamlet,
+  LogStreamlet,
+  MapStreamlet,
+  SinkStreamlet,
+  UnionStreamlet
+}
+
 import com.twitter.heron.streamlet.scala.Streamlet
 import com.twitter.heron.streamlet.scala.common.{
   BaseFunSuite,
@@ -40,7 +49,9 @@ class StreamletImplTest extends BaseFunSuite {
     assertEquals(20, supplierStreamlet.getNumPartitions)
 
     val mapStreamlet = supplierStreamlet
-      .map[Double]((num: Double) => num * 10)
+      .map[Double] { num: Double =>
+        num * 10
+      }
       .setName("Map_Streamlet_1")
       .setNumPartitions(5)
 
@@ -56,7 +67,9 @@ class StreamletImplTest extends BaseFunSuite {
       .setNumPartitions(20)
 
     supplierStreamlet
-      .map[String]((num: Double) => (num * 10).toString)
+      .map[String] { num: Double =>
+        (num * 10).toString
+      }
       .setName("Map_Streamlet_1")
       .setNumPartitions(5)
 
@@ -66,13 +79,10 @@ class StreamletImplTest extends BaseFunSuite {
     assertTrue(
       supplierStreamletImpl
         .getChildren(0)
-        .isInstanceOf[
-          com.twitter.heron.streamlet.impl.streamlets.MapStreamlet[_, _]])
+        .isInstanceOf[MapStreamlet[_, _]])
     val mapStreamlet = supplierStreamletImpl
       .getChildren(0)
-      .asInstanceOf[com.twitter.heron.streamlet.impl.streamlets.MapStreamlet[
-        Double,
-        String]]
+      .asInstanceOf[MapStreamlet[Double, String]]
     assertEquals("Map_Streamlet_1", mapStreamlet.getName)
     assertEquals(0, mapStreamlet.getChildren.size())
   }
@@ -84,7 +94,9 @@ class StreamletImplTest extends BaseFunSuite {
       .setNumPartitions(20)
 
     supplierStreamlet
-      .filter((num: Double) => num > 10)
+      .filter { num: Double =>
+        num > 10
+      }
       .setName("Filter_Streamlet_1")
       .setNumPartitions(5)
 
@@ -94,12 +106,10 @@ class StreamletImplTest extends BaseFunSuite {
     assertTrue(
       supplierStreamletImpl
         .getChildren(0)
-        .isInstanceOf[
-          com.twitter.heron.streamlet.impl.streamlets.FilterStreamlet[_]])
+        .isInstanceOf[FilterStreamlet[_]])
     val filterStreamlet = supplierStreamletImpl
       .getChildren(0)
-      .asInstanceOf[
-        com.twitter.heron.streamlet.impl.streamlets.FilterStreamlet[Double]]
+      .asInstanceOf[FilterStreamlet[Double]]
     assertEquals("Filter_Streamlet_1", filterStreamlet.getName)
     assertEquals(0, filterStreamlet.getChildren.size())
   }
@@ -122,13 +132,10 @@ class StreamletImplTest extends BaseFunSuite {
     assertTrue(
       supplierStreamletImpl
         .getChildren(0)
-        .isInstanceOf[
-          com.twitter.heron.streamlet.impl.streamlets.MapStreamlet[_, _]])
+        .isInstanceOf[MapStreamlet[_, _]])
     val repartitionedStreamlet = supplierStreamletImpl
       .getChildren(0)
-      .asInstanceOf[com.twitter.heron.streamlet.impl.streamlets.MapStreamlet[
-        String,
-        String]]
+      .asInstanceOf[MapStreamlet[String, String]]
     assertEquals("Repartitioned_Streamlet_1", repartitionedStreamlet.getName)
     assertEquals(0, repartitionedStreamlet.getChildren.size())
     assertEquals(10, repartitionedStreamlet.getNumPartitions)
@@ -161,7 +168,9 @@ class StreamletImplTest extends BaseFunSuite {
       .setNumPartitions(20)
 
     supplierStreamlet
-      .consume((num: Double) => num > 10)
+      .consume { num: Double =>
+        num > 10
+      }
 
     val supplierStreamletImpl =
       supplierStreamlet.asInstanceOf[StreamletImpl[Double]]
@@ -169,12 +178,10 @@ class StreamletImplTest extends BaseFunSuite {
     assertTrue(
       supplierStreamletImpl
         .getChildren(0)
-        .isInstanceOf[
-          com.twitter.heron.streamlet.impl.streamlets.ConsumerStreamlet[_]])
+        .isInstanceOf[ConsumerStreamlet[_]])
     val consumerStreamlet = supplierStreamletImpl
       .getChildren(0)
-      .asInstanceOf[
-        com.twitter.heron.streamlet.impl.streamlets.ConsumerStreamlet[Double]]
+      .asInstanceOf[ConsumerStreamlet[Double]]
     assertEquals(null, consumerStreamlet.getName)
     assertEquals(0, consumerStreamlet.getChildren.size())
     assertEquals(20, consumerStreamlet.getNumPartitions)
@@ -195,12 +202,10 @@ class StreamletImplTest extends BaseFunSuite {
     assertTrue(
       supplierStreamletImpl
         .getChildren(0)
-        .isInstanceOf[
-          com.twitter.heron.streamlet.impl.streamlets.LogStreamlet[_]])
+        .isInstanceOf[LogStreamlet[_]])
     val consumerStreamlet = supplierStreamletImpl
       .getChildren(0)
-      .asInstanceOf[
-        com.twitter.heron.streamlet.impl.streamlets.LogStreamlet[Double]]
+      .asInstanceOf[LogStreamlet[Double]]
     assertEquals(null, consumerStreamlet.getName)
     assertEquals(0, consumerStreamlet.getChildren.size())
     assertEquals(10, consumerStreamlet.getNumPartitions)
@@ -221,12 +226,10 @@ class StreamletImplTest extends BaseFunSuite {
     assertTrue(
       supplierStreamletImpl
         .getChildren(0)
-        .isInstanceOf[
-          com.twitter.heron.streamlet.impl.streamlets.SinkStreamlet[_]])
+        .isInstanceOf[SinkStreamlet[_]])
     val consumerStreamlet = supplierStreamletImpl
       .getChildren(0)
-      .asInstanceOf[
-        com.twitter.heron.streamlet.impl.streamlets.SinkStreamlet[Int]]
+      .asInstanceOf[SinkStreamlet[Int]]
     assertEquals(null, consumerStreamlet.getName)
     assertEquals(0, consumerStreamlet.getChildren.size())
     assertEquals(10, consumerStreamlet.getNumPartitions)
@@ -240,12 +243,10 @@ class StreamletImplTest extends BaseFunSuite {
     assertTrue(
       supplierStreamletImpl
         .getChildren(0)
-        .isInstanceOf[
-          com.twitter.heron.streamlet.impl.streamlets.UnionStreamlet[_]])
+        .isInstanceOf[UnionStreamlet[_]])
     val unionStreamlet = supplierStreamletImpl
       .getChildren(0)
-      .asInstanceOf[
-        com.twitter.heron.streamlet.impl.streamlets.UnionStreamlet[String]]
+      .asInstanceOf[UnionStreamlet[String]]
     assertEquals("Union_Streamlet_1", unionStreamlet.getName)
     assertEquals(0, unionStreamlet.getChildren.size())
     assertEquals(4, unionStreamlet.getNumPartitions)


### PR DESCRIPTION
This PR aims the following changes:

- Adding Scala Streamlet `filter`, `repartition`, `union` and `consume` functions support
- Adding `ScalaToJavaConverter` following transformation logics:
  - Scala `Predicate` to `SerializablePredicate`
  - Scala `Consumer` to `SerializableConsumer`
- `TestListBufferSink` has been moved to common package in order to be used by other parts
- Adding UT Coverages for both Scala `StreamletImpl` and `ScalaToJavaConverter`

Also: Scala Streamlet API UT cases' total execution time is as follows:
//heron/api/tests/scala:api-scala-test PASSED in 1.0s