### PR TITLE
Fix comment in heron_internals.yaml

### DIFF
--- a/heron/config/src/yaml/conf/aurora/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/aurora/heron_internals.yaml
@@ -131,7 +131,7 @@ heron.tmaster.metrics.network.bindallinterfaces: False
 heron.tmaster.stmgr.state.timeout.sec: 60
 
 ################################################################################
-# Configs related to Topology Master, starts with heron.metricsmgr.*
+# Configs related to Metrics Manager, starts with heron.metricsmgr.*
 ################################################################################
 
 # The size of packets to read from socket will be determined by the minimal of:

--- a/heron/config/src/yaml/conf/examples/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/examples/heron_internals.yaml
@@ -131,7 +131,7 @@ heron.tmaster.metrics.network.bindallinterfaces: False
 heron.tmaster.stmgr.state.timeout.sec: 60
 
 ################################################################################
-# Configs related to Topology Master, starts with heron.metricsmgr.*
+# Configs related to Metrics Manager, starts with heron.metricsmgr.*
 ################################################################################
 
 # The size of packets to read from socket will be determined by the minimal of:

--- a/heron/config/src/yaml/conf/kubernetes/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/kubernetes/heron_internals.yaml
@@ -131,7 +131,7 @@ heron.tmaster.metrics.network.bindallinterfaces: False
 heron.tmaster.stmgr.state.timeout.sec: 60
 
 ################################################################################
-# Configs related to Topology Master, starts with heron.metricsmgr.*
+# Configs related to Metrics Manager, starts with heron.metricsmgr.*
 ################################################################################
 
 # The size of packets to read from socket will be determined by the minimal of:

--- a/heron/config/src/yaml/conf/local/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/local/heron_internals.yaml
@@ -131,7 +131,7 @@ heron.tmaster.metrics.network.bindallinterfaces: False
 heron.tmaster.stmgr.state.timeout.sec: 60
 
 ################################################################################
-# Configs related to Topology Master, starts with heron.metricsmgr.*
+# Configs related to Metrics Manager, starts with heron.metricsmgr.*
 ################################################################################
 
 # The size of packets to read from socket will be determined by the minimal of:

--- a/heron/config/src/yaml/conf/localzk/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/localzk/heron_internals.yaml
@@ -131,7 +131,7 @@ heron.tmaster.metrics.network.bindallinterfaces: False
 heron.tmaster.stmgr.state.timeout.sec: 60
 
 ################################################################################
-# Configs related to Topology Master, starts with heron.metricsmgr.*
+# Configs related to Metrics Manager, starts with heron.metricsmgr.*
 ################################################################################
 
 # The size of packets to read from socket will be determined by the minimal of:

--- a/heron/config/src/yaml/conf/marathon/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/marathon/heron_internals.yaml
@@ -131,7 +131,7 @@ heron.tmaster.metrics.network.bindallinterfaces: False
 heron.tmaster.stmgr.state.timeout.sec: 60
 
 ################################################################################
-# Configs related to Topology Master, starts with heron.metricsmgr.*
+# Configs related to Metrics Manager, starts with heron.metricsmgr.*
 ################################################################################
 
 # The size of packets to read from socket will be determined by the minimal of:

--- a/heron/config/src/yaml/conf/mesos/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/mesos/heron_internals.yaml
@@ -131,7 +131,7 @@ heron.tmaster.metrics.network.bindallinterfaces: False
 heron.tmaster.stmgr.state.timeout.sec: 60
 
 ################################################################################
-# Configs related to Topology Master, starts with heron.metricsmgr.*
+# Configs related to Metrics Manager, starts with heron.metricsmgr.*
 ################################################################################
 
 # The size of packets to read from socket will be determined by the minimal of:

--- a/heron/config/src/yaml/conf/nomad/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/nomad/heron_internals.yaml
@@ -131,7 +131,7 @@ heron.tmaster.metrics.network.bindallinterfaces: False
 heron.tmaster.stmgr.state.timeout.sec: 60
 
 ################################################################################
-# Configs related to Topology Master, starts with heron.metricsmgr.*
+# Configs related to Metrics Manager, starts with heron.metricsmgr.*
 ################################################################################
 
 # The size of packets to read from socket will be determined by the minimal of:

--- a/heron/config/src/yaml/conf/sandbox/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/sandbox/heron_internals.yaml
@@ -131,7 +131,7 @@ heron.tmaster.metrics.network.bindallinterfaces: False
 heron.tmaster.stmgr.state.timeout.sec: 60
 
 ################################################################################
-# Configs related to Topology Master, starts with heron.metricsmgr.*
+# Configs related to Metrics Manager, starts with heron.metricsmgr.*
 ################################################################################
 
 # The size of packets to read from socket will be determined by the minimal of:

--- a/heron/config/src/yaml/conf/slurm/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/slurm/heron_internals.yaml
@@ -131,7 +131,7 @@ heron.tmaster.metrics.network.bindallinterfaces: False
 heron.tmaster.stmgr.state.timeout.sec: 60 
 
 ################################################################################
-# Configs related to Topology Master, starts with heron.metricsmgr.*
+# Configs related to Metrics Manager, starts with heron.metricsmgr.*
 ################################################################################
 
 # The size of packets to read from socket will be determined by the minimal of: 

--- a/heron/config/src/yaml/conf/standalone/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/standalone/heron_internals.yaml
@@ -131,7 +131,7 @@ heron.tmaster.metrics.network.bindallinterfaces: False
 heron.tmaster.stmgr.state.timeout.sec: 60
 
 ################################################################################
-# Configs related to Topology Master, starts with heron.metricsmgr.*
+# Configs related to Metrics Manager, starts with heron.metricsmgr.*
 ################################################################################
 
 # The size of packets to read from socket will be determined by the minimal of:

--- a/heron/config/src/yaml/conf/yarn/heron_internals.yaml
+++ b/heron/config/src/yaml/conf/yarn/heron_internals.yaml
@@ -131,7 +131,7 @@ heron.tmaster.metrics.network.bindallinterfaces: False
 heron.tmaster.stmgr.state.timeout.sec: 60
 
 ################################################################################
-# Configs related to Topology Master, starts with heron.metricsmgr.*
+# Configs related to Metrics Manager, starts with heron.metricsmgr.*
 ################################################################################
 
 # The size of packets to read from socket will be determined by the minimal of:


### PR DESCRIPTION
The comment does not match directly with the configurations below it.