### PR TITLE
[Streamlet Scala API] Add Scala Example Support - Part II

### DIFF
--- a/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaClassicalMusicTopology.scala
+++ b/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaClassicalMusicTopology.scala
@@ -69,9 +69,11 @@ object ScalaClassicalMusicTopology {
         getRandomClassicalMusic(classicalMusics2))
       .setName("classical-music-source-2")
 
-    builder
+    val musicSource = builder
       .newSource[ClassicalMusic](() => getRandomClassicalMusic(classicalMusics))
       .setName("classical-music-source-1")
+
+    musicSource
       .filter(_.year <= 1850)
       .setName("classical-musics-older-than-1850")
       .join[Int, ClassicalMusic, String](

--- a/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaClassicalMusicTopology.scala
+++ b/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaClassicalMusicTopology.scala
@@ -1,0 +1,103 @@
+//  Copyright 2018 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.examples.streamlet.scala
+
+import scala.util.Random
+
+import com.twitter.heron.examples.streamlet.scala.common.ScalaTopologyExampleUtils
+import com.twitter.heron.streamlet.scala.{Builder, Runner}
+import com.twitter.heron.streamlet.{Config, JoinType, WindowConfig}
+
+/**
+  * Classical Music Model
+  */
+case class ClassicalMusic(composer: String,
+                          title: String,
+                          year: Int,
+                          keyword: String) {
+  def this() = this(composer = "", title = "", year = 0, keyword = "")
+}
+
+/**
+  * This is a very simple topology that shows a series of Scala Streamlet operations
+  * on two source streamlets that are created in the light of Classical Music Records.
+  * Classical Music Records of first source are filtered as older than 1850.
+  * After then, first and second Classical Music Sources are joined by using Year field as Key
+  * and Inner as Join Type. Finally, results are printed with Log Sink.
+  */
+object ScalaClassicalMusicTopology {
+
+  val classicalMusics =
+    List(
+      ClassicalMusic("Bach", "Bourrée In E Minor", 1717, "guitar"),
+      ClassicalMusic("Vivaldi", "Four Seasons: Winter", 1723, "rousing"),
+      ClassicalMusic("Bach", "Air On The G String", 1723, "light"),
+      ClassicalMusic("Mozart", "Symphony No. 40: I", 1788, "seductive"),
+      ClassicalMusic("Beethoven", "Symphony No. 9: Ode To Joy", 1824, "joyful"),
+      ClassicalMusic("Bizet", "Carmen: Habanera", 1875, "seductive")
+    )
+
+  val classicalMusics2 =
+    List(
+      ClassicalMusic("Handel", "Water Music: Alla Hornpipe", 1717, "formal"),
+      ClassicalMusic("Vivaldi", "Four Seasons: Spring", 1723, "formal"),
+      ClassicalMusic("Bach",
+                     "Cantata 147: Jesu, Joy Of Man's Desiring",
+                     1723,
+                     "wedding"),
+      ClassicalMusic("Mozart", "Piano Sonata No. 16", 1788, "piano"),
+      ClassicalMusic("Beethoven", "Symphony No. 9: II", 1824, "powerful"),
+      ClassicalMusic("Tchaikovsky", "Piano Concerto No. 1", 1875, "piano")
+    )
+
+  def main(args: Array[String]): Unit = {
+    val builder = Builder.newBuilder()
+
+    val musicSource2 = builder
+      .newSource[ClassicalMusic](() =>
+        getRandomClassicalMusic(classicalMusics2))
+      .setName("classical-music-source-2")
+
+    builder
+      .newSource[ClassicalMusic](() => getRandomClassicalMusic(classicalMusics))
+      .setName("classical-music-source-1")
+      .filter(_.year <= 1850)
+      .setName("classical-musics-older-than-1850")
+      .join[Int, ClassicalMusic, String](
+        musicSource2,
+        (cm: ClassicalMusic) => cm.year,
+        (cm: ClassicalMusic) => cm.year,
+        WindowConfig.TumblingCountWindow(50),
+        JoinType.INNER,
+        (cm1: ClassicalMusic, cm2: ClassicalMusic) =>
+          s"${cm1.composer.toUpperCase} - ${cm1.title} - ${cm2.composer.toUpperCase} - ${cm2.title}"
+      )
+      .setName("joined-classical-musics-by-year")
+      .log()
+
+    val config = Config.defaultConfig()
+
+    // Fetches the topology name from the first command-line argument
+    val topologyName = ScalaTopologyExampleUtils.getTopologyName(args)
+
+    // Finally, the processing graph and configuration are passed to the Runner, which converts
+    // the graph into a Heron topology that can be run in a Heron cluster.
+    new Runner().run(topologyName, config, builder)
+  }
+
+  private def getRandomClassicalMusic(
+      list: List[ClassicalMusic]): ClassicalMusic =
+    list(Random.nextInt(list.size))
+
+}

--- a/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaIntegerProcessingTopology.scala
+++ b/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaIntegerProcessingTopology.scala
@@ -41,9 +41,11 @@ object ScalaIntegerProcessingTopology {
 
     val zeroes = builder.newSource(() => 0).setName("zeroes")
 
-    builder
+    val numbers = builder
       .newSource(() => ThreadLocalRandom.current.nextInt(1, 11))
       .setName("random-numbers")
+
+    numbers
       .map[Int]((i: Int) => i * 10)
       .setNumPartitions(2)
       .filter((i: Int) => i >= 50)

--- a/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaIntegerProcessingTopology.scala
+++ b/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaIntegerProcessingTopology.scala
@@ -15,8 +15,7 @@ package com.twitter.heron.examples.streamlet.scala
 
 import java.util.concurrent.ThreadLocalRandom
 
-import org.apache.commons.lang3.StringUtils
-
+import com.twitter.heron.examples.streamlet.scala.common.ScalaTopologyExampleUtils
 import com.twitter.heron.streamlet.Config
 import com.twitter.heron.streamlet.scala.{Builder, Runner}
 
@@ -60,23 +59,11 @@ object ScalaIntegerProcessingTopology {
       .build
 
     // Fetches the topology name from the first command-line argument
-    val topologyName = getTopologyName(args)
+    val topologyName = ScalaTopologyExampleUtils.getTopologyName(args)
 
     // Finally, the processing graph and configuration are passed to the Runner, which converts
     // the graph into a Heron topology that can be run in a Heron cluster.
     new Runner().run(topologyName, config, builder)
   }
 
-  /**
-    * Fetches the topology's name from the first command-line argument or
-    * throws an exception if not present.
-    */
-  private def getTopologyName(args: Array[String]) = {
-    require(args.length > 0, "A Topology name should be supplied")
-    require(StringUtils.isNotBlank(args(0)), "Topology name must not be blank")
-    args(0)
-  }
-
 }
-
-final class ScalaIntegerProcessingTopology private () {}

--- a/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaRepartitionTopology.scala
+++ b/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaRepartitionTopology.scala
@@ -1,0 +1,84 @@
+//  Copyright 2018 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.examples.streamlet.scala
+
+import java.util.logging.Logger
+
+import scala.util.Random
+
+import com.twitter.heron.examples.streamlet.scala.common.ScalaTopologyExampleUtils
+import com.twitter.heron.streamlet.Config
+import com.twitter.heron.streamlet.scala.{Builder, Runner}
+
+/**
+  * This topology demonstrates the usage of a simple repartitioning algorithm
+  * using the Heron Streamlet API for Scala. Normally, streamlet elements are
+  * distributed randomly across downstream instances when processed.
+  * Repartitioning enables you to select which instances (partitions) to send
+  * elements to on the basis of a user-defined logic. Here, a source streamlet
+  * emits an indefinite series of random integers between 0 and 99. The value
+  * of that number then determines to which topology instance (partition) the
+  * element is routed.
+  */
+object ScalaRepartitionTopology {
+
+  private val log =
+    Logger.getLogger(ScalaRepartitionTopology.getClass.getName)
+
+  def main(args: Array[String]): Unit = {
+    val builder = Builder.newBuilder
+
+    builder
+      .newSource(() => Random.nextInt(100))
+      .setNumPartitions(2)
+      .setName("numbers-lower-than-100")
+      .repartition(5, repartitionFn)
+      .setName("repartitioned-incoming-values")
+      .repartition(2)
+      .setName("reduce-partitions-for-logging-operation")
+      .log()
+
+    val config = Config.defaultConfig()
+
+    // Fetches the topology name from the first command-line argument
+    val topologyName = ScalaTopologyExampleUtils.getTopologyName(args)
+
+    // Finally, the processing graph and configuration are passed to the Runner, which converts
+    // the graph into a Heron topology that can be run in a Heron cluster.
+    new Runner().run(topologyName, config, builder)
+  }
+
+  /**
+    * The repartition function that determines to which partition each incoming
+    * streamlet element is routed (across 5 possible partitions). Integers between 0
+    * and 19 are routed to partition 1, integers between 20 and 39 to partition 2,
+    * and so on.
+    */
+  private def repartitionFn(incomingInteger: Int, numPartitions: Int) = {
+    val partitionIndex = incomingInteger match {
+      case x if (0 to 19).contains(x)  => 1
+      case x if (20 to 39).contains(x) => 2
+      case x if (40 to 59).contains(x) => 3
+      case x if (60 to 79).contains(x) => 4
+      case x if (80 to 99).contains(x) => 5
+      case x =>
+        throw new IllegalArgumentException(
+          s"Incoming number($x) must not be higher than 100")
+    }
+
+    log.info(s"Sending value: $incomingInteger to partitions: $partitionIndex")
+
+    List(partitionIndex)
+  }
+}

--- a/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaRepartitionTopology.scala
+++ b/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaRepartitionTopology.scala
@@ -39,10 +39,12 @@ object ScalaRepartitionTopology {
   def main(args: Array[String]): Unit = {
     val builder = Builder.newBuilder
 
-    builder
+    val numbers = builder
       .newSource(() => Random.nextInt(100))
       .setNumPartitions(2)
       .setName("numbers-lower-than-100")
+
+    numbers
       .repartition(5, repartitionFn)
       .setName("repartitioned-incoming-values")
       .repartition(2)
@@ -67,11 +69,7 @@ object ScalaRepartitionTopology {
     */
   private def repartitionFn(incomingInteger: Int, numPartitions: Int) = {
     val partitionIndex = incomingInteger match {
-      case x if (0 to 19).contains(x)  => 1
-      case x if (20 to 39).contains(x) => 2
-      case x if (40 to 59).contains(x) => 3
-      case x if (60 to 79).contains(x) => 4
-      case x if (80 to 99).contains(x) => 5
+      case x if (x >= 0 && x <= 99) => x / 20 + 1
       case x =>
         throw new IllegalArgumentException(
           s"Incoming number($x) must not be higher than 100")

--- a/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaTransformsAndCloneTopology.scala
+++ b/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaTransformsAndCloneTopology.scala
@@ -1,0 +1,105 @@
+//  Copyright 2018 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.examples.streamlet.scala
+
+import java.util.logging.Logger
+
+import scala.util.Random
+
+import com.twitter.heron.examples.streamlet.scala.common.ScalaTopologyExampleUtils
+
+import com.twitter.heron.streamlet.{Config, Context}
+import com.twitter.heron.streamlet.scala.{
+  Builder,
+  Runner,
+  SerializableTransformer,
+  Sink
+}
+
+/**
+  * In this topology, a supplier generates an indefinite series of random integers between 0
+  * and 99. From there, a series of transform operations are applied that ultimately leave
+  * the original value unchanged.
+  */
+object ScalaTransformsAndCloneTopology {
+
+  private val log =
+    Logger.getLogger(ScalaTransformsAndCloneTopology.getClass.getName)
+
+  def main(args: Array[String]): Unit = {
+    val builder = Builder.newBuilder
+
+    val numbers = builder
+      .newSource(() => Random.nextInt(100))
+      .setName("numbers-lower-than-100")
+
+    val clonedStreamlets = numbers
+      .transform(new IncrementTransformer(2000))
+      .transform(new IncrementTransformer(-1300))
+      .transform(new DoNothingTransformer())
+      .transform(new IncrementTransformer(-500))
+      .transform(new IncrementTransformer(-200))
+      .clone(2)
+
+    clonedStreamlets(0).log()
+
+    clonedStreamlets(1).toSink(new FormattedLogSink)
+
+    val config = Config.defaultConfig()
+
+    // Fetches the topology name from the first command-line argument
+    val topologyName = ScalaTopologyExampleUtils.getTopologyName(args)
+
+    // Finally, the processing graph and configuration are passed to the Runner, which converts
+    // the graph into a Heron topology that can be run in a Heron cluster.
+    new Runner().run(topologyName, config, builder)
+  }
+
+  /**
+    * This transformer leaves incoming values unmodified. The Consumer simply accepts incoming
+    * values as-is during the transform phase.
+    */
+  private class DoNothingTransformer extends SerializableTransformer[Int, Int] {
+    override def setup(context: Context): Unit = {}
+
+    override def transform(i: Int, f: Int => Unit): Unit = f(i)
+
+    override def cleanup(): Unit = {}
+  }
+
+  /**
+    * This transformer increments incoming values by a user-supplied increment (which can also,
+    * of course, be negative).
+    */
+  private class IncrementTransformer(factor: Int)
+      extends SerializableTransformer[Int, Int] {
+    override def setup(context: Context): Unit = {}
+
+    override def transform(i: Int, f: Int => Unit): Unit = f(i + factor)
+
+    override def cleanup(): Unit = {}
+  }
+
+  /**
+    * This is a formatted log sink, which writes incoming tuples in defined log format.
+    */
+  private class FormattedLogSink extends Sink[Int] {
+    override def setup(context: Context): Unit = {}
+
+    override def put(tuple: Int): Unit =
+      log.info(s"The current number is $tuple")
+
+    override def cleanup(): Unit = {}
+  }
+}

--- a/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaWindowedWordCountTopology.scala
+++ b/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaWindowedWordCountTopology.scala
@@ -45,9 +45,11 @@ object ScalaWindowedWordCountTopology {
   def main(args: Array[String]): Unit = {
     val builder = Builder.newBuilder()
 
-    builder
+    val sentenceSource = builder
       .newSource(() => getRandomSentence())
       .setName("random-sentences-source")
+
+    sentenceSource
       .map[String](_.toLowerCase)
       .setName("sentences-with-lower-case")
       .flatMap[String](_.split(" "))

--- a/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaWindowedWordCountTopology.scala
+++ b/examples/src/scala/com/twitter/heron/examples/streamlet/scala/ScalaWindowedWordCountTopology.scala
@@ -1,0 +1,78 @@
+//  Copyright 2018 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.examples.streamlet.scala
+
+import java.util.logging.Logger
+
+import scala.util.Random
+
+import com.twitter.heron.examples.streamlet.scala.common.ScalaTopologyExampleUtils
+import com.twitter.heron.streamlet.{Config, KeyValue, KeyedWindow, WindowConfig}
+import com.twitter.heron.streamlet.scala.{Builder, Runner}
+
+/**
+  * This topology is an implementation of the classic word count example
+  * for the Heron Streamlet API for Scala. A source streamlet emits an
+  * indefinite series of sentences chosen at random from a pre-defined list.
+  * Each sentence is then mapped to lower-case and "flattened" into a list of individual words. A
+  * reduce function keeps a running tally of the number of times each word
+  * is encountered within each time window (in this case a tumbling count
+  * window of 50 operations). The result is then logged.
+  */
+object ScalaWindowedWordCountTopology {
+
+  private val log =
+    Logger.getLogger(ScalaWindowedWordCountTopology.getClass.getName)
+
+  private val sentences = List(
+    "I HAVE NOTHING TO DECLARE BUT MY GENIUS",
+    "YOU CAN EVEN",
+    "COMPASSION IS AN ACTION WORD WITH NO BOUNDARIES",
+    "TO THINE OWN SELF BE TRUE"
+  )
+
+  def main(args: Array[String]): Unit = {
+    val builder = Builder.newBuilder()
+
+    builder
+      .newSource(() => getRandomSentence())
+      .setName("random-sentences-source")
+      .map[String](_.toLowerCase)
+      .setName("sentences-with-lower-case")
+      .flatMap[String](_.split(" "))
+      .setName("flatten-into-individual-words")
+      .reduceByKeyAndWindow[String, Int]((word: String) => word,
+                                         (x: String) => 1,
+                                         WindowConfig.TumblingCountWindow(50),
+                                         (x: Int, y: Int) => x + y)
+      .setName("reduce-operation")
+      .consume((kv: KeyValue[KeyedWindow[String], Int]) =>
+        log.info(s"word: ${kv.getKey.getKey} - count: ${kv.getValue}"))
+
+    val config = Config.defaultConfig()
+
+    // Fetches the topology name from the first command-line argument
+    val topologyName = ScalaTopologyExampleUtils.getTopologyName(args)
+
+    // Finally, the processing graph and configuration are passed to the Runner, which converts
+    // the graph into a Heron topology that can be run in a Heron cluster.
+    new Runner().run(topologyName, config, builder)
+  }
+
+  /**
+    * This function provides a random selected sentence.
+    */
+  private def getRandomSentence() =
+    sentences(Random.nextInt(sentences.size))
+}

--- a/examples/src/scala/com/twitter/heron/examples/streamlet/scala/common/ScalaTopologyExampleUtils.scala
+++ b/examples/src/scala/com/twitter/heron/examples/streamlet/scala/common/ScalaTopologyExampleUtils.scala
@@ -1,0 +1,32 @@
+//  Copyright 2018 Twitter. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package com.twitter.heron.examples.streamlet.scala.common
+
+import org.apache.commons.lang3.StringUtils
+
+/**
+  * Utility Class for Scala Streamlet Topology Examples
+  */
+object ScalaTopologyExampleUtils {
+
+  /**
+    * Fetches the topology's name from the first command-line argument or
+    * throws an exception if not present.
+    */
+  def getTopologyName(args: Array[String]) = {
+    require(args.length > 0, "A Topology name should be supplied")
+    require(StringUtils.isNotBlank(args(0)), "Topology name must not be blank")
+    args(0)
+  }
+}


### PR DESCRIPTION
This PR aims the following changes:

Adding `Scala Streamlet Examples` as follows:
- `ScalaClassicalMusicTopology` (by using `filter` and `join` operations)
- `ScalaRepartitionTopology` (by using `repartition` operation)
- `ScalaTransformsAndCloneTopology` (by using `transform` and `clone` operations)
- `ScalaWindowedWordCountTopology` (by using `map`, `flatMap`, `reduceByKeyAndWindow` and `consume` operations)

Adding `ScalaTopologyExampleUtils` to support examples level utility logics.
