### PR TITLE
[Streamlet Scala API] Add Scala StreamletImpl Support - Part V

### DIFF
--- a/heron/api/src/scala/com/twitter/heron/streamlet/scala/Streamlet.scala
+++ b/heron/api/src/scala/com/twitter/heron/streamlet/scala/Streamlet.scala
@@ -84,7 +84,7 @@ trait Streamlet[R] {
     *
     * @param flatMapFn The FlatMap Function that should be applied to each element
     */
-  def flatMap[T](flatMapFn: R => _ <: Iterable[_ <: T]): Streamlet[T]
+  def flatMap[T](flatMapFn: R => Iterable[_ <: T]): Streamlet[T]
 
   /**
     * Return a new Streamlet by applying the filterFn on each element of this streamlet

--- a/heron/api/src/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverter.scala
+++ b/heron/api/src/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverter.scala
@@ -51,7 +51,7 @@ object ScalaToJavaConverter {
       override def apply(r: R): T = f(r)
     }
 
-  def toSerializableFunctionWithIterable[R, T](f: R => scala.Iterable[_ <: T]) =
+  def toSerializableFunctionWithIterable[R, T](f: R => Iterable[_ <: T]) =
     new SerializableFunction[R, JavaIterable[_ <: T]] {
       override def apply(r: R): JavaIterable[_ <: T] =
         JavaConverters.asJavaIterableConverter(f(r)).asJava

--- a/heron/api/tests/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverterTest.scala
+++ b/heron/api/tests/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverterTest.scala
@@ -31,6 +31,7 @@ import com.twitter.heron.streamlet.{
   SerializableTransformer,
   Sink => JavaSink
 }
+
 import com.twitter.heron.streamlet.scala.{Sink, Source}
 import com.twitter.heron.streamlet.scala.common.{
   BaseFunSuite,
@@ -70,11 +71,11 @@ class ScalaToJavaConverterTest extends BaseFunSuite {
     assertTrue(
       serializableFunction
         .isInstanceOf[SerializableFunction[String, _]])
+
     val iterable = serializableFunction.apply("123")
     val list = StreamSupport
       .stream(iterable.spliterator(), false)
       .collect(Collectors.toList())
-
     assertEquals(1, list.size())
     assertTrue(list.contains(123))
   }

--- a/heron/api/tests/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverterTest.scala
+++ b/heron/api/tests/scala/com/twitter/heron/streamlet/scala/converter/ScalaToJavaConverterTest.scala
@@ -13,9 +13,12 @@
 //  limitations under the License.
 package com.twitter.heron.streamlet.scala.converter
 
-import org.junit.Assert.assertTrue
+import java.util.stream.{Collectors, StreamSupport}
+import java.util.{List => JavaList}
 
 import scala.collection.mutable.ListBuffer
+
+import org.junit.Assert.{assertEquals, assertTrue}
 
 import com.twitter.heron.streamlet.{
   Context,
@@ -28,9 +31,7 @@ import com.twitter.heron.streamlet.{
   SerializableTransformer,
   Sink => JavaSink
 }
-
 import com.twitter.heron.streamlet.scala.{Sink, Source}
-
 import com.twitter.heron.streamlet.scala.common.{
   BaseFunSuite,
   TestIncrementSerializableTransformer
@@ -58,6 +59,24 @@ class ScalaToJavaConverterTest extends BaseFunSuite {
     assertTrue(
       serializableFunction
         .isInstanceOf[SerializableFunction[String, Int]])
+  }
+
+  test(
+    "ScalaToJavaConverterTest should support SerializableFunctionWithIterable") {
+    def stringToListOfIntFunction(number: String) = List(number.toInt)
+    val serializableFunction =
+      ScalaToJavaConverter.toSerializableFunctionWithIterable[String, Int](
+        stringToListOfIntFunction)
+    assertTrue(
+      serializableFunction
+        .isInstanceOf[SerializableFunction[String, _]])
+    val iterable = serializableFunction.apply("123")
+    val list = StreamSupport
+      .stream(iterable.spliterator(), false)
+      .collect(Collectors.toList())
+
+    assertEquals(1, list.size())
+    assertTrue(list.contains(123))
   }
 
   test("ScalaToJavaConverterTest should support SerializableBiFunction") {
@@ -113,6 +132,20 @@ class ScalaToJavaConverterTest extends BaseFunSuite {
     assertTrue(
       serializableBinaryOperator
         .isInstanceOf[SerializableBinaryOperator[Int]])
+  }
+
+  test("ScalaToJavaConverterTest should support SerializableBiFunctionWithSeq") {
+    def numbersToSeqOfIntFunction(number1: String, number2: Int): Seq[Int] =
+      Seq(number1.toInt + number2)
+    val serializableBiFunction =
+      ScalaToJavaConverter.toSerializableBiFunctionWithSeq[String](
+        numbersToSeqOfIntFunction)
+    assertTrue(serializableBiFunction
+      .isInstanceOf[SerializableBiFunction[String, Integer, JavaList[Integer]]])
+
+    val list = serializableBiFunction.apply("12", 3)
+    assertEquals(1, list.size())
+    assertTrue(list.contains(15))
   }
 
   test("ScalaToJavaConverterTest should support SerializableTransformer") {


### PR DESCRIPTION
This PR aims the following changes:

- Adding Scala Streamlet `flatMap` and `repartition (with partition function)` functions support

- Adding `ScalaToJavaConverter` following transformation logics:
  - Scala `Function` to `SerializableFunctionWithIterable`
  - Scala `Function2` to `SerializableBiFunctionWithSeq`

- Adding UT Coverages for both Scala `StreamletImpl` and `ScalaToJavaConverter`

Also: Scala Streamlet API UT cases' total execution time is as follows:
//heron/api/tests/scala:api-scala-test PASSED in 0.9s