### PR TITLE
[Streamlet Scala API] Add Scala StreamletImpl Support - Part III

### DIFF
--- a/heron/api/src/scala/com/twitter/heron/streamlet/scala/Streamlet.scala
+++ b/heron/api/src/scala/com/twitter/heron/streamlet/scala/Streamlet.scala
@@ -13,11 +13,10 @@
 //  limitations under the License.
 package com.twitter.heron.streamlet.scala
 
-import com.twitter.heron.streamlet.{KeyValue, KeyedWindow}
-
-// TODO: This Java Streamlet API references will be changed with Scala versions when they are ready
 import com.twitter.heron.streamlet.{
   JoinType,
+  KeyValue,
+  KeyedWindow,
   SerializableTransformer,
   WindowConfig
 }
@@ -138,7 +137,7 @@ trait Streamlet[R] {
       thisKeyExtractor: R => K,
       otherKeyExtractor: S => K,
       windowCfg: WindowConfig,
-      joinFunction: (R, S) => _ <: T): Streamlet[KeyValue[KeyedWindow[K], T]]
+      joinFunction: (R, S) => T): Streamlet[KeyValue[KeyedWindow[K], T]]
 
   /**
     * Return a new KVStreamlet by joining 'this streamlet with ‘other’ streamlet. The type of joining
@@ -162,7 +161,7 @@ trait Streamlet[R] {
       otherKeyExtractor: S => K,
       windowCfg: WindowConfig,
       joinType: JoinType,
-      joinFunction: (R, S) => _ <: T): Streamlet[KeyValue[KeyedWindow[K], T]]
+      joinFunction: (R, S) => T): Streamlet[KeyValue[KeyedWindow[K], T]]
 
   /**
     * Return a new Streamlet accumulating tuples of this streamlet over a Window defined by
@@ -199,7 +198,7 @@ trait Streamlet[R] {
       keyExtractor: R => K,
       windowCfg: WindowConfig,
       identity: T,
-      reduceFn: (T, R) => _ <: T): Streamlet[KeyValue[KeyedWindow[K], T]]
+      reduceFn: (T, R) => T): Streamlet[KeyValue[KeyedWindow[K], T]]
 
   /**
     * Returns a new Streamlet that is the union of this and the ‘other’ streamlet. Essentially

--- a/heron/api/src/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverter.scala
+++ b/heron/api/src/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverter.scala
@@ -15,11 +15,14 @@ package com.twitter.heron.streamlet.scala.converter
 
 import com.twitter.heron.streamlet.{
   Context,
+  SerializableBiFunction,
   SerializableConsumer,
   SerializableFunction,
   SerializablePredicate,
-  SerializableSupplier
+  SerializableSupplier,
+  Sink => JavaSink
 }
+
 import com.twitter.heron.streamlet.scala.Sink
 import com.twitter.heron.streamlet.scala.Source
 import java.lang.Iterable
@@ -66,8 +69,13 @@ object ScalaToJavaConverter {
       override def accept(r: R): Unit = f(r)
     }
 
-  def toJavaSink[T](sink: Sink[T]): com.twitter.heron.streamlet.Sink[T] = {
-    new com.twitter.heron.streamlet.Sink[T] {
+  def toSerializableBiFunction[R, S, T](f: (R, S) => T) =
+    new SerializableBiFunction[R, S, T] {
+      override def apply(r: R, s: S): T = f(r, s)
+    }
+
+  def toJavaSink[T](sink: Sink[T]): JavaSink[T] = {
+    new JavaSink[T] {
       override def setup(context: Context): Unit = sink.setup(context)
 
       override def put(tuple: T): Unit = sink.put(tuple)

--- a/heron/api/src/scala/com/twitter/heron/streamlet/scala/impl/BuilderImpl.scala
+++ b/heron/api/src/scala/com/twitter/heron/streamlet/scala/impl/BuilderImpl.scala
@@ -16,20 +16,20 @@ package com.twitter.heron.streamlet.scala.impl
 import com.twitter.heron.streamlet.scala.{Builder, Source, Streamlet}
 import com.twitter.heron.streamlet.scala.converter.ScalaToJavaConverter
 
-
-class BuilderImpl(builder: com.twitter.heron.streamlet.Builder) extends Builder {
+class BuilderImpl(builder: com.twitter.heron.streamlet.Builder)
+    extends Builder {
 
   override def newSource[R](supplierFn: () => R): Streamlet[R] = {
-    val serializableSupplier = ScalaToJavaConverter.toSerializableSupplier[R](supplierFn)
+    val serializableSupplier =
+      ScalaToJavaConverter.toSerializableSupplier[R](supplierFn)
     val newJavaStreamlet = builder.newSource(serializableSupplier)
-    StreamletImpl.toScalaStreamlet[R](newJavaStreamlet)
+    StreamletImpl.fromJavaStreamlet[R](newJavaStreamlet)
   }
-
 
   override def newSource[R](sourceFn: Source[R]): Streamlet[R] = {
     val javaSourceObj = ScalaToJavaConverter.toJavaSource[R](sourceFn)
     val newJavaStreamlet = builder.newSource(javaSourceObj)
-    StreamletImpl.toScalaStreamlet[R](newJavaStreamlet)
+    StreamletImpl.fromJavaStreamlet[R](newJavaStreamlet)
   }
 
 }

--- a/heron/api/src/scala/com/twitter/heron/streamlet/scala/impl/StreamletImpl.scala
+++ b/heron/api/src/scala/com/twitter/heron/streamlet/scala/impl/StreamletImpl.scala
@@ -31,7 +31,7 @@ import com.twitter.heron.streamlet.scala.converter.ScalaToJavaConverter._
 
 object StreamletImpl {
 
-  def toScalaStreamlet[R](javaStreamlet: JavaStreamlet[R]): Streamlet[R] =
+  def fromJavaStreamlet[R](javaStreamlet: JavaStreamlet[R]): Streamlet[R] =
     new StreamletImpl[R](javaStreamlet)
 
   def toJavaStreamlet[R](streamlet: Streamlet[R]): JavaStreamlet[R] =
@@ -46,7 +46,7 @@ object StreamletImpl {
     val serializableSupplier = toSerializableSupplier[R](supplier)
     val newJavaStreamlet =
       new SupplierStreamlet[R](serializableSupplier)
-    toScalaStreamlet[R](newJavaStreamlet)
+    fromJavaStreamlet[R](newJavaStreamlet)
   }
 
 }
@@ -68,7 +68,7 @@ class StreamletImpl[R](val javaStreamlet: JavaStreamlet[R])
     * @return Returns back the Streamlet with changed name
     */
   override def setName(sName: String): Streamlet[R] =
