### PR TITLE
[Streamlet Scala API] Add Scala Example Support - Part I

### DIFF
--- a/examples/src/scala/BUILD
+++ b/examples/src/scala/BUILD
@@ -6,11 +6,11 @@ scala_binary(
     name = "streamlet-scala-examples-unshaded",
     srcs = glob(["com/twitter/heron/examples/streamlet/scala/**/*.scala"]),
     deps = [
-            "//heron/api/src/java:api-java",
-            "//heron/api/src/scala:api-scala",
-            "@org_apache_commons_commons_lang3//jar",
-            "//third_party/java:kryo"
-        ],
+        "@org_apache_commons_commons_lang3//jar",
+        "//heron/api/src/java:api-java",
+        "//heron/api/src/scala:api-scala",
+        "//third_party/java:kryo"
+    ],
     main_class = "com.twitter.heron.examples.streamlet.scala.ScalaIntegerProcessingTopology"
 )
 
@@ -18,5 +18,5 @@ genrule(
     name = 'heron-streamlet-scala-examples',
     srcs = [":streamlet-scala-examples-unshaded_deploy.jar"],
     outs = ["heron-streamlet-scala-examples.jar"],
-    cmd  = "cp $< $@",
+    cmd  = "cp $< $@"
 )

--- a/examples/src/scala/BUILD
+++ b/examples/src/scala/BUILD
@@ -1,0 +1,20 @@
+licenses(["notice"])
+
+package(default_visibility = ["//visibility:public"])
+
+scala_binary(
+    name = "streamlet-scala-examples-unshaded",
+    srcs = glob(["com/twitter/heron/examples/streamlet/scala/**/*.scala"]),
+    deps = [
+            "//heron/api/src/java:api-java",
+            "//heron/api/src/scala:api-scala",
+        ],
+    main_class = "com.twitter.heron.examples.streamlet.scala.ScalaIntegerProcessingTopology"
+)
+
+genrule(
+    name = 'heron-streamlet-scala-examples',
+    srcs = [":streamlet-scala-examples-unshaded_deploy.jar"],
+    outs = ["heron-streamlet-scala-examples.jar"],
+    cmd  = "cp $< $@",
+)

--- a/examples/src/scala/BUILD
+++ b/examples/src/scala/BUILD
@@ -8,7 +8,8 @@ scala_binary(
     deps = [
             "//heron/api/src/java:api-java",
             "//heron/api/src/scala:api-scala",
-            "@org_apache_commons_commons_lang3//jar"
+            "@org_apache_commons_commons_lang3//jar",
+            "//third_party/java:kryo"
         ],
     main_class = "com.twitter.heron.examples.streamlet.scala.ScalaIntegerProcessingTopology"
 )

--- a/examples/src/scala/BUILD
+++ b/examples/src/scala/BUILD
@@ -8,6 +8,7 @@ scala_binary(
     deps = [
             "//heron/api/src/java:api-java",
             "//heron/api/src/scala:api-scala",
+            "@org_apache_commons_commons_lang3//jar"
         ],
     main_class = "com.twitter.heron.examples.streamlet.scala.ScalaIntegerProcessingTopology"
 )

--- a/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaIntegerProcessingTopology.scala
+++ b/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaIntegerProcessingTopology.scala
@@ -11,14 +11,6 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-
-//  http://www.apache.org/licenses/LICENSE-2.0
-
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License.
 package com.twitter.heron.examples.streamlet.scala
 
 import java.util.concurrent.ThreadLocalRandom
@@ -26,7 +18,6 @@ import java.util.concurrent.ThreadLocalRandom
 import org.apache.commons.lang3.StringUtils
 
 import com.twitter.heron.streamlet.Config
