### PR TITLE
[Uploaders] Improve HttpUploader Part II

### DIFF
--- a/heron/uploaders/src/java/BUILD
+++ b/heron/uploaders/src/java/BUILD
@@ -30,7 +30,9 @@ http_uploader_deps_files = \
     uploader_spi_files + [
         "@org_apache_httpcomponents_httpmime//jar",
         "@org_apache_httpcomponents_http_client//jar",
-        "@org_apache_httpcomponents_http_core//jar"
+        "@org_apache_httpcomponents_http_core//jar",
+        "@org_apache_commons_commons_lang3//jar",
+        "//third_party/java:guava"
     ]
 
 java_library(

--- a/heron/uploaders/tests/java/BUILD
+++ b/heron/uploaders/tests/java/BUILD
@@ -105,7 +105,7 @@ java_test(
          "@org_apache_httpcomponents_http_core//jar",
          "@org_apache_httpcomponents_http_client//jar",
          "@org_apache_httpcomponents_http_client_test//jar",
-         "//heron/common/src/java:basics-java",
+         "//heron/common/src/java:basics-java"
     ],
     size = "small",
 )


### PR DESCRIPTION
This PR aims the following changes:
- Remove redundant `HttpClient`
- Adding checks for both `Uploader_Http_URI` and `Topology_Package_File` at initialization level as fail-fast.
- Using `try-with-resources` block to close `CloseableHttpClient` instance so `finally` block is being removed.
- Extending UT coverages by adding `6 negative cases`.