### PR TITLE
Add a new escaping '(61)' for '=' because the original one '&equals;'…

### DIFF
--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -181,9 +181,12 @@ class HeronExecutor(object):
     self.stmgr_binary = parsed_args.stmgr_binary
     self.metrics_manager_classpath = parsed_args.metrics_manager_classpath
     self.metricscache_manager_classpath = parsed_args.metricscache_manager_classpath
+    # '=' is escaped in two different ways. '(61)' is the new escaping. '&equals;' was
+    # the original way but it is not friendly to bash and is causing issues in some
+    # schedulers. It is still left there for backward compatibility reason
     self.instance_jvm_opts =\
         base64.b64decode(parsed_args.instance_jvm_opts.lstrip('"').
-                         rstrip('"').replace('&equals;', '='))
+                         rstrip('"').replace('(61)', '=').replace('&equals;', '='))
     self.classpath = parsed_args.classpath
     # Needed for Docker environments since the hostname of a docker container is the container's
     # id within docker, rather than the host's hostname. NOTE: this 'HOST' env variable is not
@@ -210,7 +213,7 @@ class HeronExecutor(object):
     # First we need to decode the base64 string back to a json map string
     component_jvm_opts_in_json =\
         base64.b64decode(parsed_args.component_jvm_opts.
-                         lstrip('"').rstrip('"').replace('&equals;', '='))
+                         lstrip('"').rstrip('"').replace('(61)', '=').replace('&equals;', '='))
     if component_jvm_opts_in_json != "":
       for (k, v) in json.loads(component_jvm_opts_in_json).items():
         # In json, the component name and jvm options are still in base64 encoding

--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -184,7 +184,8 @@ class HeronExecutor(object):
     # '=' can be parsed in a wrong way by some schedulers (aurora) hence it needs to be escaped.
     # It is escaped in two different ways. '(61)' is the new escaping. '&equals;' was
     # the original replacement but it is not friendly to bash and is causing issues. The original
-    # escaping is still left there for reference and backward compatibility reasons
+    # escaping is still left there for reference and backward compatibility purposes (to be
+    # removed after no topology needs it)
     self.instance_jvm_opts =\
         base64.b64decode(parsed_args.instance_jvm_opts.lstrip('"').
                          rstrip('"').replace('(61)', '=').replace('&equals;', '='))
@@ -215,7 +216,8 @@ class HeronExecutor(object):
     # '=' can be parsed in a wrong way by some schedulers (aurora) hence it needs to be escaped.
     # It is escaped in two different ways. '(61)' is the new escaping. '&equals;' was
     # the original replacement but it is not friendly to bash and is causing issues. The original
-    # escaping is still left there for reference and backward compatibility reasons
+    # escaping is still left there for reference and backward compatibility purposes (to be
+    # removed after no topology needs it)
     component_jvm_opts_in_json =\
         base64.b64decode(parsed_args.component_jvm_opts.
                          lstrip('"').rstrip('"').replace('(61)', '=').replace('&equals;', '='))

--- a/heron/executor/src/python/heron_executor.py
+++ b/heron/executor/src/python/heron_executor.py
@@ -181,9 +181,10 @@ class HeronExecutor(object):
     self.stmgr_binary = parsed_args.stmgr_binary
     self.metrics_manager_classpath = parsed_args.metrics_manager_classpath
     self.metricscache_manager_classpath = parsed_args.metricscache_manager_classpath
-    # '=' is escaped in two different ways. '(61)' is the new escaping. '&equals;' was
-    # the original way but it is not friendly to bash and is causing issues in some
-    # schedulers. It is still left there for backward compatibility reason
+    # '=' can be parsed in a wrong way by some schedulers (aurora) hence it needs to be escaped.
+    # It is escaped in two different ways. '(61)' is the new escaping. '&equals;' was
+    # the original replacement but it is not friendly to bash and is causing issues. The original
+    # escaping is still left there for reference and backward compatibility reasons
     self.instance_jvm_opts =\
         base64.b64decode(parsed_args.instance_jvm_opts.lstrip('"').
                          rstrip('"').replace('(61)', '=').replace('&equals;', '='))
@@ -210,7 +211,11 @@ class HeronExecutor(object):
     # " at the start and end. It also escapes "=" to "&equals" due to aurora limitation
     # And the json is a map from base64-encoding-component-name to base64-encoding-jvm-options
     self.component_jvm_opts = {}
-    # First we need to decode the base64 string back to a json map string
+    # First we need to decode the base64 string back to a json map string.
+    # '=' can be parsed in a wrong way by some schedulers (aurora) hence it needs to be escaped.
+    # It is escaped in two different ways. '(61)' is the new escaping. '&equals;' was
+    # the original replacement but it is not friendly to bash and is causing issues. The original
+    # escaping is still left there for reference and backward compatibility reasons
     component_jvm_opts_in_json =\
         base64.b64decode(parsed_args.component_jvm_opts.
                          lstrip('"').rstrip('"').replace('(61)', '=').replace('&equals;', '='))