-
 import com.twitter.heron.streamlet.scala.{Builder, Runner}
 
 /**

--- a/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaIntegerProcessingTopology.scala
+++ b/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaIntegerProcessingTopology.scala
@@ -23,12 +23,19 @@ package com.twitter.heron.examples.streamlet.scala
 
 import java.util.concurrent.ThreadLocalRandom
 
+import org.apache.commons.lang3.StringUtils
+
 import com.twitter.heron.streamlet.Config
 
 import com.twitter.heron.streamlet.scala.{Builder, Runner}
 
-//TODO - Add javadoc
-
+/**
+  * This is a very simple topology that shows a series of Scala Streamlet operations
+  * on a source streamlet of random integers (between 1 and 10). First, 10 is multiplied
+  * to each integer and then, the numbers that are lower than 50, are excluded form streamlet.
+  * That streamlet is then united with a streamlet that consists of an indefinite stream of zeroes.
+  * The final output of the processing graph is then logged.
+  */
 object ScalaIntegerProcessingTopology {
 
   private val CPU = 1.5f
@@ -39,7 +46,6 @@ object ScalaIntegerProcessingTopology {
     * All Heron topologies require a main function that defines the topology's behavior
     * at runtime
     */
-  @throws[Exception]
   def main(args: Array[String]): Unit = {
     val builder = Builder.newBuilder
 
@@ -48,13 +54,12 @@ object ScalaIntegerProcessingTopology {
     builder
       .newSource(() => ThreadLocalRandom.current.nextInt(1, 11))
       .setName("random-numbers")
-      .map[Int]((i: Int) => (i * 10))
-      .setNumPartitions(3)
+      .map[Int]((i: Int) => i * 10)
+      .setNumPartitions(2)
       .filter((i: Int) => i >= 50)
       .setName("numbers-higher-than-50")
       .union(zeroes)
-      .setName("unioned-numbers")
-      .setNumPartitions(3)
+      .setName("union-of-numbers")
       .log()
 
     val config = Config.newBuilder
@@ -75,9 +80,10 @@ object ScalaIntegerProcessingTopology {
     * Fetches the topology's name from the first command-line argument or
     * throws an exception if not present.
     */
-  @throws[Exception]
-  private def getTopologyName(args: Array[String]): String = {
+  private def getTopologyName(args: Array[String]) = {
     require(args.length > 0, "A Topology name should be supplied")
+    require(StringUtils.isNotBlank(args(0)),
+            "A Topology name must not be blank")
     args(0)
   }
 

--- a/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaIntegerProcessingTopology.scala
+++ b/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaIntegerProcessingTopology.scala
@@ -82,8 +82,7 @@ object ScalaIntegerProcessingTopology {
     */
   private def getTopologyName(args: Array[String]) = {
     require(args.length > 0, "A Topology name should be supplied")
-    require(StringUtils.isNotBlank(args(0)),
-            "A Topology name must not be blank")
+    require(StringUtils.isNotBlank(args(0)), "Topology name must not be blank")
     args(0)
   }
 

--- a/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaIntegerProcessingTopology.scala
+++ b/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaIntegerProcessingTopology.scala
@@ -1,0 +1,86 @@
+//  Copyright 2018 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//  http://www.apache.org/licenses/LICENSE-2.0
+
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.examples.streamlet.scala
+
+import java.util.concurrent.ThreadLocalRandom
+
+import com.twitter.heron.streamlet.Config
+
+import com.twitter.heron.streamlet.scala.{Builder, Runner}
+
+//TODO - Add javadoc
+
+object ScalaIntegerProcessingTopology {
+
+  private val CPU = 1.5f
+  private val GIGABYTES_OF_RAM = 1
+  private val NUM_CONTAINERS = 2
+
+  /**
+    * All Heron topologies require a main function that defines the topology's behavior
+    * at runtime
+    */
+  @throws[Exception]
+  def main(args: Array[String]): Unit = {
+    val builder = Builder.newBuilder
+
+    val zeroes = builder.newSource(() => 0).setName("zeroes")
+
+    builder
+      .newSource(() => ThreadLocalRandom.current.nextInt(1, 11))
+      .setName("random-numbers")
+      .map[Int]((i: Int) => (i * 10))
+      .setNumPartitions(3)
+      .filter((i: Int) => i >= 50)
+      .setName("numbers-higher-than-50")
+      .union(zeroes)
+      .setName("unioned-numbers")
+      .setNumPartitions(3)
+      .log()
+
+    val config = Config.newBuilder
+      .setNumContainers(NUM_CONTAINERS)
+      .setPerContainerRamInGigabytes(GIGABYTES_OF_RAM)
+      .setPerContainerCpu(CPU)
+      .build
+
+    // Fetches the topology name from the first command-line argument
+    val topologyName = getTopologyName(args)
+
+    // Finally, the processing graph and configuration are passed to the Runner, which converts
+    // the graph into a Heron topology that can be run in a Heron cluster.
+    new Runner().run(topologyName, config, builder)
+  }
+
+  /**
+    * Fetches the topology's name from the first command-line argument or
+    * throws an exception if not present.
+    */
+  @throws[Exception]
+  private def getTopologyName(args: Array[String]): String = {
+    require(args.length > 0, "A Topology name should be supplied")
+    args(0)
+  }
+
+}
+
+final class ScalaIntegerProcessingTopology private () {}

--- a/heron/api/src/java/com/twitter/heron/streamlet/Config.java
+++ b/heron/api/src/java/com/twitter/heron/streamlet/Config.java
@@ -87,7 +87,7 @@ public final class Config implements Serializable {
     return new Builder();
   }
 
-  com.twitter.heron.api.Config getHeronConfig() {
+  public com.twitter.heron.api.Config getHeronConfig() {
     return heronConfig;
   }
 

--- a/heron/api/src/scala/com/twitter/heron/streamlet/scala/Builder.scala
+++ b/heron/api/src/scala/com/twitter/heron/streamlet/scala/Builder.scala
@@ -1,22 +1,19 @@
-//  Copyright 2017 Twitter. All rights reserved.
+//  Copyright 2018 Twitter. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
 //  You may obtain a copy of the License at
-
+//
 //  http://www.apache.org/licenses/LICENSE-2.0
-
+//
 //  Unless required by applicable law or agreed to in writing, software
 //  distributed under the License is distributed on an "AS IS" BASIS,
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-
 package com.twitter.heron.streamlet.scala
 
-
 import com.twitter.heron.streamlet.scala.impl.BuilderImpl
-
 
 /**
   * Builder is used to register all sources. Builder thus keeps track
@@ -41,8 +38,7 @@ trait Builder {
     * @param supplier The supplier function that is used to create the streamlet
     * @return a Streamlet representation of the supplier object
     */
-  def newSource[R](supplierFn: () => R): Streamlet[R]
-
+  def newSource[R](supplier: () => R): Streamlet[R]
 
   /**
     * Creates a new Streamlet using the underlying generator
@@ -50,5 +46,5 @@ trait Builder {
     * @param generator The generator that generates the tuples of the streamlet
     * @return  a Streamlet representation of the source object
     */
-  def newSource[R](sourceFn: Source[R]): Streamlet[R]
+  def newSource[R](generator: Source[R]): Streamlet[R]
 }

--- a/heron/api/src/scala/com/twitter/heron/streamlet/scala/Runner.scala
+++ b/heron/api/src/scala/com/twitter/heron/streamlet/scala/Runner.scala
@@ -1,0 +1,51 @@
+//  Copyright 2018 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.streamlet.scala
+
+import java.util.logging.{Level, Logger}
+
+import com.twitter.heron.api.HeronSubmitter
+import com.twitter.heron.api.exception.AlreadyAliveException
+import com.twitter.heron.api.exception.InvalidTopologyException
+import com.twitter.heron.streamlet.Config
+import com.twitter.heron.streamlet.scala.impl.BuilderImpl
+
+/**
+  * Runner is used to run a topology that is built by the builder.
+  * It exports a sole function called run that takes care of constructing the topology
+  */
+class Runner {
+
+  private val LOG = Logger.getLogger(classOf[Runner].getName)
+
+  /**
+    * Runs the computation
+    *
+    * @param name    The name of the topology
+    * @param config  Any config that is passed to the topology
+    * @param builder The builder used to keep track of the sources.
+    */
+  def run(name: String, config: Config, builder: Builder): Unit = {
+    val builderImpl = builder.asInstanceOf[BuilderImpl]
+    val topologyBuilder = builderImpl.build
+    try {
+      HeronSubmitter.submitTopology(name,
+                                    config.getHeronConfig,
+                                    topologyBuilder.createTopology)
+    } catch {
+      case e @ (_: AlreadyAliveException | _: InvalidTopologyException) =>
+        LOG.log(Level.SEVERE, "Topology could not be submitted", e)
+    }
+  }
+}

--- a/heron/api/src/scala/com/twitter/heron/streamlet/scala/impl/BuilderImpl.scala
+++ b/heron/api/src/scala/com/twitter/heron/streamlet/scala/impl/BuilderImpl.scala
@@ -13,23 +13,28 @@
 //  limitations under the License.
 package com.twitter.heron.streamlet.scala.impl
 
+import com.twitter.heron.api.topology.TopologyBuilder
+import com.twitter.heron.streamlet.impl.{BuilderImpl => JavaBuilderImpl}
+
 import com.twitter.heron.streamlet.scala.{Builder, Source, Streamlet}
-import com.twitter.heron.streamlet.scala.converter.ScalaToJavaConverter
+import com.twitter.heron.streamlet.scala.converter.ScalaToJavaConverter._
 
 class BuilderImpl(builder: com.twitter.heron.streamlet.Builder)
     extends Builder {
 
-  override def newSource[R](supplierFn: () => R): Streamlet[R] = {
-    val serializableSupplier =
-      ScalaToJavaConverter.toSerializableSupplier[R](supplierFn)
+  override def newSource[R](supplier: () => R): Streamlet[R] = {
+    val serializableSupplier = toSerializableSupplier[R](supplier)
     val newJavaStreamlet = builder.newSource(serializableSupplier)
     StreamletImpl.fromJavaStreamlet[R](newJavaStreamlet)
   }
 
-  override def newSource[R](sourceFn: Source[R]): Streamlet[R] = {
-    val javaSourceObj = ScalaToJavaConverter.toJavaSource[R](sourceFn)
+  override def newSource[R](generator: Source[R]): Streamlet[R] = {
+    val javaSourceObj = toJavaSource[R](generator)
     val newJavaStreamlet = builder.newSource(javaSourceObj)
     StreamletImpl.fromJavaStreamlet[R](newJavaStreamlet)
   }
+
+  def build(): TopologyBuilder =
+    builder.asInstanceOf[JavaBuilderImpl].build()
 
 }

--- a/tools/rules/heron_examples.bzl
+++ b/tools/rules/heron_examples.bzl
@@ -22,5 +22,6 @@ def heron_examples_lib_files():
     return [
         "//examples/src/java:heron-api-examples",
         "//examples/src/java:heron-streamlet-examples",
+        "//examples/src/scala:heron-streamlet-scala-examples",
         "//eco-examples/src/java:heron-eco-examples",
     ]


### PR DESCRIPTION
This PR aims the following changes:

- Adding Scala Streamlet Example as `ScalaIntegerProcessingTopology`
- Adding Scala Topology Runner by accepting Scala `Builder`
- Adding separated `heron-streamlet-scala-examples.jar` library Support