-    toScalaStreamlet[R](javaStreamlet.setName(sName))
+    fromJavaStreamlet[R](javaStreamlet.setName(sName))
 
   /**
     * Gets the name of the Streamlet.
@@ -84,7 +84,7 @@ class StreamletImpl[R](val javaStreamlet: JavaStreamlet[R])
     * @return Returns back the Streamlet with changed number of partitions
     */
   override def setNumPartitions(numPartitions: Int): Streamlet[R] =
-    toScalaStreamlet[R](javaStreamlet.setNumPartitions(numPartitions))
+    fromJavaStreamlet[R](javaStreamlet.setNumPartitions(numPartitions))
 
   /**
     * Gets the number of partitions of this Streamlet.
@@ -101,7 +101,7 @@ class StreamletImpl[R](val javaStreamlet: JavaStreamlet[R])
   override def map[T](mapFn: R => T): Streamlet[T] = {
     val serializableFunction = toSerializableFunction[R, T](mapFn)
     val newJavaStreamlet = javaStreamlet.map[T](serializableFunction)
-    toScalaStreamlet[T](newJavaStreamlet)
+    fromJavaStreamlet[T](newJavaStreamlet)
   }
 
   /**
@@ -122,7 +122,7 @@ class StreamletImpl[R](val javaStreamlet: JavaStreamlet[R])
   override def filter(filterFn: R => Boolean): Streamlet[R] = {
     val serializablePredicate = toSerializablePredicate[R](filterFn)
     val newJavaStreamlet = javaStreamlet.filter(serializablePredicate)
-    toScalaStreamlet[R](newJavaStreamlet)
+    fromJavaStreamlet[R](newJavaStreamlet)
   }
 
   /**
@@ -130,7 +130,7 @@ class StreamletImpl[R](val javaStreamlet: JavaStreamlet[R])
     */
   override def repartition(numPartitions: Int): Streamlet[R] = {
     val newJavaStreamlet = javaStreamlet.repartition(numPartitions)
-    toScalaStreamlet[R](newJavaStreamlet)
+    fromJavaStreamlet[R](newJavaStreamlet)
   }
 
   /**
@@ -157,7 +157,7 @@ class StreamletImpl[R](val javaStreamlet: JavaStreamlet[R])
       .asScalaBufferConverter(javaClonedStreamlets)
       .asScala
     javaClonedStreamletsAsScalaList.map(streamlet =>
-      toScalaStreamlet[R](streamlet))
+      fromJavaStreamlet[R](streamlet))
   }
 
   /**
@@ -189,7 +189,7 @@ class StreamletImpl[R](val javaStreamlet: JavaStreamlet[R])
                                                        javaOtherKeyExtractor,
                                                        windowCfg,
                                                        javaJoinFunction)
-    toScalaStreamlet[KeyValue[KeyedWindow[K], T]](newJavaStreamlet)
+    fromJavaStreamlet[KeyValue[KeyedWindow[K], T]](newJavaStreamlet)
   }
 
   /**
@@ -226,7 +226,7 @@ class StreamletImpl[R](val javaStreamlet: JavaStreamlet[R])
                                                        windowCfg,
                                                        joinType,
                                                        javaJoinFunction)
-    toScalaStreamlet[KeyValue[KeyedWindow[K], T]](newJavaStreamlet)
+    fromJavaStreamlet[KeyValue[KeyedWindow[K], T]](newJavaStreamlet)
   }
 
   /**
@@ -272,7 +272,7 @@ class StreamletImpl[R](val javaStreamlet: JavaStreamlet[R])
     */
   override def union(other: Streamlet[_ <: R]): Streamlet[R] = {
     val newJavaStreamlet = javaStreamlet.union(toJavaStreamlet(other))
-    toScalaStreamlet(newJavaStreamlet)
+    fromJavaStreamlet(newJavaStreamlet)
   }
 
   /**

--- a/heron/api/tests/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverterTest.scala
+++ b/heron/api/tests/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverterTest.scala
@@ -18,10 +18,12 @@ import com.twitter.heron.streamlet.Context
 
 import com.twitter.heron.streamlet.{
   Context,
+  SerializableBiFunction,
   SerializableConsumer,
   SerializableFunction,
   SerializablePredicate,
-  SerializableSupplier
+  SerializableSupplier,
+  Sink => JavaSink
 }
 
 import com.twitter.heron.streamlet.scala.Sink
@@ -54,12 +56,23 @@ class ScalaToJavaConverterTest extends BaseFunSuite {
         .isInstanceOf[SerializableFunction[String, Int]])
   }
 
+  test("ScalaToJavaConverterTest should support SerializableBiFunction") {
+    def numbersToStringFunction(number1: Int, number2: Long): String =
+      (number1.toLong + number2).toString
+    val serializableBiFunction =
+      ScalaToJavaConverter.toSerializableBiFunction[Int, Long, String](
+        numbersToStringFunction)
+    assertTrue(
+      serializableBiFunction
+        .isInstanceOf[SerializableBiFunction[Int, Long, String]])
+  }
+
   test("ScalaToJavaConverterTest should support Java Sink") {
     val javaSink =
       ScalaToJavaConverter.toJavaSink[Int](new TestSink[Int]())
     assertTrue(
       javaSink
-        .isInstanceOf[com.twitter.heron.streamlet.Sink[Int]])
+        .isInstanceOf[JavaSink[Int]])
   }
 
   test("ScalaToJavaConverterTest should support Java Source") {

--- a/heron/api/tests/scala/com/twitter/heron/streamlet/scala/impl/BuilderImplTest.scala
+++ b/heron/api/tests/scala/com/twitter/heron/streamlet/scala/impl/BuilderImplTest.scala
@@ -13,41 +13,44 @@
 //  limitations under the License.
 package com.twitter.heron.streamlet.scala.impl
 
-
-import com.twitter.heron.streamlet.scala.{Builder,Streamlet,Source}
-import com.twitter.heron.streamlet.scala.common.BaseFunSuite
-import org.junit.Assert.{assertEquals, assertTrue}
-import com.twitter.heron.streamlet.Context
-import com.twitter.heron.streamlet.scala.converter.ScalaToJavaConverter
-import com.twitter.heron.streamlet.scala.impl.StreamletImpl
-
-
 import scala.collection.mutable.ListBuffer
+
+import org.junit.Assert.assertEquals
+
+import com.twitter.heron.streamlet.Context
+
+import com.twitter.heron.streamlet.scala.{Builder, Streamlet, Source}
+import com.twitter.heron.streamlet.scala.common.BaseFunSuite
 
 /**
   * Tests for Scala Builder Implementation functionality
   */
 class BuilderImplTest extends BaseFunSuite {
 
-
-  test("BuilderImpl should support streamlet generation from a user defined supplier function") {
-    val supplierStreamletObj = Builder.newBuilder.newSource(() => Math.random).setName("Supplier_Streamlet_1").setNumPartitions(20)
-    assert(supplierStreamletObj.isInstanceOf[Streamlet[Int]])
+  test(
+    "BuilderImpl should support streamlet generation from a user defined supplier function") {
+    val supplierStreamletObj = Builder.newBuilder
+      .newSource(() => Math.random)
+      .setName("Supplier_Streamlet_1")
+      .setNumPartitions(20)
+    assert(supplierStreamletObj.isInstanceOf[Streamlet[_]])
     assertEquals("Supplier_Streamlet_1", supplierStreamletObj.getName)
     assertEquals(20, supplierStreamletObj.getNumPartitions)
   }
 
-  test("BuilderImpl should support streamlet generation from a user defined source function") {
+  test(
+    "BuilderImpl should support streamlet generation from a user defined source function") {
     val source = new MySource
     assert(source.get == List[Int]())
-    val generatorStreamletObj = Builder.newBuilder.newSource(source).setName("Generator_Streamlet_1").setNumPartitions(20)
+    val generatorStreamletObj = Builder.newBuilder
+      .newSource(source)
+      .setName("Generator_Streamlet_1")
+      .setNumPartitions(20)
 
-    assert(generatorStreamletObj.isInstanceOf[Streamlet[Int]])
+    assert(generatorStreamletObj.isInstanceOf[Streamlet[_]])
     assertEquals("Generator_Streamlet_1", generatorStreamletObj.getName)
     assertEquals(20, generatorStreamletObj.getNumPartitions)
   }
-
-
 
   private class MySource extends Source[Int] {
     private val numbers = ListBuffer[Int]()
@@ -57,7 +60,6 @@ class BuilderImplTest extends BaseFunSuite {
     }
 
     override def get(): Iterable[Int] = numbers
-
 
     override def cleanup(): Unit = numbers.clear()
   }

--- a/heron/api/tests/scala/com/twitter/heron/streamlet/scala/impl/StreamletImplTest.scala
+++ b/heron/api/tests/scala/com/twitter/heron/streamlet/scala/impl/StreamletImplTest.scala
@@ -237,23 +237,6 @@ class StreamletImplTest extends BaseFunSuite {
     assertEquals(10, consumerStreamlet.getNumPartitions)
   }
 
-  private def verifySupplierStreamlet(
-      supplierStreamlet: Streamlet[String]): Unit = {
-    val supplierStreamletImpl =
-      supplierStreamlet.asInstanceOf[StreamletImpl[String]]
-    assertEquals(1, supplierStreamletImpl.getChildren.size)
-    assertTrue(
-      supplierStreamletImpl
-        .getChildren(0)
-        .isInstanceOf[UnionStreamlet[_]])
-    val unionStreamlet = supplierStreamletImpl
-      .getChildren(0)
-      .asInstanceOf[UnionStreamlet[String]]
-    assertEquals("Union_Streamlet_1", unionStreamlet.getName)
-    assertEquals(0, unionStreamlet.getChildren.size())
-    assertEquals(4, unionStreamlet.getNumPartitions)
-  }
-
   test("StreamletImpl should support join transformation") {
     val numberStreamlet = StreamletImpl
       .createSupplierStreamlet(() => Random.nextInt(10))
@@ -327,6 +310,23 @@ class StreamletImplTest extends BaseFunSuite {
     assertEquals(expectedName, joinStreamlet.getName)
     assertEquals(expectedNumPartitions, joinStreamlet.getNumPartitions)
     assertEquals(0, joinStreamlet.getChildren.size())
+  }
+
+  private def verifySupplierStreamlet(
+      supplierStreamlet: Streamlet[String]): Unit = {
+    val supplierStreamletImpl =
+      supplierStreamlet.asInstanceOf[StreamletImpl[String]]
+    assertEquals(1, supplierStreamletImpl.getChildren.size)
+    assertTrue(
+      supplierStreamletImpl
+        .getChildren(0)
+        .isInstanceOf[UnionStreamlet[_]])
+    val unionStreamlet = supplierStreamletImpl
+      .getChildren(0)
+      .asInstanceOf[UnionStreamlet[String]]
+    assertEquals("Union_Streamlet_1", unionStreamlet.getName)
+    assertEquals(0, unionStreamlet.getChildren.size())
+    assertEquals(4, unionStreamlet.getNumPartitions)
   }
 
 }


### PR DESCRIPTION
This PR aims the following changes:

Adding Scala Streamlet `clone`, `join` and `join with type` functions support
Adding `ScalaToJavaConverter` following transformation logics:
- Scala `Join` Function to `SerializableBiFunction`

Adding UT Coverages for both Scala `StreamletImpl` and `ScalaToJavaConverter`

Also: Scala `Streamlet` API UT cases' total execution time is as follows:
//heron/api/tests/scala:api-scala-test PASSED in 0.8s