### PR TITLE
[Streamlet Scala API] Add Scala StreamletImpl Support - Part IV

### DIFF
--- a/heron/api/src/java/com/twitter/heron/streamlet/SerializableTransformer.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/SerializableTransformer.java
@@ -11,7 +11,6 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-
 package com.twitter.heron.streamlet;
 
 import java.io.Serializable;
@@ -19,7 +18,7 @@ import java.util.function.Consumer;
 
 /**
  * All user supplied transformation functions have to be serializable.
- * Thus all Strealmet transformation definitions take Serializable
+ * Thus all Streamlet transformation definitions take Serializable
  * Functions as their input. We simply decorate java.util. function
  * definitions with a Serializable tag to ensure that any supplied
  * lambda functions automatically become serializable.

--- a/heron/api/src/scala/com/twitter/heron/streamlet/scala/SerializableTransformer.scala
+++ b/heron/api/src/scala/com/twitter/heron/streamlet/scala/SerializableTransformer.scala
@@ -1,0 +1,33 @@
+//  Copyright 2018 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.streamlet.scala
+
+import java.io.Serializable
+
+import com.twitter.heron.streamlet.Context
+
+/**
+  * All user supplied transformation functions have to be serializable.
+  * Thus all Streamlet transformation definitions take Serializable
+  * Functions as their input. We simply decorate java.util. function
+  * definitions with a Serializable tag to ensure that any supplied
+  * lambda functions automatically become serializable.
+  */
+trait SerializableTransformer[I, O] extends Serializable {
+  def setup(context: Context): Unit
+
+  def transform(i: I, f: O => Unit): Unit
+
+  def cleanup(): Unit
+}

--- a/heron/api/src/scala/com/twitter/heron/streamlet/scala/Sink.scala
+++ b/heron/api/src/scala/com/twitter/heron/streamlet/scala/Sink.scala
@@ -14,6 +14,7 @@
 package com.twitter.heron.streamlet.scala
 
 import java.io.Serializable
+
 import com.twitter.heron.streamlet.Context
 
 /**

--- a/heron/api/src/scala/com/twitter/heron/streamlet/scala/Source.scala
+++ b/heron/api/src/scala/com/twitter/heron/streamlet/scala/Source.scala
@@ -14,6 +14,7 @@
 package com.twitter.heron.streamlet.scala
 
 import java.io.Serializable
+
 import com.twitter.heron.streamlet.Context
 
 /**
@@ -31,4 +32,3 @@ trait Source[T] extends Serializable {
   def cleanup(): Unit
 
 }
-

--- a/heron/api/src/scala/com/twitter/heron/streamlet/scala/Streamlet.scala
+++ b/heron/api/src/scala/com/twitter/heron/streamlet/scala/Streamlet.scala
@@ -17,7 +17,6 @@ import com.twitter.heron.streamlet.{
   JoinType,
   KeyValue,
   KeyedWindow,
-  SerializableTransformer,
   WindowConfig
 }
 

--- a/heron/api/src/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverter.scala
+++ b/heron/api/src/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverter.scala
@@ -13,22 +13,25 @@
 //  limitations under the License.
 package com.twitter.heron.streamlet.scala.converter
 
+import java.util.Collection
+import java.util.function.Consumer
+
+import scala.collection.JavaConverters
+
 import com.twitter.heron.streamlet.{
   Context,
   SerializableBiFunction,
+  SerializableBinaryOperator,
   SerializableConsumer,
   SerializableFunction,
   SerializablePredicate,
   SerializableSupplier,
-  Sink => JavaSink
+  SerializableTransformer => JavaSerializableTransformer,
+  Sink => JavaSink,
+  Source => JavaSource
 }
 
-import com.twitter.heron.streamlet.scala.Sink
-import com.twitter.heron.streamlet.scala.Source
-import java.lang.Iterable
-import java.util.Collection
-import scala.collection.JavaConverters._
-
+import com.twitter.heron.streamlet.scala.{SerializableTransformer, Sink, Source}
 
 /**
   * This class transforms passed User defined Scala Functions, Sources, Sinks
@@ -40,18 +43,6 @@ object ScalaToJavaConverter {
     new SerializableSupplier[T] {
       override def get(): T = f()
     }
-
-
-
-  def toJavaSource[T](source: Source[T]): com.twitter.heron.streamlet.Source[T] = {
-    new com.twitter.heron.streamlet.Source[T] {
-      override def setup(context: Context): Unit = source.setup(context)
-
-      override def get(): Collection[T] = scala.collection.JavaConverters.asJavaCollectionConverter(source.get).asJavaCollection
-
-      override def cleanup(): Unit = source.cleanup()
-    }
-  }
 
   def toSerializableFunction[R, T](f: R => T) =
     new SerializableFunction[R, T] {
@@ -74,6 +65,11 @@ object ScalaToJavaConverter {
       override def apply(r: R, s: S): T = f(r, s)
     }
 
+  def toSerializableBinaryOperator[T](f: (T, T) => T) =
+    new SerializableBinaryOperator[T] {
+      override def apply(t1: T, t2: T): T = f(t1, t2)
+    }
+
   def toJavaSink[T](sink: Sink[T]): JavaSink[T] = {
     new JavaSink[T] {
       override def setup(context: Context): Unit = sink.setup(context)
@@ -81,6 +77,36 @@ object ScalaToJavaConverter {
       override def put(tuple: T): Unit = sink.put(tuple)
 
       override def cleanup(): Unit = sink.cleanup()
+    }
+  }
+
+  def toJavaSource[T](source: Source[T]): JavaSource[T] = {
+    new JavaSource[T] {
+      override def setup(context: Context): Unit = source.setup(context)
+
+      override def get(): Collection[T] =
+        JavaConverters
+          .asJavaCollectionConverter(source.get)
+          .asJavaCollection
+
+      override def cleanup(): Unit = source.cleanup()
+    }
+  }
+
+  def toSerializableTransformer[R, T](
+      transformer: SerializableTransformer[R, _ <: T])
+    : JavaSerializableTransformer[R, _ <: T] = {
+
+    def toScalaConsumerFunction[T](consumer: Consumer[T]): T => Unit =
+      (t: T) => consumer.accept(t)
+
+    new JavaSerializableTransformer[R, T] {
+      override def setup(context: Context): Unit = transformer.setup(context)
+
+      override def transform(r: R, consumer: Consumer[T]): Unit =
+        transformer.transform(r, toScalaConsumerFunction[T](consumer))
+
+      override def cleanup(): Unit = transformer.cleanup()
     }
   }
 

--- a/heron/api/tests/scala/com/twitter/heron/streamlet/scala/common/TestIncrementSerializableTransformer.scala
+++ b/heron/api/tests/scala/com/twitter/heron/streamlet/scala/common/TestIncrementSerializableTransformer.scala
@@ -1,0 +1,29 @@
+//  Copyright 2018 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.streamlet.scala.common
+
+import com.twitter.heron.streamlet.Context
+import com.twitter.heron.streamlet.scala.SerializableTransformer
+
+/**
+  * Test Increment SerializableTransformer
+  */
+class TestIncrementSerializableTransformer(factor: Int)
+    extends SerializableTransformer[Int, Int] {
+  override def setup(context: Context): Unit = {}
+
+  override def transform(i: Int, f: Int => Unit): Unit = f(i + factor)
+
+  override def cleanup(): Unit = {}
+}

