### PR TITLE
Add rate limiter in output collector

### DIFF
--- a/heron/api/src/java/com/twitter/heron/api/Config.java
+++ b/heron/api/src/java/com/twitter/heron/api/Config.java
@@ -96,7 +96,7 @@ public class Config extends HashMap<String, Object> {
    */
   public static final String TOPOLOGY_MESSAGE_TIMEOUT_SECS = "topology.message.timeout.secs";
   /**
-   * The per componentparallelism for a component in this topology.
+   * The per component parallelism for a component in this topology.
    * Note:- If you are changing this, please change the utils.h as well
    */
   public static final String TOPOLOGY_COMPONENT_PARALLELISM = "topology.component.parallelism";
@@ -290,6 +290,11 @@ public class Config extends HashMap<String, Object> {
   public static final String TOPOLOGY_DROPTUPLES_UPON_BACKPRESSURE =
       "topology.droptuples.upon.backpressure";
 
+  /**
+   * The per component output tuple per second in this topology.
+   */
+  public static final String TOPOLOGY_COMPONENT_OUTPUT_TPS = "topology.component.output.tps";
+
   private static final long serialVersionUID = 2550967708478837032L;
   // We maintain a list of all user exposed vars
   private static Set<String> apiVars = new HashSet<>();
@@ -327,6 +332,7 @@ public class Config extends HashMap<String, Object> {
     apiVars.add(TOPOLOGY_UPDATE_REACTIVATE_WAIT_SECS);
     apiVars.add(TOPOLOGY_REMOTE_DEBUGGING_ENABLE);
     apiVars.add(TOPOLOGY_DROPTUPLES_UPON_BACKPRESSURE);
+    apiVars.add(TOPOLOGY_COMPONENT_OUTPUT_TPS);
   }
 
   public Config() {
@@ -713,4 +719,9 @@ public class Config extends HashMap<String, Object> {
   public void setTopologyDropTuplesUponBackpressure(boolean dropTuples) {
     this.put(Config.TOPOLOGY_DROPTUPLES_UPON_BACKPRESSURE, String.valueOf(dropTuples));
   }
+
+  public void setTopologyComponentOutputTPS(double tps) {
+    this.put(Config.TOPOLOGY_COMPONENT_OUTPUT_TPS, String.valueOf(tps));
+  }
+
 }

--- a/heron/common/src/cpp/config/topology-config-vars.cpp
+++ b/heron/common/src/cpp/config/topology-config-vars.cpp
@@ -51,5 +51,6 @@ const sp_string TopologyConfigVars::TOPOLOGY_TEAM_NAME = "topology.team.name";
 const sp_string TopologyConfigVars::TOPOLOGY_TEAM_EMAIL = "topology.team.email";
 const sp_string TopologyConfigVars::TOPOLOGY_CAP_TICKET = "topology.cap.ticket";
 const sp_string TopologyConfigVars::TOPOLOGY_PROJECT_NAME = "topology.project.name";
+const sp_string TopologyConfigVars::TOPOLOGY_COMPONENT_OUTPUT_TPS = "topology.component.output.tps";
 }  // namespace config
 }  // namespace heron

--- a/heron/common/src/cpp/config/topology-config-vars.h
+++ b/heron/common/src/cpp/config/topology-config-vars.h
@@ -59,6 +59,7 @@ class TopologyConfigVars {
   static const sp_string TOPOLOGY_TEAM_EMAIL;
   static const sp_string TOPOLOGY_CAP_TICKET;
   static const sp_string TOPOLOGY_PROJECT_NAME;
+  static const sp_string TOPOLOGY_COMPONENT_OUTPUT_TPS;
 };
 }  // namespace config
 }  // namespace heron

