### PR TITLE
Revert "remove cpu rounding in packing algorithms (#2805)"

### DIFF
--- a/heron/packing/src/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/binpacking/FirstFitDecreasingPacking.java
@@ -144,7 +144,7 @@ public class FirstFitDecreasingPacking implements IPacking, IRepacking {
 
     this.maxContainerResources = new Resource(
         TopologyUtils.getConfigWithDefault(topologyConfig, TOPOLOGY_CONTAINER_MAX_CPU_HINT,
-            PackingUtils.increaseBy(defaultCpu, paddingPercentage)),
+            (double) Math.round(PackingUtils.increaseBy(defaultCpu, paddingPercentage))),
         TopologyUtils.getConfigWithDefault(topologyConfig, TOPOLOGY_CONTAINER_MAX_RAM_HINT,
             defaultRam.increaseBy(paddingPercentage)),
         TopologyUtils.getConfigWithDefault(topologyConfig, TOPOLOGY_CONTAINER_MAX_DISK_HINT,

--- a/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
+++ b/heron/packing/src/java/com/twitter/heron/packing/roundrobin/ResourceCompliantRRPacking.java
@@ -143,7 +143,7 @@ public class ResourceCompliantRRPacking implements IPacking, IRepacking {
 
     Resource maxContainerResources = new Resource(
         TopologyUtils.getConfigWithDefault(topologyConfig, TOPOLOGY_CONTAINER_CPU_REQUESTED,
-            PackingUtils.increaseBy(defaultCpu, paddingPercentage)),
+            (double) Math.round(PackingUtils.increaseBy(defaultCpu, paddingPercentage))),
         TopologyUtils.getConfigWithDefault(topologyConfig, TOPOLOGY_CONTAINER_RAM_REQUESTED,
             defaultRam.increaseBy(paddingPercentage)),
         TopologyUtils.getConfigWithDefault(topologyConfig, TOPOLOGY_CONTAINER_DISK_REQUESTED,


### PR DESCRIPTION
This reverts commit c25edf55fa23a6dc2d97184dff2400cf3827dea5.

- there are 3 other round() calls in this module to handle.
- need a unit test to cover the divided by 0 issue.