### PR TITLE
Do not include scribe sink when compiling on non x86 platforms.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -845,8 +845,8 @@ new_http_archive(
 # for docker image building
 http_archive(
     name = "io_bazel_rules_docker",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.3.0.tar.gz"],
-    strip_prefix = "rules_docker-0.3.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.4.0.tar.gz"],
+    strip_prefix = "rules_docker-0.4.0",
 )
 
 load(

--- a/heron/config/src/yaml/conf/aurora/metrics_sinks.yaml
+++ b/heron/config/src/yaml/conf/aurora/metrics_sinks.yaml
@@ -100,7 +100,7 @@ metricscache-sink:
 
 ### Config for scribe-sink
 # scribe-sink:
-#   class: "com.twitter.heron.metricsmgr.sink.ScribeSink"
+#   class: "com.twitter.heron.metricsmgr.sink.scribe.ScribeSink"
 #   flush-frequency-ms: 60000
 #   sink-restart-attempts: -1 # Forever
 #   scribe-host: "127.0.0.1" # The host of scribe to be exported metrics to

--- a/heron/config/src/yaml/conf/examples/metrics_sinks.yaml
+++ b/heron/config/src/yaml/conf/examples/metrics_sinks.yaml
@@ -100,7 +100,7 @@ metricscache-sink:
 
 ### Config for scribe-sink
 # scribe-sink:
-#   class: "com.twitter.heron.metricsmgr.sink.ScribeSink"
+#   class: "com.twitter.heron.metricsmgr.sink.scribe.ScribeSink"
 #   flush-frequency-ms: 60000
 #   sink-restart-attempts: -1 # Forever
 #   scribe-host: "127.0.0.1" # The host of scribe to be exported metrics to

--- a/heron/config/src/yaml/conf/kubernetes/metrics_sinks.yaml
+++ b/heron/config/src/yaml/conf/kubernetes/metrics_sinks.yaml
@@ -100,7 +100,7 @@ metricscache-sink:
 
 ### Config for scribe-sink
 # scribe-sink:
-#   class: "com.twitter.heron.metricsmgr.sink.ScribeSink"
+#   class: "com.twitter.heron.metricsmgr.sink.scribe.ScribeSink"
 #   flush-frequency-ms: 60000
 #   sink-restart-attempts: -1 # Forever
 #   scribe-host: "127.0.0.1" # The host of scribe to be exported metrics to

--- a/heron/config/src/yaml/conf/local/metrics_sinks.yaml
+++ b/heron/config/src/yaml/conf/local/metrics_sinks.yaml
@@ -100,7 +100,7 @@ metricscache-sink:
 
 ### Config for scribe-sink
 # scribe-sink:
-#   class: "com.twitter.heron.metricsmgr.sink.ScribeSink"
+#   class: "com.twitter.heron.metricsmgr.sink.scribe.ScribeSink"
 #   flush-frequency-ms: 60000
 #   sink-restart-attempts: -1 # Forever
 #   scribe-host: "127.0.0.1" # The host of scribe to be exported metrics to

--- a/heron/config/src/yaml/conf/localzk/metrics_sinks.yaml
+++ b/heron/config/src/yaml/conf/localzk/metrics_sinks.yaml
@@ -100,7 +100,7 @@ metricscache-sink:
 
 ### Config for scribe-sink
 # scribe-sink:
-#   class: "com.twitter.heron.metricsmgr.sink.ScribeSink"
+#   class: "com.twitter.heron.metricsmgr.sink.scribe.ScribeSink"
 #   flush-frequency-ms: 60000
 #   sink-restart-attempts: -1 # Forever
 #   scribe-host: "127.0.0.1" # The host of scribe to be exported metrics to

--- a/heron/config/src/yaml/conf/marathon/metrics_sinks.yaml
+++ b/heron/config/src/yaml/conf/marathon/metrics_sinks.yaml
@@ -100,7 +100,7 @@ metricscache-sink:
 
 ### Config for scribe-sink
 # scribe-sink:
-#   class: "com.twitter.heron.metricsmgr.sink.ScribeSink"
+#   class: "com.twitter.heron.metricsmgr.sink.scribe.ScribeSink"
 #   flush-frequency-ms: 60000
 #   sink-restart-attempts: -1 # Forever
 #   scribe-host: "127.0.0.1" # The host of scribe to be exported metrics to

--- a/heron/config/src/yaml/conf/mesos/metrics_sinks.yaml
+++ b/heron/config/src/yaml/conf/mesos/metrics_sinks.yaml
@@ -100,7 +100,7 @@ metricscache-sink:
 
 ### Config for scribe-sink
 # scribe-sink:
-#   class: "com.twitter.heron.metricsmgr.sink.ScribeSink"
+#   class: "com.twitter.heron.metricsmgr.sink.scribe.ScribeSink"
 #   flush-frequency-ms: 60000
 #   sink-restart-attempts: -1 # Forever
 #   scribe-host: "127.0.0.1" # The host of scribe to be exported metrics to

--- a/heron/config/src/yaml/conf/nomad/metrics_sinks.yaml
+++ b/heron/config/src/yaml/conf/nomad/metrics_sinks.yaml
@@ -100,7 +100,7 @@ metricscache-sink:
 
 ### Config for scribe-sink
 # scribe-sink:
-#   class: "com.twitter.heron.metricsmgr.sink.ScribeSink"
+#   class: "com.twitter.heron.metricsmgr.sink.scribe.ScribeSink"
 #   flush-frequency-ms: 60000
 #   sink-restart-attempts: -1 # Forever
 #   scribe-host: "127.0.0.1" # The host of scribe to be exported metrics to

--- a/heron/config/src/yaml/conf/sandbox/metrics_sinks.yaml
+++ b/heron/config/src/yaml/conf/sandbox/metrics_sinks.yaml
@@ -100,7 +100,7 @@ metricscache-sink:
 
 ### Config for scribe-sink
 # scribe-sink:
-#   class: "com.twitter.heron.metricsmgr.sink.ScribeSink"
+#   class: "com.twitter.heron.metricsmgr.sink.scribe.ScribeSink"
 #   flush-frequency-ms: 60000
 #   sink-restart-attempts: -1 # Forever
 #   scribe-host: "127.0.0.1" # The host of scribe to be exported metrics to

--- a/heron/config/src/yaml/conf/slurm/metrics_sinks.yaml
+++ b/heron/config/src/yaml/conf/slurm/metrics_sinks.yaml
@@ -100,7 +100,7 @@ metricscache-sink:
 
 ### Config for scribe-sink
 # scribe-sink:
-#   class: "com.twitter.heron.metricsmgr.sink.ScribeSink"
+#   class: "com.twitter.heron.metricsmgr.sink.scribe.ScribeSink"
 #   flush-frequency-ms: 60000
 #   sink-restart-attempts: -1 # Forever
 #   scribe-host: "127.0.0.1" # The host of scribe to be exported metrics to

--- a/heron/config/src/yaml/conf/standalone/metrics_sinks.yaml
+++ b/heron/config/src/yaml/conf/standalone/metrics_sinks.yaml
@@ -100,7 +100,7 @@ metricscache-sink:
 
 ### Config for scribe-sink
 # scribe-sink:
-#   class: "com.twitter.heron.metricsmgr.sink.ScribeSink"
+#   class: "com.twitter.heron.metricsmgr.sink.scribe.ScribeSink"
 #   flush-frequency-ms: 60000
 #   sink-restart-attempts: -1 # Forever
 #   scribe-host: "127.0.0.1" # The host of scribe to be exported metrics to

--- a/heron/config/src/yaml/conf/yarn/metrics_sinks.yaml
+++ b/heron/config/src/yaml/conf/yarn/metrics_sinks.yaml
@@ -100,7 +100,7 @@ metricscache-sink:
 
 ### Config for scribe-sink
 # scribe-sink:
-#   class: "com.twitter.heron.metricsmgr.sink.ScribeSink"
+#   class: "com.twitter.heron.metricsmgr.sink.scribe.ScribeSink"
 #   flush-frequency-ms: 60000
 #   sink-restart-attempts: -1 # Forever
 #   scribe-host: "127.0.0.1" # The host of scribe to be exported metrics to

--- a/heron/metricsmgr/src/java/BUILD
+++ b/heron/metricsmgr/src/java/BUILD
@@ -2,31 +2,51 @@ licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
+x86_files = glob(
+    ["**/*.java"],
+    exclude = ["**/MetricManager.java"],
+)
+
+non_x86_files = glob(
+    ["**/*.java"],
+    exclude = ["**/MetricManager.java", "**/sink/scribe/ScribeSink.java"],
+)
+
+non_x86_deps = [
+    "//heron/api/src/java:api-java-low-level",
+    "//heron/common/src/java:basics-java",
+    "//heron/common/src/java:config-java",
+    "//heron/common/src/java:network-java",
+    "//heron/common/src/java:utils-java",
+    "//heron/spi/src/java:metricsmgr-spi-java",
+    "//heron/proto:proto_common_java",
+    "//heron/proto:proto_metrics_java",
+    "//heron/proto:proto_tmaster_java",
+    "//third_party/java:guava", # only used in WebSink
+    "//third_party/java:jackson",
+    "//third_party/java:cli",
+    "//third_party/java:logging", # slf4j is only used for thrift in scribe-sink
+    "@com_google_protobuf//:protobuf_java",
+    "@org_apache_thrift_libthrift//jar",
+    "@org_yaml_snakeyaml//jar",
+]
+
+x86_deps = non_x86_deps + [
+    "//heron/metricsmgr/src/thrift:thrift_scribe_java",
+]
+
 java_library(
     name = "metricsmgr-java",
-    srcs = glob(
-        ["**/*.java"],
-        exclude = ["**/MetricManager.java"],
-    ),
-    deps = [
-        "//heron/api/src/java:api-java-low-level",
-        "//heron/common/src/java:basics-java",
-        "//heron/common/src/java:config-java",
-        "//heron/common/src/java:network-java",
-        "//heron/common/src/java:utils-java",
-        "//heron/spi/src/java:metricsmgr-spi-java",
-        "//heron/proto:proto_common_java",
-        "//heron/proto:proto_metrics_java",
-        "//heron/proto:proto_tmaster_java",
-        "//heron/metricsmgr/src/thrift:thrift_scribe_java",
-        "//third_party/java:guava", # only used in WebSink
-        "//third_party/java:jackson",
-        "//third_party/java:cli",
-        "//third_party/java:logging", # slf4j is only used for thrift in scribe-sink
-        "@com_google_protobuf//:protobuf_java",
-        "@org_apache_thrift_libthrift//jar",
-        "@org_yaml_snakeyaml//jar",
-    ],
+    srcs = select({
+        "//tools/platform:darwin": x86_files,
+        "//tools/platform:k8": x86_files,
+        "//conditions:default" : non_x86_files,
+    }),
+    deps = select({
+        "//tools/platform:darwin": x86_deps,
+        "//tools/platform:k8": x86_deps,
+        "//conditions:default" : non_x86_deps,
+    }),
 )
 
 java_binary(

--- a/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/scribe/ScribeSink.java
+++ b/heron/metricsmgr/src/java/com/twitter/heron/metricsmgr/sink/scribe/ScribeSink.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.twitter.heron.metricsmgr.sink;
+package com.twitter.heron.metricsmgr.sink.scribe;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;

--- a/scripts/images/BUILD
+++ b/scripts/images/BUILD
@@ -21,6 +21,7 @@ container_image(
         "/heron/heron-tools/lib/scheduler"       : "/heron/heron-core/lib/scheduler", 
         "/heron/heron-tools/lib/statemgr"        : "/heron/heron-core/lib/statemgr", 
     },
+    stamp = 1,
     directory = "/heron",
     workdir = "/heron",
     cmd = ["supervisord", "-n"]

--- a/third_party/thrift/BUILD
+++ b/third_party/thrift/BUILD
@@ -5,17 +5,7 @@ package(default_visibility = ["//visibility:public"])
 filegroup(
     name = "thrift",
     srcs = select({
-        ":darwin": ["thrift-osx-x86_64.exe"],
-        ":k8": ["thrift-linux-x86_64.exe"],
+        "//tools/platform:darwin": ["thrift-osx-x86_64.exe"],
+        "//tools/platform:k8": ["thrift-linux-x86_64.exe"],
     }),
-)
-
-config_setting(
-    name = "darwin",
-    values = {"host_cpu": "darwin"},
-)
-
-config_setting(
-    name = "k8",
-    values = {"host_cpu": "k8"},
 )

--- a/tools/platform/BUILD
+++ b/tools/platform/BUILD
@@ -7,15 +7,7 @@ config_setting(
 )
 
 config_setting(
-    name = "ubuntu",
-    values = {
-        "cpu": "k8",
-    },
-    visibility = ["//visibility:public"],
-)
-
-config_setting(
-    name = "centos",
+    name = "k8",
     values = {
         "cpu": "k8",
     },

--- a/tools/platform/BUILD
+++ b/tools/platform/BUILD
@@ -7,7 +7,15 @@ config_setting(
 )
 
 config_setting(
-    name = "k8",
+    name = "ubuntu",
+    values = {
+        "cpu": "k8",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "centos",
     values = {
         "cpu": "k8",
     },


### PR DESCRIPTION
This is due to scribe dependency on thrift which needs to generate java files - the binaries used are only x86 platforms.