--- a/heron/common/src/java/com/twitter/heron/common/utils/metrics/BoltMetrics.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/metrics/BoltMetrics.java
@@ -39,6 +39,7 @@ public class BoltMetrics implements ComponentMetrics {
   private final CountMetric failCount;
   private final CountMetric executeCount;
   private final ReducedMetric<MeanReducerState, Number, Double> executeLatency;
+  private final ReducedMetric<MeanReducerState, Number, Double> rateLimitLatency;
 
   // Time in nano-seconds spending in execute() at every interval
   private final CountMetric emitCount;
@@ -57,6 +58,7 @@ public class BoltMetrics implements ComponentMetrics {
     executeLatency = new ReducedMetric<>(new MeanReducer());
     emitCount = new CountMetric();
     outQueueFullCount = new CountMetric();
+    rateLimitLatency = new ReducedMetric<>(new MeanReducer());
   }
 
   public void registerMetrics(TopologyContextImpl topologyContext) {
@@ -73,6 +75,7 @@ public class BoltMetrics implements ComponentMetrics {
     topologyContext.registerMetric("__execute-latency/default", executeLatency, interval);
     topologyContext.registerMetric("__emit-count/default", emitCount, interval);
     topologyContext.registerMetric("__out-queue-full-count", outQueueFullCount, interval);
+    topologyContext.registerMetric("__rate-limit-latency/default", rateLimitLatency, interval);
   }
 
   // For MultiCountMetrics, we need to set the default value for all streams.
@@ -112,5 +115,9 @@ public class BoltMetrics implements ComponentMetrics {
   }
 
   public void serializeDataTuple(String streamId, long latency) {
+  }
+
+  public void rateLimitLatency(String streamId, long latency) {
+    rateLimitLatency.update(latency);
   }
 }

--- a/heron/common/src/java/com/twitter/heron/common/utils/metrics/ComponentMetrics.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/metrics/ComponentMetrics.java
@@ -24,5 +24,6 @@ import com.twitter.heron.classification.InterfaceStability;
 public interface ComponentMetrics {
 
   void serializeDataTuple(String streamId, long latency);
+  void rateLimitLatency(String streamId, long latency);
   void emittedTuple(String streamId);
 }

--- a/heron/common/src/java/com/twitter/heron/common/utils/metrics/SpoutMetrics.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/metrics/SpoutMetrics.java
@@ -42,6 +42,8 @@ public class SpoutMetrics implements ComponentMetrics {
   private final CountMetric emitCount;
   private final ReducedMetric<MeanReducerState, Number, Double> nextTupleLatency;
   private final CountMetric nextTupleCount;
+  private final ReducedMetric<MeanReducerState, Number, Double> rateLimitLatency;
+
 
   // The # of times back-pressure happens on outStreamQueue so instance could not
   // produce more tuples
@@ -61,6 +63,7 @@ public class SpoutMetrics implements ComponentMetrics {
     nextTupleCount = new CountMetric();
     outQueueFullCount = new CountMetric();
     pendingTuplesCount = new ReducedMetric<>(new MeanReducer());
+    rateLimitLatency = new ReducedMetric<>(new MeanReducer());
   }
 
   public void registerMetrics(TopologyContextImpl topologyContext) {
@@ -79,6 +82,7 @@ public class SpoutMetrics implements ComponentMetrics {
     topologyContext.registerMetric("__next-tuple-count", nextTupleCount, interval);
     topologyContext.registerMetric("__out-queue-full-count", outQueueFullCount, interval);
     topologyContext.registerMetric("__pending-acked-count", pendingTuplesCount, interval);
+    topologyContext.registerMetric("__rate-limit-latency/default", rateLimitLatency, interval);
   }
 
   // For MultiCountMetrics, we need to set the default value for all streams.
@@ -123,5 +127,9 @@ public class SpoutMetrics implements ComponentMetrics {
   }
 
   public void serializeDataTuple(String streamId, long latency) {
+  }
+
+  public void rateLimitLatency(String streamId, long latency) {
+    rateLimitLatency.update(latency);
   }
 }

--- a/heron/common/src/java/com/twitter/heron/common/utils/misc/PhysicalPlanHelper.java
+++ b/heron/common/src/java/com/twitter/heron/common/utils/misc/PhysicalPlanHelper.java
@@ -197,19 +197,24 @@ public class PhysicalPlanHelper {
 
   public void setTopologyContext(MetricsCollector metricsCollector) {
     topologyContext =
-        new TopologyContextImpl(mergeConfigs(pplan.getTopology().getTopologyConfig(), component),
+        new TopologyContextImpl(
+            mergeConfigs(pplan.getTopology().getTopologyConfig(), getComponentConfig()),
             pplan.getTopology(), makeTaskToComponentMap(), myTaskId, metricsCollector);
   }
 
-  private Map<String, Object> mergeConfigs(TopologyAPI.Config config,
-                                           TopologyAPI.Component acomponent) {
+  public TopologyAPI.Config getComponentConfig() {
+    return component.getConfig();
+  }
+
+  private Map<String, Object> mergeConfigs(TopologyAPI.Config topoConfig,
+                                           TopologyAPI.Config compConfig) {
     LOG.info("Building configs for component: " + myComponent);
 
     Map<String, Object> map = new HashMap<>();
-    addConfigsToMap(config, map);
+    addConfigsToMap(topoConfig, map);
     LOG.info("Added topology-level configs: " + map.toString());
 
-    addConfigsToMap(acomponent.getConfig(), map); // Override any component specific configs
+    addConfigsToMap(compConfig, map); // Override any component specific configs
     LOG.info("Added component-specific configs: " + map.toString());
     return map;
   }

--- a/heron/instance/src/java/BUILD
+++ b/heron/instance/src/java/BUILD
@@ -10,7 +10,8 @@ instance_deps_files =  \
         "//heron/common/src/java:config-java",
         "//heron/common/src/java:network-java",
         "//heron/common/src/java:utils-java",
-        "@commons_cli_commons_cli//jar"
+        "@com_google_guava_guava//jar",
+        "@commons_cli_commons_cli//jar",
     ]
 
 java_library(

--- a/heron/instance/src/java/com/twitter/heron/instance/Slave.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/Slave.java
@@ -399,7 +399,7 @@ public class Slave implements Runnable, AutoCloseable {
   }
 
   @VisibleForTesting
-  public static double getOutputRate(Map<String, Object> topoConf) {
+  protected static double getOutputRate(Map<String, Object> topoConf) {
     if (topoConf.containsKey(Config.TOPOLOGY_COMPONENT_OUTPUT_TPS)
         && topoConf.containsKey(Config.TOPOLOGY_COMPONENT_PARALLELISM)) {
       String tpsString = (String) topoConf.get(Config.TOPOLOGY_COMPONENT_OUTPUT_TPS);

--- a/heron/instance/src/java/com/twitter/heron/instance/Slave.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/Slave.java
@@ -415,6 +415,6 @@ public class Slave implements Runnable, AutoCloseable {
         return validated;
       } catch (NumberFormatException e) { }
     }
-    return maxOutputTuplePerSecond;
+    return outputRateLimiter.getRate();  // Use the current rate as fallback
   }
 }

--- a/heron/instance/src/java/com/twitter/heron/instance/Slave.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/Slave.java
@@ -19,6 +19,8 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.RateLimiter;
 import com.google.protobuf.Message;
 
 import com.twitter.heron.api.Config;
@@ -49,6 +51,12 @@ import com.twitter.heron.proto.system.Metrics;
 public class Slave implements Runnable, AutoCloseable {
   private static final Logger LOG = Logger.getLogger(Slave.class.getName());
 
+  private static double maxOutputTuplePerSecond = Double.MAX_VALUE;
+  // Minimal 1 tuple per second. Rate limiter would cause emit() to wait when the tuple per second
+  // rate is higher than expected, which may block other operations. Therefore it is safer to make
+  // sure the rate is higher than a threshold.
+  private static double minOutputTuplePerSecond = 1;
+
   private final SlaveLooper slaveLooper;
   private MetricsCollector metricsCollector;
   // Communicator
@@ -65,6 +73,8 @@ public class Slave implements Runnable, AutoCloseable {
 
   private State<Serializable, Serializable> instanceState;
   private boolean isStatefulProcessingStarted;
+  // Rate limiter for output data tuples
+  private RateLimiter outputRateLimiter;
 
   public Slave(SlaveLooper slaveLooper,
                final Communicator<Message> streamInCommunicator,
@@ -87,6 +97,8 @@ public class Slave implements Runnable, AutoCloseable {
         (SystemConfig) SingletonRegistry.INSTANCE.getSingleton(SystemConfig.HERON_SYSTEM_CONFIG);
 
     this.metricsCollector = new MetricsCollector(slaveLooper, metricsOutCommunicator);
+
+    this.outputRateLimiter = RateLimiter.create(maxOutputTuplePerSecond);
 
     handleControlMessage();
   }
@@ -127,8 +139,10 @@ public class Slave implements Runnable, AutoCloseable {
   private void resetCurrentAssignment() {
     helper.setTopologyContext(metricsCollector);
     instance = helper.getMySpout() != null
-        ? new SpoutInstance(helper, streamInCommunicator, streamOutCommunicator, slaveLooper)
-        : new BoltInstance(helper, streamInCommunicator, streamOutCommunicator, slaveLooper);
+        ? new SpoutInstance(helper, streamInCommunicator, streamOutCommunicator,
+                            outputRateLimiter, slaveLooper)
+        : new BoltInstance(helper, streamInCommunicator, streamOutCommunicator,
+                           outputRateLimiter, slaveLooper);
 
     startInstanceIfNeeded();
   }
@@ -146,7 +160,8 @@ public class Slave implements Runnable, AutoCloseable {
     // we would add a bunch of tasks to slaveLooper's tasksOnWakeup
     if (helper.getMySpout() != null) {
       instance =
-          new SpoutInstance(helper, streamInCommunicator, streamOutCommunicator, slaveLooper);
+          new SpoutInstance(helper, streamInCommunicator, streamOutCommunicator,
+                            outputRateLimiter, slaveLooper);
 
       streamInCommunicator.init(systemConfig.getInstanceInternalSpoutReadQueueCapacity(),
           systemConfig.getInstanceTuningExpectedSpoutReadQueueSize(),
@@ -156,7 +171,8 @@ public class Slave implements Runnable, AutoCloseable {
           systemConfig.getInstanceTuningCurrentSampleWeight());
     } else {
       instance =
-          new BoltInstance(helper, streamInCommunicator, streamOutCommunicator, slaveLooper);
+          new BoltInstance(helper, streamInCommunicator, streamOutCommunicator,
+                           outputRateLimiter, slaveLooper);
 
       streamInCommunicator.init(systemConfig.getInstanceInternalBoltReadQueueCapacity(),
           systemConfig.getInstanceTuningExpectedBoltReadQueueSize(),
@@ -200,6 +216,11 @@ public class Slave implements Runnable, AutoCloseable {
       LOG.info("Setting topology environment: " + envProps);
       System.getProperties().putAll(envProps);
     }
+
+    // Update rate limiter config before starting
+    double rate = getOutputRate(topoConf);
+    LOG.info("Setting output TPS to " + String.valueOf(rate));
+    outputRateLimiter.setRate(rate);
 
     if (helper.isTopologyStateful()) {
       // For stateful topology, `init(state)` will be invoked
@@ -375,5 +396,25 @@ public class Slave implements Runnable, AutoCloseable {
         LOG.info("Topology state remains the same in Slave: " + oldTopologyState);
       }
     }
+  }
+
+  @VisibleForTesting
+  public static double getOutputRate(Map<String, Object> topoConf) {
+    if (topoConf.containsKey(Config.TOPOLOGY_COMPONENT_OUTPUT_TPS)
+        && topoConf.containsKey(Config.TOPOLOGY_COMPONENT_PARALLELISM)) {
+      String tpsString = (String) topoConf.get(Config.TOPOLOGY_COMPONENT_OUTPUT_TPS);
+      String parallelsmString = (String) topoConf.get(Config.TOPOLOGY_COMPONENT_PARALLELISM);
+
+      try {
+        double rate = Double.parseDouble(tpsString);
+        double parallelsm = Double.parseDouble(parallelsmString);
+        // Assuming traffic is evenly distributed to all instances.
+        double perInstanceRate = rate / parallelsm;
+        double validated = Math.max(minOutputTuplePerSecond,
+                                    Math.min(maxOutputTuplePerSecond, perInstanceRate));
+        return validated;
+      } catch (NumberFormatException e) { }
+    }
+    return maxOutputTuplePerSecond;
   }
 }

--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltInstance.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
+import com.google.common.util.concurrent.RateLimiter;
 import com.google.protobuf.Message;
 
 import com.twitter.heron.api.Config;
@@ -73,6 +74,7 @@ public class BoltInstance implements IInstance {
   public BoltInstance(PhysicalPlanHelper helper,
                       Communicator<Message> streamInQueue,
                       Communicator<Message> streamOutQueue,
+                      RateLimiter outputRateLimiter,
                       SlaveLooper looper) {
     this.helper = helper;
     this.looper = looper;
@@ -112,7 +114,8 @@ public class BoltInstance implements IInstance {
     } else {
       throw new RuntimeException("Neither java_object nor java_class_name set for bolt");
     }
-    collector = new BoltOutputCollectorImpl(serializer, helper, streamOutQueue, boltMetrics);
+    collector = new BoltOutputCollectorImpl(serializer, helper, streamOutQueue, outputRateLimiter,
+                                            boltMetrics);
   }
 
   @Override

--- a/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltOutputCollectorImpl.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/bolt/BoltOutputCollectorImpl.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.google.common.util.concurrent.RateLimiter;
 import com.google.protobuf.Message;
 
 import com.twitter.heron.api.bolt.IOutputCollector;
@@ -61,8 +62,9 @@ public class BoltOutputCollectorImpl extends AbstractOutputCollector implements 
   protected BoltOutputCollectorImpl(IPluggableSerializer serializer,
                                     PhysicalPlanHelper helper,
                                     Communicator<Message> streamOutQueue,
+                                    RateLimiter rateLimiter,
                                     BoltMetrics boltMetrics) {
-    super(serializer, helper, streamOutQueue, boltMetrics);
+    super(serializer, helper, streamOutQueue, rateLimiter, boltMetrics);
     this.boltMetrics = boltMetrics;
 
     if (helper.getMyBolt() == null) {

--- a/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutInstance.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutInstance.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
+import com.google.common.util.concurrent.RateLimiter;
 import com.google.protobuf.Message;
 
 import com.twitter.heron.api.Config;
@@ -78,6 +79,7 @@ public class SpoutInstance implements IInstance {
   public SpoutInstance(PhysicalPlanHelper helper,
                        Communicator<Message> streamInQueue,
                        Communicator<Message> streamOutQueue,
+                       RateLimiter outputRateLimiter,
                        SlaveLooper looper) {
     this.helper = helper;
     this.looper = looper;
@@ -119,7 +121,8 @@ public class SpoutInstance implements IInstance {
     }
 
     IPluggableSerializer serializer = SerializeDeSerializeHelper.getSerializer(config);
-    collector = new SpoutOutputCollectorImpl(serializer, helper, streamOutQueue, spoutMetrics);
+    collector = new SpoutOutputCollectorImpl(serializer, helper, streamOutQueue, outputRateLimiter,
+                                             spoutMetrics);
     this.ackEnabled = collector.isAckEnabled();
 
     LOG.info("Enable Ack: " + this.ackEnabled);

--- a/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutOutputCollectorImpl.java
+++ b/heron/instance/src/java/com/twitter/heron/instance/spout/SpoutOutputCollectorImpl.java
@@ -24,6 +24,7 @@ import java.util.Queue;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.google.common.util.concurrent.RateLimiter;
 import com.google.protobuf.Message;
 
 import com.twitter.heron.api.serializer.IPluggableSerializer;
@@ -64,8 +65,9 @@ public class SpoutOutputCollectorImpl
   protected SpoutOutputCollectorImpl(IPluggableSerializer serializer,
                                      PhysicalPlanHelper helper,
                                      Communicator<Message> streamOutQueue,
+                                     RateLimiter rateLimiter,
                                      ComponentMetrics spoutMetrics) {
-    super(serializer, helper, streamOutQueue, spoutMetrics);
+    super(serializer, helper, streamOutQueue, rateLimiter, spoutMetrics);
     if (helper.getMySpout() == null) {
       throw new RuntimeException(helper.getMyTaskId() + " is not a spout ");
     }

--- a/heron/instance/tests/java/BUILD
+++ b/heron/instance/tests/java/BUILD
@@ -23,6 +23,7 @@ java_tests(
         "com.twitter.heron.grouping.CustomGroupingTest",
         "com.twitter.heron.grouping.EmitDirectBoltTest",
         "com.twitter.heron.grouping.EmitDirectSpoutTest",
+        "com.twitter.heron.instance.SlaveTest",
         "com.twitter.heron.instance.bolt.BoltInstanceTest",
         "com.twitter.heron.instance.spout.ActivateDeactivateTest",
         "com.twitter.heron.instance.spout.SpoutInstanceTest",

--- a/heron/instance/tests/java/com/twitter/heron/instance/SlaveTest.java
+++ b/heron/instance/tests/java/com/twitter/heron/instance/SlaveTest.java
@@ -1,0 +1,42 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.twitter.heron.instance;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.twitter.heron.api.Config;
+
+import static org.junit.Assert.assertEquals;
+
+public class SlaveTest {
+
+  /**
+   * We will test whether spout would pull activate/deactivate state change and
+   * invoke activate()/deactivate()
+   */
+  @Test
+  public void testGetOutputRate() throws Exception {
+    Map<String, Object> conf = new HashMap<String, Object>();
+    conf.put(Config.TOPOLOGY_COMPONENT_PARALLELISM, "2");
+    conf.put(Config.TOPOLOGY_COMPONENT_OUTPUT_TPS, "10.0");
+
+    double rate = Slave.getOutputRate(conf);
+
+    assertEquals(5.0, rate, 0.001);
+  }
+}

--- a/heron/instance/tests/java/com/twitter/heron/instance/SlaveTest.java
+++ b/heron/instance/tests/java/com/twitter/heron/instance/SlaveTest.java
@@ -1,4 +1,4 @@
-// Copyright 2016 Twitter. All rights reserved.
+// Copyright 2018 Twitter. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/heron/instance/tests/java/com/twitter/heron/instance/bolt/BoltInstanceTest.java
+++ b/heron/instance/tests/java/com/twitter/heron/instance/bolt/BoltInstanceTest.java
@@ -85,7 +85,7 @@ public class BoltInstanceTest {
    */
   @Test
   public void testReadTupleAndExecute() {
-    PhysicalPlans.PhysicalPlan physicalPlan = UnitTestHelper.getPhysicalPlan(false, -1);
+    PhysicalPlans.PhysicalPlan physicalPlan = UnitTestHelper.getPhysicalPlan(false, -1, 1000);
 
     PhysicalPlanHelper physicalPlanHelper = new PhysicalPlanHelper(physicalPlan, BOLT_INSTANCE_ID);
     InstanceControlMsg instanceControlMsg = InstanceControlMsg.newBuilder().

--- a/heron/instance/tests/java/com/twitter/heron/instance/spout/ActivateDeactivateTest.java
+++ b/heron/instance/tests/java/com/twitter/heron/instance/spout/ActivateDeactivateTest.java
@@ -80,7 +80,7 @@ public class ActivateDeactivateTest {
   }
 
   private InstanceControlMsg buildMessage(TopologyAPI.TopologyState state) {
-    PhysicalPlans.PhysicalPlan physicalPlan = UnitTestHelper.getPhysicalPlan(true, -1, state);
+    PhysicalPlans.PhysicalPlan physicalPlan = UnitTestHelper.getPhysicalPlan(true, -1, 100, state);
     PhysicalPlanHelper physicalPlanHelper = new PhysicalPlanHelper(physicalPlan, SPOUT_INSTANCE_ID);
     return InstanceControlMsg.newBuilder()
         .setNewPhysicalPlanHelper(physicalPlanHelper)

--- a/heron/instance/tests/java/com/twitter/heron/resource/UnitTestHelper.java
+++ b/heron/instance/tests/java/com/twitter/heron/resource/UnitTestHelper.java
@@ -55,10 +55,11 @@ public final class UnitTestHelper {
   public static PhysicalPlans.PhysicalPlan getPhysicalPlan(
       boolean ackEnabled,
       int messageTimeout,
+      int tuplePerSecond,
       TopologyAPI.TopologyState topologyState) {
     PhysicalPlans.PhysicalPlan.Builder pPlan = PhysicalPlans.PhysicalPlan.newBuilder();
 
-    setTopology(pPlan, ackEnabled, messageTimeout, topologyState);
+    setTopology(pPlan, ackEnabled, messageTimeout, tuplePerSecond, topologyState);
 
     setInstances(pPlan);
 
@@ -67,12 +68,18 @@ public final class UnitTestHelper {
     return pPlan.build();
   }
 
-  public static PhysicalPlans.PhysicalPlan getPhysicalPlan(boolean ackEnabled, int messageTimeout) {
-    return getPhysicalPlan(ackEnabled, messageTimeout, TopologyAPI.TopologyState.RUNNING);
+  public static PhysicalPlans.PhysicalPlan getPhysicalPlan(boolean ackEnabled,
+                                                           int messageTimeout,
+                                                           int tuplePerSecond) {
+    return getPhysicalPlan(ackEnabled, messageTimeout, tuplePerSecond,
+                           TopologyAPI.TopologyState.RUNNING);
   }
 
-  private static void setTopology(PhysicalPlans.PhysicalPlan.Builder pPlan, boolean ackEnabled,
-                                  int messageTimeout, TopologyAPI.TopologyState topologyState) {
+  private static void setTopology(PhysicalPlans.PhysicalPlan.Builder pPlan,
+                                  boolean ackEnabled,
+                                  int messageTimeout,
+                                  int tuplePerSecond,
+                                  TopologyAPI.TopologyState topologyState) {
     TopologyBuilder topologyBuilder = new TopologyBuilder();
     topologyBuilder.setSpout("test-spout", new TestSpout(), 1);
     // Here we need case switch to corresponding grouping
@@ -84,6 +91,7 @@ public final class UnitTestHelper {
     conf.setTopologyProjectName("heron-integration-test");
     conf.setNumStmgrs(1);
     conf.setMaxSpoutPending(100);
+    conf.setTopologyComponentOutputTPS(tuplePerSecond);
     if (ackEnabled) {
       conf.setTopologyReliabilityMode(Config.TopologyReliabilityMode.ATLEAST_ONCE);
     } else {
@@ -183,7 +191,7 @@ public final class UnitTestHelper {
   public static StreamManager.RegisterInstanceResponse getRegisterInstanceResponse() {
     StreamManager.RegisterInstanceResponse.Builder registerInstanceResponse =
         StreamManager.RegisterInstanceResponse.newBuilder();
-    registerInstanceResponse.setPplan(getPhysicalPlan(false, -1));
+    registerInstanceResponse.setPplan(getPhysicalPlan(false, -1, 1000));
     Common.Status.Builder status = Common.Status.newBuilder();
     status.setStatus(Common.StatusCode.OK);
     registerInstanceResponse.setStatus(status);

--- a/heron/simulator/src/java/BUILD
+++ b/heron/simulator/src/java/BUILD
@@ -9,6 +9,7 @@ simulator_deps_files = \
         "//heron/common/src/java:config-java",
         "//heron/common/src/java:utils-java",
         "//heron/instance/src/java:instance-java",
+        "@com_google_guava_guava//jar",
         "@org_yaml_snakeyaml//jar",
     ]
 

--- a/heron/simulator/src/java/com/twitter/heron/simulator/executors/InstanceExecutor.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/executors/InstanceExecutor.java
@@ -66,7 +66,7 @@ public class InstanceExecutor implements Runnable {
     streamOutQueue = new Communicator<>();
     metricsOutQueue = new Communicator<>();
     looper = new SlaveLooper();
-    outputRateLimiter = RateLimiter.create(10000000);
+    outputRateLimiter = RateLimiter.create(Double.MAX_VALUE);
 
     MetricsCollector metricsCollector = new MetricsCollector(looper, metricsOutQueue);
 

--- a/heron/simulator/src/java/com/twitter/heron/simulator/instance/BoltInstance.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/instance/BoltInstance.java
@@ -18,6 +18,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.common.util.concurrent.RateLimiter;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
 
@@ -42,8 +43,9 @@ public class BoltInstance
   public BoltInstance(PhysicalPlanHelper helper,
                       Communicator<Message> streamInQueue,
                       Communicator<Message> streamOutQueue,
+                      RateLimiter outputRateLimiter,
                       SlaveLooper looper) {
-    super(helper, streamInQueue, streamOutQueue, looper);
+    super(helper, streamInQueue, streamOutQueue, outputRateLimiter, looper);
     SystemConfig systemConfig =
         (SystemConfig) SingletonRegistry.INSTANCE.getSingleton(SystemConfig.HERON_SYSTEM_CONFIG);
 

--- a/heron/simulator/src/java/com/twitter/heron/simulator/instance/SpoutInstance.java
+++ b/heron/simulator/src/java/com/twitter/heron/simulator/instance/SpoutInstance.java
@@ -17,6 +17,7 @@ package com.twitter.heron.simulator.instance;
 import java.time.Duration;
 import java.util.Map;
 
+import com.google.common.util.concurrent.RateLimiter;
 import com.google.protobuf.Message;
 
 import com.twitter.heron.api.Config;
@@ -43,8 +44,10 @@ public class SpoutInstance
   @SuppressWarnings("deprecation")
   public SpoutInstance(PhysicalPlanHelper helper,
                        Communicator<Message> streamInQueue,
-                       Communicator<Message> streamOutQueue, SlaveLooper looper) {
-    super(helper, streamInQueue, streamOutQueue, looper);
+                       Communicator<Message> streamOutQueue,
+                       RateLimiter outputRateLimiter,
+                       SlaveLooper looper) {
+    super(helper, streamInQueue, streamOutQueue, outputRateLimiter, looper);
     Map<String, Object> config = helper.getTopologyContext().getTopologyConfig();
     SystemConfig systemConfig =
         (SystemConfig) SingletonRegistry.INSTANCE.getSingleton(SystemConfig.HERON_SYSTEM_CONFIG);

--- a/heronpy/api/api_constants.py
+++ b/heronpy/api/api_constants.py
@@ -87,3 +87,5 @@ TOPOLOGY_PROJECT_NAME = "topology.project.name"
 # Any user defined classpath that needs to be passed to instances should be set in to config
 # through this key.
 TOPOLOGY_ADDITIONAL_CLASSPATH = "topology.additional.classpath"
+# The per component output tuple per second in this topology.
+TOPOLOGY_COMPONENT_OUTPUT_TPS = "topology.component.output.tps"


### PR DESCRIPTION
The rate limiter is only available in Java. Python/C++ support will be done later.

Guava RateLimiter is used, which provides a continuous rate limiting.

For performance concerns, I used unit test to run a few tests on my laptop. When the test spout  (super simple generating logic) generates 1k tuples, rate limiter slows down process slightly, 140+ ms to 160+ ms. But when the spout generates 100k tuples, there is no difference.

In this PR, I am adding rate limiter in Slave and passing it to SpoutInstance/BoltInstance to be applied on OutputCollectors. The considerations are:
- It needs to be applied to OutputCollectors because tuples are emitted to it one by one. In other objects, tuples are batched.
- Ratelimiter is created in Slave because it can be shared by both Spout and Bolt.
I am open to other thoughts about the two considerations above.