--- a/heron/executor/tests/python/heron_executor_unittest.py
+++ b/heron/executor/tests/python/heron_executor_unittest.py
@@ -237,7 +237,7 @@ class HeronExecutorTest(unittest.TestCase):
       ("--tmaster-binary", "tmaster_binary"),
       ("--stmgr-binary", "stmgr_binary"),
       ("--metrics-manager-classpath", "metricsmgr_classpath"),
-      ("--instance-jvm-opts", "LVhYOitIZWFwRHVtcE9uT3V0T2ZNZW1vcnlFcnJvcg&equals;&equals;"),
+      ("--instance-jvm-opts", "LVhYOitIZWFwRHVtcE9uT3V0T2ZNZW1vcnlFcnJvcg(61)(61)"),
       ("--classpath", "classpath"),
       ("--master-port", "master_port"),
       ("--tmaster-controller-port", "tmaster_controller_port"),

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/SchedulerUtils.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/SchedulerUtils.java
@@ -442,21 +442,24 @@ public final class SchedulerUtils {
    * Encode the JVM options
    * <br> 1. Convert it into Base64 format
    * <br> 2. Add \" at the start and at the end
-   * <br> 3. replace "=" with "&amp;equals;"
+   * <br> 3. replace "=" with "(61)" and "&amp;equals;"
+   * Note that '=' is escaped in two different ways. '(61)' is the new escaping.
+   * '&amp;equals;' was the original way but it is not friendly to bash and is
+   * causing issues in some schedulers. It is still left there for backward compatibility
+   * reason
    *
    * @return encoded string
    */
   public static String encodeJavaOpts(String javaOpts) {
     String javaOptsBase64 = DatatypeConverter.printBase64Binary(
         javaOpts.getBytes(StandardCharsets.UTF_8));
-
-    return String.format("\"%s\"", javaOptsBase64.replace("=", "&equals;"));
+    return String.format("\"%s\"", javaOptsBase64.replace("=", "(61)").replace("=", "&equals;"));
   }
 
   /**
    * Decode the JVM options
    * <br> 1. strip \" at the start and at the end
-   * <br> 2. replace "&amp;equals;" with "="
+   * <br> 2. replace "(61)" and "&amp;equals;" with "="
    * <br> 3. Revert from Base64 format
    *
    * @return decoded string
@@ -466,6 +469,7 @@ public final class SchedulerUtils {
         encodedJavaOpts.
             replaceAll("^\"+", "").
             replaceAll("\\s+$", "").
+            replace("(61)", "=").
             replace("&equals;", "=");
 
     return new String(

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/SchedulerUtils.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/SchedulerUtils.java
@@ -443,10 +443,11 @@ public final class SchedulerUtils {
    * <br> 1. Convert it into Base64 format
    * <br> 2. Add \" at the start and at the end
    * <br> 3. replace "=" with "(61)" and "&amp;equals;"
-   * Note that '=' is escaped in two different ways. '(61)' is the new escaping.
-   * '&amp;equals;' was the original way but it is not friendly to bash and is
-   * causing issues in some schedulers. It is still left there for backward compatibility
-   * reason
+   * '=' can be parsed in a wrong way by some schedulers (aurora) hence it needs to be escaped.
+   * Note that it is escaped in two different ways. '(61)' is the new escaping.
+   * '&equals;' was the original replacement but it is not friendly to bash and
+   * is causing issues. The original escaping is still left there for reference
+   * and backward compatibility reasons
    *
    * @return encoded string
    */

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/SchedulerUtils.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/SchedulerUtils.java
@@ -444,17 +444,13 @@ public final class SchedulerUtils {
    * <br> 2. Add \" at the start and at the end
    * <br> 3. replace "=" with "(61)" and "&amp;equals;"
    * '=' can be parsed in a wrong way by some schedulers (aurora) hence it needs to be escaped.
-   * Note that it is escaped in two different ways. '(61)' is the new escaping.
-   * '&equals;' was the original replacement but it is not friendly to bash and
-   * is causing issues. The original escaping is still left there for reference
-   * and backward compatibility reasons
    *
    * @return encoded string
    */
   public static String encodeJavaOpts(String javaOpts) {
     String javaOptsBase64 = DatatypeConverter.printBase64Binary(
         javaOpts.getBytes(StandardCharsets.UTF_8));
-    return String.format("\"%s\"", javaOptsBase64.replace("=", "(61)").replace("=", "&equals;"));
+    return String.format("\"%s\"", javaOptsBase64.replace("=", "(61)"));
   }
 
   /**
@@ -462,6 +458,11 @@ public final class SchedulerUtils {
    * <br> 1. strip \" at the start and at the end
    * <br> 2. replace "(61)" and "&amp;equals;" with "="
    * <br> 3. Revert from Base64 format
+   * Note that '=' is escaped in two different ways. '(61)' is the new escaping.
+   * '&equals;' was the original replacement but it is not friendly to bash and
+   * was causing issues. The original escaping is still left there for reference
+   * and backward compatibility purposes (to be removed after no topology needs
+   * it)
    *
    * @return decoded string
    */


### PR DESCRIPTION
… is not friendly to bash