--- a/heron/api/tests/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverterTest.scala
+++ b/heron/api/tests/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverterTest.scala
@@ -14,23 +14,27 @@
 package com.twitter.heron.streamlet.scala.converter
 
 import org.junit.Assert.assertTrue
-import com.twitter.heron.streamlet.Context
+
+import scala.collection.mutable.ListBuffer
 
 import com.twitter.heron.streamlet.{
   Context,
   SerializableBiFunction,
+  SerializableBinaryOperator,
   SerializableConsumer,
   SerializableFunction,
   SerializablePredicate,
   SerializableSupplier,
+  SerializableTransformer,
   Sink => JavaSink
 }
 
-import com.twitter.heron.streamlet.scala.Sink
-import com.twitter.heron.streamlet.scala.Source
-import com.twitter.heron.streamlet.scala.common.BaseFunSuite
+import com.twitter.heron.streamlet.scala.{Sink, Source}
 
-import scala.collection.mutable.ListBuffer
+import com.twitter.heron.streamlet.scala.common.{
+  BaseFunSuite,
+  TestIncrementSerializableTransformer
+}
 
 /**
   * Tests for Streamlet APIs' Scala to Java Conversion functionality
@@ -83,7 +87,6 @@ class ScalaToJavaConverterTest extends BaseFunSuite {
         .isInstanceOf[com.twitter.heron.streamlet.Source[Int]])
   }
 
-
   test("ScalaToJavaConverterTest should support SerializablePredicate") {
     def intToBooleanFunction(number: Int) = number.<(5)
     val serializablePredicate =
@@ -100,6 +103,28 @@ class ScalaToJavaConverterTest extends BaseFunSuite {
     assertTrue(
       serializableConsumer
         .isInstanceOf[SerializableConsumer[Int]])
+  }
+
+  test("ScalaToJavaConverterTest should support SerializableBinaryOperator") {
+    def addNumbersFunction(number1: Int, number2: Int): Int =
+      number1 + number2
+    val serializableBinaryOperator =
+      ScalaToJavaConverter.toSerializableBinaryOperator[Int](addNumbersFunction)
+    assertTrue(
+      serializableBinaryOperator
+        .isInstanceOf[SerializableBinaryOperator[Int]])
+  }
+
+  test("ScalaToJavaConverterTest should support SerializableTransformer") {
+    val serializableTransformer =
+      new TestIncrementSerializableTransformer(factor = 100)
+
+    val javaSerializableTransformer =
+      ScalaToJavaConverter.toSerializableTransformer[Int, Int](
+        serializableTransformer)
+    assertTrue(
+      javaSerializableTransformer
+        .isInstanceOf[SerializableTransformer[Int, Int]])
   }
 
   private class TestSink[T] extends Sink[T] {


### PR DESCRIPTION
This PR aims the following changes:

- Adding Scala Streamlet `transform`, `reduceByKeyAndWindow` and `reduceByKeyAndWindow with identity` functions support
- Adding Scala `SerializableTransformer` Support
- Adding `ScalaToJavaConverter` following transformation logics:
  - Scala `Function2` to `SerializableBinaryOperator`
  - Scala `Transformer Trait` to `SerializableTransformer Interface`
- Adding UT Coverages for both Scala `StreamletImpl` and `ScalaToJavaConverter`

Also: Scala Streamlet API UT cases' total execution time is as follows:
//heron/api/tests/scala:api-scala-test PASSED in 1.4s