### PR TITLE
Retain heron-core package for YARN like schedulers

### DIFF
--- a/scripts/packages/template_bin.sh
+++ b/scripts/packages/template_bin.sh
@@ -125,7 +125,6 @@ echo "Uncompressing."
 untar ${base}/dist/heron-core.tar.gz ${base}/dist
 
 rm "${base}/heron.tar.gz"
-rm "${base}/dist/heron-core.tar.gz"
 rm -f "${base}/dist/release.yaml"
 
 cat <<EOF


### PR DESCRIPTION
Fixes #2774

Current YARN scheduler expects the client to provide the heron-core package. It does assume HDFS or docker deployment. Retain the heron-core package for backward compatibility with YARN like deployments.